### PR TITLE
Optimization work for the fallout subroutine

### DIFF
--- a/src/kessler.F
+++ b/src/kessler.F
@@ -737,16 +737,17 @@
       real, dimension(0:nk) :: ffk
       real, dimension(nk) :: qtmp
 
-      integer :: nfall
-      real :: crmax,dtfall
+      integer,dimension(ni) :: nfall !made into an array by SM
+      real,dimension(ni) :: dtfall !made into an array by SM
+      real :: crmax
 
       double precision :: tem
       double precision, dimension(nj) :: bud
 
 !--------------------------------------------------------------------
 
-    !$acc data create(bud)
-    !$acc parallel default(present) private(i,j,k,crmax,nfall,rq,n,dtfall,nr) 
+    !$acc data create(bud,nfall,dtfall)
+    !$acc parallel default(present) private(i,j,k,crmax,rq,n,nr) 
     !$acc loop gang vector 
     !$omp parallel do default(shared) private(i,j,k,crmax,nfall,rq,n,dtfall,nr)
     do j=1,nj
@@ -758,35 +759,54 @@
       do k=1,nk
         crmax = max( crmax , vq(i,j,k)*dt*rdz*mh(i,j,k) )
       enddo
-      nfall = max( 1 , int(crmax+1.0) )
+      nfall(i) = max( 1 , int(crmax+1.0) )
+      dtfall(i)=dt/nfall(i)
+    enddo
       ! cm1r17:  following code is needed if nfall is large.
       !  - below edge of falling precip, set fallspeed to
       !    value at gridpoint above:
-      !$acc loop gang vector
+    !$acc loop gang vector collapse(2)
+    do i=1,ni
       do k=(nk-1),1,-1
         if( q3d(i,j,k).lt.1.0e-8 ) vq(i,j,k) = vq(i,j,k+1)
       enddo
-      dtfall=dt/nfall
-      !$acc loop gang vector
-      do n=1,nfall
-        !$acc loop gang vector
+    enddo
+      !!dtfall=dt/nfall(i) moved to up above
+    !$acc loop collapse(3) gang vector
+    do i=1,ni
+      do n=1,nfall(i)
         do k=1,nk
-          rq(k)=rho(i,j,k)*vq(i,j,k)*max(0.0,q3d(i,j,k))
+         rq(k)=rho(i,j,k)*vq(i,j,k)*max(0.0,q3d(i,j,k))
+          rq(nk+1)=0.0 ! Added here from below by SM
         enddo
-        rq(nk+1)=0.0
-        !$acc loop gang vector
+      enddo
+    enddo
+    !$acc loop collapse(3) gang vector
+    do i=1,ni
+      do n=1,nfall(i)
+        !rq(nk+1)=0.0
+        !!!$acc loop gang vector
         do k=1,nk
-          q3d(i,j,k)=q3d(i,j,k)+dtfall*(rq(k+1)-rq(k))   &
+          q3d(i,j,k)=q3d(i,j,k)+dtfall(i)*(rq(k+1)-rq(k))   &
                                      *rdz*mh(i,j,k)/rho(i,j,k)
         enddo
-        !$acc loop gang vector
+      enddo
+    enddo
+    !$acc loop collapse(3) gang vector
+    do i=1,ni
+      do n=1,nfall(i)
         do nr=1,nrain
-          rain(i,j,nr)=rain(i,j,nr)+0.1*dtfall*rq(1)
+          rain(i,j,nr)=rain(i,j,nr)+0.1*dtfall(i)*rq(1)
                                 ! mult by 100 cm/m  (convert from m to cm)
                                 ! div by 1000 kg/m^3  (density of water)
         enddo
+      enddo
+    enddo
+    !$acc loop collapse(2) gang vector
+    do i=1,ni
+      do n=1,nfall(i)
         prate(i,j) = rq(1)
-        bud(j)=bud(j)+dtfall*rr(i,j,1)*vq(i,j,1)*max(0.0,q3d(i,j,1))*ruh(i)*rvh(j)
+        bud(j)=bud(j)+dtfall(i)*rr(i,j,1)*vq(i,j,1)*max(0.0,q3d(i,j,1))*ruh(i)*rvh(j)
       enddo
     enddo
     enddo
@@ -797,6 +817,8 @@
         train=train+bud(j)*dx*dy
       enddo
       !$acc end data
+      !$acc compare(prate,train)
+
       if(timestats.ge.1) time_fall=time_fall+mytime()
 
       end subroutine fallout_GPU


### PR DESCRIPTION
Optimization of the fallout_gpu subroutine
Original timing:
```fallout  :        5.87    9.34%```
New timing:
```fallout  :        1.00    1.77%```
Timings use default grid and faster options.