### PR TITLE
New location search implementation for droplet parcels

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -74,16 +74,16 @@ FC   = mpif90
 CPP  = cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
 #
 # -------PERF-------
-#OPTS = -Mfree -O2 -Ktrap=none -Mautoinline -Minline=reshape -Mpcast -Mnofma -Minfo=accel -ta=tesla:cc70,lineinfo,nofma
-#OPTS = -Mfree -O2 -Ktrap=none -Mautoinline -Minline=reshape -Mpcast -Minfo=accel -ta=tesla:cc70,lineinfo
-OPTS = -Mfree -g -O2 -acc -gpu=cc70,lineinfo,math_uniform -Ktrap=none -Mautoinline -Minline=reshape -Mpcast -Minfo=accel
+#OPTS = -Mfree -O2 -Ktrap=none -Mautoinline -Minline=reshape -Mpcast -Mnofma -Minfo=accel -ta=tesla:cc70,lineinfo,nofma -Kieee
+#OPTS = -Mfree -O2 -Ktrap=none -Mautoinline -Minline=reshape -Mpcast -Minfo=accel -ta=tesla:cc70,lineinfo -Kieee
+OPTS = -Mfree -g -O2 -acc -gpu=cc70,lineinfo,math_uniform -Ktrap=none -Mautoinline -Minline=reshape -Mpcast -Minfo=accel -Kieee
 #DM   = -DMPI -D_OPENACC 
 # -------END PERF------
 #
 # -------DEBUG------
-#OPTS = -Mfree -g -O2 -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Ktrap=none -Mnoinline -Minline=reshape -Mpcast -Mnofma -Minfo=accel
-#OPTS = -Mfree -g -O2 -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Ktrap=none -Mautoinline -Minline=reshape -Mpcast -Mnofma -Minfo=accel
-DM   = -DMPI -D_OPENACC -D_B4B
+#OPTS = -Mfree -g -O2 -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Ktrap=none -Mnoinline -Minline=reshape -Mpcast -Mnofma -Minfo=accel -Kieee
+#OPTS = -Mfree -g -O2 -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Ktrap=none -Mautoinline -Minline=reshape -Mpcast -Mnofma -Minfo=accel -Kieee
+DM   = -DMPI -D_OPENACC -D_VERIFY_FIND_LOC # -D_B4B
 # -------END DEBUG------
 #
 # if NVTX performance analysis

--- a/src/Makefile
+++ b/src/Makefile
@@ -83,7 +83,8 @@ OPTS = -Mfree -g -O2 -acc -gpu=cc70,lineinfo,math_uniform -Ktrap=none -Mautoinli
 # -------DEBUG------
 #OPTS = -Mfree -g -O2 -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Ktrap=none -Mnoinline -Minline=reshape -Mpcast -Mnofma -Minfo=accel -Kieee
 #OPTS = -Mfree -g -O2 -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Ktrap=none -Mautoinline -Minline=reshape -Mpcast -Mnofma -Minfo=accel -Kieee
-DM   = -DMPI -D_OPENACC -D_VERIFY_FIND_LOC # -D_B4B
+#DM = -DMPI -D_OPENACC -D_B4B
+DM = -DMPI -D_OPENACC -D_VERIFY_FIND_LOC
 # -------END DEBUG------
 #
 # if NVTX performance analysis

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2811,7 +2811,8 @@
     !$acc copyin(dt) &
     !$acc copyin(reqs_s,reqs_u,reqs_p3, &
     !$acc   reqs_v,reqs_w,reqs_x,reqs_y,reqs_s,reqs_p2,reqs_z) &
-    !$acc copyin(rru,ua,u3d,uten,uten1,rrv,va,v3d,th3d,phi2,vten,vten1,rrw,wa,w3d,wten,wten1)
+    !$acc copyin(rru,ua,u3d,uten,uten1,rrv,va,v3d,th3d,phi2,vten,vten1,rrw,wa,w3d,wten,wten1) &
+    !$acc copy(pdata_locind)
 
     !$acc compare(lu_index)
     if(timestats.ge.1) time_H2D=time_H2D+mytime()

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -3268,7 +3268,7 @@
                    bndy,kbdy,hflxw,hflxe,hflxs,hflxn,                &
                    dowriteout,dorad,getdbz,getvt,dotdwrite,          &
                    dotbud,doqbud,doubud,dovbud,dowbud,donudge,       &
-                   doazimwrite,dorestart)
+                   doazimwrite,dorestart,ipdata,jpdata,kpdata)
         ! end_solve3
         !stop 'cm1: after call to solve3'
 !$acc compare(khh,khv)

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -263,7 +263,7 @@
       integer :: ndev,idev
 #endif
 
-      integer, dimension(:), allocatable :: ipdata,jpdata,kpdata  ! 1-D array to store parcel x/y/z location index
+      integer, dimension(:,:), allocatable :: pdata_locind  ! 2-D array to store parcel x/y/z location index
 
 !----------------------------------------------------------------------
 
@@ -2209,12 +2209,8 @@
       pdata = 0.0
       allocate(   ploc(nparcels,  3   ) )
       ploc = 0.0
-      allocate(  ipdata(nparcels) )
-      ipdata = -100
-      allocate(  jpdata(nparcels) )
-      jpdata = -100
-      allocate(  kpdata(nparcels) )
-      kpdata = -100
+      allocate(  pdata_locind(nparcels,3) )
+      pdata_locind = -100
 
       allocate( dpten(ib:ie,jb:je,kb:ke,2) )
       dpten = 0.0
@@ -3268,7 +3264,7 @@
                    bndy,kbdy,hflxw,hflxe,hflxs,hflxn,                &
                    dowriteout,dorad,getdbz,getvt,dotdwrite,          &
                    dotbud,doqbud,doubud,dovbud,dowbud,donudge,       &
-                   doazimwrite,dorestart,ipdata,jpdata,kpdata)
+                   doazimwrite,dorestart,pdata_locind)
         ! end_solve3
         !stop 'cm1: after call to solve3'
 !$acc compare(khh,khv)

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2210,7 +2210,7 @@
       allocate(   ploc(nparcels,  3   ) )
       ploc = 0.0
       allocate(  pdata_locind(nparcels,3) )
-      pdata_locind = -100
+      pdata_locind = undefined_index
 
       allocate( dpten(ib:ie,jb:je,kb:ke,2) )
       dpten = 0.0

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -263,6 +263,8 @@
       integer :: ndev,idev
 #endif
 
+      integer, dimension(:), allocatable :: ipdata,jpdata,kpdata  ! 1-D array to store parcel x/y/z location index
+
 !----------------------------------------------------------------------
 
       nstep = 0
@@ -2207,6 +2209,12 @@
       pdata = 0.0
       allocate(   ploc(nparcels,  3   ) )
       ploc = 0.0
+      allocate(  ipdata(nparcels) )
+      ipdata = -100
+      allocate(  jpdata(nparcels) )
+      jpdata = -100
+      allocate(  kpdata(nparcels) )
+      kpdata = -100
 
       allocate( dpten(ib:ie,jb:je,kb:ke,2) )
       dpten = 0.0

--- a/src/constants.F
+++ b/src/constants.F
@@ -63,6 +63,8 @@
 
       real, parameter :: grads_undef  =  -999999.9
 
+      integer, parameter :: undefined_index = -100
+
   CONTAINS
 
     !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -104,6 +104,10 @@
       real :: xv,yv,zv,dV,wtx,wty,wtz,wtt
       real :: esl
 
+#ifdef _VERIFY_FIND_LOC
+      integer :: iflag_ori, jflag_ori, kflag_ori
+#endif
+
       logical, parameter :: debug = .false.
       !$acc declare present(rho,prs,qa,wa,sigma)
 
@@ -301,6 +305,21 @@
     ELSE
       ! cm1r19:
       call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+1, iflag) 
+#ifdef _VERIFY_FIND_LOC
+      iflag_ori = -100
+      i = ni+1
+      do while( iflag_ori.lt.0 .and. i.gt.1 )
+        i = i-1
+        if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
+          iflag_ori = i
+        endif
+      enddo
+      if ( iflag .ne. iflag_ori ) then
+         stop "Failed verification test: iflag is not the same..."
+      else
+         print *, "Pass the verification test for iflag..."
+      end if
+#endif
     ENDIF
 
     IF(axisymm.eq.1.or.ny.eq.1)THEN
@@ -308,6 +327,21 @@
     ELSE
       ! cm1r19:
       call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+1, jflag)  
+#ifdef _VERIFY_FIND_LOC
+      jflag_ori = -100
+      j = nj+1
+      do while( jflag_ori.lt.0 .and. j.gt.1 )
+        j = j-1
+        if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
+          jflag_ori = j
+        endif
+      enddo
+      if ( jflag .ne. jflag_ori ) then
+         stop "Failed verification test: jflag is not the same..."
+      else
+         print *, "Pass the verification test for jflag..."
+      end if
+#endif
     ENDIF
 
   ELSE     ! re-initialize x/y/z location index array if a parcel is not on this process
@@ -331,8 +365,30 @@
       kflag = 1
       if( .not. terrain_flag )then
         call find_vertical_location_index (pdata_locind(:,3), np, z3d, zf(iflag,jflag,:), kflag)
+#ifdef _VERIFY_FIND_LOC
+        kflag_ori = 1
+        do while( z3d.ge.zf(iflag,jflag,kflag_ori+1) )
+          kflag_ori = kflag_ori+1
+        enddo
+        if ( kflag .ne. kflag_ori ) then
+           stop "Failed verification test: kflag is not the same..."
+        else
+           print *, "Pass the verification test for kflag..."
+        end if
+#endif
       else
         call find_vertical_location_index (pdata_locind(:,3), np, sig3d, sigmaf, kflag)
+#ifdef _VERIFY_FIND_LOC
+        kflag_ori = 1
+        do while( sig3d.ge.sigmaf(kflag_ori+1) )
+          kflag_ori = kflag_ori+1
+        enddo
+        if ( kflag .ne. kflag_ori ) then
+           stop "Failed verification test: kflag is not the same..."
+        else
+           print *, "Pass the verification test for kflag..."
+        end if
+#endif
       endif
 !      !Store these for two-way coupling
 !      iflag_s=iflag
@@ -379,6 +435,21 @@
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+2, iflag)
+#ifdef _VERIFY_FIND_LOC
+          iflag_ori = -100
+          i = ni+2
+          do while( iflag_ori.lt.0 .and. i.gt.0 )
+            i = i-1
+            if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
+              iflag_ori = i
+            endif
+          enddo
+          if ( iflag .ne. iflag_ori ) then
+             stop "Failed verification test: iflag is not the same..."
+          else
+             print *, "Pass the verification test for iflag..."
+          end if
+#endif
         ENDIF
 
         IF(axisymm.eq.1.or.ny.eq.1)THEN
@@ -386,6 +457,21 @@
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+2, jflag)
+#ifdef _VERIFY_FIND_LOC
+          jflag_ori = -100
+          j = nj+2
+          do while( jflag_ori.lt.0 .and. j.gt.0 )
+            j = j-1
+            if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
+              jflag_ori = j
+            endif
+          enddo
+          if ( jflag .ne. jflag_ori ) then
+             stop "Failed verification test: jflag is not the same..."
+          else
+             print *, "Pass the verification test for jflag..."
+          end if
+#endif
         ENDIF
         i=iflag
         j=jflag
@@ -394,8 +480,30 @@
         kflag = 1
         if( .not. terrain_flag )then
           call find_vertical_location_index (pdata_locind(:,3), np, z3d, zf(iflag,jflag,:), kflag)
+#ifdef _VERIFY_FIND_LOC
+          kflag_ori = 1
+          do while( z3d.gt.zf(iflag,jflag,kflag_ori+1) )
+            kflag_ori = kflag_ori+1
+          enddo
+          if ( kflag .ne. kflag_ori ) then
+             stop "Failed verification test: kflag is not the same..."
+          else
+             print *, "Pass the verification test for kflag..."
+          end if
+#endif
         else
           call find_vertical_location_index (pdata_locind(:,3), np, sig3d, sigmaf, kflag)
+#ifdef _VERIFY_FIND_LOC
+          kflag_ori = 1
+          do while( sig3d.gt.sigmaf(kflag_ori+1) )
+            kflag_ori = kflag_ori+1
+          enddo
+          if ( kflag .ne. kflag_ori ) then
+             stop "Failed verification test: kflag is not the same..."
+          else
+             print *, "Pass the verification test for kflag..."
+          end if
+#endif
         endif
 
 !JMD-debug
@@ -1000,12 +1108,43 @@
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+2, iflag)
+#ifdef _VERIFY_FIND_LOC
+          iflag_ori = -100
+          i = ni+2
+          do while( iflag_ori.lt.0 .and. i.gt.0 )
+            i = i-1
+            if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
+              iflag_ori = i
+            endif
+          enddo
+          if ( iflag .ne. iflag_ori ) then
+             stop "Failed verification test: iflag is not the same..."
+          else
+             print *, "Pass the verification test for iflag..."
+          end if
+#endif
         ENDIF
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           jflag = 1
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+2, jflag)
+#ifdef _VERIFY_FIND_LOC
+          jflag_ori = -100
+          j = nj+2
+          do while( jflag_ori.lt.0 .and. j.gt.0 )
+            !print *,'j: ',j
+            j = j-1
+            if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
+              jflag_ori = j
+            endif
+          enddo
+          if ( jflag .ne. jflag_ori ) then
+             stop "Failed verification test: jflag is not the same..."
+          else
+             print *, "Pass the verification test for jflag..."
+          end if
+#endif
           if(mod(np,PITER)==0) then
              print *,'after dowhile loop: ',jflag
           endif
@@ -1036,8 +1175,30 @@
         kflag = 1
         if( .not. terrain_flag )then
           call find_vertical_location_index (pdata_locind(:,3), np, z3d, zf(iflag,jflag,:), kflag)
+#ifdef _VERIFY_FIND_LOC
+          kflag_ori = 1
+          do while( z3d.gt.zf(iflag,jflag,kflag_ori+1) )
+            kflag_ori = kflag_ori+1
+          enddo
+          if ( kflag .ne. kflag_ori ) then
+             stop "Failed verification test: kflag is not the same..."
+          else
+             print *, "Pass the verification test for kflag..."
+          end if
+#endif
         else
           call find_vertical_location_index (pdata_locind(:,3), np, sig3d, sigmaf, kflag)
+#ifdef _VERIFY_FIND_LOC
+          kflag_ori = 1
+          do while( sig3d.gt.sigmaf(kflag_ori+1) )
+            kflag_ori = kflag_ori+1
+          enddo
+          if ( kflag .ne. kflag_ori ) then
+             stop "Failed verification test: kflag is not the same..."
+          else
+             print *, "Pass the verification test for kflag..."
+          end if
+#endif
         endif
 
 #if 0

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -105,10 +105,6 @@
       real :: xv,yv,zv,dV,wtx,wty,wtz,wtt
       real :: esl
 
-#ifdef _VERIFY_FIND_LOC
-      integer :: iflag_ori, jflag_ori, kflag_ori
-#endif
-
       logical, parameter :: debug = .false.
       !$acc declare present(rho,prs,qa,wa,sigma)
 
@@ -306,22 +302,6 @@
     ELSE
       ! cm1r19:
       call find_horizontal_location_index (pdata_locind(:,1), np, x3d, ib, ie+1, xf, ni+1, iflag) 
-#ifdef _VERIFY_FIND_LOC
-      iflag_ori = neg_hundred
-      i = ni+1
-      do while( iflag_ori.lt.0 .and. i.gt.1 )
-        i = i-1
-        if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
-          iflag_ori = i
-        endif
-      enddo
-      if ( iflag .ne. iflag_ori ) then
-         print *, "iflag ori = ", iflag_ori
-         stop "Failed verification test: iflag is not the same..."
-      else
-         print *, "Pass the verification test for iflag..."
-      end if
-#endif
     ENDIF
 
     IF(axisymm.eq.1.or.ny.eq.1)THEN
@@ -329,21 +309,6 @@
     ELSE
       ! cm1r19:
       call find_horizontal_location_index (pdata_locind(:,2), np, y3d, jb, je+1, yf, nj+1, jflag)  
-#ifdef _VERIFY_FIND_LOC
-      jflag_ori = neg_hundred
-      j = nj+1
-      do while( jflag_ori.lt.0 .and. j.gt.1 )
-        j = j-1
-        if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
-          jflag_ori = j
-        endif
-      enddo
-      if ( jflag .ne. jflag_ori ) then
-         stop "Failed verification test: jflag is not the same..."
-      else
-         print *, "Pass the verification test for jflag..."
-      end if
-#endif
     ENDIF
 
   ELSE     ! re-initialize x/y/z location index array if a parcel is not on this process
@@ -367,30 +332,8 @@
       kflag = 1
       if( .not. terrain_flag )then
         call find_vertical_location_index (pdata_locind(:,3), np, z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .TRUE.)
-#ifdef _VERIFY_FIND_LOC
-        kflag_ori = 1
-        do while( z3d.ge.zf(iflag,jflag,kflag_ori+1) )
-          kflag_ori = kflag_ori+1
-        enddo
-        if ( kflag .ne. kflag_ori ) then
-           stop "Failed verification test: kflag is not the same..."
-        else
-           print *, "Pass the verification test for kflag..."
-        end if
-#endif
       else
         call find_vertical_location_index (pdata_locind(:,3), np, sig3d, kb, ke+1, sigmaf, kflag, .TRUE.)
-#ifdef _VERIFY_FIND_LOC
-        kflag_ori = 1
-        do while( sig3d.ge.sigmaf(kflag_ori+1) )
-          kflag_ori = kflag_ori+1
-        enddo
-        if ( kflag .ne. kflag_ori ) then
-           stop "Failed verification test: kflag is not the same..."
-        else
-           print *, "Pass the verification test for kflag..."
-        end if
-#endif
       endif
 !      !Store these for two-way coupling
 !      iflag_s=iflag
@@ -437,21 +380,6 @@
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,1), np, x3d, ib, ie+1, xf, ni+2, iflag)
-#ifdef _VERIFY_FIND_LOC
-          iflag_ori = neg_hundred
-          i = ni+2
-          do while( iflag_ori.lt.0 .and. i.gt.0 )
-            i = i-1
-            if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
-              iflag_ori = i
-            endif
-          enddo
-          if ( iflag .ne. iflag_ori ) then
-             stop "Failed verification test: iflag is not the same..."
-          else
-             print *, "Pass the verification test for iflag..."
-          end if
-#endif
         ENDIF
 
         IF(axisymm.eq.1.or.ny.eq.1)THEN
@@ -459,21 +387,6 @@
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,2), np, y3d, jb, je+1, yf, nj+2, jflag)
-#ifdef _VERIFY_FIND_LOC
-          jflag_ori = neg_hundred
-          j = nj+2
-          do while( jflag_ori.lt.0 .and. j.gt.0 )
-            j = j-1
-            if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
-              jflag_ori = j
-            endif
-          enddo
-          if ( jflag .ne. jflag_ori ) then
-             stop "Failed verification test: jflag is not the same..."
-          else
-             print *, "Pass the verification test for jflag..."
-          end if
-#endif
         ENDIF
         i=iflag
         j=jflag
@@ -482,30 +395,8 @@
         kflag = 1
         if( .not. terrain_flag )then
           call find_vertical_location_index (pdata_locind(:,3), np, z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .FALSE.)
-#ifdef _VERIFY_FIND_LOC
-          kflag_ori = 1
-          do while( z3d.gt.zf(iflag,jflag,kflag_ori+1) )
-            kflag_ori = kflag_ori+1
-          enddo
-          if ( kflag .ne. kflag_ori ) then
-             stop "Failed verification test: kflag is not the same..."
-          else
-             print *, "Pass the verification test for kflag..."
-          end if
-#endif
         else
           call find_vertical_location_index (pdata_locind(:,3), np, sig3d, kb, ke+1, sigmaf, kflag, .FALSE.)
-#ifdef _VERIFY_FIND_LOC
-          kflag_ori = 1
-          do while( sig3d.gt.sigmaf(kflag_ori+1) )
-            kflag_ori = kflag_ori+1
-          enddo
-          if ( kflag .ne. kflag_ori ) then
-             stop "Failed verification test: kflag is not the same..."
-          else
-             print *, "Pass the verification test for kflag..."
-          end if
-#endif
         endif
 
 !JMD-debug
@@ -1110,43 +1001,12 @@
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,1), np, x3d, ib, ie+1, xf, ni+2, iflag)
-#ifdef _VERIFY_FIND_LOC
-          iflag_ori = neg_hundred
-          i = ni+2
-          do while( iflag_ori.lt.0 .and. i.gt.0 )
-            i = i-1
-            if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
-              iflag_ori = i
-            endif
-          enddo
-          if ( iflag .ne. iflag_ori ) then
-             stop "Failed verification test: iflag is not the same..."
-          else
-             print *, "Pass the verification test for iflag..."
-          end if
-#endif
         ENDIF
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           jflag = 1
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,2), np, y3d, jb, je+1, yf, nj+2, jflag)
-#ifdef _VERIFY_FIND_LOC
-          jflag_ori = neg_hundred
-          j = nj+2
-          do while( jflag_ori.lt.0 .and. j.gt.0 )
-            !print *,'j: ',j
-            j = j-1
-            if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
-              jflag_ori = j
-            endif
-          enddo
-          if ( jflag .ne. jflag_ori ) then
-             stop "Failed verification test: jflag is not the same..."
-          else
-             print *, "Pass the verification test for jflag..."
-          end if
-#endif
           if(mod(np,PITER)==0) then
              print *,'after dowhile loop: ',jflag
           endif
@@ -1177,30 +1037,8 @@
         kflag = 1
         if( .not. terrain_flag )then
           call find_vertical_location_index (pdata_locind(:,3), np, z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .FALSE.)
-#ifdef _VERIFY_FIND_LOC
-          kflag_ori = 1
-          do while( z3d.gt.zf(iflag,jflag,kflag_ori+1) )
-            kflag_ori = kflag_ori+1
-          enddo
-          if ( kflag .ne. kflag_ori ) then
-             stop "Failed verification test: kflag is not the same..."
-          else
-             print *, "Pass the verification test for kflag..."
-          end if
-#endif
         else
           call find_vertical_location_index (pdata_locind(:,3), np, sig3d, kb, ke+1, sigmaf, kflag, .FALSE.)
-#ifdef _VERIFY_FIND_LOC
-          kflag_ori = 1
-          do while( sig3d.gt.sigmaf(kflag_ori+1) )
-            kflag_ori = kflag_ori+1
-          enddo
-          if ( kflag .ne. kflag_ori ) then
-             stop "Failed verification test: kflag is not the same..."
-          else
-             print *, "Pass the verification test for kflag..."
-          end if
-#endif
         endif
 
 #if 0
@@ -3970,6 +3808,11 @@
 
       ! local variable
       integer :: i
+#ifdef _VERIFY_FIND_LOC
+      integer :: ind_ori
+
+      ind_ori = ind
+#endif
 
       ! Sanity check:
       ! - If input x/y location is outside the x/y range, return directly
@@ -4000,6 +3843,22 @@
                end if
             end do
          end if
+#ifdef _VERIFY_FIND_LOC
+         ind_ori = ind
+         i = end_ind
+         do while( ind_ori .lt. 0 .and. i .gt. 1 )
+            i = i - 1
+            if ( loc .ge. dsize(i) .and. loc .le. dsize(i+1) ) then
+               ind_ori = i
+            end if
+         end do
+         if ( ind_ori .ne. ind ) then
+            print *, "original search scheme finds x/y index = ", ind_ori, ", new search scheme finds x/y index = ", ind 
+            stop "Failed verification test: x/y index is not the same..."
+         else
+            print *, "Pass the verification test for x/y index..."
+         end if
+#endif
       else ! Always search from the end when:
            !    - it is the first time step
            !    - a parcel enters a new or different MPI process
@@ -4033,6 +3892,11 @@
 
       ! Local variable
       integer :: i
+#ifdef _VERIFY_FIND_LOC
+      integer :: ind_ori
+
+      ind_ori = ind
+#endif
 
       ! Sanity check:
       ! - If input x/y location is outside the x/y range, return directly
@@ -4059,6 +3923,23 @@
             end do
          end if
          ind = i
+#ifdef _VERIFY_FIND_LOC
+         if ( is_ge ) then
+            do while( loc .ge. dsize(ind_ori+1) )
+               ind_ori = ind_ori + 1
+            end do
+         else
+            do while( loc .gt. dsize(ind_ori+1) )
+               ind_ori = ind_ori + 1
+            end do
+         end if
+         if ( ind_ori .ne. ind ) then
+            print *, "original search scheme finds z index = ", ind_ori, ", new search scheme finds z index = ", ind
+            stop "Failed verification test: z index is not the same..."
+         else
+            print *, "Pass the verification test for z index..."
+         end if
+#endif
       else ! Always search from the end when:
            !    - it is the first time step
            !    - a parcel enters a new or different MPI process

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -12,6 +12,14 @@
   private
   public :: droplet_driver,parcel_driver,parcel_interp,parcel_write,setup_parcel_vars,getparcelzs
 
+  ! If we already know that a parcel stays on the same process 
+  !    in the previous time step and it is still here, we start 
+  !    the location search from the previous index and limit 
+  !    the search range using the parameter below;
+  ! This assumes that a parcel does not move too far and does
+  !    not move between processes within this subroutine?
+  integer, parameter :: location_offset = 4 
+
   CONTAINS
 
       subroutine droplet_driver(dt,xh,uh,ruh,xf,yh,vh,rvh,yf,zh,mh,rmh,zf,mf,zs,    &
@@ -21,7 +29,7 @@
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p,              &
                                sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,             &
                                n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,      &
-                               uten,vten,wten,thten,qten)
+                               uten,vten,wten,thten,qten,ipdata)
       use input
       use constants
       use bc_module
@@ -67,7 +75,7 @@
       real, intent(inout), dimension(imp,cmp,kmp)   :: ss31,ss32,sn31,sn32
       real, intent(inout), dimension(cmp,cmp,kmt+1) :: n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2
       integer, intent(inout), dimension(rmp) :: reqs_s
-
+      integer, intent(inout), dimension(nparcels)   :: ipdata 
 
       !Need to compute the true temperature
       real, dimension(ib:ie,jb:je,kb:ke) :: ta
@@ -292,13 +300,25 @@
       iflag = 1
     ELSE
       ! cm1r19:
-      i = ni+1
-      do while( iflag.lt.0 .and. i.gt.1 )
-        i = i-1
-        if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
-          iflag = i
-        endif
-      enddo
+      IF (ipdata(np) .ne. 0) THEN
+        i = ipdata(np) + location_offset + 1 
+        do while( iflag .lt. 0 .and. i .gt. (ipdata(np) - location_offset) )
+           i = i - 1
+           if ( x3d .ge. xf(i) .and. x3d .le. xf(i+1) )then
+              iflag = i
+              ipdata(np) = iflag
+           endif
+        enddo
+      ELSE                          
+        i = ni+1
+        do while( iflag.lt.0 .and. i.gt.1 )
+          i = i-1
+          if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
+            iflag = i
+            ipdata(np) = iflag
+          endif
+        enddo
+      ENDIF
     ENDIF
 
     IF(axisymm.eq.1.or.ny.eq.1)THEN
@@ -314,6 +334,8 @@
       enddo
     ENDIF
 
+  ELSE ! re-initialize ipdata
+    ipdata(np) = 0
   ENDIF  haveit1
 
 #ifdef MPI

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -19,6 +19,7 @@
   ! This assumes that a parcel does not move too far and does
   !    not move between processes within this subroutine?
   integer, parameter :: location_offset = 100 
+  integer, parameter :: neg_hundred = -100    ! define constant for initial value  
 
   CONTAINS
 
@@ -291,8 +292,8 @@
         sig3d = pdata(np,prsig)
       endif
 
-      iflag = -100
-      jflag = -100
+      iflag = neg_hundred
+      jflag = neg_hundred
       kflag = 0
 
   ! cm1r19:  skip if we already know this processor doesnt have this parcel
@@ -304,10 +305,9 @@
       iflag = 1
     ELSE
       ! cm1r19:
-      call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+1, iflag) 
-print *, 'iflag = ', iflag
+      call find_horizontal_location_index (pdata_locind(:,1), np, x3d, ib, ie+1, xf, ni+1, iflag) 
 #ifdef _VERIFY_FIND_LOC
-      iflag_ori = -100
+      iflag_ori = neg_hundred
       i = ni+1
       do while( iflag_ori.lt.0 .and. i.gt.1 )
         i = i-1
@@ -316,6 +316,7 @@ print *, 'iflag = ', iflag
         endif
       enddo
       if ( iflag .ne. iflag_ori ) then
+         print *, "iflag ori = ", iflag_ori
          stop "Failed verification test: iflag is not the same..."
       else
          print *, "Pass the verification test for iflag..."
@@ -327,10 +328,9 @@ print *, 'iflag = ', iflag
       jflag = 1
     ELSE
       ! cm1r19:
-      call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+1, jflag)  
-print *, 'jflag = ', jflag
+      call find_horizontal_location_index (pdata_locind(:,2), np, y3d, jb, je+1, yf, nj+1, jflag)  
 #ifdef _VERIFY_FIND_LOC
-      jflag_ori = -100
+      jflag_ori = neg_hundred
       j = nj+1
       do while( jflag_ori.lt.0 .and. j.gt.1 )
         j = j-1
@@ -347,9 +347,9 @@ print *, 'jflag = ', jflag
     ENDIF
 
   ELSE     ! re-initialize x/y/z location index array if a parcel is not on this process
-    pdata_locind(np,1) = -100
-    pdata_locind(np,2) = -100
-    pdata_locind(np,3) = -100
+    pdata_locind(np,1) = neg_hundred
+    pdata_locind(np,2) = neg_hundred
+    pdata_locind(np,3) = neg_hundred
   ENDIF  haveit1
 
 #ifdef MPI
@@ -366,7 +366,7 @@ print *, 'jflag = ', jflag
 
       kflag = 1
       if( .not. terrain_flag )then
-        call find_vertical_location_index (pdata_locind(:,3), np, z3d, zf(iflag,jflag,:), kflag)
+        call find_vertical_location_index (pdata_locind(:,3), np, z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .TRUE.)
 #ifdef _VERIFY_FIND_LOC
         kflag_ori = 1
         do while( z3d.ge.zf(iflag,jflag,kflag_ori+1) )
@@ -379,7 +379,7 @@ print *, 'jflag = ', jflag
         end if
 #endif
       else
-        call find_vertical_location_index (pdata_locind(:,3), np, sig3d, sigmaf, kflag)
+        call find_vertical_location_index (pdata_locind(:,3), np, sig3d, kb, ke+1, sigmaf, kflag, .TRUE.)
 #ifdef _VERIFY_FIND_LOC
         kflag_ori = 1
         do while( sig3d.ge.sigmaf(kflag_ori+1) )
@@ -430,16 +430,15 @@ print *, 'jflag = ', jflag
         i=iflag
         j=jflag
       ELSE
-        iflag = -100
-        jflag = -100
+        iflag = neg_hundred
+        jflag = neg_hundred
         IF(nx.eq.1)THEN
           iflag = 1
         ELSE
           ! cm1r19:
-          call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+2, iflag)
-print *, '2nd iflag = ', iflag
+          call find_horizontal_location_index (pdata_locind(:,1), np, x3d, ib, ie+1, xf, ni+2, iflag)
 #ifdef _VERIFY_FIND_LOC
-          iflag_ori = -100
+          iflag_ori = neg_hundred
           i = ni+2
           do while( iflag_ori.lt.0 .and. i.gt.0 )
             i = i-1
@@ -459,10 +458,9 @@ print *, '2nd iflag = ', iflag
           jflag = 1
         ELSE
           ! cm1r19:
-          call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+2, jflag)
-print *, '2nd jflag = ', jflag
+          call find_horizontal_location_index (pdata_locind(:,2), np, y3d, jb, je+1, yf, nj+2, jflag)
 #ifdef _VERIFY_FIND_LOC
-          jflag_ori = -100
+          jflag_ori = neg_hundred
           j = nj+2
           do while( jflag_ori.lt.0 .and. j.gt.0 )
             j = j-1
@@ -483,7 +481,7 @@ print *, '2nd jflag = ', jflag
 
         kflag = 1
         if( .not. terrain_flag )then
-          call find_vertical_location_index (pdata_locind(:,3), np, z3d, zf(iflag,jflag,:), kflag)
+          call find_vertical_location_index (pdata_locind(:,3), np, z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .FALSE.)
 #ifdef _VERIFY_FIND_LOC
           kflag_ori = 1
           do while( z3d.gt.zf(iflag,jflag,kflag_ori+1) )
@@ -496,7 +494,7 @@ print *, '2nd jflag = ', jflag
           end if
 #endif
         else
-          call find_vertical_location_index (pdata_locind(:,3), np, sig3d, sigmaf, kflag)
+          call find_vertical_location_index (pdata_locind(:,3), np, sig3d, kb, ke+1, sigmaf, kflag, .FALSE.)
 #ifdef _VERIFY_FIND_LOC
           kflag_ori = 1
           do while( sig3d.gt.sigmaf(kflag_ori+1) )
@@ -1105,16 +1103,15 @@ print *, '2nd jflag = ', jflag
       ! GHB, 210714:
       ! get i,j,k for final parcel location:
 
-        iflag = -100
-        jflag = -100
+        iflag = neg_hundred
+        jflag = neg_hundred
         IF(nx.eq.1)THEN
           iflag = 1
         ELSE
           ! cm1r19:
-          call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+2, iflag)
-print *, '3rd iflag = ', iflag
+          call find_horizontal_location_index (pdata_locind(:,1), np, x3d, ib, ie+1, xf, ni+2, iflag)
 #ifdef _VERIFY_FIND_LOC
-          iflag_ori = -100
+          iflag_ori = neg_hundred
           i = ni+2
           do while( iflag_ori.lt.0 .and. i.gt.0 )
             i = i-1
@@ -1133,11 +1130,9 @@ print *, '3rd iflag = ', iflag
           jflag = 1
         ELSE
           ! cm1r19:
-print * , 'nj = ', nj, ', y3d = ', y3d, ', yf = ', yf
-          call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+2, jflag)
-print *, '3rd jflag = ', jflag
+          call find_horizontal_location_index (pdata_locind(:,2), np, y3d, jb, je+1, yf, nj+2, jflag)
 #ifdef _VERIFY_FIND_LOC
-          jflag_ori = -100
+          jflag_ori = neg_hundred
           j = nj+2
           do while( jflag_ori.lt.0 .and. j.gt.0 )
             !print *,'j: ',j
@@ -1181,7 +1176,7 @@ print *, '3rd jflag = ', jflag
         !print *,'droplet_driver: point #4'
         kflag = 1
         if( .not. terrain_flag )then
-          call find_vertical_location_index (pdata_locind(:,3), np, z3d, zf(iflag,jflag,:), kflag)
+          call find_vertical_location_index (pdata_locind(:,3), np, z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .FALSE.)
 #ifdef _VERIFY_FIND_LOC
           kflag_ori = 1
           do while( z3d.gt.zf(iflag,jflag,kflag_ori+1) )
@@ -1194,7 +1189,7 @@ print *, '3rd jflag = ', jflag
           end if
 #endif
         else
-          call find_vertical_location_index (pdata_locind(:,3), np, sig3d, sigmaf, kflag)
+          call find_vertical_location_index (pdata_locind(:,3), np, sig3d, kb, ke+1, sigmaf, kflag, .FALSE.)
 #ifdef _VERIFY_FIND_LOC
           kflag_ori = 1
           do while( sig3d.gt.sigmaf(kflag_ori+1) )
@@ -1357,30 +1352,30 @@ print *, '3rd jflag = ', jflag
 
         if(x3d.lt.minx)then
           x3d=x3d+(maxx-minx)
-          pdata_locind(np,1) = -100
+          pdata_locind(np,1) = neg_hundred
         endif
         if(x3d.gt.maxx)then
           x3d=x3d-(maxx-minx)
-          pdata_locind(np,1) = -100
+          pdata_locind(np,1) = neg_hundred
         endif
 
         if( (y3d.gt.maxy).and.(axisymm.ne.1).and.(ny.ne.1) )then
           y3d=y3d-(maxy-miny)
-          pdata_locind(np,2) = -100
+          pdata_locind(np,2) = neg_hundred
         endif
         if( (y3d.lt.miny).and.(axisymm.ne.1).and.(ny.ne.1) )then
           y3d=y3d+(maxy-miny)
-          pdata_locind(np,2) = -100
+          pdata_locind(np,2) = neg_hundred
         endif
 
         pdata(np,prx)=x3d
         pdata(np,pry)=y3d
         if( .not. terrain_flag )then
           pdata(np,prz)=z3d
-          pdata_locind(np,3) = -100
+          pdata_locind(np,3) = neg_hundred
         else
           pdata(np,prsig)=sig3d
-          pdata_locind(np,3) = -100
+          pdata_locind(np,3) = neg_hundred
         endif
 
 #ifdef MPI
@@ -1602,8 +1597,8 @@ print *, '3rd jflag = ', jflag
         sig3d = pdata(np,prsig)
       endif
 
-      iflag = -100
-      jflag = -100
+      iflag = neg_hundred
+      jflag = neg_hundred
       kflag = 0
 
   ! cm1r19:  skip if we already know this processor doesnt have this parcel
@@ -1657,8 +1652,8 @@ print *, '3rd jflag = ', jflag
         i=iflag
         j=jflag
       ELSE
-        iflag = -100
-        jflag = -100
+        iflag = neg_hundred
+        jflag = neg_hundred
         IF(nx.eq.1)THEN
           iflag = 1
         ELSE
@@ -2706,8 +2701,8 @@ print *, '3rd jflag = ', jflag
       y3d = pdata(np,pry)
       z3d = pdata(np,prz)
 
-      iflag = -100
-      jflag = -100
+      iflag = neg_hundred
+      jflag = neg_hundred
       kflag = 0
 
   ! cm1r19:  skip if we already know this processor doesnt have this parcel
@@ -3451,8 +3446,8 @@ print *, '3rd jflag = ', jflag
       x3d = pdata(np,prx)
       y3d = pdata(np,pry)
 
-      iflag = -100
-      jflag = -100
+      iflag = neg_hundred
+      jflag = neg_hundred
 
   ! cm1r19:  skip if we already know this processor doesnt have this parcel
   zshaveit1:  &
@@ -3957,7 +3952,8 @@ print *, '3rd jflag = ', jflag
       ! These two subroutines are added by following John Dennis's suggestion
       !      to optimize the location search for a parcel in a process
 
-      subroutine find_horizontal_location_index (loc_ind, par_id, loc, dsize, end_ind, ind)
+      subroutine find_horizontal_location_index (loc_ind, par_id, loc, lb, ub, dsize, end_ind, ind)
+      !$acc routine seq
 
       use input
 
@@ -3966,7 +3962,8 @@ print *, '3rd jflag = ', jflag
       integer, dimension(nparcels), intent(inout) :: loc_ind    ! array to store x/y location index
       integer,                      intent(in)    :: par_id     ! parcel index in pdata
       real,                         intent(in)    :: loc        ! current x/y location index of a parcel
-      real, dimension(:),           intent(in)    :: dsize      ! range of x/y dimension
+      integer,                      intent(in)    :: lb, ub     ! lower and upper bounds of dsize
+      real, dimension(lb:ub),       intent(in)    :: dsize      ! range of x/y dimension
       integer,                      intent(in)    :: end_ind    ! end index of x/y dimension
       integer,                      intent(inout) :: ind        ! return the x/y location index closest to 
                                                                 ! the current parcel location
@@ -3974,7 +3971,7 @@ print *, '3rd jflag = ', jflag
       ! local variable
       integer :: i
 
-      if (loc_ind(par_id) .ne. -100) then
+      if (loc_ind(par_id) .ne. neg_hundred) then
          i = min (end_ind, loc_ind(par_id) + location_offset)
          do while( ind .lt. 0 .and. i .gt. loc_ind(par_id) - location_offset - 1 )
             i = i - 1
@@ -4014,7 +4011,8 @@ print *, '3rd jflag = ', jflag
 
       end subroutine find_horizontal_location_index
 
-      subroutine find_vertical_location_index (loc_ind, par_id, loc, dsize, ind)
+      subroutine find_vertical_location_index (loc_ind, par_id, loc, lb, ub, dsize, ind, is_ge)
+      !$acc routine seq
 
       use input
 
@@ -4023,14 +4021,16 @@ print *, '3rd jflag = ', jflag
       integer, dimension(nparcels), intent(inout) :: loc_ind    ! array to store z location index
       integer,                      intent(in)    :: par_id     ! parcel index in pdata
       real,                         intent(in)    :: loc        ! current z location index of a parcel
-      real, dimension(:),           intent(in)    :: dsize      ! range of z dimension
+      integer,                      intent(in)    :: lb, ub     ! lower and upper bounds of dsize
+      real, dimension(lb:ub),       intent(in)    :: dsize      ! range of z dimension
       integer,                      intent(inout) :: ind        ! return the z location index closest
                                                                 ! to the current parcel location
+      logical,                      intent(in)    :: is_ge      ! TRUE if use "ge"; FALSE if use "gt"
 
       ! Local variable
       integer :: i
 
-      if (loc_ind(par_id) .ne. -100) then 
+      if (loc_ind(par_id) .ne. neg_hundred) then 
          i = max (ind, loc_ind(par_id) - location_offset - 1)
          ! Sanity check: 
          ! - If a parcel falls too low and outside search range,
@@ -4041,19 +4041,30 @@ print *, '3rd jflag = ', jflag
             print *, 'Search from the input index instead...'
             i = ind
          end if
-         do while( loc .ge. dsize(i+1) )
-            i = i + 1
-         end do
-         loc_ind(par_id) = i
+         if ( is_ge ) then
+            do while( loc .ge. dsize(i+1) )
+               i = i + 1
+            end do
+         else
+            do while( loc .gt. dsize(i+1) )
+               i = i + 1
+            end do
+         end if
          ind = i
       else ! Always search from the end when:
            !    - it is the first time step
            !    - a parcel enters a new or different MPI process
-         do while ( loc .ge. dsize(ind+1) )
-            ind = ind + 1
-         end do
-         loc_ind(par_id) = ind
+         if ( is_ge ) then
+            do while ( loc .ge. dsize(ind+1) )
+               ind = ind + 1
+            end do
+         else
+            do while ( loc .gt. dsize(ind+1) )
+               ind = ind + 1
+            end do
+         end if
       end if
+      loc_ind(par_id) = ind 
 
       end subroutine find_vertical_location_index
 

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -398,10 +398,49 @@
       ENDIF
 
         kflag = 1
+! JS - jflag could be negative somehow, which will break
+!           the find_vertical_location_index subroutine;
+!      use the original interface but with the pdata_locind(:,3) here
+#ifdef _VERIFY_FIND_LOC
+        tmp_flag = kflag
+#endif
+        kflag = max (kflag, pdata_locind(np,3) - location_offset - 1)
         if( .not. terrain_flag )then
-          call find_vertical_location_index (pdata_locind(:,3), np, z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .FALSE.)
+          if ( z3d.lt.zf(iflag,jflag,kflag) ) then
+            kflag = 1
+          end if
+          do while( z3d.gt.zf(iflag,jflag,kflag+1) )
+            kflag = kflag+1
+          enddo
+#ifdef _VERIFY_FIND_LOC
+          do while( z3d.gt.zf(iflag,jflag,tmp_flag+1) )
+            tmp_flag = tmp_flag+1
+          enddo
+          if ( kflag .ne. tmp_flag ) then
+            print *, "original search scheme finds z index = ", tmp_flag, ", new search scheme finds z index = ", kflag
+            stop "Failed verification test: z index is not the same..."
+          else
+            print *, "Pass the verification test for z index..."
+          end if
+#endif
         else
-          call find_vertical_location_index (pdata_locind(:,3), np, sig3d, kb, ke+1, sigmaf, kflag, .FALSE.)
+          if ( sig3d.lt.sigmaf(kflag) ) then
+            kflag = 1
+          end if
+          do while( sig3d.gt.sigmaf(kflag+1) )
+            kflag = kflag+1
+          enddo
+#ifdef _VERIFY_FIND_LOC
+          do while( sig3d.gt.sigmaf(tmp_flag+1) )
+            tmp_flag = tmp_flag+1
+          enddo
+          if ( kflag .ne. tmp_flag ) then
+            print *, "original search scheme finds z index = ", tmp_flag, ", new search scheme finds z index = ", kflag
+            stop "Failed verification test: z index is not the same..."
+          else
+            print *, "Pass the verification test for z index..."
+          end if
+#endif
         endif
 
 !JMD-debug

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -3988,7 +3988,16 @@ print *, '3rd jflag = ', jflag
          !      this scheme would fail;
          ! - Issue an error in this case
          if ( ind .lt. 0 ) then
-            stop 'Parcel x/y location searching fails...'
+            print *, 'Parcel x/y location searching fails...'
+            print *, 'Switch back to the original search scheme...'
+            i = end_ind
+            do while( ind .lt. 0 .and. i .gt. 1 )
+               i = i - 1
+               if ( loc .ge. dsize(i) .and. loc .le. dsize(i+1) ) then
+                  ind = i
+                  loc_ind(par_id) = ind
+               end if
+            end do
          end if
       else ! Always search from the end when:
            !    - it is the first time step
@@ -4018,19 +4027,25 @@ print *, '3rd jflag = ', jflag
       integer,                      intent(inout) :: ind        ! return the z location index closest
                                                                 ! to the current parcel location
 
+      ! Local variable
+      integer :: i
+
       if (loc_ind(par_id) .ne. -100) then 
-         ind = max (ind, loc_ind(par_id) - location_offset - 1)
+         i = max (ind, loc_ind(par_id) - location_offset - 1)
          ! Sanity check: 
          ! - If a parcel falls too low and outside search range,
          !      this scheme would fail;
          ! - Issue an error in this case
-         if ( loc .lt. dsize(ind) ) then
-            stop 'Parcel z location searching fails...'
+         if ( loc .lt. dsize(i) ) then
+            print *, 'Parcel z location is outside search range...'
+            print *, 'Search from the input index instead...'
+            i = ind
          end if
-         do while( loc .ge. dsize(ind+1) )
-            ind = ind + 1
+         do while( loc .ge. dsize(i+1) )
+            i = i + 1
          end do
-         loc_ind(par_id) = ind
+         loc_ind(par_id) = i
+         ind = i
       else ! Always search from the end when:
            !    - it is the first time step
            !    - a parcel enters a new or different MPI process

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -29,7 +29,7 @@
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p,              &
                                sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,             &
                                n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,      &
-                               uten,vten,wten,thten,qten,ipdata)
+                               uten,vten,wten,thten,qten,ipdata,jpdata,kpdata)
       use input
       use constants
       use bc_module
@@ -355,13 +355,27 @@
 
       kflag = 1
       if( .not. terrain_flag )then
-        do while( z3d.ge.zf(iflag,jflag,kflag+1) )
-          kflag = kflag+1
-        enddo
+        IF (kpdata(np) .ne. -100) THEN
+           call find_location_index (kpdata, np, z3d, zf, kflag, iflag, jflag)
+        ELSE ! Always search from the end when:
+           !    - it is the first time step
+           !    - the first time a parcel enters a process
+           do while( z3d.ge.zf(iflag,jflag,kflag+1) )
+             kflag = kflag+1
+           enddo
+           kpdata(np) = kflag
+        ENDIF
       else
-        do while( sig3d.ge.sigmaf(kflag+1) )
-          kflag = kflag+1
-        enddo
+        IF (kpdata(np) .ne. -100) THEN
+           call find_location_index (kpdata, np, sig3d, sigmaf, kflag)
+        ELSE ! Always search from the end when:
+           !    - it is the first time step
+           !    - the first time a parcel enters a process
+           do while( sig3d.ge.sigmaf(kflag+1) )
+             kflag = kflag+1
+           enddo
+           kpdata(np) = kflag
+        ENDIF
       endif
 !      !Store these for two-way coupling
 !      iflag_s=iflag
@@ -407,29 +421,41 @@
           iflag = 1
         ELSE
           ! cm1r19:
-          i = ni+2
-          do while( iflag.lt.0 .and. i.gt.0 )
-            i = i-1
-            if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
-              iflag = i
-            endif
-          enddo
+          IF (ipdata(np) .ne. -100) THEN
+            call find_location_index (ipdata, np, x3d, xf, iflag)
+          ELSE
+            i = ni+2
+            do while( iflag.lt.0 .and. i.gt.0 )
+              i = i-1
+              if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
+                iflag = i
+                ipdata(np) = iflag
+              endif
+            enddo
+          ENDIF
         ENDIF
+
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           jflag = 1
         ELSE
-          !$acc loop seq
-          do j=0,nj+1
-            if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) ) jflag=j
-          enddo
-          ! cm1r19:
-          j = nj+2
-          do while( jflag.lt.0 .and. j.gt.0 )
-            j = j-1
-            if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
-              jflag = j
-            endif
-          enddo
+          IF (jpdata(np) .ne. -100) THEN
+            call find_location_index (jpdata, np, y3d, yf, jflag)
+          ELSE
+! JS: comment out this acc loop and use the original version
+!!!            !$acc loop seq
+!!!            do j=0,nj+1
+!!!              if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) ) jflag=j
+!!!            enddo
+            ! cm1r19:
+            j = nj+2
+            do while( jflag.lt.0 .and. j.gt.0 )
+              j = j-1
+              if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
+                jflag = j
+                jpdata(np) = jflag
+              endif
+            enddo
+          ENDIF
         ENDIF
         i=iflag
         j=jflag
@@ -437,13 +463,23 @@
 
         kflag = 1
         if( .not. terrain_flag )then
-          do while( z3d.gt.zf(iflag,jflag,kflag+1) )
-            kflag = kflag+1
-          enddo
+          IF (kpdata(np) .ne. -100) THEN
+             call find_location_index (kpdata, np, z3d, zf, kflag, iflag, jflag)
+          ELSE
+             do while( z3d.ge.zf(iflag,jflag,kflag+1) )
+               kflag = kflag+1
+             enddo
+             kpdata(np) = kflag
+          ENDIF
         else
-          do while( sig3d.gt.sigmaf(kflag+1) )
-            kflag = kflag+1
-          enddo
+          IF (kpdata(np) .ne. -100) THEN
+             call find_location_index (kpdata, np, sig3d, sigmaf, kflag)
+          ELSE
+             do while( sig3d.ge.sigmaf(kflag+1) )
+               kflag = kflag+1
+             enddo
+             kpdata(np) = kflag
+          ENDIF
         endif
 
 !JMD-debug
@@ -1047,32 +1083,41 @@
           iflag = 1
         ELSE
           ! cm1r19:
-          i = ni+2
-          do while( iflag.lt.0 .and. i.gt.0 )
-            i = i-1
-            if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
-              iflag = i
-            endif
-          enddo
+          IF (ipdata(np) .ne. -100) THEN
+            call find_location_index (ipdata, np, x3d, xf, iflag)
+          ELSE
+            i = ni+2
+            do while( iflag.lt.0 .and. i.gt.0 )
+              i = i-1
+              if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
+                iflag = i
+                ipdata(np) = iflag
+              endif
+            enddo
+          ENDIF
         ENDIF
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           jflag = 1
         ELSE
-          do j=0,nj+1
-            if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) ) jflag=j
-          enddo
-          if(mod(np,PITER)==0) then
-            print *,'second loop: jflag: ',jflag
-          endif
           ! cm1r19:
-          j = nj+2
-          do while( jflag.lt.0 .and. j.gt.0 )
-            !print *,'j: ',j
-            j = j-1
-            if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
-              jflag = j
-            endif
-          enddo
+          IF (jpdata(np) .ne. -100) THEN
+            call find_location_index (jpdata, np, y3d, yf, jflag)
+          ELSE
+! JS: comment out this acc loop and use the original version
+!!!            !$acc loop seq
+!!!            do j=0,nj+1
+!!!              if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) ) jflag=j
+!!!            enddo
+            ! cm1r19:
+            j = nj+2
+            do while( jflag.lt.0 .and. j.gt.0 )
+              j = j-1
+              if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
+                jflag = j
+                jpdata(np) = jflag
+              endif
+            enddo
+          ENDIF
           if(mod(np,PITER)==0) then
              print *,'after dowhile loop: ',jflag
           endif
@@ -1102,13 +1147,23 @@
         !print *,'droplet_driver: point #4'
         kflag = 1
         if( .not. terrain_flag )then
-          do while( z3d.gt.zf(iflag,jflag,kflag+1) )
-            kflag = kflag+1
-          enddo
+          IF (kpdata(np) .ne. -100) THEN
+             call find_location_index (kpdata, np, z3d, zf, kflag, iflag, jflag)
+          ELSE
+             do while( z3d.gt.zf(iflag,jflag,kflag+1) )
+               kflag = kflag+1
+             enddo
+             kpdata(np) = kflag
+          ENDIF
         else
-          do while( sig3d.gt.sigmaf(kflag+1) )
-            kflag = kflag+1
-          enddo
+          IF (kpdata(np) .ne. -100) THEN
+             call find_location_index (kpdata, np, sig3d, sigmaf, kflag)
+          ELSE
+             do while( sig3d.gt.sigmaf(kflag+1) )
+               kflag = kflag+1
+             enddo
+             kpdata(np) = kflag
+          ENDIF
         endif
 
 #if 0
@@ -1260,24 +1315,30 @@
 
         if(x3d.lt.minx)then
           x3d=x3d+(maxx-minx)
+          ipdata(np) = -100
         endif
         if(x3d.gt.maxx)then
           x3d=x3d-(maxx-minx)
+          ipdata(np) = -100
         endif
 
         if( (y3d.gt.maxy).and.(axisymm.ne.1).and.(ny.ne.1) )then
           y3d=y3d-(maxy-miny)
+          jpdata(np) = -100
         endif
         if( (y3d.lt.miny).and.(axisymm.ne.1).and.(ny.ne.1) )then
           y3d=y3d+(maxy-miny)
+          jpdata(np) = -100
         endif
 
         pdata(np,prx)=x3d
         pdata(np,pry)=y3d
         if( .not. terrain_flag )then
           pdata(np,prz)=z3d
+          kpdata(np) = -100
         else
           pdata(np,prsig)=sig3d
+          kpdata(np) = -100
         endif
 
 #ifdef MPI
@@ -3853,29 +3914,48 @@
 
       ! This subroutine is added by following John Dennis's suggestion
       !      to optimize the location search for a parcel in a process
-      subroutine find_location_index (loc_ind, par_id, loc, dsize, ind)
+      subroutine find_location_index (loc_ind, par_id, loc, dsize, ind, ind1, ind2)
       implicit none
 
       use input
 
-      integer, dimension(nparcels), intent(inout) :: loc_ind ! array to store x/y/z location index
-      integer,                      intent(in)    :: par_id  ! parcel index in pdata
-      real,                         intent(in)    :: loc     ! current x/y/z location index of a parcel
-      real, dimension(:),           intent(in)    :: dsize   ! range of x/y/z dimension
-      integer,                      intent(inout) :: ind     ! return the location index closest to 
-                                                             ! the current parcel location
+      integer, dimension(nparcels), intent(inout) :: loc_ind    ! array to store x/y/z location index
+      integer,                      intent(in)    :: par_id     ! parcel index in pdata
+      real,                         intent(in)    :: loc        ! current x/y/z location index of a parcel
+      real, dimension(:),           intent(in)    :: dsize      ! range of x/y/z dimension
+      integer,                      intent(inout) :: ind        ! return the location index closest to 
+                                                                ! the current parcel location
+      integer, optional,            intent(in)    :: ind1, ind2 ! x/y location index for zf array
 
       ! local variable
       integer :: i
+      logical :: present_ind1, present_ind2
 
-      i = loc_ind(par_id) + location_offset
-      do while( ind .lt. 0 .and. i .gt. (loc_ind(par_id) - location_offset) )
-         i = i - 1
-         if ( loc .ge. dsize(i) .and. loc .le. dsize(i+1) )then
-            ind = i
-            loc_ind(par_id) = ind
-         end if
-      end do
+      present_ind1 = present(ind1)
+      present_ind2 = present(ind2)
+
+      if (present_ind1 .ne. present_ind2) then
+         stop 'x and y location index must be both present or not present'
+      end if
+
+      ! we always search from the smaller index to the larger one
+      i = max (1, loc_ind(par_id) - location_offset - 1)
+
+      if ( present_ind1 ) then
+         do while( loc .ge. dsize(ind1,ind2,i+1) )
+            i = i + 1
+         end do
+         ind = i
+         loc_ind(par_id) = ind
+      else
+         do while( ind .lt. 0 .and. i .lt. (loc_ind(par_id) + location_offset) )
+            i = i + 1
+            if ( loc .ge. dsize(i) .and. loc .le. dsize(i+1) )then
+               ind = i
+               loc_ind(par_id) = ind
+            end if
+         end do
+      end if
 
       ! Sanity check: 
       ! - If a parcel moves too far, this scheme would fail;

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -399,12 +399,16 @@
 
         kflag = 1
 ! JS - jflag could be negative somehow, which will break
-!           the find_vertical_location_index subroutine;
-!      use the original interface but with the pdata_locind(:,3) here
+!        the find_vertical_location_index subroutine;
+!        use the original interface but with the 
+!        pdata_locind(:,3) here
+!    - z3d could be NaN somehow, reset kflag = 1 to be 
+!        consistent with the original implementation
 #ifdef _VERIFY_FIND_LOC
         tmp_flag = kflag
 #endif
         kflag = max (kflag, pdata_locind(np,3) - location_offset - 1)
+        if ( z3d .ne. z3d ) kflag = 1
         if( .not. terrain_flag )then
           if ( z3d.lt.zf(iflag,jflag,kflag) ) then
             kflag = 1
@@ -412,11 +416,13 @@
           do while( z3d.gt.zf(iflag,jflag,kflag+1) )
             kflag = kflag+1
           enddo
+          pdata_locind(np,3) = kflag
 #ifdef _VERIFY_FIND_LOC
           do while( z3d.gt.zf(iflag,jflag,tmp_flag+1) )
             tmp_flag = tmp_flag+1
           enddo
           if ( kflag .ne. tmp_flag ) then
+            print *, "z3d = ", z3d, ", old scheme finds ", zf(iflag,jflag,tmp_flag+1), ", new scheme finds ", zf(iflag,jflag,kflag+1)
             print *, "original search scheme finds z index = ", tmp_flag, ", new search scheme finds z index = ", kflag
             stop "Failed verification test: z index is not the same..."
           else
@@ -430,6 +436,7 @@
           do while( sig3d.gt.sigmaf(kflag+1) )
             kflag = kflag+1
           enddo
+          pdata_locind(np,3) = kflag
 #ifdef _VERIFY_FIND_LOC
           do while( sig3d.gt.sigmaf(tmp_flag+1) )
             tmp_flag = tmp_flag+1
@@ -1080,12 +1087,16 @@
         !print *,'droplet_driver: point #4'
         kflag = 1
 ! JS - jflag could be negative somehow, which will break
-!           the find_vertical_location_index subroutine;
-!      use the original interface but with the pdata_locind(:,3) here
+!        the find_vertical_location_index subroutine;
+!        use the original interface but with the 
+!        pdata_locind(:,3) here
+!    - z3d could be NaN somehow, reset kflag = 1 to be 
+!        consistent with the original implementation
 #ifdef _VERIFY_FIND_LOC
         tmp_flag = kflag
 #endif
         kflag = max (kflag, pdata_locind(np,3) - location_offset - 1)
+        if ( z3d .ne. z3d ) kflag = 1
         if( .not. terrain_flag )then
           if ( z3d.lt.zf(iflag,jflag,kflag) ) then
             kflag = 1
@@ -1093,6 +1104,7 @@
           do while( z3d.gt.zf(iflag,jflag,kflag+1) )
             kflag = kflag+1
           enddo
+          pdata_locind(np,3) = kflag
 #ifdef _VERIFY_FIND_LOC
           do while( z3d.gt.zf(iflag,jflag,tmp_flag+1) )
             tmp_flag = tmp_flag+1
@@ -1111,6 +1123,7 @@
           do while( sig3d.gt.sigmaf(kflag+1) )
             kflag = kflag+1
           enddo
+          pdata_locind(np,3) = kflag
 #ifdef _VERIFY_FIND_LOC
           do while( sig3d.gt.sigmaf(tmp_flag+1) )
             tmp_flag = tmp_flag+1

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -301,7 +301,7 @@
     ELSE
       ! cm1r19:
       IF (ipdata(np) .ne. -100) THEN
-        call find_location_index (ipdata, np, x3d, xf, iflag) 
+        call find_location_index (ipdata, np, x3d, xf, iflag, .FALSE.) 
       ELSE ! Always search from the end when:
            !    - it is the first time step
            !    - the first time a parcel enters a process
@@ -321,7 +321,7 @@
     ELSE
       ! cm1r19:
       IF (jpdata(np) .ne. -100) THEN
-        call find_location_index (jpdata, np, y3d, yf, jflag)
+        call find_location_index (jpdata, np, y3d, yf, jflag, .FALSE.)
       ELSE ! Always search from the end when:
            !    - it is the first time step
            !    - the first time a parcel enters a process
@@ -356,7 +356,7 @@
       kflag = 1
       if( .not. terrain_flag )then
         IF (kpdata(np) .ne. -100) THEN
-           call find_location_index (kpdata, np, z3d, zf, kflag, iflag, jflag)
+           call find_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag, .TRUE.)
         ELSE ! Always search from the end when:
            !    - it is the first time step
            !    - the first time a parcel enters a process
@@ -367,7 +367,7 @@
         ENDIF
       else
         IF (kpdata(np) .ne. -100) THEN
-           call find_location_index (kpdata, np, sig3d, sigmaf, kflag)
+           call find_location_index (kpdata, np, sig3d, sigmaf, kflag, .TRUE.)
         ELSE ! Always search from the end when:
            !    - it is the first time step
            !    - the first time a parcel enters a process
@@ -422,7 +422,7 @@
         ELSE
           ! cm1r19:
           IF (ipdata(np) .ne. -100) THEN
-            call find_location_index (ipdata, np, x3d, xf, iflag)
+            call find_location_index (ipdata, np, x3d, xf, iflag, .FALSE.)
           ELSE
             i = ni+2
             do while( iflag.lt.0 .and. i.gt.0 )
@@ -439,7 +439,7 @@
           jflag = 1
         ELSE
           IF (jpdata(np) .ne. -100) THEN
-            call find_location_index (jpdata, np, y3d, yf, jflag)
+            call find_location_index (jpdata, np, y3d, yf, jflag, .FALSE.)
           ELSE
 ! JS: comment out this acc loop and use the original version
 !!!            !$acc loop seq
@@ -464,7 +464,7 @@
         kflag = 1
         if( .not. terrain_flag )then
           IF (kpdata(np) .ne. -100) THEN
-             call find_location_index (kpdata, np, z3d, zf, kflag, iflag, jflag)
+             call find_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag, .TRUE.)
           ELSE
              do while( z3d.ge.zf(iflag,jflag,kflag+1) )
                kflag = kflag+1
@@ -473,7 +473,7 @@
           ENDIF
         else
           IF (kpdata(np) .ne. -100) THEN
-             call find_location_index (kpdata, np, sig3d, sigmaf, kflag)
+             call find_location_index (kpdata, np, sig3d, sigmaf, kflag, .TRUE.)
           ELSE
              do while( sig3d.ge.sigmaf(kflag+1) )
                kflag = kflag+1
@@ -1084,7 +1084,7 @@
         ELSE
           ! cm1r19:
           IF (ipdata(np) .ne. -100) THEN
-            call find_location_index (ipdata, np, x3d, xf, iflag)
+            call find_location_index (ipdata, np, x3d, xf, iflag, .FALSE.)
           ELSE
             i = ni+2
             do while( iflag.lt.0 .and. i.gt.0 )
@@ -1101,7 +1101,7 @@
         ELSE
           ! cm1r19:
           IF (jpdata(np) .ne. -100) THEN
-            call find_location_index (jpdata, np, y3d, yf, jflag)
+            call find_location_index (jpdata, np, y3d, yf, jflag, .FALSE.)
           ELSE
 ! JS: comment out this acc loop and use the original version
 !!!            !$acc loop seq
@@ -1148,7 +1148,7 @@
         kflag = 1
         if( .not. terrain_flag )then
           IF (kpdata(np) .ne. -100) THEN
-             call find_location_index (kpdata, np, z3d, zf, kflag, iflag, jflag)
+             call find_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag, .TRUE.)
           ELSE
              do while( z3d.gt.zf(iflag,jflag,kflag+1) )
                kflag = kflag+1
@@ -1157,7 +1157,7 @@
           ENDIF
         else
           IF (kpdata(np) .ne. -100) THEN
-             call find_location_index (kpdata, np, sig3d, sigmaf, kflag)
+             call find_location_index (kpdata, np, sig3d, sigmaf, kflag, .TRUE.)
           ELSE
              do while( sig3d.gt.sigmaf(kflag+1) )
                kflag = kflag+1
@@ -3914,10 +3914,11 @@
 
       ! This subroutine is added by following John Dennis's suggestion
       !      to optimize the location search for a parcel in a process
-      subroutine find_location_index (loc_ind, par_id, loc, dsize, ind, ind1, ind2)
-      implicit none
+      subroutine find_location_index (loc_ind, par_id, loc, dsize, ind, search_z)
 
       use input
+
+      implicit none
 
       integer, dimension(nparcels), intent(inout) :: loc_ind    ! array to store x/y/z location index
       integer,                      intent(in)    :: par_id     ! parcel index in pdata
@@ -3925,45 +3926,42 @@
       real, dimension(:),           intent(in)    :: dsize      ! range of x/y/z dimension
       integer,                      intent(inout) :: ind        ! return the location index closest to 
                                                                 ! the current parcel location
-      integer, optional,            intent(in)    :: ind1, ind2 ! x/y location index for zf array
+      logical,                      intent(in)    :: search_z   ! TRUE if searching the z-dimension index
 
       ! local variable
       integer :: i
-      logical :: present_ind1, present_ind2
-
-      present_ind1 = present(ind1)
-      present_ind2 = present(ind2)
-
-      if (present_ind1 .ne. present_ind2) then
-         stop 'x and y location index must be both present or not present'
-      end if
 
       ! we always search from the smaller index to the larger one
       i = max (1, loc_ind(par_id) - location_offset - 1)
 
-      if ( present_ind1 ) then
-         do while( loc .ge. dsize(ind1,ind2,i+1) )
+      if ( search_z ) then
+         ! Sanity check: 
+         ! - If a parcel falls too low and outside search range, this scheme would fail;
+         ! - Issue an error in this case
+         if ( loc .lt. dsize(i) ) then
+            stop 'Parcel location searching fails...'
+         end if
+         do while( loc .ge. dsize(i+1) )
             i = i + 1
          end do
          ind = i
          loc_ind(par_id) = ind
       else
          do while( ind .lt. 0 .and. i .lt. (loc_ind(par_id) + location_offset) )
-            i = i + 1
             if ( loc .ge. dsize(i) .and. loc .le. dsize(i+1) )then
                ind = i
                loc_ind(par_id) = ind
             end if
+            i = i + 1
          end do
+         ! Sanity check: 
+         ! - If a parcel moves too far and outside search range, this scheme would fail;
+         ! - Issue an error in this case
+         if ( ind .lt. 0 ) then
+            stop 'Parcel location searching fails...'
+         end if
       end if
 
-      ! Sanity check: 
-      ! - If a parcel moves too far, this scheme would fail;
-      ! - Issue an error in this case
-      if ( ind .lt. 0 ) then
-         stop 'Parcel location searching fails...' 
-      end if
- 
       end subroutine find_location_index
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -29,7 +29,7 @@
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p,              &
                                sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,             &
                                n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,      &
-                               uten,vten,wten,thten,qten,ipdata,jpdata,kpdata)
+                               uten,vten,wten,thten,qten,pdata_locind)
       use input
       use constants
       use bc_module
@@ -75,7 +75,7 @@
       real, intent(inout), dimension(imp,cmp,kmp)   :: ss31,ss32,sn31,sn32
       real, intent(inout), dimension(cmp,cmp,kmt+1) :: n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2
       integer, intent(inout), dimension(rmp) :: reqs_s
-      integer, intent(inout), dimension(nparcels)   :: ipdata, jpdata, kpdata 
+      integer, intent(inout), dimension(nparcels,3) :: pdata_locind    ! x/y/z location index of each parcel
 
       !Need to compute the true temperature
       real, dimension(ib:ie,jb:je,kb:ke) :: ta
@@ -300,20 +300,20 @@
       iflag = 1
     ELSE
       ! cm1r19:
-      call find_horizontal_location_index (ipdata, np, x3d, xf, ni+1, iflag) 
+      call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+1, iflag) 
     ENDIF
 
     IF(axisymm.eq.1.or.ny.eq.1)THEN
       jflag = 1
     ELSE
       ! cm1r19:
-      call find_horizontal_location_index (jpdata, np, y3d, yf, nj+1, yflag)  
+      call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+1, jflag)  
     ENDIF
 
-  ELSE     ! re-initialize location index array 
-           ! if a parcel is not on this process
-    ipdata(np) = -100
-    jpdata(np) = -100
+  ELSE     ! re-initialize x/y/z location index array if a parcel is not on this process
+    pdata_locind(np,1) = -100
+    pdata_locind(np,2) = -100
+    pdata_locind(np,3) = -100
   ENDIF  haveit1
 
 #ifdef MPI
@@ -330,9 +330,9 @@
 
       kflag = 1
       if( .not. terrain_flag )then
-        call find_vertical_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag)
+        call find_vertical_location_index (pdata_locind(:,3), np, z3d, zf(iflag,jflag,:), kflag)
       else
-        call find_vertical_location_index (kpdata, np, sig3d, sigmaf, kflag)
+        call find_vertical_location_index (pdata_locind(:,3), np, sig3d, sigmaf, kflag)
       endif
 !      !Store these for two-way coupling
 !      iflag_s=iflag
@@ -378,14 +378,14 @@
           iflag = 1
         ELSE
           ! cm1r19:
-          call find_horizontal_location_index (ipdata, np, x3d, xf, ni+2, iflag)
+          call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+2, iflag)
         ENDIF
 
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           jflag = 1
         ELSE
           ! cm1r19:
-          call find_horizontal_location_index (jpdata, np, y3d, yf, nj+2, jflag)
+          call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+2, jflag)
         ENDIF
         i=iflag
         j=jflag
@@ -393,9 +393,9 @@
 
         kflag = 1
         if( .not. terrain_flag )then
-          call find_vertical_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag)
+          call find_vertical_location_index (pdata_locind(:,3), np, z3d, zf(iflag,jflag,:), kflag)
         else
-          call find_vertical_location_index (kpdata, np, sig3d, sigmaf, kflag)
+          call find_vertical_location_index (pdata_locind(:,3), np, sig3d, sigmaf, kflag)
         endif
 
 !JMD-debug
@@ -999,13 +999,13 @@
           iflag = 1
         ELSE
           ! cm1r19:
-          call find_horizontal_location_index (ipdata, np, x3d, xf, ni+2, iflag)
+          call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+2, iflag)
         ENDIF
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           jflag = 1
         ELSE
           ! cm1r19:
-          call find_horizontal_location_index (jpdata, np, y3d, yf, nj+2, jflag)
+          call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+2, jflag)
           if(mod(np,PITER)==0) then
              print *,'after dowhile loop: ',jflag
           endif
@@ -1035,9 +1035,9 @@
         !print *,'droplet_driver: point #4'
         kflag = 1
         if( .not. terrain_flag )then
-          call find_vertical_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag)
+          call find_vertical_location_index (pdata_locind(:,3), np, z3d, zf(iflag,jflag,:), kflag)
         else
-          call find_vertical_location_index (kpdata, np, sig3d, sigmaf, kflag)
+          call find_vertical_location_index (pdata_locind(:,3), np, sig3d, sigmaf, kflag)
         endif
 
 #if 0
@@ -1189,30 +1189,30 @@
 
         if(x3d.lt.minx)then
           x3d=x3d+(maxx-minx)
-          ipdata(np) = -100
+          pdata_locind(np,1) = -100
         endif
         if(x3d.gt.maxx)then
           x3d=x3d-(maxx-minx)
-          ipdata(np) = -100
+          pdata_locind(np,1) = -100
         endif
 
         if( (y3d.gt.maxy).and.(axisymm.ne.1).and.(ny.ne.1) )then
           y3d=y3d-(maxy-miny)
-          jpdata(np) = -100
+          pdata_locind(np,2) = -100
         endif
         if( (y3d.lt.miny).and.(axisymm.ne.1).and.(ny.ne.1) )then
           y3d=y3d+(maxy-miny)
-          jpdata(np) = -100
+          pdata_locind(np,2) = -100
         endif
 
         pdata(np,prx)=x3d
         pdata(np,pry)=y3d
         if( .not. terrain_flag )then
           pdata(np,prz)=z3d
-          kpdata(np) = -100
+          pdata_locind(np,3) = -100
         else
           pdata(np,prsig)=sig3d
-          kpdata(np) = -100
+          pdata_locind(np,3) = -100
         endif
 
 #ifdef MPI

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -18,7 +18,7 @@
   !    the search range using the parameter below;
   ! This assumes that a parcel does not move too far and does
   !    not move between processes within this subroutine?
-  integer, parameter :: location_offset = 4 
+  integer, parameter :: location_offset = 100 
 
   CONTAINS
 
@@ -305,6 +305,7 @@
     ELSE
       ! cm1r19:
       call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+1, iflag) 
+print *, 'iflag = ', iflag
 #ifdef _VERIFY_FIND_LOC
       iflag_ori = -100
       i = ni+1
@@ -327,6 +328,7 @@
     ELSE
       ! cm1r19:
       call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+1, jflag)  
+print *, 'jflag = ', jflag
 #ifdef _VERIFY_FIND_LOC
       jflag_ori = -100
       j = nj+1
@@ -435,6 +437,7 @@
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+2, iflag)
+print *, '2nd iflag = ', iflag
 #ifdef _VERIFY_FIND_LOC
           iflag_ori = -100
           i = ni+2
@@ -457,6 +460,7 @@
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+2, jflag)
+print *, '2nd jflag = ', jflag
 #ifdef _VERIFY_FIND_LOC
           jflag_ori = -100
           j = nj+2
@@ -1108,6 +1112,7 @@
         ELSE
           ! cm1r19:
           call find_horizontal_location_index (pdata_locind(:,1), np, x3d, xf, ni+2, iflag)
+print *, '3rd iflag = ', iflag
 #ifdef _VERIFY_FIND_LOC
           iflag_ori = -100
           i = ni+2
@@ -1128,7 +1133,9 @@
           jflag = 1
         ELSE
           ! cm1r19:
+print * , 'nj = ', nj, ', y3d = ', y3d, ', yf = ', yf
           call find_horizontal_location_index (pdata_locind(:,2), np, y3d, yf, nj+2, jflag)
+print *, '3rd jflag = ', jflag
 #ifdef _VERIFY_FIND_LOC
           jflag_ori = -100
           j = nj+2
@@ -3981,7 +3988,7 @@
          !      this scheme would fail;
          ! - Issue an error in this case
          if ( ind .lt. 0 ) then
-            stop 'Parcel x location searching fails...'
+            stop 'Parcel x/y location searching fails...'
          end if
       else ! Always search from the end when:
            !    - it is the first time step

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -18,7 +18,7 @@
   !    the search range using the parameter below;
   ! This assumes that a parcel does not move too far and does
   !    not move between processes within this subroutine?
-  integer, parameter :: location_offset = 100 
+  integer, parameter :: location_offset = 3 
   integer, parameter :: neg_hundred = -100    ! define constant for initial value  
 
   CONTAINS
@@ -3961,7 +3961,7 @@
 
       integer, dimension(nparcels), intent(inout) :: loc_ind    ! array to store x/y location index
       integer,                      intent(in)    :: par_id     ! parcel index in pdata
-      real,                         intent(in)    :: loc        ! current x/y location index of a parcel
+      real,                         intent(in)    :: loc        ! current x/y location of a parcel
       integer,                      intent(in)    :: lb, ub     ! lower and upper bounds of dsize
       real, dimension(lb:ub),       intent(in)    :: dsize      ! range of x/y dimension
       integer,                      intent(in)    :: end_ind    ! end index of x/y dimension
@@ -3971,7 +3971,11 @@
       ! local variable
       integer :: i
 
-      if (loc_ind(par_id) .ne. neg_hundred) then
+      ! Sanity check:
+      ! - If input x/y location is outside the x/y range, return directly
+      if ( loc .lt. dsize(lb) .or. loc .gt. dsize(end_ind) ) return
+
+      if ( loc_ind(par_id) .ne. neg_hundred ) then
          i = min (end_ind, loc_ind(par_id) + location_offset)
          do while( ind .lt. 0 .and. i .gt. loc_ind(par_id) - location_offset - 1 )
             i = i - 1
@@ -3983,7 +3987,7 @@
          ! Sanity check: 
          ! - If a parcel moves too far and outside search range, 
          !      this scheme would fail;
-         ! - Issue an error in this case
+         ! - Switch back to the original linear search scheme 
          if ( ind .lt. 0 ) then
             print *, 'Parcel x/y location searching fails...'
             print *, 'Switch back to the original search scheme...'
@@ -4020,7 +4024,7 @@
 
       integer, dimension(nparcels), intent(inout) :: loc_ind    ! array to store z location index
       integer,                      intent(in)    :: par_id     ! parcel index in pdata
-      real,                         intent(in)    :: loc        ! current z location index of a parcel
+      real,                         intent(in)    :: loc        ! current z location of a parcel
       integer,                      intent(in)    :: lb, ub     ! lower and upper bounds of dsize
       real, dimension(lb:ub),       intent(in)    :: dsize      ! range of z dimension
       integer,                      intent(inout) :: ind        ! return the z location index closest
@@ -4030,12 +4034,16 @@
       ! Local variable
       integer :: i
 
-      if (loc_ind(par_id) .ne. neg_hundred) then 
+      ! Sanity check:
+      ! - If input x/y location is outside the x/y range, return directly
+      if ( loc .lt. dsize(lb) .or. loc .gt. dsize(ub) ) return
+
+      if ( loc_ind(par_id) .ne. neg_hundred ) then 
          i = max (ind, loc_ind(par_id) - location_offset - 1)
          ! Sanity check: 
          ! - If a parcel falls too low and outside search range,
          !      this scheme would fail;
-         ! - Issue an error in this case
+         ! - Reset the lower bound in this case
          if ( loc .lt. dsize(i) ) then
             print *, 'Parcel z location is outside search range...'
             print *, 'Search from the input index instead...'

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -19,7 +19,6 @@
   ! This assumes that a parcel does not move too far and does
   !    not move between processes within this subroutine?
   integer, parameter :: location_offset = 3 
-  integer, parameter :: neg_hundred = -100    ! define constant for initial value  
 
   CONTAINS
 
@@ -293,8 +292,8 @@
         sig3d = pdata(np,prsig)
       endif
 
-      iflag = neg_hundred
-      jflag = neg_hundred
+      iflag = undefined_index
+      jflag = undefined_index
       kflag = 0
 
   ! cm1r19:  skip if we already know this processor doesnt have this parcel
@@ -317,9 +316,9 @@
     ENDIF
 
   ELSE     ! re-initialize x/y/z location index array if a parcel is not on this process
-    pdata_locind(np,1) = neg_hundred
-    pdata_locind(np,2) = neg_hundred
-    pdata_locind(np,3) = neg_hundred
+    pdata_locind(np,1) = undefined_index
+    pdata_locind(np,2) = undefined_index
+    pdata_locind(np,3) = undefined_index
   ENDIF  haveit1
 
 #ifdef MPI
@@ -378,8 +377,8 @@
         i=iflag
         j=jflag
       ELSE
-        iflag = neg_hundred
-        jflag = neg_hundred
+        iflag = undefined_index
+        jflag = undefined_index
         IF(nx.eq.1)THEN
           iflag = 1
         ELSE
@@ -1045,8 +1044,8 @@
       ! GHB, 210714:
       ! get i,j,k for final parcel location:
 
-        iflag = neg_hundred
-        jflag = neg_hundred
+        iflag = undefined_index
+        jflag = undefined_index
         IF(nx.eq.1)THEN
           iflag = 1
         ELSE
@@ -1286,30 +1285,30 @@
 
         if(x3d.lt.minx)then
           x3d=x3d+(maxx-minx)
-          pdata_locind(np,1) = neg_hundred
+          pdata_locind(np,1) = undefined_index
         endif
         if(x3d.gt.maxx)then
           x3d=x3d-(maxx-minx)
-          pdata_locind(np,1) = neg_hundred
+          pdata_locind(np,1) = undefined_index
         endif
 
         if( (y3d.gt.maxy).and.(axisymm.ne.1).and.(ny.ne.1) )then
           y3d=y3d-(maxy-miny)
-          pdata_locind(np,2) = neg_hundred
+          pdata_locind(np,2) = undefined_index
         endif
         if( (y3d.lt.miny).and.(axisymm.ne.1).and.(ny.ne.1) )then
           y3d=y3d+(maxy-miny)
-          pdata_locind(np,2) = neg_hundred
+          pdata_locind(np,2) = undefined_index
         endif
 
         pdata(np,prx)=x3d
         pdata(np,pry)=y3d
         if( .not. terrain_flag )then
           pdata(np,prz)=z3d
-          pdata_locind(np,3) = neg_hundred
+          pdata_locind(np,3) = undefined_index
         else
           pdata(np,prsig)=sig3d
-          pdata_locind(np,3) = neg_hundred
+          pdata_locind(np,3) = undefined_index
         endif
 
 #ifdef MPI
@@ -1531,8 +1530,8 @@
         sig3d = pdata(np,prsig)
       endif
 
-      iflag = neg_hundred
-      jflag = neg_hundred
+      iflag = undefined_index
+      jflag = undefined_index
       kflag = 0
 
   ! cm1r19:  skip if we already know this processor doesnt have this parcel
@@ -1586,8 +1585,8 @@
         i=iflag
         j=jflag
       ELSE
-        iflag = neg_hundred
-        jflag = neg_hundred
+        iflag = undefined_index
+        jflag = undefined_index
         IF(nx.eq.1)THEN
           iflag = 1
         ELSE
@@ -2635,8 +2634,8 @@
       y3d = pdata(np,pry)
       z3d = pdata(np,prz)
 
-      iflag = neg_hundred
-      jflag = neg_hundred
+      iflag = undefined_index
+      jflag = undefined_index
       kflag = 0
 
   ! cm1r19:  skip if we already know this processor doesnt have this parcel
@@ -3359,6 +3358,7 @@
 
       subroutine getparcelzs(xh,uh,ruh,xf,yh,vh,rvh,yf,zs,pdata)
       use input
+      use constants
 #ifdef MPI
       use mpi
 #endif
@@ -3380,8 +3380,8 @@
       x3d = pdata(np,prx)
       y3d = pdata(np,pry)
 
-      iflag = neg_hundred
-      jflag = neg_hundred
+      iflag = undefined_index
+      jflag = undefined_index
 
   ! cm1r19:  skip if we already know this processor doesnt have this parcel
   zshaveit1:  &
@@ -3890,6 +3890,7 @@
       !$acc routine seq
 
       use input
+      use constants
 
       implicit none
 
@@ -3914,7 +3915,7 @@
       ! - If input x/y location is outside the x/y range, return directly
       if ( loc .lt. dsize(lb) .or. loc .gt. dsize(end_ind) ) return
 
-      if ( loc_ind(par_id) .ne. neg_hundred ) then
+      if ( loc_ind(par_id) .ne. undefined_index ) then
          i = min (end_ind, loc_ind(par_id) + location_offset)
          do while( ind .lt. 0 .and. i .gt. loc_ind(par_id) - location_offset - 1 )
             i = i - 1
@@ -3974,6 +3975,7 @@
       !$acc routine seq
 
       use input
+      use constants
 
       implicit none
 
@@ -3998,7 +4000,7 @@
       ! - If input x/y location is outside the x/y range, return directly
       if ( loc .lt. dsize(lb) .or. loc .gt. dsize(ub) ) return
 
-      if ( loc_ind(par_id) .ne. neg_hundred ) then 
+      if ( loc_ind(par_id) .ne. undefined_index ) then 
          i = max (ind, loc_ind(par_id) - location_offset - 1)
          ! Sanity check: 
          ! - If a parcel falls too low and outside search range,

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -75,7 +75,7 @@
       real, intent(inout), dimension(imp,cmp,kmp)   :: ss31,ss32,sn31,sn32
       real, intent(inout), dimension(cmp,cmp,kmt+1) :: n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2
       integer, intent(inout), dimension(rmp) :: reqs_s
-      integer, intent(inout), dimension(nparcels)   :: ipdata 
+      integer, intent(inout), dimension(nparcels)   :: ipdata, jpdata, kpdata 
 
       !Need to compute the true temperature
       real, dimension(ib:ie,jb:je,kb:ke) :: ta
@@ -300,16 +300,11 @@
       iflag = 1
     ELSE
       ! cm1r19:
-      IF (ipdata(np) .ne. 0) THEN
-        i = ipdata(np) + location_offset + 1 
-        do while( iflag .lt. 0 .and. i .gt. (ipdata(np) - location_offset) )
-           i = i - 1
-           if ( x3d .ge. xf(i) .and. x3d .le. xf(i+1) )then
-              iflag = i
-              ipdata(np) = iflag
-           endif
-        enddo
-      ELSE                          
+      IF (ipdata(np) .ne. -100) THEN
+        call find_location_index (ipdata, np, x3d, xf, iflag) 
+      ELSE ! Always search from the end when:
+           !    - it is the first time step
+           !    - the first time a parcel enters a process
         i = ni+1
         do while( iflag.lt.0 .and. i.gt.1 )
           i = i-1
@@ -325,17 +320,25 @@
       jflag = 1
     ELSE
       ! cm1r19:
-      j = nj+1
-      do while( jflag.lt.0 .and. j.gt.1 )
-        j = j-1
-        if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
-          jflag = j
-        endif
-      enddo
+      IF (jpdata(np) .ne. -100) THEN
+        call find_location_index (jpdata, np, y3d, yf, jflag)
+      ELSE ! Always search from the end when:
+           !    - it is the first time step
+           !    - the first time a parcel enters a process
+        j = nj+1
+        do while( jflag.lt.0 .and. j.gt.1 )
+          j = j-1
+          if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
+            jflag = j
+          endif
+        enddo
+      ENDIF
     ENDIF
 
-  ELSE ! re-initialize ipdata
-    ipdata(np) = 0
+  ELSE     ! re-initialize location index array 
+           ! if a parcel is not on this process
+    ipdata(np) = -100
+    jpdata(np) = -100
   ENDIF  haveit1
 
 #ifdef MPI
@@ -3844,7 +3847,44 @@
  
       end subroutine calcWeights
 
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
+      ! This subroutine is added by following John Dennis's suggestion
+      !      to optimize the location search for a parcel in a process
+      subroutine find_location_index (loc_ind, par_id, loc, dsize, ind)
+      implicit none
+
+      use input
+
+      integer, dimension(nparcels), intent(inout) :: loc_ind ! array to store x/y/z location index
+      integer,                      intent(in)    :: par_id  ! parcel index in pdata
+      real,                         intent(in)    :: loc     ! current x/y/z location index of a parcel
+      real, dimension(:),           intent(in)    :: dsize   ! range of x/y/z dimension
+      integer,                      intent(inout) :: ind     ! return the location index closest to 
+                                                             ! the current parcel location
+
+      ! local variable
+      integer :: i
+
+      i = loc_ind(par_id) + location_offset
+      do while( ind .lt. 0 .and. i .gt. (loc_ind(par_id) - location_offset) )
+         i = i - 1
+         if ( loc .ge. dsize(i) .and. loc .le. dsize(i+1) )then
+            ind = i
+            loc_ind(par_id) = ind
+         end if
+      end do
+
+      ! Sanity check: 
+      ! - If a parcel moves too far, this scheme would fail;
+      ! - Issue an error in this case
+      if ( ind .lt. 0 ) then
+         stop 'Parcel location searching fails...' 
+      end if
+ 
+      end subroutine find_location_index
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -300,39 +300,14 @@
       iflag = 1
     ELSE
       ! cm1r19:
-      IF (ipdata(np) .ne. -100) THEN
-        call find_location_index (ipdata, np, x3d, xf, iflag, .FALSE.) 
-      ELSE ! Always search from the end when:
-           !    - it is the first time step
-           !    - the first time a parcel enters a process
-        i = ni+1
-        do while( iflag.lt.0 .and. i.gt.1 )
-          i = i-1
-          if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
-            iflag = i
-            ipdata(np) = iflag
-          endif
-        enddo
-      ENDIF
+      call find_horizontal_location_index (ipdata, np, x3d, xf, ni+1, iflag) 
     ENDIF
 
     IF(axisymm.eq.1.or.ny.eq.1)THEN
       jflag = 1
     ELSE
       ! cm1r19:
-      IF (jpdata(np) .ne. -100) THEN
-        call find_location_index (jpdata, np, y3d, yf, jflag, .FALSE.)
-      ELSE ! Always search from the end when:
-           !    - it is the first time step
-           !    - the first time a parcel enters a process
-        j = nj+1
-        do while( jflag.lt.0 .and. j.gt.1 )
-          j = j-1
-          if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
-            jflag = j
-          endif
-        enddo
-      ENDIF
+      call find_horizontal_location_index (jpdata, np, y3d, yf, nj+1, yflag)  
     ENDIF
 
   ELSE     ! re-initialize location index array 
@@ -355,27 +330,9 @@
 
       kflag = 1
       if( .not. terrain_flag )then
-        IF (kpdata(np) .ne. -100) THEN
-           call find_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag, .TRUE.)
-        ELSE ! Always search from the end when:
-           !    - it is the first time step
-           !    - the first time a parcel enters a process
-           do while( z3d.ge.zf(iflag,jflag,kflag+1) )
-             kflag = kflag+1
-           enddo
-           kpdata(np) = kflag
-        ENDIF
+        call find_vertical_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag)
       else
-        IF (kpdata(np) .ne. -100) THEN
-           call find_location_index (kpdata, np, sig3d, sigmaf, kflag, .TRUE.)
-        ELSE ! Always search from the end when:
-           !    - it is the first time step
-           !    - the first time a parcel enters a process
-           do while( sig3d.ge.sigmaf(kflag+1) )
-             kflag = kflag+1
-           enddo
-           kpdata(np) = kflag
-        ENDIF
+        call find_vertical_location_index (kpdata, np, sig3d, sigmaf, kflag)
       endif
 !      !Store these for two-way coupling
 !      iflag_s=iflag
@@ -421,41 +378,14 @@
           iflag = 1
         ELSE
           ! cm1r19:
-          IF (ipdata(np) .ne. -100) THEN
-            call find_location_index (ipdata, np, x3d, xf, iflag, .FALSE.)
-          ELSE
-            i = ni+2
-            do while( iflag.lt.0 .and. i.gt.0 )
-              i = i-1
-              if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
-                iflag = i
-                ipdata(np) = iflag
-              endif
-            enddo
-          ENDIF
+          call find_horizontal_location_index (ipdata, np, x3d, xf, ni+2, iflag)
         ENDIF
 
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           jflag = 1
         ELSE
-          IF (jpdata(np) .ne. -100) THEN
-            call find_location_index (jpdata, np, y3d, yf, jflag, .FALSE.)
-          ELSE
-! JS: comment out this acc loop and use the original version
-!!!            !$acc loop seq
-!!!            do j=0,nj+1
-!!!              if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) ) jflag=j
-!!!            enddo
-            ! cm1r19:
-            j = nj+2
-            do while( jflag.lt.0 .and. j.gt.0 )
-              j = j-1
-              if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
-                jflag = j
-                jpdata(np) = jflag
-              endif
-            enddo
-          ENDIF
+          ! cm1r19:
+          call find_horizontal_location_index (jpdata, np, y3d, yf, nj+2, jflag)
         ENDIF
         i=iflag
         j=jflag
@@ -463,23 +393,9 @@
 
         kflag = 1
         if( .not. terrain_flag )then
-          IF (kpdata(np) .ne. -100) THEN
-             call find_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag, .TRUE.)
-          ELSE
-             do while( z3d.ge.zf(iflag,jflag,kflag+1) )
-               kflag = kflag+1
-             enddo
-             kpdata(np) = kflag
-          ENDIF
+          call find_vertical_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag)
         else
-          IF (kpdata(np) .ne. -100) THEN
-             call find_location_index (kpdata, np, sig3d, sigmaf, kflag, .TRUE.)
-          ELSE
-             do while( sig3d.ge.sigmaf(kflag+1) )
-               kflag = kflag+1
-             enddo
-             kpdata(np) = kflag
-          ENDIF
+          call find_vertical_location_index (kpdata, np, sig3d, sigmaf, kflag)
         endif
 
 !JMD-debug
@@ -1083,41 +999,13 @@
           iflag = 1
         ELSE
           ! cm1r19:
-          IF (ipdata(np) .ne. -100) THEN
-            call find_location_index (ipdata, np, x3d, xf, iflag, .FALSE.)
-          ELSE
-            i = ni+2
-            do while( iflag.lt.0 .and. i.gt.0 )
-              i = i-1
-              if( x3d.ge.xf(i) .and. x3d.le.xf(i+1) )then
-                iflag = i
-                ipdata(np) = iflag
-              endif
-            enddo
-          ENDIF
+          call find_horizontal_location_index (ipdata, np, x3d, xf, ni+2, iflag)
         ENDIF
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           jflag = 1
         ELSE
           ! cm1r19:
-          IF (jpdata(np) .ne. -100) THEN
-            call find_location_index (jpdata, np, y3d, yf, jflag, .FALSE.)
-          ELSE
-! JS: comment out this acc loop and use the original version
-!!!            !$acc loop seq
-!!!            do j=0,nj+1
-!!!              if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) ) jflag=j
-!!!            enddo
-            ! cm1r19:
-            j = nj+2
-            do while( jflag.lt.0 .and. j.gt.0 )
-              j = j-1
-              if( y3d.ge.yf(j) .and. y3d.le.yf(j+1) )then
-                jflag = j
-                jpdata(np) = jflag
-              endif
-            enddo
-          ENDIF
+          call find_horizontal_location_index (jpdata, np, y3d, yf, nj+2, jflag)
           if(mod(np,PITER)==0) then
              print *,'after dowhile loop: ',jflag
           endif
@@ -1147,23 +1035,9 @@
         !print *,'droplet_driver: point #4'
         kflag = 1
         if( .not. terrain_flag )then
-          IF (kpdata(np) .ne. -100) THEN
-             call find_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag, .TRUE.)
-          ELSE
-             do while( z3d.gt.zf(iflag,jflag,kflag+1) )
-               kflag = kflag+1
-             enddo
-             kpdata(np) = kflag
-          ENDIF
+          call find_vertical_location_index (kpdata, np, z3d, zf(iflag,jflag,:), kflag)
         else
-          IF (kpdata(np) .ne. -100) THEN
-             call find_location_index (kpdata, np, sig3d, sigmaf, kflag, .TRUE.)
-          ELSE
-             do while( sig3d.gt.sigmaf(kflag+1) )
-               kflag = kflag+1
-             enddo
-             kpdata(np) = kflag
-          ENDIF
+          call find_vertical_location_index (kpdata, np, sig3d, sigmaf, kflag)
         endif
 
 #if 0
@@ -3912,57 +3786,94 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      ! This subroutine is added by following John Dennis's suggestion
+      ! These two subroutines are added by following John Dennis's suggestion
       !      to optimize the location search for a parcel in a process
-      subroutine find_location_index (loc_ind, par_id, loc, dsize, ind, search_z)
+
+      subroutine find_horizontal_location_index (loc_ind, par_id, loc, dsize, end_ind, ind)
 
       use input
 
       implicit none
 
-      integer, dimension(nparcels), intent(inout) :: loc_ind    ! array to store x/y/z location index
+      integer, dimension(nparcels), intent(inout) :: loc_ind    ! array to store x/y location index
       integer,                      intent(in)    :: par_id     ! parcel index in pdata
-      real,                         intent(in)    :: loc        ! current x/y/z location index of a parcel
-      real, dimension(:),           intent(in)    :: dsize      ! range of x/y/z dimension
-      integer,                      intent(inout) :: ind        ! return the location index closest to 
+      real,                         intent(in)    :: loc        ! current x/y location index of a parcel
+      real, dimension(:),           intent(in)    :: dsize      ! range of x/y dimension
+      integer,                      intent(in)    :: end_ind    ! end index of x/y dimension
+      integer,                      intent(inout) :: ind        ! return the x/y location index closest to 
                                                                 ! the current parcel location
-      logical,                      intent(in)    :: search_z   ! TRUE if searching the z-dimension index
 
       ! local variable
       integer :: i
 
-      ! we always search from the smaller index to the larger one
-      i = max (1, loc_ind(par_id) - location_offset - 1)
-
-      if ( search_z ) then
-         ! Sanity check: 
-         ! - If a parcel falls too low and outside search range, this scheme would fail;
-         ! - Issue an error in this case
-         if ( loc .lt. dsize(i) ) then
-            stop 'Parcel location searching fails...'
-         end if
-         do while( loc .ge. dsize(i+1) )
-            i = i + 1
-         end do
-         ind = i
-         loc_ind(par_id) = ind
-      else
-         do while( ind .lt. 0 .and. i .lt. (loc_ind(par_id) + location_offset) )
-            if ( loc .ge. dsize(i) .and. loc .le. dsize(i+1) )then
+      if (loc_ind(par_id) .ne. -100) then
+         i = min (end_ind, loc_ind(par_id) + location_offset)
+         do while( ind .lt. 0 .and. i .gt. loc_ind(par_id) - location_offset - 1 )
+            i = i - 1
+            if ( loc .ge. dsize(i) .and. loc .le. dsize(i+1) ) then
                ind = i
                loc_ind(par_id) = ind
             end if
-            i = i + 1
          end do
          ! Sanity check: 
-         ! - If a parcel moves too far and outside search range, this scheme would fail;
+         ! - If a parcel moves too far and outside search range, 
+         !      this scheme would fail;
          ! - Issue an error in this case
          if ( ind .lt. 0 ) then
-            stop 'Parcel location searching fails...'
+            stop 'Parcel x location searching fails...'
          end if
+      else ! Always search from the end when:
+           !    - it is the first time step
+           !    - a parcel enters a new or different MPI process
+         i = end_ind
+         do while( ind .lt. 0 .and. i .gt. 1 )
+            i = i - 1
+            if ( loc .ge. dsize(i) .and. loc .le. dsize(i+1) ) then
+               ind = i
+               loc_ind(par_id) = ind
+            end if
+         end do
       end if
 
-      end subroutine find_location_index
+      end subroutine find_horizontal_location_index
+
+      subroutine find_vertical_location_index (loc_ind, par_id, loc, dsize, ind)
+
+      use input
+
+      implicit none
+
+      integer, dimension(nparcels), intent(inout) :: loc_ind    ! array to store z location index
+      integer,                      intent(in)    :: par_id     ! parcel index in pdata
+      real,                         intent(in)    :: loc        ! current z location index of a parcel
+      real, dimension(:),           intent(in)    :: dsize      ! range of z dimension
+      integer,                      intent(inout) :: ind        ! return the z location index closest
+                                                                ! to the current parcel location
+
+      if (loc_ind(par_id) .ne. -100) then 
+         ind = max (ind, loc_ind(par_id) - location_offset - 1)
+         ! Sanity check: 
+         ! - If a parcel falls too low and outside search range,
+         !      this scheme would fail;
+         ! - Issue an error in this case
+         if ( loc .lt. dsize(ind) ) then
+            stop 'Parcel z location searching fails...'
+         end if
+         do while( loc .ge. dsize(ind+1) )
+            ind = ind + 1
+         end do
+         loc_ind(par_id) = ind
+      else ! Always search from the end when:
+           !    - it is the first time step
+           !    - a parcel enters a new or different MPI process
+         do while ( loc .ge. dsize(ind+1) )
+            ind = ind + 1
+         end do
+         loc_ind(par_id) = ind
+      end if
+
+      end subroutine find_vertical_location_index
+
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1048,6 +1048,9 @@
 #endif
         kflag = max (kflag, pdata_locind(np,3) - location_offset - 1)
         if( .not. terrain_flag )then
+          if ( z3d.lt.zf(iflag,jflag,kflag) ) then
+            kflag = 1
+          end if
           do while( z3d.gt.zf(iflag,jflag,kflag+1) )
             kflag = kflag+1
           enddo
@@ -1063,11 +1066,14 @@
           end if
 #endif
         else
+          if ( sig3d.lt.sigmaf(kflag) ) then
+            kflag = 1
+          end if
           do while( sig3d.gt.sigmaf(kflag+1) )
             kflag = kflag+1
           enddo
 #ifdef _VERIFY_FIND_LOC
-          do while( ig3d.gt.sigmaf(tmp_flag+1) )
+          do while( sig3d.gt.sigmaf(tmp_flag+1) )
             tmp_flag = tmp_flag+1
           enddo
           if ( kflag .ne. tmp_flag ) then

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -106,6 +106,11 @@
       real :: esl
 
       logical, parameter :: debug = .false.
+
+#ifdef _VERIFY_FIND_LOC
+      integer :: tmp_flag
+#endif
+
       !$acc declare present(rho,prs,qa,wa,sigma)
 
       !integer :: nip1
@@ -1035,10 +1040,43 @@
 
         !print *,'droplet_driver: point #4'
         kflag = 1
+! JS - jflag could be negative somehow, which will break
+!           the find_vertical_location_index subroutine;
+!      use the original interface but with the pdata_locind(:,3) here
+#ifdef _VERIFY_FIND_LOC
+        tmp_flag = kflag
+#endif
+        kflag = max (kflag, pdata_locind(np,3) - location_offset - 1)
         if( .not. terrain_flag )then
-          call find_vertical_location_index (pdata_locind(:,3), np, z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .FALSE.)
+          do while( z3d.gt.zf(iflag,jflag,kflag+1) )
+            kflag = kflag+1
+          enddo
+#ifdef _VERIFY_FIND_LOC
+          do while( z3d.gt.zf(iflag,jflag,tmp_flag+1) )
+            tmp_flag = tmp_flag+1
+          enddo
+          if ( kflag .ne. tmp_flag ) then
+            print *, "original search scheme finds z index = ", tmp_flag, ", new search scheme finds z index = ", kflag
+            stop "Failed verification test: z index is not the same..."
+          else
+            print *, "Pass the verification test for z index..."
+          end if
+#endif
         else
-          call find_vertical_location_index (pdata_locind(:,3), np, sig3d, kb, ke+1, sigmaf, kflag, .FALSE.)
+          do while( sig3d.gt.sigmaf(kflag+1) )
+            kflag = kflag+1
+          enddo
+#ifdef _VERIFY_FIND_LOC
+          do while( ig3d.gt.sigmaf(tmp_flag+1) )
+            tmp_flag = tmp_flag+1
+          enddo
+          if ( kflag .ne. tmp_flag ) then
+            print *, "original search scheme finds z index = ", tmp_flag, ", new search scheme finds z index = ", kflag
+            stop "Failed verification test: z index is not the same..."
+          else
+            print *, "Pass the verification test for z index..."
+          end if
+#endif
         endif
 
 #if 0

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -140,7 +140,7 @@
                    bndy,kbdy,hflxw,hflxe,hflxs,hflxn,                &
                    dowriteout,dorad,getdbz,getvt,dotdwrite,          &
                    dotbud,doqbud,doubud,dovbud,dowbud,donudge,       &
-                   doazimwrite,dorestart,ipdata,jpdata,kpdata)
+                   doazimwrite,dorestart,pdata_locind)
         ! end_solve3
       use input
       use constants
@@ -301,7 +301,7 @@
       integer, intent(in), dimension(ibib:ieib,jbib:jeib,kmaxib) :: hflxw,hflxe,hflxs,hflxn
       logical, intent(in) :: dowriteout,dorad,dotdwrite,doazimwrite,dorestart
       logical, intent(inout) :: getdbz,getvt,dotbud,doqbud,doubud,dovbud,dowbud,donudge
-      integer, intent(inout), dimension(nparcels) :: ipdata,jpdata,kpdata
+      integer, intent(inout), dimension(nparcels,3) :: pdata_locind
 
 !-----------------------------------------------------------------------
 ! Arrays and variables defined inside solve
@@ -989,7 +989,7 @@
                                sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,             &
                                n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,      &
                                uten,vten,wten,dpten(ib,jb,kb,1),dpten(ib,jb,kb,2),  &
-                               ipdata,jpdata,kpdata)
+                               pdata_locind)
           if(timestats.ge.1) time_parcels=time_parcels+mytime()
           !print *,'solve3: after call to droplet_driver' 
           !$acc compare(dpten)

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -140,7 +140,7 @@
                    bndy,kbdy,hflxw,hflxe,hflxs,hflxn,                &
                    dowriteout,dorad,getdbz,getvt,dotdwrite,          &
                    dotbud,doqbud,doubud,dovbud,dowbud,donudge,       &
-                   doazimwrite,dorestart)
+                   doazimwrite,dorestart,ipdata,jpdata,kpdata)
         ! end_solve3
       use input
       use constants
@@ -301,6 +301,7 @@
       integer, intent(in), dimension(ibib:ieib,jbib:jeib,kmaxib) :: hflxw,hflxe,hflxs,hflxn
       logical, intent(in) :: dowriteout,dorad,dotdwrite,doazimwrite,dorestart
       logical, intent(inout) :: getdbz,getvt,dotbud,doqbud,doubud,dovbud,dowbud,donudge
+      integer, intent(inout), dimension(nparcels) :: ipdata,jpdata,kpdata
 
 !-----------------------------------------------------------------------
 ! Arrays and variables defined inside solve
@@ -987,7 +988,8 @@
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p,              &
                                sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,             &
                                n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,      &
-                               uten,vten,wten,dpten(ib,jb,kb,1),dpten(ib,jb,kb,2))
+                               uten,vten,wten,dpten(ib,jb,kb,1),dpten(ib,jb,kb,2),  &
+                               ipdata,jpdata,kpdata)
           if(timestats.ge.1) time_parcels=time_parcels+mytime()
           !print *,'solve3: after call to droplet_driver' 
           !$acc compare(dpten)


### PR DESCRIPTION
For a particular parcel, the current location search implementation in the `droplet_driver` subroutine always started from the end of a dimension and scanned backwards until the parcel was found. Such a linear search strategy at every time step was computationally costly and not necessary since a parcel would not move too far.

According to @johnmauff's suggestions, it is better to store the previous location of a parcel and use that as the starting search point for the next time step. In addition, the search range could be restricted to a small value with the assumption that a parcel does not move too far from one time step to another.

This PR introduces the new implementation following @johnmauff's suggestions. We also add a verification test and could confirm that the new implementation returns the identical location indexes as the original implementation.