### PR TITLE
Fix the GPU bugs in CM1 with updated droplet code

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -74,7 +74,7 @@ endif
 #  NVHPC compiler
 #-----------------------------------------------------------------------------
 ifeq (${FC},nvfortran)
-    OPTS         += -Mfree -Ktrap=none -Mautoinline -Minline=reshape
+    OPTS         += -Mfree -Ktrap=none -Mautoinline -Minline=reshape -Kieee
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${DEBUG_L},true)
          OPTS    += -g -O0
@@ -104,7 +104,7 @@ endif
 #  PGI compiler
 #-----------------------------------------------------------------------------
 ifeq (${FC},pgf90)
-    OPTS         += -Mfree -Ktrap=none -Mautoinline -Minline=reshape
+    OPTS         += -Mfree -Ktrap=none -Mautoinline -Minline=reshape -Kieee
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${DEBUG_L},true)
          OPTS    += -g -O0

--- a/src/bc.F
+++ b/src/bc.F
@@ -3409,16 +3409,16 @@
       real, dimension(ib:ie,jb:je,kb:ke) :: s
 
       integer i,j,k
-      !$acc declare present(s)
 
-    !$acc parallel default(present) private(i,j,k)
+      !$acc data present(s)
+
 !-----------------------------------------------------------------------
 !  west boundary condition
-
 
 #ifndef MPI
       if(wbc.eq.1)then
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=jb,je
@@ -3427,11 +3427,13 @@
         enddo
         enddo
     ENDDO
+    !$acc end parallel
       elseif(wbc.eq.2)then
 #else
       if(ibw.eq.1.and.wbc.eq.2)then
 #endif
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=0,nj+1
@@ -3440,12 +3442,14 @@
         enddo
         enddo
     ENDDO
+    !$acc end parallel
 #ifdef MPI
       elseif(ibw.eq.1.and.(wbc.eq.3.or.wbc.eq.4))then
 #else
       elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=0,nj+1
@@ -3454,17 +3458,16 @@
         enddo
         enddo
     ENDDO
-      endif
     !$acc end parallel
+      endif
 
-    !$acc parallel private(i,j,k)
 !-----------------------------------------------------------------------
 !  east boundary condition
-
 
 #ifndef MPI
       if(ebc.eq.1)then
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=jb,je
@@ -3473,11 +3476,13 @@
         enddo
         enddo
     ENDDO
+    !$acc end parallel
       elseif(ebc.eq.2)then
 #else
       if(ibe.eq.1.and.ebc.eq.2)then
 #endif
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=0,nj+1
@@ -3486,12 +3491,14 @@
         enddo
         enddo
     ENDDO
+    !$acc end parallel
 #ifdef MPI
       elseif(ibe.eq.1.and.(ebc.eq.3.or.ebc.eq.4))then
 #else
       elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=0,nj+1
@@ -3500,17 +3507,16 @@
         enddo
         enddo
     ENDDO
-      endif
     !$acc end parallel
+      endif
 
-    !$acc parallel private(i,j,k)
 !-----------------------------------------------------------------------
 !  south boundary condition
-
 
 #ifndef MPI
       if(sbc.eq.1)then
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=1,ngxy
@@ -3519,11 +3525,13 @@
         enddo
         enddo
     ENDDO
+    !$acc end parallel
       elseif(sbc.eq.2)then
 #else
       if(ibs.eq.1.and.sbc.eq.2)then
 #endif
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=1-ngxy,0
@@ -3532,12 +3540,14 @@
         enddo
         enddo
     ENDDO
+    !$acc end parallel
 #ifdef MPI
       elseif(ibs.eq.1.and.(sbc.eq.3.or.sbc.eq.4))then
 #else
       elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=1,ngxy
@@ -3546,17 +3556,16 @@
         enddo
         enddo
     ENDDO
-      endif
    !$acc end parallel
+      endif
 
-    !$acc parallel private(i,j,k)
 !-----------------------------------------------------------------------
 !  north boundary condition
-
 
 #ifndef MPI
       if(nbc.eq.1)then
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=1,ngxy
@@ -3565,11 +3574,13 @@
         enddo
         enddo
     ENDDO
+   !$acc end parallel
       elseif(nbc.eq.2)then
 #else
       if(ibn.eq.1.and.nbc.eq.2)then
 #endif
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=nj+1,nj+ngxy
@@ -3578,12 +3589,14 @@
         enddo
         enddo
     ENDDO
+   !$acc end parallel
 #ifdef MPI
       elseif(ibn.eq.1.and.(nbc.eq.3.or.nbc.eq.4))then
 #else
       elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) private(i,j,k)
     !$acc loop gang vector collapse(3)
     DO k=1,nk
         do j=1,ngxy
@@ -3592,9 +3605,12 @@
         enddo
         enddo
     ENDDO
-      endif
    !$acc end parallel
+      endif
+
 !-----------------------------------------------------------------------
+
+      !$acc end data
 
       if(timestats.ge.1) time_bcs=time_bcs+mytime()
 
@@ -4350,7 +4366,8 @@
       real s(ib:ie,jb:je,kb:ke)
 
       integer i,j,k
-      !$acc declare present(s)
+
+      !$acc data present(s)
 
 !---------------------------------------------------------
 !  This subroutine sets the corner points
@@ -4467,6 +4484,8 @@
         endif
 
       endif
+      
+      !$acc end data
 
       if(timestats.ge.1) time_bcs2=time_bcs2+mytime()
 

--- a/src/bc.F
+++ b/src/bc.F
@@ -3417,48 +3417,48 @@
 
 #ifndef MPI
       if(wbc.eq.1)then
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=jb,je
-        do i=1,ngxy
-          s(1-i,j,k)=s(ni+1-i,j,k)
-        enddo
-        enddo
-    ENDDO
-    !$acc end parallel
+        !$omp parallel do default(shared) private(i,j,k)
+        !$acc parallel default(present)
+        !$acc loop gang vector collapse(3)
+        do k=1,nk
+           do j=jb,je
+              do i=1,ngxy
+                 s(1-i,j,k)=s(ni+1-i,j,k)
+              end do
+           end do
+        end do
+        !$acc end parallel
       elseif(wbc.eq.2)then
 #else
       if(ibw.eq.1.and.wbc.eq.2)then
 #endif
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=0,nj+1
-        do i=1-ngxy,0
-          s(i,j,k)=s(1,j,k)
-        enddo
-        enddo
-    ENDDO
-    !$acc end parallel
+        !$omp parallel do default(shared) private(i,j,k)
+        !$acc parallel default(present)
+        !$acc loop gang vector collapse(3)
+        do k=1,nk
+           do j=0,nj+1
+              do i=1-ngxy,0
+                 s(i,j,k)=s(1,j,k)
+              end do
+           end do
+        end do
+        !$acc end parallel
 #ifdef MPI
       elseif(ibw.eq.1.and.(wbc.eq.3.or.wbc.eq.4))then
 #else
       elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=0,nj+1
-        do i=1,ngxy
-          s(1-i,j,k)=s(i,j,k)
-        enddo
-        enddo
-    ENDDO
-    !$acc end parallel
+       !$omp parallel do default(shared) private(i,j,k)
+       !$acc parallel default(present)
+       !$acc loop gang vector collapse(3)
+       do k=1,nk
+          do j=0,nj+1
+             do i=1,ngxy
+                s(1-i,j,k)=s(i,j,k)
+             enddo
+          enddo
+       end do
+       !$acc end parallel
       endif
 
 !-----------------------------------------------------------------------
@@ -3466,48 +3466,48 @@
 
 #ifndef MPI
       if(ebc.eq.1)then
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=jb,je
-        do i=1,ngxy
-          s(ni+i,j,k)=s(i,j,k)
-        enddo
-        enddo
-    ENDDO
-    !$acc end parallel
+        !$omp parallel do default(shared) private(i,j,k)
+        !$acc parallel default(present)
+        !$acc loop gang vector collapse(3)
+        do k=1,nk
+           do j=jb,je
+              do i=1,ngxy
+                 s(ni+i,j,k)=s(i,j,k)
+              end do
+           end do
+        end do
+        !$acc end parallel
       elseif(ebc.eq.2)then
 #else
       if(ibe.eq.1.and.ebc.eq.2)then
 #endif
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=0,nj+1
-        do i=ni+1,ni+ngxy
-          s(i,j,k)=s(ni,j,k)
-        enddo
-        enddo
-    ENDDO
-    !$acc end parallel
+       !$omp parallel do default(shared) private(i,j,k)
+       !$acc parallel default(present)
+       !$acc loop gang vector collapse(3)
+       do k=1,nk
+          do j=0,nj+1
+             do i=ni+1,ni+ngxy
+                s(i,j,k)=s(ni,j,k)
+             end do
+          end do
+       end do
+       !$acc end parallel
 #ifdef MPI
       elseif(ibe.eq.1.and.(ebc.eq.3.or.ebc.eq.4))then
 #else
       elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=0,nj+1
-        do i=1,ngxy
-          s(ni+i,j,k)=s(ni+1-i,j,k)
-        enddo
-        enddo
-    ENDDO
-    !$acc end parallel
+       !$omp parallel do default(shared) private(i,j,k)
+       !$acc parallel default(present)
+       !$acc loop gang vector collapse(3)
+       do k=1,nk
+          do j=0,nj+1
+             do i=1,ngxy
+                s(ni+i,j,k)=s(ni+1-i,j,k)
+             end do
+          end do
+       end do 
+       !$acc end parallel
       endif
 
 !-----------------------------------------------------------------------
@@ -3515,48 +3515,48 @@
 
 #ifndef MPI
       if(sbc.eq.1)then
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=1,ngxy
-        do i=ib,ie
-          s(i,1-j,k)=s(i,nj+1-j,k)
-        enddo
-        enddo
-    ENDDO
-    !$acc end parallel
+       !$omp parallel do default(shared) private(i,j,k)
+       !$acc parallel default(present)
+       !$acc loop gang vector collapse(3)
+       do k=1,nk
+          do j=1,ngxy
+             do i=ib,ie
+                s(i,1-j,k)=s(i,nj+1-j,k)
+             end do
+          end do
+       end do 
+       !$acc end parallel
       elseif(sbc.eq.2)then
 #else
       if(ibs.eq.1.and.sbc.eq.2)then
 #endif
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=1-ngxy,0
-        do i=0,ni+1
-          s(i,j,k)=s(i,1,k)
-        enddo
-        enddo
-    ENDDO
-    !$acc end parallel
+       !$omp parallel do default(shared) private(i,j,k)
+       !$acc parallel default(present)
+       !$acc loop gang vector collapse(3)
+       do k=1,nk
+          do j=1-ngxy,0
+             do i=0,ni+1
+                s(i,j,k)=s(i,1,k)
+             end do
+          end do
+       end do 
+       !$acc end parallel
 #ifdef MPI
       elseif(ibs.eq.1.and.(sbc.eq.3.or.sbc.eq.4))then
 #else
       elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=1,ngxy
-        do i=0,ni+1
-          s(i,1-j,k)=s(i,j,k)
-        enddo
-        enddo
-    ENDDO
-   !$acc end parallel
+       !$omp parallel do default(shared) private(i,j,k)
+       !$acc parallel default(present)
+       !$acc loop gang vector collapse(3)
+       do k=1,nk
+          do j=1,ngxy
+             do i=0,ni+1
+                s(i,1-j,k)=s(i,j,k)
+             end do
+          end do
+       end do 
+       !$acc end parallel
       endif
 
 !-----------------------------------------------------------------------
@@ -3564,48 +3564,48 @@
 
 #ifndef MPI
       if(nbc.eq.1)then
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=1,ngxy
-        do i=ib,ie
-          s(i,nj+j,k)=s(i,j,k)
-        enddo
-        enddo
-    ENDDO
-   !$acc end parallel
+       !$omp parallel do default(shared) private(i,j,k)
+       !$acc parallel default(present)
+       !$acc loop gang vector collapse(3)
+       do k=1,nk
+          do j=1,ngxy
+             do i=ib,ie
+                s(i,nj+j,k)=s(i,j,k)
+             end do
+          end do
+       end do 
+       !$acc end parallel
       elseif(nbc.eq.2)then
 #else
       if(ibn.eq.1.and.nbc.eq.2)then
 #endif
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=nj+1,nj+ngxy
-        do i=0,ni+1
-          s(i,j,k)=s(i,nj,k)
-        enddo
-        enddo
-    ENDDO
-   !$acc end parallel
+       !$omp parallel do default(shared) private(i,j,k)
+       !$acc parallel default(present)
+       !$acc loop gang vector collapse(3)
+       do k=1,nk
+          do j=nj+1,nj+ngxy
+             do i=0,ni+1
+                s(i,j,k)=s(i,nj,k)
+             end do
+          end do
+       end do
+       !$acc end parallel
 #ifdef MPI
       elseif(ibn.eq.1.and.(nbc.eq.3.or.nbc.eq.4))then
 #else
       elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
-    !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel default(present) private(i,j,k)
-    !$acc loop gang vector collapse(3)
-    DO k=1,nk
-        do j=1,ngxy
-        do i=0,ni+1
-          s(i,nj+j,k)=s(i,nj+1-j,k)
-        enddo
-        enddo
-    ENDDO
-   !$acc end parallel
+       !$omp parallel do default(shared) private(i,j,k)
+       !$acc parallel default(present) private(i,j,k)
+       !$acc loop gang vector collapse(3)
+       do k=1,nk
+          do j=1,ngxy
+             do i=0,ni+1
+                s(i,nj+j,k)=s(i,nj+1-j,k)
+             end do
+          end do
+       end do 
+       !$acc end parallel
       endif
 
 !-----------------------------------------------------------------------
@@ -3623,51 +3623,58 @@
       real, dimension(ib:ie+1,jb:je,kb:ke) :: u
 
       integer i,j,k  
-      !$acc declare present(u)
+
+      !$acc data present(u)
 
 !-----------------------------------------------------------------------
 !  west boundary condition
 
-
 #ifndef MPI
     if(wbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
-      DO k=1,nk
-        do j=jb,je
-        do i=1,ngxy
-          u(1-i,j,k)=u(ni+1-i,j,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(3)
+      do k=1,nk
+         do j=jb,je
+            do i=1,ngxy
+               u(1-i,j,k)=u(ni+1-i,j,k)
+            end do
+         end do
+      end do
+      !$acc end parallel
     elseif(wbc.eq.2)then
 #else
     if(ibw.eq.1.and.wbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
-      DO k=1,nk
-        do j=0,nj+1
-        do i=1-ngxy,0
-          u(i,j,k)=u(1,j,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(3)
+      do k=1,nk
+         do j=0,nj+1
+            do i=1-ngxy,0
+               u(i,j,k)=u(1,j,k)
+            end do
+         end do
+      end do
+      !$acc end parallel
 #ifdef MPI
     elseif(ibw.eq.1.and.(wbc.eq.3.or.wbc.eq.4))then
 #else
     elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(2) private(i,j,k)
-      DO k=1,nk
-        do j=0,nj+1
-          u(1,j,k)=0.
-        do i=1,ngxy
-          u(1-i,j,k)=-u(1+i,j,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(2)
+      do k=1,nk
+         do j=0,nj+1
+            u(1,j,k)=0.
+            !$acc loop seq
+            do i=1,ngxy
+               u(1-i,j,k)=-u(1+i,j,k)
+            end do
+         end do
+      end do
+      !$acc end parallel
     endif
 
 !-----------------------------------------------------------------------
@@ -3676,42 +3683,49 @@
 #ifndef MPI
     if(ebc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
-      DO k=1,nk
-        do j=jb,je
-        do i=1,ngxy
-          u(ni+1+i,j,k)=u(1+i,j,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(3)
+      do k=1,nk
+         do j=jb,je
+            do i=1,ngxy
+               u(ni+1+i,j,k)=u(1+i,j,k)
+            end do
+         end do
+      end do
+      !$acc end parallel
     elseif(ebc.eq.2)then
 #else
     if(ibe.eq.1.and.ebc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
-      DO k=1,nk
-        do j=0,nj+1
-        do i=ni+2,ni+1+ngxy
-          u(i,j,k)=u(ni+1,j,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(3)
+      do k=1,nk
+         do j=0,nj+1
+            do i=ni+2,ni+1+ngxy
+               u(i,j,k)=u(ni+1,j,k)
+            end do
+         end do
+      end do
+      !$acc end parallel
 #ifdef MPI
     elseif(ibe.eq.1.and.(ebc.eq.3.or.ebc.eq.4))then
 #else
     elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(2) private(i,j,k)
-      DO k=1,nk
-        do j=0,nj+1
-          u(ni+1,j,k)=0.0
-        do i=1,ngxy
-          u(ni+1+i,j,k)=-u(ni+1-i,j,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(2)
+      do k=1,nk
+         do j=0,nj+1
+            u(ni+1,j,k)=0.0
+            !$acc loop seq
+            do i=1,ngxy
+               u(ni+1+i,j,k)=-u(ni+1-i,j,k)
+            end do
+        end do
+      end do
+      !$acc end parallel
     endif
 
 !-----------------------------------------------------------------------
@@ -3720,41 +3734,47 @@
 #ifndef MPI
     if(sbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
-      DO k=1,nk
-        do j=1,ngxy
-        do i=ib,ie+1
-          u(i,1-j,k)=u(i,nj+1-j,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(3)
+      do k=1,nk
+         do j=1,ngxy
+            do i=ib,ie+1
+               u(i,1-j,k)=u(i,nj+1-j,k)
+            end do
+         end do
+      end do
+      !$acc end parallel
     elseif(sbc.eq.2)then
 #else
     if(ibs.eq.1.and.sbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
-      DO k=1,nk
-        do j=1-ngxy,0
-        do i=0,ni+2
-          u(i,j,k)=u(i,1,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(3)
+      do k=1,nk
+         do j=1-ngxy,0
+            do i=0,ni+2
+               u(i,j,k)=u(i,1,k)
+            end do
+         end do
+      end do
+      !$acc end parallel
 #ifdef MPI
     elseif(ibs.eq.1.and.(sbc.eq.3.or.sbc.eq.4))then
 #else
     elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
-      DO k=1,nk
-        do j=1,ngxy
-        do i=0,ni+2
-          u(i,1-j,k)=u(i,j,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(3)
+      do k=1,nk
+         do j=1,ngxy
+            do i=0,ni+2
+               u(i,1-j,k)=u(i,j,k)
+            end do
+         end do
+      end do
+      !$acc end parallel
     endif
 
 !-----------------------------------------------------------------------
@@ -3763,43 +3783,50 @@
 #ifndef MPI
     if(nbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
-      DO k=1,nk
-        do j=1,ngxy
-        do i=ib,ie+1
-          u(i,nj+j,k)=u(i,j,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(3)
+      do k=1,nk
+         do j=1,ngxy
+            do i=ib,ie+1
+               u(i,nj+j,k)=u(i,j,k)
+            end do
+        end do
+      end do
+      !$acc end parallel
     elseif(nbc.eq.2)then
 #else
     if(ibn.eq.1.and.nbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
-      DO k=1,nk
-        do j=nj+1,nj+ngxy
-        do i=0,ni+2
-          u(i,j,k)=u(i,nj,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(3)
+      do k=1,nk
+         do j=nj+1,nj+ngxy
+            do i=0,ni+2
+               u(i,j,k)=u(i,nj,k)
+            end do
+         end do
+      end do
+      !$acc end parallel
 #ifdef MPI
     elseif(ibn.eq.1.and.(nbc.eq.3.or.nbc.eq.4))then
 #else
     elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
-      DO k=1,nk
-        do j=1,ngxy
-        do i=0,ni+2
-          u(i,nj+j,k)=u(i,nj+1-j,k)
-        enddo
-        enddo
-      ENDDO
+      !$acc parallel default(present)
+      !$acc loop gang vector collapse(3)
+      do k=1,nk
+         do j=1,ngxy
+            do i=0,ni+2
+               u(i,nj+j,k)=u(i,nj+1-j,k)
+            end do
+         end do
+      end do
+      !$acc end parallel
     endif
 
+    !$acc end data
 
 !-----------------------------------------------------------------------
 
@@ -4357,8 +4384,6 @@
 
       end subroutine bcs2
 
-
-
       subroutine bcs2_GPU(s)
       use input
       implicit none
@@ -4379,24 +4404,24 @@
           j=0
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2)
           do k=1,nk
-          do i=1-ngxy,0
-            s(i,j,k)=s(1,j,k)
-          enddo
-          enddo
+             do i=1-ngxy,0
+                s(i,j,k)=s(1,j,k)
+             end do
+          end do
         endif
 
         if(patchnww)then
           j=nj+1
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2)
           do k=1,nk
-          do i=1-ngxy,0
-            s(i,j,k)=s(1,j,k)
-          enddo
-          enddo
+             do i=1-ngxy,0
+                s(i,j,k)=s(1,j,k)
+             end do
+          end do
         endif
 
       endif
@@ -4407,24 +4432,24 @@
           j=0
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2)
           do k=1,nk
-          do i=ni+1,ni+ngxy
-            s(i,j,k)=s(ni,j,k)
-          enddo
-          enddo
+             do i=ni+1,ni+ngxy
+                s(i,j,k)=s(ni,j,k)
+             end do
+          end do
         endif
 
         if(patchnee)then
           j=nj+1
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2)
           do k=1,nk
-          do i=ni+1,ni+ngxy
-            s(i,j,k)=s(ni,j,k)
-          enddo
-          enddo
+             do i=ni+1,ni+ngxy
+                s(i,j,k)=s(ni,j,k)
+             end do
+          end do
         endif
 
       endif
@@ -4435,24 +4460,24 @@
           i=0
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2)
           do k=1,nk
-          do j=1-ngxy,0
-            s(i,j,k)=s(i,1,k)
-          enddo
-          enddo
+             do j=1-ngxy,0
+                s(i,j,k)=s(i,1,k)
+             end do
+          end do
         endif
 
         if(patchses)then
           i=ni+1
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2)
           do k=1,nk
-          do j=1-ngxy,0
-            s(i,j,k)=s(i,1,k)
-          enddo
-          enddo
+             do j=1-ngxy,0
+                s(i,j,k)=s(i,1,k)
+             end do
+          end do
         endif
 
       endif
@@ -4463,24 +4488,24 @@
           i=0
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2)
           do k=1,nk
-          do j=nj+1,nj+ngxy
-            s(i,j,k)=s(i,nj,k)
-          enddo
-          enddo
+             do j=nj+1,nj+ngxy
+                s(i,j,k)=s(i,nj,k)
+             end do
+          end do
         endif
 
         if(patchnen)then
           i=ni+1
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2)
           do k=1,nk
-          do j=nj+1,nj+ngxy
-            s(i,j,k)=s(i,nj,k)
-          enddo
-          enddo
+             do j=nj+1,nj+ngxy
+                s(i,j,k)=s(i,nj,k)
+             end do
+          end do
         endif
 
       endif
@@ -4490,9 +4515,5 @@
       if(timestats.ge.1) time_bcs2=time_bcs2+mytime()
 
       end subroutine bcs2_GPU
-
-
-
-
 
   END MODULE bc_module

--- a/src/bcast.F
+++ b/src/bcast.F
@@ -5,12 +5,12 @@ MODULE bcast_module
 
 interface bcast_int 
    module procedure bcast_int_scalar 
-   module procedure bcast_int_array
+   module procedure bcast_int_vector
 end interface bcast_int
 
 interface bcast_real
    module procedure bcast_real_scalar
-   module procedure bcast_real_array
+   module procedure bcast_real_vector
 end interface bcast_real
 
   CONTAINS
@@ -31,20 +31,23 @@ end interface bcast_real
       end subroutine bcast_int_scalar
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-      subroutine bcast_int_array(val,len)
+      subroutine bcast_int_vector(val,str_ind,end_ind)
 
 #ifdef MPI
       use mpi
 #endif
       integer :: ierr
-      integer,intent(in) :: len
-      integer,intent(inout) :: val(*)
+      integer,intent(in) :: str_ind,end_ind
+      integer,intent(inout) :: val(str_ind:end_ind)
+      integer :: length
+   
+      length = end_ind - str_ind + 1
 #ifdef MPI
-      call MPI_BCAST(val,len,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+      call MPI_BCAST(val,length,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 #endif
-      !$acc update device(val)
+      !$acc update device(val(str_ind:end_ind))
 
-      end subroutine bcast_int_array
+      end subroutine bcast_int_vector
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       subroutine bcast_real_scalar(val)
@@ -62,20 +65,24 @@ end interface bcast_real
       end subroutine bcast_real_scalar
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-      subroutine bcast_real_array(val,len)
+      subroutine bcast_real_vector(val,str_ind,end_ind)
 
 #ifdef MPI
       use mpi
 #endif
       integer :: ierr
-      integer,intent(in) :: len
-      real,intent(inout) :: val(*)
-#ifdef MPI
-      call MPI_BCAST(val,len,MPI_REAL,0,MPI_COMM_WORLD,ierr)
-#endif
-      !$acc update device(val)
+      integer,intent(in) :: str_ind,end_ind
+      real,intent(inout) :: val(str_ind:end_ind)
+      integer :: length
 
-      end subroutine bcast_real_array
+      length = end_ind - str_ind + 1
+
+#ifdef MPI
+      call MPI_BCAST(val,length,MPI_REAL,0,MPI_COMM_WORLD,ierr)
+#endif
+      !$acc update device(val(str_ind:end_ind))
+
+      end subroutine bcast_real_vector
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -579,13 +579,11 @@
       njp1 = nj+1
       nkp1 = nk+1
       nkm1 = nk-1
-      !$acc update device(nip1,njp1,nkp1,nkm1)
-      !$acc update device(ni,nj,nk)
-      !$acc update device(nparcels,npvals)
-      !$acc update device(terrain_flag,numq)
-      !$acc update device(bbc,tbc)
-      !$acc update device(viscosity,pr_num,sc_num)
-      !$acc update device(prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pract)
+      !$acc update device(nip1,njp1,nkp1,nkm1,ni,nj,nk,nparcels, &
+      !$acc               npvals,terrain_flag,numq,bbc,tbc, &
+      !$acc               viscosity,pr_num,sc_num,prvpx,prvpy, &
+      !$acc               prvpz,prrp,prms,prtp,prx,pry,prsig,prz, &
+      !$acc               pract,nodex,nodey)
 
       nimax = ni
       njmax = nj
@@ -756,6 +754,7 @@
 !-----------------------------------------------
 #endif
 
+      !$acc update device (myi,myj)
 
       call wenocheck
 
@@ -775,6 +774,7 @@
 
       ! number of 'ghost' points in the vertical direction:
       ngz   = 1
+
       !$acc update device (ngxy,ngz)
 
 !---------------------------------------------------------------------

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -267,6 +267,7 @@
 #endif
 
       integer, dimension(:,:), allocatable :: pdata_locind  ! 2-D array to store parcel x/y/z location index
+      integer :: ios
 
 !----------------------------------------------------------------------
 
@@ -510,7 +511,7 @@
   ! determine values for nodex and nodey:
     if(myid.eq.0)then
       minval = 1.0e30
-      open(unit=10,file='proc.info',status='unknown')
+      open(unit=10,file='proc.info')
       write(10,*)
     IF( nx.eq.1 .and. ny.eq.1 )THEN
       print *
@@ -775,10 +776,7 @@
 
       ! number of 'ghost' points in the vertical direction:
       ngz   = 1
-      !print *,'cm1: copyin of (ngzy,ngz): ',ngxy,ngz 
       !$acc update device (ngxy,ngz)
-      !stop 'after call to data copyin()'
-      
 
 !---------------------------------------------------------------------
 !      For ZVD:
@@ -976,6 +974,7 @@
       rmp = 1
       cmp = 1
 #endif
+      !$acc update device (imp,jmp,kmp,kmt,rmp,cmp)
 
       allocate( reqs_u(rmp) )
       reqs_u = 0
@@ -1271,7 +1270,6 @@
                        uw31,uw32,ue31,ue32,us31,us32,un31,un32,         &
                        vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,         &
                        ww31,ww32,we31,we32,ws31,ws32,wn31,wn32)
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
 
 !----------------------------------------------------------------------
 
@@ -1461,8 +1459,6 @@
                       uw31,uw32,ue31,ue32,us31,us32,un31,un32,              &
                       vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,              &
                       sw31,sw32,se31,se32,ss31,ss32,sn31,sn32)
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
-
 
 !----------------------------------------------------------------------
 !  Now, allocate the mother lode, then call INIT3D
@@ -2191,7 +2187,6 @@
                        ws31(1,1,1),ws32(1,1,1),wn31(1,1,1),wn32(1,1,1),reqs_p)
 
       ENDIF
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
 
       allocate( hflxw(ibib:ieib,jbib:jeib,kmaxib) )
       hflxw = 0
@@ -2297,8 +2292,6 @@
                   kmh,kmv,khh,khv,tkea,tke3d,tketen,                &
                   pta,pt3d,ptten,                                   &
                   pdata,cfb,cfa,cfc,d1,d2,pdt,lgbth,lgbph,rhs,trans)
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
-
 
 !----------------------------------------------------------------------
 
@@ -2471,7 +2464,6 @@
                         emiss,thc,albd,znt,rznt,mavail,dsxy,prs0s,prs0,   &
                         tmn,tml,t0ml,hml,h0ml,huml,hvml,tmoml,z0base)
 
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
       IF(irst.eq.1)THEN
 
         startup = .false.
@@ -2512,7 +2504,6 @@
                               icenter,jcenter,xcenter,ycenter,adaptmovetim,mvrec,nwritemv,ug,vg, &
                               gamk,kmw,u1b,v1b,cmz,csz,ce1z,ce2z,                  &
                               dum1,dat1,dat2,dat3,reqt,myi1p,myi2p,myj1p,myj2p,restarted,restart_prcl)
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
           ! end_read_restart
         !  In case user wants to change values on a restart:
         IF( restart_reset_frqtim )THEN 
@@ -2602,7 +2593,6 @@
         if(dowr) write(outfile,*)
       ENDIF
 
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
       call       getset(restarted,mass1,uh,ruh,vh,rvh,xh,yh,xf,yf,         &
                         zs,gz,sigma,sigmaf,rmh,mf,dzdx,dzdy,dumk1,dumk2,   &
                         pi0,th0,rho0,prs0,ust,u1,v1,s1,u0,v0,rth0,         &
@@ -2662,7 +2652,7 @@
 
       !$acc data &
       !$acc copyin(uh,vh,mh,u3d,v3d,w3d) &
-      !$acc copyin(kmh,kmv,khh,khv,ksmax)
+      !$acc copyin(kmh,kmv,khh,khv)
       if( adapt_dt.eq.1 )then
         dt = dbldt
         if( .not. restarted )then
@@ -2698,8 +2688,6 @@
         endif
       endif
       !$acc end data
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
-
 
       ! cm1r19:  nsound is always determined diagnostically
       call dtsmall(dt,dbldt)
@@ -2782,77 +2770,59 @@
       IF( imoist.eq.1 .and. dodomaindiag .and. ptype.eq.5 ) getvt = .true.
       IF( imoist.eq.1 .and. dodomaindiag .and. testcase.eq.5 ) getvt = .true.
 
-    !$acc data &
-    !$acc copyin(thten,sten,ksmax) &
-    !$acc copyin(rho0,thv0,th0,qv0) &
-    !$acc copyin(prs0,rth0,qc0) &
-    !$acc copyin(xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf, &
-    !$acc   yh,vh,rvh,yf,vf,rvf,rds,sigma,rdsf,sigmaf,zh,mh,rmh,zf,mf,rmf, &
-    !$acc   zs,gz,rgz,gzu,rgzu,gzv,rgzv,dzdx,dzdy,gx,gxu,gy,gyv) &
-    !$acc copyin(c1,c2,wprof,f2d,m11,m12,m13,m22,m23,m33,kmw,u1b,v1b, &
-    !$acc   tauh,tauf,taus,bndy,kbdy,phi1,pt3d,rdx,rdy,rzt,zt, &
-    !$acc   cgs1, cgs2, cgs3, cgt1, cgt2, cgt3, xland) &
-    !$acc copyin(avgsfcu,avgsfcv,avgsfcs,avgsfct) &
-    !$acc copyin(p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2) &
-    !$acc copyin(pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2) &
-    !$acc copyin(uw31,uw32,ue31,ue32,us31,us32,un31,un32) &
-    !$acc copyin(zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2) &
-    !$acc copyin(tw1,tw2,te1,te2,ts1,ts2,tn1,tn2) &
-    !$acc copyin(tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2) &
-    !$acc copyin(ww1,ww2,we1,we2,ws1,ws2,wn1,wn2) &
-    !$acc copyin(vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2) &
-    !$acc copyin(vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32) &
-    !$acc copyin(ww31,ww32,we31,we32,ws31,ws32,wn31,wn32) &
-    !$acc copyin(qw31,qw32,qe31,qe32,qs31,qs32,qn31,qn32) &
-    !$acc copyin(sw31,sw32,se31,se32,ss31,ss32,sn31,sn32) &
-    !$acc copyin(rw31,rw32,re31,re32,rs31,rs32,rn31,rn32) &
-    !$acc copyin(p3w1,p3w2,p3e1,p3e2,p3s1,p3s2,p3n1,p3n2) &
-    !$acc copyin( &
-    !$acc   n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2, &
-    !$acc   nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,                  &
-    !$acc   n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,          &
-    !$acc   kw1,kw2,ke1,ke2,ks1,ks2,kn1,kn2)                  &
-    !$acc copyin(taux,tauy,gamwall,l2p,t2pm1,t2pm2,t2pm3,t2pm4) &
-    !$acc copyin(udiag,vdiag,wdiag,kdiag,tdiag,qdiag) &
-    !$acc copyin(dum1,dum2,dum3,dum4,dum5,dum6,dum7,dum8,dum9) &
-    !$acc copyin(dum2d1,dum2d2,dum2d3,dum2d4,dum2d5) & ! does not appear to be used
-    !$acc copyin(defv,defh,lenscl,dissten, &
-    !$acc      epst,epsd1,epsd2,thpten,upten,vpten,psfc,u10,v10,s10,hpbl, &
-    !$acc      wspd,gz1oz0,br,brcr,phim,phih,swspd,cpmm,zol,mavail,mol,rmol,dsxy,cda,psim,psih, &
-    !$acc      psiq,fm,fh,th2,q2,t2,gamk,cmz,csz,ce1z,ce2z) &
-    !$acc copyin(stau,ustt,ut,vt,st,cd,ch,cq,tlh,u1,v1,s1,t1) &
-    !$acc copyin(znt,zntmp,ust,hfx,qfx,qsfc,tsk,tmn,tslb) &
-    !$acc copyin(sws,svs,sps,srs,sgs,sus,shs) &
-    !$acc copyin(bud2,ufrc,vfrc,thfrc,qvfrc,t11,t12,t13,t22,t23,t33, &
-    !$acc      thflux,qvflux,radbcw,radbce,radbcs,radbcn,dtu,dtv,dumk1,dumk2,divx, &
-    !$acc      nm,dissten,epst,pta,pt3d,ptten,u2pt,v2pt,qke_adv,qke,qke3d) &
-    !$acc copyin(chklowq,flqc,ch_out,cd_out) &
-    !$acc copyin(pdata,dpten) &
-    !$acc copyin(zkmax,CHS,CHS2,CQS2,flhc,lh,QGH,smois,charn,msang,scurx,scury,s2p,s2b) &
-    !$acc copyin(lu_index) &
-    !$acc copyin(qi0,rr0,rf0,rrf0,dtu0,dtv0,u0,v0) &
-    !$acc copyin(rho,rr,rf,prs,o30,zir)  &
-    !$acc copyin(flag) &
-    !$acc copyin(pi0) &
-    !$acc copyin(ug,vg) &
-    !$acc copyin(tke_myj,xkzh,xkzq,xkzm) &
-    !$acc copyin(xfref,xhref,yfref,yhref,dvdr) &
-    !$acc copyin(qpten,qtten,qvten,qcten,qa,q3d,qten,kmh,kmv,khh,khv,tkea,tke3d,tketen) &
-    !$acc copyin(effc,effi,effs,effr,effg,effis,out2d,out3d) &  ! physics only 
-    !$acc copyin(rain,prate,p3a,p3o) & ! physics only
-    !$acc copyin(qbudget,asq,bsq) &
-    !$acc copyin(qavg,cavg,cloudvar,rho0s,pi0s,prs0s,rth0s,tst,qst,z0t,z0q,mznt) &
-    !$acc copyin(ppi,pp3d,ppten,sadv,ppx,tha) &
-    !$acc copyin(thten1,thterm) &
-    !$acc copyin(glw,gsw) &
-    !$acc copyin(ulspg,vlspg) &
-    !$acc copyin(savg,pavg,uavg,vavg,thavg) &
-    !$acc copyin(lsnudge_u, lsnudge_v) &
-    !$acc copyin(dt) &
-    !$acc copyin(reqs_s,reqs_u,reqs_p3, &
-    !$acc   reqs_v,reqs_w,reqs_x,reqs_y,reqs_s,reqs_p2,reqs_z) &
-    !$acc copyin(rru,ua,u3d,uten,uten1,rrv,va,v3d,th3d,phi2,vten,vten1,rrw,wa,w3d,wten,wten1) &
-    !$acc copy(pdata_locind)
+!$acc data copyin (thten,sten,rho0,thv0,th0,qv0,prs0,rth0,qc0, &
+!$acc              xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf, &
+!$acc              ruf,yh,vh,rvh,yf,vf,rvf,rds,sigma,rdsf,sigmaf, &
+!$acc              zh,mh,rmh,zf,mf,rmf,zs,gz,rgz,gzu,rgzu,gzv, &
+!$acc              rgzv,dzdx,dzdy,gx,gxu,gy,gyv,c1,c2,wprof,f2d, &
+!$acc              m11,m12,m13,m22,m23,m33,kmw,u1b,v1b,tauh,tauf, &
+!$acc              taus,bndy,kbdy,phi1,pt3d,xland,p2w1,p2w2,p2e1, &
+!$acc              p2e2,p2s1,p2s2,p2n1,p2n2,pw1,pw2,pe1,pe2,ps1, &
+!$acc              ps2,pn1,pn2,uw31,uw32,ue31,ue32,us31,us32,un31, &
+!$acc              un32,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,tw1,tw2, &
+!$acc              te1,te2,ts1,ts2,tn1,tn2,tkw1,tkw2,tke1,tke2, &
+!$acc              tks1,tks2,tkn1,tkn2,ww1,ww2,we1,we2,ws1,ws2, &
+!$acc              wn1,wn2,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2, &
+!$acc              vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32, &
+!$acc              ww31,ww32,we31,we32,ws31,ws32,wn31,wn32, &
+!$acc              qw31,qw32,qe31,qe32,qs31,qs32,qn31,qn32, &
+!$acc              sw31,sw32,se31,se32,ss31,ss32,sn31,sn32, &
+!$acc              rw31,rw32,re31,re32,rs31,rs32,rn31,rn32, &
+!$acc              p3w1,p3w2,p3e1,p3e2,p3s1,p3s2,p3n1,p3n2, &
+!$acc              n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2, &
+!$acc              nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,kw1,kw2, &
+!$acc              ke1,ke2,ks1,ks2,kn1,kn2,taux,tauy,gamwall, &
+!$acc              l2p,t2pm1,t2pm2,t2pm3,t2pm4,udiag,vdiag, &
+!$acc              wdiag,kdiag,tdiag,qdiag,dum1,dum2,dum3,dum4, &
+!$acc              dum5,dum6,dum7,dum8,dum9,defv,defh,lenscl, &
+!$acc              dissten,epst,epsd1,epsd2,thpten,upten,vpten, &
+!$acc              psfc,u10,v10,s10,hpbl,wspd,gz1oz0,br,brcr, &
+!$acc              phim,phih,swspd,cpmm,zol,mavail,mol,rmol, &
+!$acc              dsxy,cda,psim,psih,psiq,fm,fh,th2,q2,t2, &
+!$acc              gamk,cmz,csz,ce1z,ce2z,stau,ustt,ut,vt,st, &
+!$acc              cd,ch,cq,tlh,u1,v1,s1,t1,znt,zntmp,ust,hfx, &
+!$acc              qfx,qsfc,tsk,tmn,tslb,sws,svs,sps,srs,sgs, &
+!$acc              sus,shs,bud2,ufrc,vfrc,thfrc,qvfrc,t11,t12, &
+!$acc              t13,t22,t23,t33,thflux,qvflux,radbcw,radbce, &
+!$acc              radbcs,radbcn,dtu,dtv,dumk1,dumk2,divx,nm, &
+!$acc              dissten,epst,pta,pt3d,ptten,u2pt,v2pt,qke_adv, &
+!$acc              qke,qke3d,chklowq,flqc,ch_out,cd_out,pdata, &
+!$acc              dpten,zkmax,CHS,CHS2,CQS2,QGH,smois,charn, &
+!$acc              msang, scurx,scury,s2p,s2b,lu_index,qi0,rr0, &
+!$acc              rf0,rrf0,dtu0,dtv0,u0,v0,rho,rr,rf,prs,o30, &
+!$acc              zir,flag,pi0,ug,vg,tke_myj,xkzh,xkzq,xkzm, &
+!$acc              xfref,xhref,yfref,yhref,dvdr,qpten,qtten, &
+!$acc              qvten,qcten,qa,q3d,qten,kmh,kmv,khh,khv,tkea, &
+!$acc              tke3d,tketen,effc,effi,effs,effr,effg,effis, &
+!$acc              out2d,out3d,rain,prate,p3a,p3o,qbudget,asq, &
+!$acc              bsq,qavg,cavg,cloudvar,rho0s,pi0s,prs0s,rth0s, &
+!$acc              tst,qst,z0t,z0q,mznt,ppi,pp3d,ppten,sadv,ppx, &
+!$acc              tha,thten1,thterm,glw,gsw,ulspg,vlspg,savg,pavg, &
+!$acc              uavg,vavg,thavg,lsnudge_u,lsnudge_v,reqs_s, &
+!$acc              reqs_u,reqs_p3,reqs_v,reqs_w,reqs_x,reqs_y, &
+!$acc              reqs_p2,reqs_z,rru,ua,u3d,uten,uten1,rrv,va,v3d, &
+!$acc              th3d,phi2,vten,vten1,rrw,wa,w3d,wten,wten1,pdata_locind, &
+!$acc              dum2d1,dum2d2,dum2d3,dum2d4,dum2d5)    ! JMD: does not appear to be used
 
     if(timestats.ge.1) time_H2D=time_H2D+mytime()
 
@@ -3003,8 +2973,6 @@
 
         if(timestats.ge.1) time_misc=time_misc+mytime()
 
-
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
 #ifdef _NVTX
         call nvtxStartRange("solve1 ",id=0)
 #endif
@@ -3182,7 +3150,6 @@
 #ifdef _NVTX
         call nvtxEndRange
 #endif
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
       !print *,'cm1: after call to solve2'
       !$acc compare(dum1)
 
@@ -3215,7 +3182,6 @@
 #endif
 
       ENDIF
-      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
 !$acc compare(qbudget)
 
 

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -581,9 +581,9 @@
       nkm1 = nk-1
       !$acc update device(nip1,njp1,nkp1,nkm1,ni,nj,nk,nparcels, &
       !$acc               npvals,terrain_flag,numq,bbc,tbc, &
-      !$acc               viscosity,pr_num,sc_num,prvpx,prvpy, &
-      !$acc               prvpz,prrp,prms,prtp,prx,pry,prsig,prz, &
-      !$acc               pract,nodex,nodey)
+      !$acc               pr_num,sc_num,prvpx,prvpy,prvpz,prrp, &
+      !$acc               prms,prtp,prx,pry,prsig,prz,pract, &
+      !$acc               nodex,nodey)
 
       nimax = ni
       njmax = nj

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -267,7 +267,6 @@
 #endif
 
       integer, dimension(:,:), allocatable :: pdata_locind  ! 2-D array to store parcel x/y/z location index
-      integer :: ios
 
 !----------------------------------------------------------------------
 
@@ -511,7 +510,7 @@
   ! determine values for nodex and nodey:
     if(myid.eq.0)then
       minval = 1.0e30
-      open(unit=10,file='proc.info')
+      open(unit=10,file='proc.info',status='unknown')
       write(10,*)
     IF( nx.eq.1 .and. ny.eq.1 )THEN
       print *
@@ -584,7 +583,7 @@
       !$acc update device(ni,nj,nk)
       !$acc update device(nparcels,npvals)
       !$acc update device(terrain_flag,numq)
-      !$acc update device(zt,rzt,bbc,tbc)
+      !$acc update device(bbc,tbc)
       !$acc update device(viscosity,pr_num,sc_num)
       !$acc update device(prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pract)
 

--- a/src/comm.F
+++ b/src/comm.F
@@ -13936,8 +13936,9 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
       integer, intent(in) :: comm
       logical, parameter :: Debug = .FALSE.
       integer :: i,j
-      !$acc declare present(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32) &
-      !$acc         present(n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2)
+      !$acc data present (s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32, &
+      !$acc               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2, &
+      !$acc               reqs_s)
 
 if(Debug) print *, "prepcorners3_GPU: Im called"
 
@@ -13972,7 +13973,9 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       ENDIF
-      !!$acc update device(s)
+
+      !$acc end data
+
       end subroutine prepcorners3_GPU
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/constants.F
+++ b/src/constants.F
@@ -8,10 +8,12 @@
             cpdcv,rovcp,rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1,       &
             cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi,lv1,lv2,ls1,ls2,  &
             rhow,c_e1,c_e2,c_s,rcs,earth_radius,govtwo,mw,ms,surften,ion,os,ru
-!$acc declare create(g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp) &
-!$acc create(cpdcv,rovcp,rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1) &
-!$acc create(cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi,lv1,lv2,ls1,ls2) &
-!$acc create(rhow,c_e1,c_e2,c_s,rcs,earth_radius,govtwo,surften,mw,ms,ion,os,ru)
+
+!$acc declare create(g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp,cpdcv,rovcp, &
+!$acc                rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1, &
+!$acc                cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi, &
+!$acc                lv1,lv2,ls1,ls2,rhow,c_e1,c_e2,c_s,rcs,govtwo, &
+!$acc                earth_radius,govtwo,surften,mw,ms,ion,os,ru)
 
       !----------------
 
@@ -177,11 +179,11 @@
       c_s = ( c_m * c_m * c_m / ( c_e1 + c_e2 ) )**0.25   ! Smagorinsky constant
       rcs = 1.0/c_s
 
-!$acc update device(g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp) &
-!$acc device(cpdcv,rovcp,rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1) &
-!$acc device(cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi,lv1,lv2,ls1,ls2) &
-!$acc device(rhow,c_e1,c_e2,c_s,rcs,earth_radius,govtwo,surften,ms,mw,ion,os,ru)
-
+!$acc update device(g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp,cpdcv,rovcp, &
+!$acc               rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1, &
+!$acc               cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi, &
+!$acc               lv1,lv2,ls1,ls2,rhow,c_e1,c_e2,c_s,rcs,govtwo, &
+!$acc               earth_radius,govtwo,surften,ms,mw,ion,os,ru)
 
       end subroutine set_constants
 

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -1139,16 +1139,15 @@
     ziflag:  &
     IF( ( testcase.ge.1 .and. testcase.le.7 ) .or. testcase.eq.9 .or. testcase.eq.10 .or. testcase.eq.11 )THEN
 
-        !$acc parallel private(i,j,k,zi,tmax,dtdz) &
-        !$acc   reduction(min:zimin) &
-        !$acc   reduction(max:zimax)
         zimin =  1.0e30
         zimax = -1.0e30
-        !$acc loop vector collapse(2)
+        !$acc parallel default(present) reduction(min:zimin) reduction(max:zimax)
+        !$acc loop gang vector collapse(2)
         do j=1,nj
         do i=1,ni
           zi = 0.0
           tmax = 0.0
+          !$acc loop seq
           do k=nk,2,-1
             dtdz = (thv(i,j,k)-thv(i,j,k-1))*rdz*mf(i,j,k)
             if( dtdz .ge. tmax )then
@@ -1161,8 +1160,6 @@
           zimin = min( zimin , zi )
         enddo
         enddo
-!!!        print *,'zimin: ',zimin
-!!!        print *,'zimax: ',zimax
         !$acc end parallel
 
 #ifdef MPI

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -1609,68 +1609,81 @@
       !$acc update device(qcrit)
 #endif
 
-      !$acc parallel default(present) private(i,j,k)
-      do k=nk,1,-1
         ! use minimum of 1.0e-5 and 1% of saturation wrt liquid (using last known t,p)
         !qcrit(k) = min( 1.0e-5 , 0.01*rslf(pavg(k),thavg(k)*((pavg(k)*rp00)**rovcp)) )
         if( nqc.ge.1 )then
-          !$acc loop gang vector collapse(2)
-          do j=1,nj
-          do i=1,ni
-            if( q3d(i,j,k,nqc).ge.qcrit(k) ) dum1(i,j,1) = zh(i,j,k)
-          enddo
-          enddo
+          !$acc parallel default(present)
+          !$acc loop gang vector collapse(3)
+          do k=nk,1,-1
+             do j=1,nj
+                do i=1,ni
+                   if( q3d(i,j,k,nqc).ge.qcrit(k) ) dum1(i,j,1) = zh(i,j,k)
+                end do
+             end do
+          end do
+          !$acc end parallel
         endif
         if( nqr.ge.1 )then
-          !$acc loop gang vector collapse(2)
-          do j=1,nj
-          do i=1,ni
-            if( q3d(i,j,k,nqr).ge.qcrit(k) ) dum1(i,j,2) = zh(i,j,k)
-          enddo
-          enddo
+          !$acc parallel default(present)
+          !$acc loop gang vector collapse(3)
+          do k=nk,1,-1
+             do j=1,nj
+                do i=1,ni
+                   if( q3d(i,j,k,nqr).ge.qcrit(k) ) dum1(i,j,2) = zh(i,j,k)
+                end do
+             end do
+          end do
+          !$acc end parallel
         endif
-        !$acc loop gang vector collapse(2)
-        do j=1,nj
-        do i=1,ni
-          if( ql(i,j,k).ge.qcrit(k) ) dum1(i,j,3) = zh(i,j,k)
-        enddo
-        enddo
+        !$acc parallel default(present)
+        !$acc loop gang vector collapse(3)
+        do k=nk,1,-1
+           do j=1,nj
+              do i=1,ni
+                 if( ql(i,j,k).ge.qcrit(k) ) dum1(i,j,3) = zh(i,j,k)
+              end do
+           end do
+        end do
+        !$acc end parallel
         if( iice.eq.1 )then
-        !$acc loop gang vector collapse(2)
-        do j=1,nj
-        do i=1,ni
-          if( qice(i,j,k).ge.qcrit(k) ) dum1(i,j,4) = zh(i,j,k)
-        enddo
-        enddo
+        !$acc parallel default(present)
+        !$acc loop gang vector collapse(3)
+        do k=nk,1,-1
+           do j=1,nj
+              do i=1,ni
+                 if( qice(i,j,k).ge.qcrit(k) ) dum1(i,j,4) = zh(i,j,k)
+              end do
+           end do
+        end do
+        !$acc end parallel
         endif
-        !$acc loop gang vector collapse(2)
-        do j=1,nj
-        do i=1,ni
-          if( (ql(i,j,k)+qice(i,j,k)).ge.qcrit(k) ) dum1(i,j,5) = zh(i,j,k)
-        enddo
-        enddo
-      enddo
-      !$acc end parallel
+        !$acc parallel default(present)
+        !$acc loop gang vector collapse(3)
+        do k=nk,1,-1
+           do j=1,nj
+              do i=1,ni
+                 if( (ql(i,j,k)+qice(i,j,k)).ge.qcrit(k) ) dum1(i,j,5) = zh(i,j,k)
+              end do
+           end do
+        end do
+        !$acc end parallel
 
-      !$acc parallel default(present) private(i,j) &
-      !$acc   reduction(+:qcfrac,qrfrac,qlfrac,qifrac,qtfrac)
       qcfrac = 0.0
       qrfrac = 0.0
       qlfrac = 0.0
       qifrac = 0.0
       qtfrac = 0.0
-
-      !$acc loop gang vector collapse(2) &
-      !$acc   reduction(+:qcfrac,qrfrac,qlfrac,qifrac,qtfrac)
+      !$acc parallel default(present) reduction(+:qcfrac,qrfrac,qlfrac,qifrac,qtfrac)
+      !$acc loop gang vector collapse(2) reduction(+:qcfrac,qrfrac,qlfrac,qifrac,qtfrac)
       do j=1,nj
-      do i=1,ni
-        if( dum1(i,j,1).gt.0.01*zh(1,1,1) ) qcfrac = qcfrac+1.0
-        if( dum1(i,j,2).gt.0.01*zh(1,1,1) ) qrfrac = qrfrac+1.0
-        if( dum1(i,j,3).gt.0.01*zh(1,1,1) ) qlfrac = qlfrac+1.0
-        if( dum1(i,j,4).gt.0.01*zh(1,1,1) ) qifrac = qifrac+1.0
-        if( dum1(i,j,5).gt.0.01*zh(1,1,1) ) qtfrac = qtfrac+1.0
-      enddo
-      enddo
+         do i=1,ni
+            if( dum1(i,j,1).gt.0.01*zh(1,1,1) ) qcfrac = qcfrac+1.0
+            if( dum1(i,j,2).gt.0.01*zh(1,1,1) ) qrfrac = qrfrac+1.0
+            if( dum1(i,j,3).gt.0.01*zh(1,1,1) ) qlfrac = qlfrac+1.0
+            if( dum1(i,j,4).gt.0.01*zh(1,1,1) ) qifrac = qifrac+1.0
+            if( dum1(i,j,5).gt.0.01*zh(1,1,1) ) qtfrac = qtfrac+1.0
+         end do
+      end do
       !$acc end parallel
 
 #ifdef MPI

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -1182,8 +1182,6 @@
 
       !c-c-c-c-c-c-c-c-c-c
 
-      !JMD need to verify that zimin is still incorrect
-      !JMD-BUG:  for some reason zimin is still not set properly 
       nvar = nvar+1
       varname(nvar) = 'zimin'
       vardesc(nvar) = 'minimum value of zi'

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -102,7 +102,7 @@
       integer :: tmp_flag
 #endif
 
-      !$acc declare present(rho,prs,qa,wa,sigma)
+!!!!      !$acc declare present(rho,prs,qa,wa,sigma)
 
       !integer :: nip1
 
@@ -115,40 +115,54 @@
 
       !$acc data create(ta)
 
-!$omp parallel do default(shared) private(i,j)
-!$acc parallel loop gang vector default(present) private(i,j)
-  DO j=jb,je+1
-
     IF(bbc.eq.1)THEN
       ! free slip ... extrapolate:
-      IF(j.le.je)THEN
-      do i=ib,ie+1
-        ua(i,j,0) = cgs1*ua(i,j,1)+cgs2*ua(i,j,2)+cgs3*ua(i,j,3)
-      enddo
-      ENDIF
-      do i=ib,ie
-        va(i,j,0) = cgs1*va(i,j,1)+cgs2*va(i,j,2)+cgs3*va(i,j,3)
-      enddo
+      !$acc parallel loop gang vector collapse(2) default(present)
+      do j=jb,je
+         do i=ib,ie+1
+            ua(i,j,0) = cgs1*ua(i,j,1)+cgs2*ua(i,j,2)+cgs3*ua(i,j,3)
+         end do
+      end do
+      !$acc end parallel
+      !$acc parallel loop gang vector collapse(2) default(present)
+      do j=jb,je+1
+         do i=ib,ie
+            va(i,j,0) = cgs1*va(i,j,1)+cgs2*va(i,j,2)+cgs3*va(i,j,3)
+         end do
+      end do
+      !$acc end parallel
     ELSEIF(bbc.eq.2)THEN
       ! no slip:
       if( imove.eq.1 )then
-        IF(j.le.je)THEN
-        do i=ib,ie+1
-          ua(i,j,0) = 0.0 - umove
-        enddo
-        ENDIF
-        do i=ib,ie
-          va(i,j,0) = 0.0 - vmove
-        enddo
+        !$acc parallel loop gang vector collapse(2) default(present)
+        do j=jb,je
+           do i=ib,ie+1
+              ua(i,j,0) = 0.0 - umove
+           end do
+        end do
+        !$acc end parallel
+        !$acc parallel loop gang vector collapse(2) default(present)
+        do j=jb,je+1
+           do i=ib,ie
+              va(i,j,0) = 0.0 - vmove
+           end do
+        end do
+        !$acc end parallel
       else
-        IF(j.le.je)THEN
-        do i=ib,ie+1
-          ua(i,j,0) = 0.0
-        enddo
-        ENDIF
-        do i=ib,ie
-          va(i,j,0) = 0.0
-        enddo
+        !$acc parallel loop gang vector collapse(2) default(present)
+        do j=jb,je
+           do i=ib,ie+1
+              ua(i,j,0) = 0.0
+           end do
+        end do
+        !$acc end parallel
+        !$acc parallel loop gang vector collapse(2) default(present)
+        do j=jb,je+1
+           do i=ib,ie
+              va(i,j,0) = 0.0
+           end do
+        end do
+        !$acc end parallel
       endif
     ELSEIF(bbc.eq.3)THEN
       ! u,v near sfc are determined below using log-layer equations
@@ -158,37 +172,47 @@
 
     IF(tbc.eq.1)THEN
       ! free slip ... extrapolate:
-      IF(j.le.je)THEN
-      do i=ib,ie+1
-        ua(i,j,nk+1) = cgt1*ua(i,j,nk)+cgt2*ua(i,j,nk-1)+cgt3*ua(i,j,nk-2)
-      enddo
-      ENDIF
-      do i=ib,ie
-        va(i,j,nk+1) = cgt1*va(i,j,nk)+cgt2*va(i,j,nk-1)+cgt3*va(i,j,nk-2)
-      enddo
+      !$acc parallel loop gang vector collapse(2) default(present)
+      do j=jb,je
+         do i=ib,ie+1
+            ua(i,j,nk+1) = cgt1*ua(i,j,nk)+cgt2*ua(i,j,nk-1)+cgt3*ua(i,j,nk-2)
+         end do
+      end do
+      !$acc end parallel
+      !$acc parallel loop gang vector collapse(2) default(present)
+      do j=jb,je+1
+         do i=ib,ie
+            va(i,j,nk+1) = cgt1*va(i,j,nk)+cgt2*va(i,j,nk-1)+cgt3*va(i,j,nk-2)
+         end do
+      end do
+      !$acc end parallel
     ELSEIF(tbc.eq.2)THEN
       ! no slip:
-      IF(j.le.je)THEN
-      do i=ib,ie+1
-        ua(i,j,nk+1) = 0.0
-      enddo
-      ENDIF
-      do i=ib,ie
-        va(i,j,nk+1) = 0.0
-      enddo
+      !$acc parallel loop gang vector collapse(2) default(present)
+      do j=jb,je
+         do i=ib,ie+1
+            ua(i,j,nk+1) = 0.0
+         end do
+      end do
+      !$acc end parallel
+      !$acc parallel loop gang vector collapse(2) default(present)
+      do j=jb,je+1
+         do i=ib,ie
+            va(i,j,nk+1) = 0.0
+         end do
+      end do
+      !$acc end parallel
     ENDIF
 
 !----------
 
-      IF(j.le.je)THEN
-      do i=ib,ie
-        wa(i,j,nk+1) = 0.0
-      enddo
-      ENDIF
-
-    !NEED SCALARS
-
-  ENDDO
+    !$acc parallel loop gang vector collapse(2) default(present)
+    do j=jb,je
+       do i=ib,ie
+          wa(i,j,nk+1) = 0.0
+       end do
+    end do
+    !$acc end parallel
 
   !Compute temperature for interpolation
 
@@ -341,8 +365,8 @@
       dmvdt    = rhow*4.0/3.0*pi*pdata(np,prrp)**3
 
 
-      !idropmethod = 0 !RK2 for droplet time integration
-      idropmethod = 1 !Implicit backward Euler for droplet time integration
+      idropmethod = 0 !RK2 for droplet time integration
+      !idropmethod = 1 !Implicit backward Euler for droplet time integration
 
       dropmethod: IF ( idropmethod .eq. 0) THEN !RK2 for droplet time integration
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -102,12 +102,8 @@
       integer :: tmp_flag
 #endif
 
-!!!!      !$acc declare present(rho,prs,qa,wa,sigma)
-
-      !integer :: nip1
-
       call reinit_random_seed
-      !print *,'droplet_driver: point #1'
+
 !----------------------------------------------------------------------
 !  apply bottom/top boundary conditions:
 !  [Note:  for u,v the array index (i,j,0) means the surface, ie z=0]
@@ -231,8 +227,6 @@
   enddo
   !$acc end parallel
 
-  !!$acc compare(qa,ta,pi0,th_in,th0,ppa)
-  !stop 'droplet_driver: after first compare'
   ! GHB 210714:
     call prepcorners3_GPU( ta,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,1)
@@ -242,12 +236,6 @@
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,1)
     call prepcorners3_GPU(qa(ib,jb,kb,nqv),sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,1)
-    !$acc compare(rho)
-    !!$acc compare(qa,ta,pi0,th_in,th0,ppa)
-    !!$acc compare(sigma)
-!  print *, 'droplet_driver: after call to prepcorners'
-
-
 
 !----------------------------------------------------------------------
 !  Loop through all parcels:  if you have it, update it's properties
@@ -266,14 +254,8 @@
     !$acc host(pdata,xf,yf,zf,zh,sigma,sigmaf, &
     !$acc      ua,va,wa,qa,ta,rho,prs,znt,qten,thten,zs)
 #else
-    !$acc compare(pdata)
     !JMD WARNING: Loop does not yet match CPU version.
-    !$acc parallel &
-    !$acc default(present) &
-    !$acc private(i,j,k,x3d,y3d,z3d,sig3d,iflag,jflag,kflag,nrkp,rhoval, &
-    !$acc         rhop0,taup0,Nup,dvpdt1,dvpdt2,dvpdt3,drpdt,dtpdt,dmvdt, &
-    !$acc         dV,ix,iy,iz,xv,yv,zv,wtx,wty,wtz,wtt,esl,part_grav1, &
-    !$acc         part_grav2,part_grav3,rp0)
+    !$acc parallel default(present)
     !$acc loop gang vector 
 #endif
     nploop:  &
@@ -295,7 +277,6 @@
   haveit1:  &
   IF( x3d.ge.xf(1) .and. x3d.le.xf(ni+1) .and.  &
       y3d.ge.yf(1) .and. y3d.le.yf(nj+1) )THEN
-
     IF(nx.eq.1)THEN
       iflag = 1
     ELSE
@@ -309,7 +290,6 @@
       ! cm1r19:
       call find_horizontal_location_index (pdata_locind(np,2), y3d, jb, je+1, yf, nj+1, jflag)  
     ENDIF
-
   ELSE     ! re-initialize x/y/z location index array if a parcel is not on this process
     pdata_locind(np,1) = undefined_index
     pdata_locind(np,2) = undefined_index
@@ -364,9 +344,8 @@
       drpdt    = pdata(np,prrp)
       dmvdt    = rhow*4.0/3.0*pi*pdata(np,prrp)**3
 
-
-      idropmethod = 0 !RK2 for droplet time integration
-      !idropmethod = 1 !Implicit backward Euler for droplet time integration
+      !idropmethod = 0 !RK2 for droplet time integration
+      idropmethod = 1 !Implicit backward Euler for droplet time integration
 
       dropmethod: IF ( idropmethod .eq. 0) THEN !RK2 for droplet time integration
 
@@ -376,16 +355,13 @@
 
       call BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000)
 
-
       ENDIF dropmethod
 
 
       ENDIF dropalive1
       
-
     dropalive2:  &
     IF (pdata(np,pract).gt.0.0) THEN
-
 
 !-----------------------------------------------------
 !  Now perform the two-way coupling based on the changes in droplet momentum,
@@ -484,18 +460,17 @@
 
       dmvdt = (rhow*4.0/3.0*pi*pdata(np,prrp)**3-dmvdt)/dt
 
-
       !Volume where the droplet finds itself
       dV = (xh(iflag+1)-xh(iflag))*   &
            (yh(jflag+1)-yh(jflag))*   &
            (zh(iflag,jflag,kflag+1)-zh(iflag,jflag,kflag))
 
       !Loop over all nodes surrounding droplet
-      !!$acc loop seq
+      !$acc loop seq
       do i=0,1
-      !!$acc loop seq
+      !$acc loop seq
       do j=0,1
-      !!$acc loop seq
+      !$acc loop seq
       do k=0,1
 
         ix = iflag+i
@@ -529,7 +504,6 @@
       enddo
 
     ENDIF dropalive2
-
 
 !-----------------------------------------------------
 !  Account for boundary conditions (if necessary)
@@ -572,6 +546,7 @@
       ELSE
 
         ! set to really small number (so we can use the allreduce command below)
+
         pdata(np,prx) = -1.0e30
         pdata(np,pry) = -1.0e30
         if( .not. terrain_flag )then
@@ -587,12 +562,12 @@
         pdata(np,prms) = -1.0e30
         pdata(np,prmult) = -1.0e30
         pdata(np,pract) = -1.0e30
+
 #endif
 
       ENDIF  myparcel
 
     ENDDO  nploop
-    !print *,'droplet_driver: after the nploop'
 #ifdef _B4B01F
     !$acc update device(pdata,qten,thten)
 #else
@@ -602,9 +577,7 @@
 !----------------------------------------------------------------------
 !  communicate data  (for MPI runs)
 
-     !$acc compare(pdata)
 #ifdef MPI
-      !print *,'droplet_driver: before call to MPI_ALLREDUCE'
       !$acc update host(pdata)
       !!$acc host_data use_device(pdata)
       if( .not. terrain_flag )then
@@ -617,10 +590,7 @@
         call MPI_ALLREDUCE(MPI_IN_PLACE,pdata,npvars*nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
       endif
       !$acc update device(pdata)
-      !$acc compare(pdata)
-      !stop 'droplet_driver: after call to MPI_ALLREDUCE'
       if(timestats.ge.1) time_droplet_reduce=time_droplet_reduce+mytime()
-     
 #endif
 
 
@@ -704,48 +674,20 @@
       !Unique to rk2_integration
       integer :: nrkp
 
-
       dt2 = dt/2.0      
 
       !HERE print *,'before rkloop np: ',np
       !$acc loop seq
       rkloop:  DO nrkp = 1,2
 
-
        call interpolate_to_parcel(np,nrkp,pdata_locind,iflag,jflag,kflag,x3d,y3d,z3d,sig3d,uval,vval,wval,tval,qval,rhoval,prsval,xh,xf,yh,yf,zh,zf,zs,znt,sigma,sigmaf,ua,va,wa,ta,qa,rho,prs,sigdot)
 
-       !qval = 0.008807098199749
-       !tval = 282.3
-       !uval = 0.0
-       !vval = 0.0
-       !wval = 0.0
-
-      if(np==TROUBLE) then 
-        print *,'before eslf: tval: ',tval 
-      endif
       estar = eslf(prsval,tval)  !Saturation vapor pressure based on interpolated temp,pressure
       lhv=lv1-lv2*tval
-
 
 !-----------------------------------------------------
 !  Update droplet position, velocity, etc.
 !-----------------------------------------------------
-      if(np==TROUBLE) then 
-        !print *,'before: pdata(np,prrp): ',pdata(np,prrp)
-        !print *,'before: pdata(np,prms): ',pdata(np,prms)
-        !print *,'before: pdata(np,prtp): ',pdata(np,prtp)
-        print *,'after eslf: tval: ',tval 
-        !print *,'prsval: ',prsval
-        !print *,'lv1: ',lv1
-        !print *,'lv2: ',lv2
-        !print *,'ru: ',ru
-        !print *,'ms: ',ms
-        !print *,'mw: ',mw
-        !print *,'ion: ',ion
-        !print *,'os: ',os
-        !print *,'surften: ',surften
-      endif
-
 
       ! RK2 scheme:
       IF(nrkp.eq.1)THEN
@@ -1002,7 +944,6 @@
       use misclibs
       use parcel_module
       use cm1libs , only : eslf
-      use ieee_arithmetic
 
       implicit none
 
@@ -1064,9 +1005,7 @@
        !vval = 0.0
        !wval = 0.0
 
-      estar = eslf(prsval,tval)  !Saturation humidity based on interpolated temp,pressure
-
-
+       estar = eslf(prsval,tval)  !Saturation humidity based on interpolated temp,pressure
 
 !-----------------------------------------------------
 !  Update droplet position, velocity, etc.
@@ -1130,34 +1069,27 @@
          rt_start(2) = 1.0
       end if
 
-
       call gauss_newton_2d(diffnorm,dt_nondim,taup_scale,rt_start,rt_zeros,flag,prsval,rhoval,tval,qval,pdata(np,prtp),pdata(np,prms),pdata(np,prrp),np)
-
 
       if (flag==1) then
          num100 = num100+1
-
-
          call LV_solver(diffnorm,dt_nondim,taup_scale,rt_start,rt_zeros,flag,prsval,rhoval,tval,qval,pdata(np,prtp),pdata(np,prms),pdata(np,prrp),np)
-
       end if
 
       if (flag==1) num1000 = num1000+1
 
       !In rare cases the nonlinear solvers fail to converge
-      if (ieee_is_nan(rt_zeros(1)) .OR.  ieee_is_nan(rt_zeros(2)) .OR. rt_zeros(2)<0) then
-
+      if ( (rt_zeros(1) .ne. rt_zeros(1)) .OR. &
+           (rt_zeros(2) .ne. rt_zeros(2)) .OR. &
+           (rt_zeros(2) .lt. 0) ) then
          !If this happens keep radius unchanged and temp equal to surrounding
          rt_zeros(1) = 1.0
          rt_zeros(2) = tval/pdata(np,prtp)
-
       end if
 
       !Now redimsionalize
       pdata(np,prrp) = rt_zeros(1)*pdata(np,prrp)
       pdata(np,prtp) = rt_zeros(2)*pdata(np,prtp)
-
-
 
       !Finally, take care of particle BCs
 
@@ -1832,7 +1764,6 @@
 
       subroutine gauss_newton_2d(diffnorm,dt_nondim,taup_scale,rt_start,rt_zeros,flag,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
         !$acc routine seq
-        use ieee_arithmetic
 
         implicit none
 
@@ -1894,7 +1825,7 @@
                 relax = 1.0
                 counts = 0
 
-                do while ((diff<0).OR.(rt_zeros(1)<0) .OR. (rt_zeros(2)<0) .OR. ieee_is_nan(rt_zeros(1)))
+                do while ((diff<0) .OR. (rt_zeros(1)<0) .OR. (rt_zeros(2)<0) .OR. (rt_zeros(1) .ne. rt_zeros(1)))
                    counts = counts + 1
                    coeff = 0.5
                    relax = relax * coeff
@@ -1912,7 +1843,7 @@
                 call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),fv2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
         end do
       if (iterations == 100) flag = 1
-      if (ieee_is_nan(rt_zeros(1)) .OR. rt_zeros(1)<0 .OR. ieee_is_nan(rt_zeros(2)) .OR. rt_zeros(2)<0) flag = 1
+      if ((rt_zeros(1) .ne. rt_zeros(1)) .OR. rt_zeros(1)<0 .OR. (rt_zeros(2) .ne. rt_zeros(2)) .OR. rt_zeros(2)<0) flag = 1
 
       end subroutine gauss_newton_2d
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1801,10 +1801,10 @@
 
                 call inverse_finder_2d(fancy, inv)
 
-                fancy(1,1) = inv(1,1)*J(1,1)+inv(1,2)*J(1,2)
-                fancy(1,2) = inv(1,1)*J(2,1)+inv(1,2)*J(2,2)
-                fancy(2,1) = inv(2,1)*J(1,1)+inv(2,2)*J(1,2)
-                fancy(2,2) = inv(2,1)*J(2,1)+inv(2,2)*J(2,2)
+                finalJ(1,1) = inv(1,1)*J(1,1)+inv(1,2)*J(1,2)
+                finalJ(1,2) = inv(1,1)*J(2,1)+inv(1,2)*J(2,2)
+                finalJ(2,1) = inv(2,1)*J(1,1)+inv(2,2)*J(1,2)
+                finalJ(2,2) = inv(2,1)*J(2,1)+inv(2,2)*J(2,2)
 
                 correct(1) = finalJ(1,1)*fv1(1)+finalJ(1,2)*fv1(2)
                 correct(2) = finalJ(2,1)*fv1(1)+finalJ(2,2)*fv1(2)

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -983,12 +983,13 @@
       pdata(np,pry)=y3d
       if( .not. terrain_flag )then
         pdata(np,prz)=z3d
-        pdata_locind(np,3) = undefined_index
       else
         pdata(np,prsig)=sig3d
-        pdata_locind(np,3) = undefined_index
       endif
-
+      if (pdata_locind(np,1) .eq. undefined_index .or. &
+          pdata_locind(np,2) .eq. undefined_index) then
+          pdata_locind(np,3) = undefined_index
+      end if
 
       end subroutine rk2_integration
 
@@ -1195,17 +1196,18 @@
         pdata_locind(np,2) = undefined_index
       endif
 
-
       pdata(np,prx)=x3d
       pdata(np,pry)=y3d
       if( .not. terrain_flag )then
         pdata(np,prz)=z3d
-        pdata_locind(np,3) = undefined_index
       else
         pdata(np,prsig)=sig3d
-        pdata_locind(np,3) = undefined_index
       endif
 
+      if (pdata_locind(np,1) .eq. undefined_index .or. &
+          pdata_locind(np,2) .eq. undefined_index) then
+          pdata_locind(np,3) = undefined_index
+      end if
 
       end subroutine BE_integration
 
@@ -1268,57 +1270,22 @@
 
         kflag = 1
 ! JS - jflag could be negative somehow, which will break
-!        the find_vertical_location_index subroutine;
-!        use the original interface but with the 
-!        pdata_locind(:,3) here
-!    - z3d could be NaN somehow, reset kflag = 1 to be 
-!        consistent with the original implementation
-#ifdef _VERIFY_FIND_LOC
-        tmp_flag = kflag
-#endif
-        kflag = max (kflag, pdata_locind(np,3) - location_offset - 1)
-        if ( z3d .ne. z3d ) kflag = 1
+!        the find_vertical_location_index subroutine and 
+!        lead to invalid access to zf(iflag,jflag,kflag);
+!        revert to the old implementation
         if( .not. terrain_flag )then
-          if ( z3d.lt.zf(iflag,jflag,kflag) ) then
-            kflag = 1
-          end if
+           if (jflag .lt. 0) then
+              print *, 'z3d = ', z3d, ', zf(iflag,jflag,2) = ', zf(iflag,jflag,2), ', zf(iflag,jflag,ke+1) = ', zf(iflag,jflag,ke+1)
+           end if
           do while( z3d.gt.zf(iflag,jflag,kflag+1) )
             kflag = kflag+1
           enddo
-          pdata_locind(np,3) = kflag
-#ifdef _VERIFY_FIND_LOC
-          do while( z3d.gt.zf(iflag,jflag,tmp_flag+1) )
-            tmp_flag = tmp_flag+1
-          enddo
-          if ( kflag .ne. tmp_flag ) then
-            print *, "z3d = ", z3d, ", old scheme finds ", zf(iflag,jflag,tmp_flag+1), ", new scheme finds ", zf(iflag,jflag,kflag+1)
-            print *, "original search scheme finds z index = ", tmp_flag, ", new search scheme finds z index = ", kflag
-            stop "Failed verification test: z index is not the same..."
-          else
-            print *, "Pass the verification test for z index..."
-          end if
-#endif
         else
-          if ( sig3d.lt.sigmaf(kflag) ) then
-            kflag = 1
-          end if
           do while( sig3d.gt.sigmaf(kflag+1) )
             kflag = kflag+1
           enddo
-          pdata_locind(np,3) = kflag
-#ifdef _VERIFY_FIND_LOC
-          do while( sig3d.gt.sigmaf(tmp_flag+1) )
-            tmp_flag = tmp_flag+1
-          enddo
-          if ( kflag .ne. tmp_flag ) then
-            print *, "original search scheme finds z index = ", tmp_flag, ", new search scheme finds z index = ", kflag
-            stop "Failed verification test: z index is not the same..."
-          else
-            print *, "Pass the verification test for z index..."
-          end if
-#endif
         endif
-
+        pdata_locind(np,3) = kflag
 
 !JMD-debug
 !----------------------------------------------------------------------
@@ -1758,7 +1725,8 @@
 #endif
 
       ! Sanity check:
-      ! - If input x/y location is outside the x/y range, return directly
+      ! - If input z location is outside the z range, return directly
+
       if ( loc .lt. dsize(lb) .or. loc .gt. dsize(ub) ) return
 
       if ( loc_ind .ne. undefined_index ) then 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1274,9 +1274,6 @@
 !        lead to invalid access to zf(iflag,jflag,kflag);
 !        revert to the old implementation
         if( .not. terrain_flag )then
-           if (jflag .lt. 0) then
-              print *, 'z3d = ', z3d, ', zf(iflag,jflag,2) = ', zf(iflag,jflag,2), ', zf(iflag,jflag,ke+1) = ', zf(iflag,jflag,ke+1)
-           end if
           do while( z3d.gt.zf(iflag,jflag,kflag+1) )
             kflag = kflag+1
           enddo

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -106,18 +106,15 @@
 
       !integer :: nip1
 
-      !JMD no idea why these values hae not already been set previously
-      !$acc update device(ib,jb,kb,ie,je,ke)
-      !!$acc compare(wten,thten)
-      !KLUDGE-JMD
       call reinit_random_seed
       !print *,'droplet_driver: point #1'
 !----------------------------------------------------------------------
 !  apply bottom/top boundary conditions:
 !  [Note:  for u,v the array index (i,j,0) means the surface, ie z=0]
 !     (for the parcel subroutines only!)
-      !$acc data create(ta) copyin(ngz,ngxy)
-      !print *,'droplet_driver: {ngxy,ngxy}: ',ngxy,ngz
+
+      !$acc data create(ta)
+
 !$omp parallel do default(shared) private(i,j)
 !$acc parallel loop gang vector default(present) private(i,j)
   DO j=jb,je+1
@@ -189,28 +186,13 @@
       enddo
       ENDIF
 
-
     !NEED SCALARS
-    
 
   ENDDO
 
-
-  !!$acc compare(pi0,th_in,th0,ppa)
   !Compute temperature for interpolation
+
   !$acc parallel default(present) private(i,j,k)
-
-   
-  !JMD zero out the prevent PCAST errors
-  !!$acc loop gang vector collapse(3)
-  !do k=kb,ke
-  !do j=jb,je
-  !do i=ib,ie
-  !   ta(i,j,k)=0.0
-  !enddo
-  !enddo
-  !enddo
-
   !$acc loop gang vector collapse(3)
   do k=kb,ke
     do j=jb,je
@@ -261,16 +243,13 @@
     !$acc      ua,va,wa,qa,ta,rho,prs,znt,qten,thten,zs)
 #else
     !$acc compare(pdata)
-    !JMD no idea why these values hae not already been set previously
-    !$acc update device(ngxy,ngz)
     !JMD WARNING: Loop does not yet match CPU version.
     !$acc parallel &
     !$acc default(present) &
     !$acc private(i,j,k,x3d,y3d,z3d,sig3d,iflag,jflag,kflag,nrkp,rhoval, &
-    !$acc     rhop0,taup0,Nup,&
-    !$acc     dvpdt1,dvpdt2,dvpdt3,drpdt,dtpdt,dmvdt,dV,ix,iy,iz,xv,yv,zv,wtx,wty,wtz,wtt, &
-    !$acc     esl,part_grav1,part_grav2,part_grav3,rp0)
-    !$acc compare(ngxy,ngz)
+    !$acc         rhop0,taup0,Nup,dvpdt1,dvpdt2,dvpdt3,drpdt,dtpdt,dmvdt, &
+    !$acc         dV,ix,iy,iz,xv,yv,zv,wtx,wty,wtz,wtt,esl,part_grav1, &
+    !$acc         part_grav2,part_grav3,rp0)
     !$acc loop gang vector 
 #endif
     nploop:  &
@@ -646,6 +625,7 @@
       end subroutine droplet_driver
 
       subroutine rk2_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug)
+      !$acc routine seq
       use input
       use constants
       use bc_module
@@ -989,6 +969,7 @@
       end subroutine rk2_integration
 
       subroutine BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000)
+      !$acc routine seq
       use input
       use constants
       use bc_module
@@ -1205,6 +1186,7 @@
       end subroutine BE_integration
 
       subroutine interpolate_to_parcel(np,nrkp,pdata_locind,iflag,jflag,kflag,x3d,y3d,z3d,sig3d,uval,vval,wval,tval,qval,rhoval,prsval,xh,xf,yh,yf,zh,zf,zs,znt,sigma,sigmaf,ua,va,wa,ta,qa,rho,prs,sigdot)
+      !$acc routine seq
       use input
       use constants
       use parcel_module
@@ -1811,6 +1793,7 @@
       end subroutine find_vertical_location_index
 
       subroutine rad_solver2(guess,mflag,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+      !$acc routine seq
       use constants
       use cm1libs , only : eslf
       implicit none
@@ -1879,52 +1862,63 @@
         flag = 0
         error = 1.e-8
 
-        v1 = rt_start
+        v1(1) = rt_start(1)
+        v1(2) = rt_start(2)
         fv2 = (/1., 1./)
         coeff = 0.1
-        do while ((sqrt(dot_product(fv2, fv2)) > error) .AND. (iterations<1000))
 
+        do while ((sqrt(fv2(1)*fv2(1)+fv2(2)*fv2(2)) > error) .AND. (iterations<1000))
 
                 iterations = iterations + 1
 
                 call ie_vrt_nd(diffnorm,v1(1),v1(2),fv1,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
                 call jacob_approx_2d(diffnorm,v1(1),v1(2),dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-                fancy = matmul(transpose(J),J)
+                fancy(1,1) = J(1,1)*J(1,1)+J(2,1)*J(2,1)
+                fancy(1,2) = J(1,1)*J(1,2)+J(2,1)*J(2,2)
+                fancy(2,1) = J(1,2)*J(1,1)+J(2,2)*J(2,1)
+                fancy(2,2) = J(1,2)*J(1,2)+J(2,2)*J(2,2)
 
                 call inverse_finder_2d(fancy, inv)
 
-                finalJ = matmul(inv, transpose(J))
+                fancy(1,1) = inv(1,1)*J(1,1)+inv(1,2)*J(1,2)
+                fancy(1,2) = inv(1,1)*J(2,1)+inv(1,2)*J(2,2)
+                fancy(2,1) = inv(2,1)*J(1,1)+inv(2,2)*J(1,2)
+                fancy(2,2) = inv(2,1)*J(2,1)+inv(2,2)*J(2,2)
 
-                correct = matmul(finalJ,fv1)
-                rt_zeros = v1 - correct
+                correct(1) = finalJ(1,1)*fv1(1)+finalJ(1,2)*fv1(2)
+                correct(2) = finalJ(2,1)*fv1(1)+finalJ(2,2)*fv1(2)
+
+                rt_zeros(1) = v1(1) - correct(1)
+                rt_zeros(2) = v1(2) - correct(2)
 
                 call ie_vrt_nd(diffnorm,v1(1),v1(2),temp1,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
                 call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),temp2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
+                diff = sqrt(temp1(1)*temp1(1)+temp1(2)*temp1(2))-sqrt(temp2(1)*temp2(1)+temp2(2)*temp2(2))
 
-                diff = sqrt(dot_product(temp1,temp1))-sqrt(dot_product(temp2,temp2))
-
-                if (sqrt(dot_product(correct,correct))<error) then
+                if (sqrt(correct(1)*correct(1)+correct(2)*correct(2))<error) then
                         EXIT
                 end if
 
                 relax = 1.0
                 counts = 0
 
-               do while ((diff<0).OR.(rt_zeros(1)<0) .OR. (rt_zeros(2)<0) .OR. ieee_is_nan(rt_zeros(1)))
-                        counts = counts + 1
-                        coeff = 0.5
-                        relax = relax * coeff
-                        rt_zeros = v1-matmul(finalJ,fv1)*relax
-                        call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),temp2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
-                        diff = sqrt(dot_product(temp1,temp1))-sqrt(dot_product(temp2,temp2))
+                do while ((diff<0).OR.(rt_zeros(1)<0) .OR. (rt_zeros(2)<0) .OR. ieee_is_nan(rt_zeros(1)))
+                   counts = counts + 1
+                   coeff = 0.5
+                   relax = relax * coeff
+                   rt_zeros(1) = v1(1)-(finalJ(1,1)*fv1(1)+finalJ(1,2)*fv1(2))*relax
+                   rt_zeros(2) = v1(2)-(finalJ(2,1)*fv1(1)+finalJ(2,2)*fv1(2))*relax
+                   call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),temp2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+                   diff = sqrt(temp1(1)*temp1(1)+temp1(2)*temp1(2))-sqrt(temp2(1)*temp2(1)+temp2(2)*temp2(2))
 
-                        if (counts>10) EXIT
+                   if (counts>10) EXIT
                 end do
 
-                v1 = rt_zeros
+                v1(1) = rt_zeros(1)
+                v1(2) = rt_zeros(2)
 
                 call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),fv2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
         end do
@@ -1932,6 +1926,7 @@
       if (ieee_is_nan(rt_zeros(1)) .OR. rt_zeros(1)<0 .OR. ieee_is_nan(rt_zeros(2)) .OR. rt_zeros(2)<0) flag = 1
 
       end subroutine gauss_newton_2d
+
       subroutine LV_solver(diffnorm,dt_nondim,taup_scale,rt_start,rt_zeros,flag,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
         !$acc routine seq
         implicit none
@@ -1950,53 +1945,64 @@
 
         error = 1.0e-8
 
-        ! I = reshape((/1, 0, 0, 1/),shape(I))
         I = reshape((/1, 0, 0, 1/),(/2,2/))
         iterations = 0
         flag = 0
-        v1 = rt_start
+        v1(1) = rt_start(1)
+        v1(2) = rt_start(2)
         fv2 = (/1., 1./)
 
         lambda = 0.001
         lup = 2.0
         ldown = 2.0
 
-        do while ((sqrt(dot_product(fv2, fv2)) > error) .AND. (iterations<1000))
+        do while ((sqrt(fv2(1)*fv2(1)+fv2(2)*fv2(2)) > error) .AND. (iterations<1000))
 
         iterations = iterations + 1
-        call jacob_approx_2d(diffnorm,v1(1),v1(2),dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
+        call jacob_approx_2d(diffnorm,v1(1),v1(2),dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
         call ie_vrt_nd(diffnorm,v1(1),v1(2),fv1,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-        g = matmul(transpose(J),J)+lambda*I
-        gradC = matmul(transpose(J),fv1)
-        C = 0.5*fv1*fv1
+        g(1,1) = J(1,1)*J(1,1)+J(2,1)*J(2,1)+lambda*I(1,1)
+        g(1,2) = J(1,1)*J(1,2)+J(2,1)*J(2,2)+lambda*I(1,2)
+        g(2,1) = J(1,2)*J(1,1)+J(2,2)*J(2,1)+lambda*I(2,1)
+        g(2,2) = J(1,2)*J(1,2)+J(2,2)*J(2,2)+lambda*I(2,2)
+
+        gradC(1) = J(1,1)*fv1(1)+J(2,1)*fv1(2)
+        gradC(2) = J(1,2)*fv1(1)+J(2,2)*fv1(2)
+
+        C(1) = 0.5*fv1(1)*fv1(1)
+        C(2) = 0.5*fv1(2)*fv1(2)
 
         call inverse_finder_2d(g, invg)
-        correct = matmul(invg, gradC)
-        if (sqrt(dot_product(correct,correct)) < error) then
-                EXIT
+        correct(1) = invg(1,1)*gradC(1)+invg(1,2)*gradC(2)
+        correct(2) = invg(2,1)*gradC(1)+invg(2,2)*gradC(2)
+        if (sqrt(correct(1)*correct(1)+correct(2)*correct(2)) < error) then
+           EXIT
         end if
 
-        rt_zeros = v1 - correct
+        rt_zeros(1) = v1(1) - correct(1)
+        rt_zeros(2) = v1(2) - correct(2)
         call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),fv2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
-        newC = 0.5*fv2*fv2
-         
-        if (sqrt(dot_product(newC,newC))<sqrt(dot_product(C,C))) then
-                v1 = rt_zeros
-                lambda = lambda/ldown
+        newC(1) = 0.5*fv2(1)*fv2(1)
+        newC(2) = 0.5*fv2(2)*fv2(2)
+
+        if (sqrt(newC(1)*newC(1)+newC(2)*newC(2))<sqrt(C(1)*C(1)+C(2)*C(2))) then
+           v1(1) = rt_zeros(1)
+           v1(2) = rt_zeros(2)
+           lambda = lambda/ldown
         else
-                lambda = lambda*lup
+           lambda = lambda*lup
         end if
 
         end do
 
         if (iterations==1000) then
-                flag = 1
+           flag = 1
         end if
 
         if (rt_zeros(1) < 0 .OR. rt_zeros(2) < 0) then
-                flag = 1
+           flag = 1
         end if
 
       end subroutine LV_solver
@@ -2010,12 +2016,13 @@
 
         det = C(1, 1) * C(2, 2) - C(1, 2) * C(2, 1)
 
-        ! invC = reshape((/C(2, 2), -C(2,1), -C(1, 2), C(1, 1)/),shape(invC))
         invC = reshape((/C(2, 2), -C(2,1), -C(1, 2), C(1, 1)/),(/2,2/))
         invC = (1./det)*invC
 
       end subroutine inverse_finder_2d
+
       subroutine jacob_approx_2d(diffnorm,rnext,tnext,dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+        !$acc routine seq
         implicit none
         integer :: n
 
@@ -2031,24 +2038,28 @@
 
         call ie_vrt_nd(diffnorm,rnext,tnext,rt_output,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-        xper = ynext
-        xper2 = ynext
+        xper(1) = ynext(1)
+        xper(2) = ynext(2)
+        xper2(1) = ynext(1)
+        xper2(2) = ynext(2)
 
         do n=1, 2
-                xper(n) = xper(n) + diff
-                xper2(n) = xper2(n) - diff
-                call ie_vrt_nd(diffnorm,xper(1),xper(2),fxper,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+           xper(n) = xper(n) + diff
+           xper2(n) = xper2(n) - diff
+           call ie_vrt_nd(diffnorm,xper(1),xper(2),fxper,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-                call ie_vrt_nd(diffnorm,xper2(1),xper2(2),fxper2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+           call ie_vrt_nd(diffnorm,xper2(1),xper2(2),fxper2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-                J(:, n) = (fxper-rt_output)/diff
-                xper(n) = ynext(n)
-                xper2(n) = ynext(n)
+           J(1,n) = (fxper(1)-rt_output(1))/diff
+           J(2,n) = (fxper(2)-rt_output(2))/diff
+           xper(n) = ynext(n)
+           xper2(n) = ynext(n)
         end do
 
-
       end subroutine jacob_approx_2d
+
       subroutine ie_vrt_nd(diffnorm,tempr,tempt,rt_output,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+      !$acc routine seq
       use constants
       use input
       use cm1libs , only : eslf
@@ -2061,12 +2072,10 @@
       real :: esa,dnext,rhop,Rep,taup,rprime,Tprime,qstr,Shp,Nup,VolP,lhv
       real :: Tnext,rnext
 
-
         ! quantities come in already non-dimensionalized, so must be converted back;
         rnext = tempr*radius
         Tnext = tempt*Tp
         dnext = rnext*2.0
-
 
         esa = eslf(prsval,tval)
         VolP = (4.0/3.0)*pi*rnext**3
@@ -2079,16 +2088,13 @@
 
         lhv=lv1-lv2*tval
 
-
         !!! Humidity !!!
         qstr = (mw/(ru*Tnext*rhoval))*esa*exp(((lhv*mw/ru)*((1.0/tval)-(1.0/Tnext))) + ((2.0*mw*surften)/(ru*rhow*rnext*Tnext)) - ((ion*os*m_s*(mw/ms))/(VolP*rhop-m_s)))
         !!!!!!!!!!!!!!!!!!
 
-
         !!! Radius !!!
         rprime = (1.0/9.0)*(Shp/sc_num)*(rhop/rhow)*(rnext/taup)*(qval - qstr)
         rprime = rprime*(taup_scale/radius)
-
 
         !!! Temperature !!!
         Tprime = -(1.0/3.0)*(Nup/pr_num)*(cp/cpl)*(rhop/rhow)/taup*(Tnext-tval) + 3.0*lhv/(rnext*cpl)*rprime*(radius/taup_scale)
@@ -2097,10 +2103,7 @@
         rT_output(1) = rnext/radius - 1.0  - dt_nondim*rprime
         rT_output(2) = Tnext/Tp - 1.0  - dt_nondim*Tprime
 
-
       end subroutine ie_vrt_nd
-
-
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/init_terrain.F
+++ b/src/init_terrain.F
@@ -178,6 +178,7 @@
 
         zt = maxz
         rzt = 1.0/maxz
+        !$acc update device (zt,rzt)
 
         if(dowr) write(outfile,*)
         do k=1,nk+1

--- a/src/input.F
+++ b/src/input.F
@@ -160,23 +160,17 @@
               bl_mynn_cloudmix,bl_mynn_mixqt,initflag,spp_pbl,bl_mynn_output, &
               nutk,nvtk,nwtk
 
-!$acc declare create(nqs1,nqs2)
-!$acc declare create(nqr,nqi,nqs,nqg,nnci,nncc)
-!$acc declare create(ptype,psolver)
-!$acc declare create(ngxy,ngz)
-!$acc declare create(nx,ny,nz)
-!$acc declare create(axisymm)
-!$acc declare create(nparcels,npvals,npvars)
-!$acc declare create(ni,nj,nk)
-!$acc declare create(nip1,njp1,nkm1,nkp1)
-!$acc declare create(ib,ie,jb,je,kb,ke)
-!$acc declare create(terrain_flag,numq)
-!$acc declare create(imoist,imove,nqv,bbc,tbc)
-!$acc declare create(prx,pry,prz,pru,prv,prw,prth,prt,prprs,prtime)           &
-!$acc         create(prpt1,prpt2,prqv,prq1,prq2,prnc1,prnc2,prkm,prkh,prtke)  &
-!$acc         create(prdbz,prb,prvpg,przv,prrho,prqsl,prqsi,prznt,prust,przs) &
-!$acc         create(prsig,prvpx,prvpy,prvpz,prrp,prms,prtp,prmult,pract)
-!$acc declare create(ntwk)
+!$acc declare create(nqs1,nqs2,nqr,nqi,nqs,nqg,nnci,nncc, &
+!$acc                ptype,psolver,ngxy,ngz,nx,ny,nz,axisymm, &
+!$acc                nparcels,npvals,npvars,ni,nj,nk,nip1,njp1, &
+!$acc                nkm1,nkp1,ib,ie,jb,je,kb,ke,terrain_flag, &
+!$acc                numq,imoist,imove,nqv,bbc,tbc,prx,pry,prz, &
+!$acc                pru,prv,prw,prth,prt,prprs,prtime,prpt1, &
+!$acc                prpt2,prqv,prq1,prq2,prnc1,prnc2,prkm,prkh, &
+!$acc                prtke,prdbz,prb,prvpg,przv,prrho,prqsl,prqsi, &
+!$acc                prznt,prust,przs,prsig,prvpx,prvpy,prvpz,prrp, &
+!$acc                prms,prtp,prmult,pract,ntwk,imp,jmp,kmp,kmt, &
+!$acc                rmp,cmp,vd_vadv,ibw,ibe,ibs,ibn)
 !-----------------------------------------------------------------------
 
       real dx,dy,dz,dtl,timax,run_time,                                       &
@@ -212,18 +206,12 @@
            base_pbot,base_ptop,base_thbot,base_thtop,base_qvbot,base_qvtop,   &
            base_tbot,base_ttop,base_pibot,base_pitop
 
-!$acc declare create(dx,dy,dz,dtl,timax,run_time)
-!$acc declare create(tapfrq,rstfrq,statfrq,prclfrq,diagfrq)
-!$acc declare create(kdiff2,kdiff6,fcor,alph,kdiv)
-!$acc declare create(wbc,ebc,sbc,nbc)
-!$acc declare create(rdx,rdy,rdz)
-!$acc declare create(minx,maxx)
-!$acc declare create(miny,maxy)
-!$acc declare create(cflmax,ksmax)
-!$acc declare create(zt,rzt)
-!$acc declare create(umove,vmove)
-!$acc declare create(viscosity,pr_num,sc_num)
-!$acc declare create(maxz)
+!$acc declare create(dx,dy,dz,dtl,timax,run_time,tapfrq,rstfrq,    &
+!$acc                statfrq,prclfrq,diagfrq,kdiff2,kdiff6,fcor,   &
+!$acc                alph,kdiv,wbc,ebc,sbc,nbc,rdx,rdy,rdz,minx,   &
+!$acc                maxx,miny,maxy,cflmax,ksmax,zt,rzt,umove,     &
+!$acc                vmove,viscosity,pr_num,sc_num,maxz,cgs1,cgs2, &
+!$acc                cgs3,cgt1,cgt2,cgt3)
 !-----------------------------------------------------------------------
 
       character(len=maxstring) :: string

--- a/src/input.F
+++ b/src/input.F
@@ -170,7 +170,8 @@
 !$acc                prtke,prdbz,prb,prvpg,przv,prrho,prqsl,prqsi, &
 !$acc                prznt,prust,przs,prsig,prvpx,prvpy,prvpz,prrp, &
 !$acc                prms,prtp,prmult,pract,ntwk,imp,jmp,kmp,kmt, &
-!$acc                rmp,cmp,vd_vadv,ibw,ibe,ibs,ibn)
+!$acc                rmp,cmp,vd_vadv,ibw,ibe,ibs,ibn,nodex,nodey, &
+!$acc                myi,myj)
 !-----------------------------------------------------------------------
 
       real dx,dy,dz,dtl,timax,run_time,                                       &

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3254,7 +3254,7 @@
 
       fmax=-99999999.
       !$acc parallel default(present) reduction(max:fmax)
-      !$acc loop gang verctor reduction(max:fmax)
+      !$acc loop gang vector reduction(max:fmax)
       do k=2,nk
          fmax = max( fmax , ks(k) )
       end do

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3252,20 +3252,21 @@
         stop 1112
       endif
 
-      !$acc parallel default(present) private(k) reduction(max:fmax)
       fmax=-99999999.
-      !$acc loop private(k) reduction(max:fmax)
+      !$acc parallel default(present) reduction(max:fmax)
+      !$acc loop gang verctor reduction(max:fmax)
       do k=2,nk
-        fmax = max( fmax , ks(k) )
-      enddo
+         fmax = max( fmax , ks(k) )
+      end do
       !$acc end parallel
       ksmax = fmax
+
       !$acc end data
 
 #ifdef MPI
       call MPI_IALLREDUCE(MPI_IN_PLACE,ksmax,1,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,reqk,ierr)
-      !$acc update device(ksmax)
 #endif
+      !$acc update device(ksmax)
 
       if(ksmax.ge.0.50) then 
          stopit=.true.
@@ -3311,75 +3312,66 @@
 !JMD-FIXME
 !!$acc update host(nstat,rstat,dt,uh,vh,mf,kmh,kmv,khh,khv)
 
-!$acc data create(imaxth,jmaxth,kmaxth,imaxtv,jmaxtv,kmaxtv,ksh,ksv,mmax,nmax)
+!$acc data copyout (ksh,ksv,imaxth,jmaxth,kmaxth,imaxtv,jmaxtv,kmaxtv) &
+!$acc      copyin (khh,vh,uh,mf)
 
       dtdx=dt*rdx*rdx
       dtdy=dt*rdy*rdy
       dtdz=dt*rdz*rdz
 
-!$acc parallel loop gang vector default(present) private(k)
-      do k=2,nk
-        ksh(k)=-99999.0
-        ksv(k)=-99999.0
-      enddo
-
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k,tem)
-!$acc parallel default(present) private(i,j,k,tem) reduction(max:maxksh) reduction(max:maxksv)
+
+!$acc parallel default(present) reduction(max:maxksh,maxksv)
+!$acc loop gang reduction(max:maxksh,maxksv)
       do k=2,nk
-        maxksh = -99999.0
-        maxksv = -99999.0
-!$acc loop collapse(2) private(i,j,k,tem) reduction(max:maxksh) reduction(max:maxksv)
-        do j=1,nj
-        do i=1,ni
-          tem = khh(i,j,k)*dtdx*uh(i)*uh(i)
-          maxksh=max(tem,maxksh)
+         maxksh = -99999.0
+         maxksv = -99999.0
+!$acc loop vector collapse(2) reduction(max:maxksh,maxksv)
+         do j=1,nj
+            do i=1,ni
+               tem = khh(i,j,k)*dtdx*uh(i)*uh(i)
+               maxksh=max(tem,maxksh)
 
-          tem = khh(i,j,k)*dtdy*vh(j)*vh(j)
-          maxksh=max(tem,maxksh)
+               tem = khh(i,j,k)*dtdy*vh(j)*vh(j)
+               maxksh=max(tem,maxksh)
 
-          tem = khv(i,j,k)*dtdz*mf(i,j,k)*mf(i,j,k)
-          maxksv=max(tem,maxksv)
-        enddo
-        enddo
-        ksh(k)=maxksh
-        ksv(k)=maxksv
-      enddo
+               tem = khv(i,j,k)*dtdz*mf(i,j,k)*mf(i,j,k)
+               maxksv=max(tem,maxksv)
+            end do
+         end do
+         ksh(k)=maxksh
+         ksv(k)=maxksv
+      end do
 !$acc end parallel
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k,tem)
-!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,tem)
+!$acc parallel loop gang vector collapse(3) default(present)
       do k=2,nk
-        do j=1,nj
-        do i=1,ni
-!!!          tem = max( abs(kmh(i,j,k))*dtdx*uh(i)*uh(i) ,   &
-!!!                     abs(khh(i,j,k))*dtdx*uh(i)*uh(i) )
-          tem = khh(i,j,k)*dtdx*uh(i)*uh(i)
-          if( tem.eq.ksh(k) )then
-            imaxth(k)=i
-            jmaxth(k)=j
-            kmaxth(k)=k
-          endif
-!!!          tem = max( abs(kmh(i,j,k))*dtdy*vh(j)*vh(j) ,   &
-!!!                     abs(khh(i,j,k))*dtdy*vh(j)*vh(j) )
-          tem = khh(i,j,k)*dtdy*vh(j)*vh(j)
-          if( tem.eq.ksh(k) )then
-            imaxth(k)=i
-            jmaxth(k)=j
-            kmaxth(k)=k
-          endif
-!!!          tem = max( abs(kmv(i,j,k))*dtdz*mf(i,j,k)*mf(i,j,k) ,   &
-!!!                     abs(khv(i,j,k))*dtdz*mf(i,j,k)*mf(i,j,k) )
-          tem = khv(i,j,k)*dtdz*mf(i,j,k)*mf(i,j,k)
-          if( tem.eq.ksv(k) )then
-            imaxtv(k)=i
-            jmaxtv(k)=j
-            kmaxtv(k)=k
-          endif
-        enddo
-        enddo
-      enddo
+         do j=1,nj
+            do i=1,ni
+               tem = khh(i,j,k)*dtdx*uh(i)*uh(i)
+               if( tem.eq.ksh(k) )then
+                 imaxth(k)=i
+                 jmaxth(k)=j
+                 kmaxth(k)=k
+               end if
+               tem = khh(i,j,k)*dtdy*vh(j)*vh(j)
+               if( tem.eq.ksh(k) )then
+                 imaxth(k)=i
+                 jmaxth(k)=j
+                 kmaxth(k)=k
+               end if
+               tem = khv(i,j,k)*dtdz*mf(i,j,k)*mf(i,j,k)
+               if( tem.eq.ksv(k) )then
+                 imaxtv(k)=i
+                 jmaxtv(k)=j
+                 kmaxtv(k)=k
+               endif
+            end do
+         end do
+      end do
 
       fhmax=-99999999.
       fvmax=-99999999.
@@ -3389,20 +3381,20 @@
       imaxv=1
       jmaxv=1
       kmaxv=1
-      !$acc parallel loop gang vector default(present) private(k)
+      !$acc parallel loop gang vector default(present)
       do k=2,nk
-        if(ksh(k).gt.fhmax)then
-          fhmax=ksh(k)
-          imaxh=imaxth(k)
-          jmaxh=jmaxth(k)
-          kmaxh=kmaxth(k)
-        endif
-        if(ksv(k).gt.fvmax)then
-          fvmax=ksv(k)
-          imaxv=imaxtv(k)
-          jmaxv=jmaxtv(k)
-          kmaxv=kmaxtv(k)
-        endif
+         if(ksh(k).gt.fhmax)then
+           fhmax=ksh(k)
+           imaxh=imaxth(k)
+           jmaxh=jmaxth(k)
+           kmaxh=kmaxth(k)
+         endif
+         if(ksv(k).gt.fvmax)then
+           fvmax=ksv(k)
+           imaxv=imaxtv(k)
+           jmaxv=jmaxtv(k)
+           kmaxv=kmaxtv(k)
+         endif
       enddo
 
       if( cm1setup.eq.2 .and. horizturb.eq.0 )then

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3258,15 +3258,11 @@
       do k=2,nk
         fmax = max( fmax , ks(k) )
       enddo
-
-      ksmax = fmax
       !$acc end parallel
+      ksmax = fmax
       !$acc end data
 
 #ifdef MPI
-#ifndef _B4B04R
-      !$acc update host(ksmax)
-#endif
       call MPI_IALLREDUCE(MPI_IN_PLACE,ksmax,1,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,reqk,ierr)
       !$acc update device(ksmax)
 #endif

--- a/src/param.F
+++ b/src/param.F
@@ -6230,12 +6230,14 @@
       if(dowr) write(outfile,*) '    prmult   = ',prmult
       if(dowr) write(outfile,*) '    pract    = ',pract
       if(dowr) write(outfile,*)
-      !$acc update device(nparcels,npvals,npvars,prx,pry,prz,pru,prv,prw) &
-      !$acc device(prtime,prth,prt,prprs,prpt1,prpt2,prqv,prq1,prq2,prnc1) &
-      !$acc device(prnc2,prkm,prkh,prtke,prdbz,prb,prvpg,przv,prrho,prqsl) &
-      !$acc device(prqsi,prznt,prust,przs,prsig,prvpx,prvpy,prvpz,prrp,prms) &
-      !$acc device(prtp,prmult,pract)
-      
+
+      !$acc update device (nparcels,npvals,npvars,prx,pry,prz,pru, &
+      !$acc                prv,prw,prtime,prth,prt,prprs,prpt1, &
+      !$acc                prpt2,prqv,prq1,prq2,prnc1,prnc2,prkm, &
+      !$acc                prkh,prtke,prdbz,prb,prvpg,przv,prrho, &
+      !$acc                prqsl,prqsi,prznt,prust,przs,prsig, &
+      !$acc                prvpx,prvpy,prvpz,prrp,prms,prtp, &
+      !$acc                prmult,pract)
 
 !--------------------------------------------------------------
 !  Get identity

--- a/src/param.F
+++ b/src/param.F
@@ -5334,6 +5334,7 @@
 
         nvdiag = nvdiag+1
         vd_vadv = nvdiag
+        !$acc update device (vd_vadv)
 
         if( cm1setup.ge.1 .or. ipbl.ge.1 )then
           nvdiag = nvdiag+1
@@ -6408,6 +6409,8 @@
         ibn=1
       endif
 #endif
+
+      !$acc update device (ibw,ibe,ibs,ibn)
 
 !--------------------------------------------------------------
 
@@ -8697,6 +8700,8 @@
       if(dowr) write(outfile,*) '  ---------------------------------- '
 
   ENDDO
+
+  !$acc update device (cgs1,cgs2,cgs3,cgt1,cgt2,cgt3)
 
 !--------------------------------------------------------------
 !  cm1r18:  Set ghost points for zh

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -50,12 +50,9 @@
       real :: wsp,wlast,var,rznt,usave,vsave,ssave
       logical :: convergeFail
 
-      !$acc declare &
-      !$acc present(xh,za,xland) &
-      !$acc present(u1,v1,s1) &
-      !$acc present(u10,v10,s10) &
-      !$acc present(znt,ust,cd,ch,cq) &
-      !$acc present(avgsfcu,avgsfcv,avgsfcs,avgsfct)
+      !$acc declare present(xh,za,xland,u1,v1,s1,u10,v10,s10, &
+      !$acc                 znt,ust,cd,ch,cq)
+
 !-----------------------------------------------------------------------
 !
 !  This subroutine determines several important variables at the surface

--- a/src/turb.F
+++ b/src/turb.F
@@ -2564,8 +2564,7 @@
 
     ENDIF
      
-
-
+    !$acc update host (grdscl)
     if( nstep.eq.0 .and. myid.eq.0 )then
       print *
       print *,'  zf,grdscl:'


### PR DESCRIPTION
This pull request fixes some existing GPU bugs on the latest `gpu-opt` branch:

- `NaN` value in the output log
- Wrong `grdscl` and `min boundary-layer depth` in the output log
- Replace `acc declare copyin` by `acc declare create` and `acc update device` directives
- Wrong implementations for some `acc reduction` directives
- Replace `ieee_is_nan()` with a naive implementation to detect the `NaN` value (`ieee_is_nan()` does not work on GPU)
- Replace the `matmul` and `dot_product` with an explicit expression for small matrix/vector