### PR TITLE
Eliminate B4B

### DIFF
--- a/run/namelist.baseline.dx=40m.short
+++ b/run/namelist.baseline.dx=40m.short
@@ -19,8 +19,8 @@
  run_time =  -999.9,
  tapfrq =   900.0,
  rstfrq = 10800.0,
- statfrq =  60.0,
- prclfrq =   60.0,
+ statfrq =   1.0,
+ prclfrq =   1.0,
  /
 
  &param2

--- a/src/Makefile
+++ b/src/Makefile
@@ -78,7 +78,7 @@ ifeq (${FC},nvfortran)
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${DEBUG_L},true)
          OPTS    += -g -O0
-         # DM      += -D_B4B
+         DM      += -D_B4B
     else
          OPTS    += -g -O2
     endif
@@ -124,7 +124,7 @@ ifeq (${FC},pgf90)
         ifeq (${DEBUG_L},true)
             OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Mnofma
         else
-            OPTS += -acc -gpu=cc70,lineinfo,math_uniform -Mpcast -Minfo=accel -Mnofma
+            OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel -Mnofma
         endif
         DM       += -D_OPENACC
     endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -78,9 +78,9 @@ ifeq (${FC},nvfortran)
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${DEBUG_L},true)
          OPTS    += -g -O0
-         DM      += -D_B4B
+         # DM      += -D_B4B
     else
-         OPTS    += -O2
+         OPTS    += -g -O2
     endif
     ifeq (${USE_DOUBLE_L},true)
          OPTS    += -r8
@@ -94,7 +94,7 @@ ifeq (${FC},nvfortran)
         ifeq (${DEBUG_L},true)
             OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Mnofma
         else
-            OPTS += -acc -gpu=cc70,lineinfo,math_uniform -Mpcast -Minfo=accel
+            OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel -Mnofma
         endif
         DM       += -D_OPENACC
     endif
@@ -124,7 +124,7 @@ ifeq (${FC},pgf90)
         ifeq (${DEBUG_L},true)
             OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Mnofma
         else
-            OPTS += -acc -gpu=cc70,lineinfo,math_uniform -Mpcast -Minfo=accel
+            OPTS += -acc -gpu=cc70,lineinfo,math_uniform -Mpcast -Minfo=accel -Mnofma
         endif
         DM       += -D_OPENACC
     endif
@@ -138,7 +138,7 @@ endif
 #  Intel compiler
 #-----------------------------------------------------------------------------
 ifeq (${FC},ifort)
-    OPTS         += -g -O3 -xHost -ip -assume byterecl -fp-model precise -ftz -init=snan,arrays -traceback
+    OPTS         += -g -O3 -xHost -ip -assume byterecl -fp-model precise -ftz -init=snan,arrays -traceback -no-fma
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${USE_OPENMP_L},true)
         OPTS     += -qopenmp

--- a/src/Makefile
+++ b/src/Makefile
@@ -74,7 +74,7 @@ endif
 #  NVHPC compiler
 #-----------------------------------------------------------------------------
 ifeq (${FC},nvfortran)
-    OPTS         += -Mfree -Ktrap=none -Mautoinline -Minline=reshape -Kieee
+    OPTS         += -Mfree -Ktrap=none -Mautoinline -Minline=reshape
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${DEBUG_L},true)
          OPTS    += -g -O0
@@ -104,7 +104,7 @@ endif
 #  PGI compiler
 #-----------------------------------------------------------------------------
 ifeq (${FC},pgf90)
-    OPTS         += -Mfree -Ktrap=none -Mautoinline -Minline=reshape -Kieee
+    OPTS         += -Mfree -Ktrap=none -Mautoinline -Minline=reshape
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${DEBUG_L},true)
          OPTS    += -g -O0

--- a/src/bc.F
+++ b/src/bc.F
@@ -3409,208 +3409,192 @@
       real, dimension(ib:ie,jb:je,kb:ke) :: s
 
       integer i,j,k
+      !$acc declare present(s)
 
-      !$acc data present(s)
-
+    !$acc parallel default(present) private(i,j,k)
 !-----------------------------------------------------------------------
 !  west boundary condition
 
+
 #ifndef MPI
       if(wbc.eq.1)then
-        !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(3)
-        do k=1,nk
-           do j=jb,je
-              do i=1,ngxy
-                 s(1-i,j,k)=s(ni+1-i,j,k)
-              end do
-           end do
-        end do
-        !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=jb,je
+        do i=1,ngxy
+          s(1-i,j,k)=s(ni+1-i,j,k)
+        enddo
+        enddo
+    ENDDO
       elseif(wbc.eq.2)then
 #else
       if(ibw.eq.1.and.wbc.eq.2)then
 #endif
-        !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(3)
-        do k=1,nk
-           do j=0,nj+1
-              do i=1-ngxy,0
-                 s(i,j,k)=s(1,j,k)
-              end do
-           end do
-        end do
-        !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=0,nj+1
+        do i=1-ngxy,0
+          s(i,j,k)=s(1,j,k)
+        enddo
+        enddo
+    ENDDO
 #ifdef MPI
       elseif(ibw.eq.1.and.(wbc.eq.3.or.wbc.eq.4))then
 #else
       elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
-       !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
-       do k=1,nk
-          do j=0,nj+1
-             do i=1,ngxy
-                s(1-i,j,k)=s(i,j,k)
-             enddo
-          enddo
-       end do
-       !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=0,nj+1
+        do i=1,ngxy
+          s(1-i,j,k)=s(i,j,k)
+        enddo
+        enddo
+    ENDDO
       endif
+    !$acc end parallel
 
+    !$acc parallel private(i,j,k)
 !-----------------------------------------------------------------------
 !  east boundary condition
 
+
 #ifndef MPI
       if(ebc.eq.1)then
-        !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(3)
-        do k=1,nk
-           do j=jb,je
-              do i=1,ngxy
-                 s(ni+i,j,k)=s(i,j,k)
-              end do
-           end do
-        end do
-        !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=jb,je
+        do i=1,ngxy
+          s(ni+i,j,k)=s(i,j,k)
+        enddo
+        enddo
+    ENDDO
       elseif(ebc.eq.2)then
 #else
       if(ibe.eq.1.and.ebc.eq.2)then
 #endif
-       !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
-       do k=1,nk
-          do j=0,nj+1
-             do i=ni+1,ni+ngxy
-                s(i,j,k)=s(ni,j,k)
-             end do
-          end do
-       end do
-       !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=0,nj+1
+        do i=ni+1,ni+ngxy
+          s(i,j,k)=s(ni,j,k)
+        enddo
+        enddo
+    ENDDO
 #ifdef MPI
       elseif(ibe.eq.1.and.(ebc.eq.3.or.ebc.eq.4))then
 #else
       elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
-       !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
-       do k=1,nk
-          do j=0,nj+1
-             do i=1,ngxy
-                s(ni+i,j,k)=s(ni+1-i,j,k)
-             end do
-          end do
-       end do 
-       !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=0,nj+1
+        do i=1,ngxy
+          s(ni+i,j,k)=s(ni+1-i,j,k)
+        enddo
+        enddo
+    ENDDO
       endif
+    !$acc end parallel
 
+    !$acc parallel private(i,j,k)
 !-----------------------------------------------------------------------
 !  south boundary condition
 
+
 #ifndef MPI
       if(sbc.eq.1)then
-       !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
-       do k=1,nk
-          do j=1,ngxy
-             do i=ib,ie
-                s(i,1-j,k)=s(i,nj+1-j,k)
-             end do
-          end do
-       end do 
-       !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=1,ngxy
+        do i=ib,ie
+          s(i,1-j,k)=s(i,nj+1-j,k)
+        enddo
+        enddo
+    ENDDO
       elseif(sbc.eq.2)then
 #else
       if(ibs.eq.1.and.sbc.eq.2)then
 #endif
-       !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
-       do k=1,nk
-          do j=1-ngxy,0
-             do i=0,ni+1
-                s(i,j,k)=s(i,1,k)
-             end do
-          end do
-       end do 
-       !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=1-ngxy,0
+        do i=0,ni+1
+          s(i,j,k)=s(i,1,k)
+        enddo
+        enddo
+    ENDDO
 #ifdef MPI
       elseif(ibs.eq.1.and.(sbc.eq.3.or.sbc.eq.4))then
 #else
       elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
-       !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
-       do k=1,nk
-          do j=1,ngxy
-             do i=0,ni+1
-                s(i,1-j,k)=s(i,j,k)
-             end do
-          end do
-       end do 
-       !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=1,ngxy
+        do i=0,ni+1
+          s(i,1-j,k)=s(i,j,k)
+        enddo
+        enddo
+    ENDDO
       endif
+   !$acc end parallel
 
+    !$acc parallel private(i,j,k)
 !-----------------------------------------------------------------------
 !  north boundary condition
 
+
 #ifndef MPI
       if(nbc.eq.1)then
-       !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
-       do k=1,nk
-          do j=1,ngxy
-             do i=ib,ie
-                s(i,nj+j,k)=s(i,j,k)
-             end do
-          end do
-       end do 
-       !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=1,ngxy
+        do i=ib,ie
+          s(i,nj+j,k)=s(i,j,k)
+        enddo
+        enddo
+    ENDDO
       elseif(nbc.eq.2)then
 #else
       if(ibn.eq.1.and.nbc.eq.2)then
 #endif
-       !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
-       do k=1,nk
-          do j=nj+1,nj+ngxy
-             do i=0,ni+1
-                s(i,j,k)=s(i,nj,k)
-             end do
-          end do
-       end do
-       !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=nj+1,nj+ngxy
+        do i=0,ni+1
+          s(i,j,k)=s(i,nj,k)
+        enddo
+        enddo
+    ENDDO
 #ifdef MPI
       elseif(ibn.eq.1.and.(nbc.eq.3.or.nbc.eq.4))then
 #else
       elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
-       !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present) private(i,j,k)
-       !$acc loop gang vector collapse(3)
-       do k=1,nk
-          do j=1,ngxy
-             do i=0,ni+1
-                s(i,nj+j,k)=s(i,nj+1-j,k)
-             end do
-          end do
-       end do 
-       !$acc end parallel
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc loop gang vector collapse(3)
+    DO k=1,nk
+        do j=1,ngxy
+        do i=0,ni+1
+          s(i,nj+j,k)=s(i,nj+1-j,k)
+        enddo
+        enddo
+    ENDDO
       endif
-
+   !$acc end parallel
 !-----------------------------------------------------------------------
-
-      !$acc end data
 
       if(timestats.ge.1) time_bcs=time_bcs+mytime()
 
@@ -3623,58 +3607,51 @@
       real, dimension(ib:ie+1,jb:je,kb:ke) :: u
 
       integer i,j,k  
-
-      !$acc data present(u)
+      !$acc declare present(u)
 
 !-----------------------------------------------------------------------
 !  west boundary condition
 
+
 #ifndef MPI
     if(wbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
-      do k=1,nk
-         do j=jb,je
-            do i=1,ngxy
-               u(1-i,j,k)=u(ni+1-i,j,k)
-            end do
-         end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      DO k=1,nk
+        do j=jb,je
+        do i=1,ngxy
+          u(1-i,j,k)=u(ni+1-i,j,k)
+        enddo
+        enddo
+      ENDDO
     elseif(wbc.eq.2)then
 #else
     if(ibw.eq.1.and.wbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
-      do k=1,nk
-         do j=0,nj+1
-            do i=1-ngxy,0
-               u(i,j,k)=u(1,j,k)
-            end do
-         end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      DO k=1,nk
+        do j=0,nj+1
+        do i=1-ngxy,0
+          u(i,j,k)=u(1,j,k)
+        enddo
+        enddo
+      ENDDO
 #ifdef MPI
     elseif(ibw.eq.1.and.(wbc.eq.3.or.wbc.eq.4))then
 #else
     elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(2)
-      do k=1,nk
-         do j=0,nj+1
-            u(1,j,k)=0.
-            !$acc loop seq
-            do i=1,ngxy
-               u(1-i,j,k)=-u(1+i,j,k)
-            end do
-         end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(2) private(i,j,k)
+      DO k=1,nk
+        do j=0,nj+1
+          u(1,j,k)=0.
+        do i=1,ngxy
+          u(1-i,j,k)=-u(1+i,j,k)
+        enddo
+        enddo
+      ENDDO
     endif
 
 !-----------------------------------------------------------------------
@@ -3683,49 +3660,42 @@
 #ifndef MPI
     if(ebc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
-      do k=1,nk
-         do j=jb,je
-            do i=1,ngxy
-               u(ni+1+i,j,k)=u(1+i,j,k)
-            end do
-         end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      DO k=1,nk
+        do j=jb,je
+        do i=1,ngxy
+          u(ni+1+i,j,k)=u(1+i,j,k)
+        enddo
+        enddo
+      ENDDO
     elseif(ebc.eq.2)then
 #else
     if(ibe.eq.1.and.ebc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
-      do k=1,nk
-         do j=0,nj+1
-            do i=ni+2,ni+1+ngxy
-               u(i,j,k)=u(ni+1,j,k)
-            end do
-         end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      DO k=1,nk
+        do j=0,nj+1
+        do i=ni+2,ni+1+ngxy
+          u(i,j,k)=u(ni+1,j,k)
+        enddo
+        enddo
+      ENDDO
 #ifdef MPI
     elseif(ibe.eq.1.and.(ebc.eq.3.or.ebc.eq.4))then
 #else
     elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(2)
-      do k=1,nk
-         do j=0,nj+1
-            u(ni+1,j,k)=0.0
-            !$acc loop seq
-            do i=1,ngxy
-               u(ni+1+i,j,k)=-u(ni+1-i,j,k)
-            end do
-        end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(2) private(i,j,k)
+      DO k=1,nk
+        do j=0,nj+1
+          u(ni+1,j,k)=0.0
+        do i=1,ngxy
+          u(ni+1+i,j,k)=-u(ni+1-i,j,k)
+        enddo
+        enddo
+      ENDDO
     endif
 
 !-----------------------------------------------------------------------
@@ -3734,47 +3704,41 @@
 #ifndef MPI
     if(sbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
-      do k=1,nk
-         do j=1,ngxy
-            do i=ib,ie+1
-               u(i,1-j,k)=u(i,nj+1-j,k)
-            end do
-         end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      DO k=1,nk
+        do j=1,ngxy
+        do i=ib,ie+1
+          u(i,1-j,k)=u(i,nj+1-j,k)
+        enddo
+        enddo
+      ENDDO
     elseif(sbc.eq.2)then
 #else
     if(ibs.eq.1.and.sbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
-      do k=1,nk
-         do j=1-ngxy,0
-            do i=0,ni+2
-               u(i,j,k)=u(i,1,k)
-            end do
-         end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      DO k=1,nk
+        do j=1-ngxy,0
+        do i=0,ni+2
+          u(i,j,k)=u(i,1,k)
+        enddo
+        enddo
+      ENDDO
 #ifdef MPI
     elseif(ibs.eq.1.and.(sbc.eq.3.or.sbc.eq.4))then
 #else
     elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
-      do k=1,nk
-         do j=1,ngxy
-            do i=0,ni+2
-               u(i,1-j,k)=u(i,j,k)
-            end do
-         end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      DO k=1,nk
+        do j=1,ngxy
+        do i=0,ni+2
+          u(i,1-j,k)=u(i,j,k)
+        enddo
+        enddo
+      ENDDO
     endif
 
 !-----------------------------------------------------------------------
@@ -3783,50 +3747,43 @@
 #ifndef MPI
     if(nbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
-      do k=1,nk
-         do j=1,ngxy
-            do i=ib,ie+1
-               u(i,nj+j,k)=u(i,j,k)
-            end do
-        end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      DO k=1,nk
+        do j=1,ngxy
+        do i=ib,ie+1
+          u(i,nj+j,k)=u(i,j,k)
+        enddo
+        enddo
+      ENDDO
     elseif(nbc.eq.2)then
 #else
     if(ibn.eq.1.and.nbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
-      do k=1,nk
-         do j=nj+1,nj+ngxy
-            do i=0,ni+2
-               u(i,j,k)=u(i,nj,k)
-            end do
-         end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      DO k=1,nk
+        do j=nj+1,nj+ngxy
+        do i=0,ni+2
+          u(i,j,k)=u(i,nj,k)
+        enddo
+        enddo
+      ENDDO
 #ifdef MPI
     elseif(ibn.eq.1.and.(nbc.eq.3.or.nbc.eq.4))then
 #else
     elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
-      do k=1,nk
-         do j=1,ngxy
-            do i=0,ni+2
-               u(i,nj+j,k)=u(i,nj+1-j,k)
-            end do
-         end do
-      end do
-      !$acc end parallel
+      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      DO k=1,nk
+        do j=1,ngxy
+        do i=0,ni+2
+          u(i,nj+j,k)=u(i,nj+1-j,k)
+        enddo
+        enddo
+      ENDDO
     endif
 
-    !$acc end data
 
 !-----------------------------------------------------------------------
 
@@ -4384,6 +4341,8 @@
 
       end subroutine bcs2
 
+
+
       subroutine bcs2_GPU(s)
       use input
       implicit none
@@ -4391,8 +4350,7 @@
       real s(ib:ie,jb:je,kb:ke)
 
       integer i,j,k
-
-      !$acc data present(s)
+      !$acc declare present(s)
 
 !---------------------------------------------------------
 !  This subroutine sets the corner points
@@ -4404,24 +4362,24 @@
           j=0
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
           do k=1,nk
-             do i=1-ngxy,0
-                s(i,j,k)=s(1,j,k)
-             end do
-          end do
+          do i=1-ngxy,0
+            s(i,j,k)=s(1,j,k)
+          enddo
+          enddo
         endif
 
         if(patchnww)then
           j=nj+1
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
           do k=1,nk
-             do i=1-ngxy,0
-                s(i,j,k)=s(1,j,k)
-             end do
-          end do
+          do i=1-ngxy,0
+            s(i,j,k)=s(1,j,k)
+          enddo
+          enddo
         endif
 
       endif
@@ -4432,24 +4390,24 @@
           j=0
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
           do k=1,nk
-             do i=ni+1,ni+ngxy
-                s(i,j,k)=s(ni,j,k)
-             end do
-          end do
+          do i=ni+1,ni+ngxy
+            s(i,j,k)=s(ni,j,k)
+          enddo
+          enddo
         endif
 
         if(patchnee)then
           j=nj+1
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
           do k=1,nk
-             do i=ni+1,ni+ngxy
-                s(i,j,k)=s(ni,j,k)
-             end do
-          end do
+          do i=ni+1,ni+ngxy
+            s(i,j,k)=s(ni,j,k)
+          enddo
+          enddo
         endif
 
       endif
@@ -4460,24 +4418,24 @@
           i=0
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
           do k=1,nk
-             do j=1-ngxy,0
-                s(i,j,k)=s(i,1,k)
-             end do
-          end do
+          do j=1-ngxy,0
+            s(i,j,k)=s(i,1,k)
+          enddo
+          enddo
         endif
 
         if(patchses)then
           i=ni+1
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
           do k=1,nk
-             do j=1-ngxy,0
-                s(i,j,k)=s(i,1,k)
-             end do
-          end do
+          do j=1-ngxy,0
+            s(i,j,k)=s(i,1,k)
+          enddo
+          enddo
         endif
 
       endif
@@ -4488,32 +4446,34 @@
           i=0
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
           do k=1,nk
-             do j=nj+1,nj+ngxy
-                s(i,j,k)=s(i,nj,k)
-             end do
-          end do
+          do j=nj+1,nj+ngxy
+            s(i,j,k)=s(i,nj,k)
+          enddo
+          enddo
         endif
 
         if(patchnen)then
           i=ni+1
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
           do k=1,nk
-             do j=nj+1,nj+ngxy
-                s(i,j,k)=s(i,nj,k)
-             end do
-          end do
+          do j=nj+1,nj+ngxy
+            s(i,j,k)=s(i,nj,k)
+          enddo
+          enddo
         endif
 
       endif
-      
-      !$acc end data
 
       if(timestats.ge.1) time_bcs2=time_bcs2+mytime()
 
       end subroutine bcs2_GPU
+
+
+
+
 
   END MODULE bc_module

--- a/src/bcast.F
+++ b/src/bcast.F
@@ -5,12 +5,12 @@ MODULE bcast_module
 
 interface bcast_int 
    module procedure bcast_int_scalar 
-   module procedure bcast_int_vector
+   module procedure bcast_int_array
 end interface bcast_int
 
 interface bcast_real
    module procedure bcast_real_scalar
-   module procedure bcast_real_vector
+   module procedure bcast_real_array
 end interface bcast_real
 
   CONTAINS
@@ -31,23 +31,20 @@ end interface bcast_real
       end subroutine bcast_int_scalar
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-      subroutine bcast_int_vector(val,str_ind,end_ind)
+      subroutine bcast_int_array(val,len)
 
 #ifdef MPI
       use mpi
 #endif
       integer :: ierr
-      integer,intent(in) :: str_ind,end_ind
-      integer,intent(inout) :: val(str_ind:end_ind)
-      integer :: length
-   
-      length = end_ind - str_ind + 1
+      integer,intent(in) :: len
+      integer,intent(inout) :: val(*)
 #ifdef MPI
-      call MPI_BCAST(val,length,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+      call MPI_BCAST(val,len,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
 #endif
-      !$acc update device(val(str_ind:end_ind))
+      !$acc update device(val)
 
-      end subroutine bcast_int_vector
+      end subroutine bcast_int_array
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       subroutine bcast_real_scalar(val)
@@ -65,24 +62,20 @@ end interface bcast_real
       end subroutine bcast_real_scalar
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-      subroutine bcast_real_vector(val,str_ind,end_ind)
+      subroutine bcast_real_array(val,len)
 
 #ifdef MPI
       use mpi
 #endif
       integer :: ierr
-      integer,intent(in) :: str_ind,end_ind
-      real,intent(inout) :: val(str_ind:end_ind)
-      integer :: length
-
-      length = end_ind - str_ind + 1
-
+      integer,intent(in) :: len
+      real,intent(inout) :: val(*)
 #ifdef MPI
-      call MPI_BCAST(val,length,MPI_REAL,0,MPI_COMM_WORLD,ierr)
+      call MPI_BCAST(val,len,MPI_REAL,0,MPI_COMM_WORLD,ierr)
 #endif
-      !$acc update device(val(str_ind:end_ind))
+      !$acc update device(val)
 
-      end subroutine bcast_real_vector
+      end subroutine bcast_real_array
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -3779,10 +3779,7 @@
       if(iprcl.eq.1)then
       IF( doprclout )THEN
       
-#ifdef _OPENACC
-!        stop 'ERROR: parcel_interp not supported in OpenACC'
-#endif
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
+        !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
         call     parcel_interp(dt,mtime,xh,uh,ruh,xf,uf,yh,vh,rvh,yf,vf, &
                                zh,mh,rmh,zf,mf,zntmp,ust,c1,c2,        &
                                zs,sigma,sigmaf,rds,gz,                 &
@@ -3796,13 +3793,7 @@
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p, &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2)
 
-#if 0
-#endif
-       !stop 'cm1: after call to parcel_interp'
-!#ifdef _OPENACC
-!        stop 'ERROR: parcel_write not supported in OpenACC'
-!#endif
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
+        !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 
         call     parcel_write(prec,rtime,qname,name_prcl,desc_prcl,unit_prcl,pdata,ploc)
         prec = prec+1

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -579,11 +579,13 @@
       njp1 = nj+1
       nkp1 = nk+1
       nkm1 = nk-1
-      !$acc update device(nip1,njp1,nkp1,nkm1,ni,nj,nk,nparcels, &
-      !$acc               npvals,terrain_flag,numq,bbc,tbc, &
-      !$acc               viscosity,pr_num,sc_num,prvpx,prvpy, &
-      !$acc               prvpz,prrp,prms,prtp,prx,pry,prsig,prz, &
-      !$acc               pract,nodex,nodey)
+      !$acc update device(nip1,njp1,nkp1,nkm1)
+      !$acc update device(ni,nj,nk)
+      !$acc update device(nparcels,npvals)
+      !$acc update device(terrain_flag,numq)
+      !$acc update device(zt,rzt,bbc,tbc)
+      !$acc update device(viscosity,pr_num,sc_num)
+      !$acc update device(prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pract)
 
       nimax = ni
       njmax = nj
@@ -754,7 +756,6 @@
 !-----------------------------------------------
 #endif
 
-      !$acc update device (myi,myj)
 
       call wenocheck
 
@@ -774,8 +775,10 @@
 
       ! number of 'ghost' points in the vertical direction:
       ngz   = 1
-
+      !print *,'cm1: copyin of (ngzy,ngz): ',ngxy,ngz 
       !$acc update device (ngxy,ngz)
+      !stop 'after call to data copyin()'
+      
 
 !---------------------------------------------------------------------
 !      For ZVD:
@@ -973,7 +976,6 @@
       rmp = 1
       cmp = 1
 #endif
-      !$acc update device (imp,jmp,kmp,kmt,rmp,cmp)
 
       allocate( reqs_u(rmp) )
       reqs_u = 0
@@ -1269,6 +1271,7 @@
                        uw31,uw32,ue31,ue32,us31,us32,un31,un32,         &
                        vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,         &
                        ww31,ww32,we31,we32,ws31,ws32,wn31,wn32)
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
 
 !----------------------------------------------------------------------
 
@@ -1458,6 +1461,8 @@
                       uw31,uw32,ue31,ue32,us31,us32,un31,un32,              &
                       vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,              &
                       sw31,sw32,se31,se32,ss31,ss32,sn31,sn32)
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
+
 
 !----------------------------------------------------------------------
 !  Now, allocate the mother lode, then call INIT3D
@@ -2186,6 +2191,7 @@
                        ws31(1,1,1),ws32(1,1,1),wn31(1,1,1),wn32(1,1,1),reqs_p)
 
       ENDIF
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
 
       allocate( hflxw(ibib:ieib,jbib:jeib,kmaxib) )
       hflxw = 0
@@ -2291,6 +2297,8 @@
                   kmh,kmv,khh,khv,tkea,tke3d,tketen,                &
                   pta,pt3d,ptten,                                   &
                   pdata,cfb,cfa,cfc,d1,d2,pdt,lgbth,lgbph,rhs,trans)
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
+
 
 !----------------------------------------------------------------------
 
@@ -2463,6 +2471,7 @@
                         emiss,thc,albd,znt,rznt,mavail,dsxy,prs0s,prs0,   &
                         tmn,tml,t0ml,hml,h0ml,huml,hvml,tmoml,z0base)
 
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
       IF(irst.eq.1)THEN
 
         startup = .false.
@@ -2503,6 +2512,7 @@
                               icenter,jcenter,xcenter,ycenter,adaptmovetim,mvrec,nwritemv,ug,vg, &
                               gamk,kmw,u1b,v1b,cmz,csz,ce1z,ce2z,                  &
                               dum1,dat1,dat2,dat3,reqt,myi1p,myi2p,myj1p,myj2p,restarted,restart_prcl)
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
           ! end_read_restart
         !  In case user wants to change values on a restart:
         IF( restart_reset_frqtim )THEN 
@@ -2592,6 +2602,7 @@
         if(dowr) write(outfile,*)
       ENDIF
 
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
       call       getset(restarted,mass1,uh,ruh,vh,rvh,xh,yh,xf,yf,         &
                         zs,gz,sigma,sigmaf,rmh,mf,dzdx,dzdy,dumk1,dumk2,   &
                         pi0,th0,rho0,prs0,ust,u1,v1,s1,u0,v0,rth0,         &
@@ -2651,7 +2662,7 @@
 
       !$acc data &
       !$acc copyin(uh,vh,mh,u3d,v3d,w3d) &
-      !$acc copyin(kmh,kmv,khh,khv)
+      !$acc copyin(kmh,kmv,khh,khv,ksmax)
       if( adapt_dt.eq.1 )then
         dt = dbldt
         if( .not. restarted )then
@@ -2687,6 +2698,8 @@
         endif
       endif
       !$acc end data
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
+
 
       ! cm1r19:  nsound is always determined diagnostically
       call dtsmall(dt,dbldt)
@@ -2769,59 +2782,77 @@
       IF( imoist.eq.1 .and. dodomaindiag .and. ptype.eq.5 ) getvt = .true.
       IF( imoist.eq.1 .and. dodomaindiag .and. testcase.eq.5 ) getvt = .true.
 
-!$acc data copyin (thten,sten,rho0,thv0,th0,qv0,prs0,rth0,qc0, &
-!$acc              xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf, &
-!$acc              ruf,yh,vh,rvh,yf,vf,rvf,rds,sigma,rdsf,sigmaf, &
-!$acc              zh,mh,rmh,zf,mf,rmf,zs,gz,rgz,gzu,rgzu,gzv, &
-!$acc              rgzv,dzdx,dzdy,gx,gxu,gy,gyv,c1,c2,wprof,f2d, &
-!$acc              m11,m12,m13,m22,m23,m33,kmw,u1b,v1b,tauh,tauf, &
-!$acc              taus,bndy,kbdy,phi1,pt3d,xland,p2w1,p2w2,p2e1, &
-!$acc              p2e2,p2s1,p2s2,p2n1,p2n2,pw1,pw2,pe1,pe2,ps1, &
-!$acc              ps2,pn1,pn2,uw31,uw32,ue31,ue32,us31,us32,un31, &
-!$acc              un32,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,tw1,tw2, &
-!$acc              te1,te2,ts1,ts2,tn1,tn2,tkw1,tkw2,tke1,tke2, &
-!$acc              tks1,tks2,tkn1,tkn2,ww1,ww2,we1,we2,ws1,ws2, &
-!$acc              wn1,wn2,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2, &
-!$acc              vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32, &
-!$acc              ww31,ww32,we31,we32,ws31,ws32,wn31,wn32, &
-!$acc              qw31,qw32,qe31,qe32,qs31,qs32,qn31,qn32, &
-!$acc              sw31,sw32,se31,se32,ss31,ss32,sn31,sn32, &
-!$acc              rw31,rw32,re31,re32,rs31,rs32,rn31,rn32, &
-!$acc              p3w1,p3w2,p3e1,p3e2,p3s1,p3s2,p3n1,p3n2, &
-!$acc              n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2, &
-!$acc              nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,kw1,kw2, &
-!$acc              ke1,ke2,ks1,ks2,kn1,kn2,taux,tauy,gamwall, &
-!$acc              l2p,t2pm1,t2pm2,t2pm3,t2pm4,udiag,vdiag, &
-!$acc              wdiag,kdiag,tdiag,qdiag,dum1,dum2,dum3,dum4, &
-!$acc              dum5,dum6,dum7,dum8,dum9,defv,defh,lenscl, &
-!$acc              dissten,epst,epsd1,epsd2,thpten,upten,vpten, &
-!$acc              psfc,u10,v10,s10,hpbl,wspd,gz1oz0,br,brcr, &
-!$acc              phim,phih,swspd,cpmm,zol,mavail,mol,rmol, &
-!$acc              dsxy,cda,psim,psih,psiq,fm,fh,th2,q2,t2, &
-!$acc              gamk,cmz,csz,ce1z,ce2z,stau,ustt,ut,vt,st, &
-!$acc              cd,ch,cq,tlh,u1,v1,s1,t1,znt,zntmp,ust,hfx, &
-!$acc              qfx,qsfc,tsk,tmn,tslb,sws,svs,sps,srs,sgs, &
-!$acc              sus,shs,bud2,ufrc,vfrc,thfrc,qvfrc,t11,t12, &
-!$acc              t13,t22,t23,t33,thflux,qvflux,radbcw,radbce, &
-!$acc              radbcs,radbcn,dtu,dtv,dumk1,dumk2,divx,nm, &
-!$acc              dissten,epst,pta,pt3d,ptten,u2pt,v2pt,qke_adv, &
-!$acc              qke,qke3d,chklowq,flqc,ch_out,cd_out,pdata, &
-!$acc              dpten,zkmax,CHS,CHS2,CQS2,QGH,smois,charn, &
-!$acc              msang, scurx,scury,s2p,s2b,lu_index,qi0,rr0, &
-!$acc              rf0,rrf0,dtu0,dtv0,u0,v0,rho,rr,rf,prs,o30, &
-!$acc              zir,flag,pi0,ug,vg,tke_myj,xkzh,xkzq,xkzm, &
-!$acc              xfref,xhref,yfref,yhref,dvdr,qpten,qtten, &
-!$acc              qvten,qcten,qa,q3d,qten,kmh,kmv,khh,khv,tkea, &
-!$acc              tke3d,tketen,effc,effi,effs,effr,effg,effis, &
-!$acc              out2d,out3d,rain,prate,p3a,p3o,qbudget,asq, &
-!$acc              bsq,qavg,cavg,cloudvar,rho0s,pi0s,prs0s,rth0s, &
-!$acc              tst,qst,z0t,z0q,mznt,ppi,pp3d,ppten,sadv,ppx, &
-!$acc              tha,thten1,thterm,glw,gsw,ulspg,vlspg,savg,pavg, &
-!$acc              uavg,vavg,thavg,lsnudge_u,lsnudge_v,reqs_s, &
-!$acc              reqs_u,reqs_p3,reqs_v,reqs_w,reqs_x,reqs_y, &
-!$acc              reqs_p2,reqs_z,rru,ua,u3d,uten,uten1,rrv,va,v3d, &
-!$acc              th3d,phi2,vten,vten1,rrw,wa,w3d,wten,wten1,pdata_locind, &
-!$acc              dum2d1,dum2d2,dum2d3,dum2d4,dum2d5)    ! JMD: does not appear to be used
+    !$acc data &
+    !$acc copyin(thten,sten,ksmax) &
+    !$acc copyin(rho0,thv0,th0,qv0) &
+    !$acc copyin(prs0,rth0,qc0) &
+    !$acc copyin(xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf, &
+    !$acc   yh,vh,rvh,yf,vf,rvf,rds,sigma,rdsf,sigmaf,zh,mh,rmh,zf,mf,rmf, &
+    !$acc   zs,gz,rgz,gzu,rgzu,gzv,rgzv,dzdx,dzdy,gx,gxu,gy,gyv) &
+    !$acc copyin(c1,c2,wprof,f2d,m11,m12,m13,m22,m23,m33,kmw,u1b,v1b, &
+    !$acc   tauh,tauf,taus,bndy,kbdy,phi1,pt3d,rdx,rdy,rzt,zt, &
+    !$acc   cgs1, cgs2, cgs3, cgt1, cgt2, cgt3, xland) &
+    !$acc copyin(avgsfcu,avgsfcv,avgsfcs,avgsfct) &
+    !$acc copyin(p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2) &
+    !$acc copyin(pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2) &
+    !$acc copyin(uw31,uw32,ue31,ue32,us31,us32,un31,un32) &
+    !$acc copyin(zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2) &
+    !$acc copyin(tw1,tw2,te1,te2,ts1,ts2,tn1,tn2) &
+    !$acc copyin(tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2) &
+    !$acc copyin(ww1,ww2,we1,we2,ws1,ws2,wn1,wn2) &
+    !$acc copyin(vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2) &
+    !$acc copyin(vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32) &
+    !$acc copyin(ww31,ww32,we31,we32,ws31,ws32,wn31,wn32) &
+    !$acc copyin(qw31,qw32,qe31,qe32,qs31,qs32,qn31,qn32) &
+    !$acc copyin(sw31,sw32,se31,se32,ss31,ss32,sn31,sn32) &
+    !$acc copyin(rw31,rw32,re31,re32,rs31,rs32,rn31,rn32) &
+    !$acc copyin(p3w1,p3w2,p3e1,p3e2,p3s1,p3s2,p3n1,p3n2) &
+    !$acc copyin( &
+    !$acc   n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2, &
+    !$acc   nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,                  &
+    !$acc   n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,          &
+    !$acc   kw1,kw2,ke1,ke2,ks1,ks2,kn1,kn2)                  &
+    !$acc copyin(taux,tauy,gamwall,l2p,t2pm1,t2pm2,t2pm3,t2pm4) &
+    !$acc copyin(udiag,vdiag,wdiag,kdiag,tdiag,qdiag) &
+    !$acc copyin(dum1,dum2,dum3,dum4,dum5,dum6,dum7,dum8,dum9) &
+    !$acc copyin(dum2d1,dum2d2,dum2d3,dum2d4,dum2d5) & ! does not appear to be used
+    !$acc copyin(defv,defh,lenscl,dissten, &
+    !$acc      epst,epsd1,epsd2,thpten,upten,vpten,psfc,u10,v10,s10,hpbl, &
+    !$acc      wspd,gz1oz0,br,brcr,phim,phih,swspd,cpmm,zol,mavail,mol,rmol,dsxy,cda,psim,psih, &
+    !$acc      psiq,fm,fh,th2,q2,t2,gamk,cmz,csz,ce1z,ce2z) &
+    !$acc copyin(stau,ustt,ut,vt,st,cd,ch,cq,tlh,u1,v1,s1,t1) &
+    !$acc copyin(znt,zntmp,ust,hfx,qfx,qsfc,tsk,tmn,tslb) &
+    !$acc copyin(sws,svs,sps,srs,sgs,sus,shs) &
+    !$acc copyin(bud2,ufrc,vfrc,thfrc,qvfrc,t11,t12,t13,t22,t23,t33, &
+    !$acc      thflux,qvflux,radbcw,radbce,radbcs,radbcn,dtu,dtv,dumk1,dumk2,divx, &
+    !$acc      nm,dissten,epst,pta,pt3d,ptten,u2pt,v2pt,qke_adv,qke,qke3d) &
+    !$acc copyin(chklowq,flqc,ch_out,cd_out) &
+    !$acc copyin(pdata,dpten) &
+    !$acc copyin(zkmax,CHS,CHS2,CQS2,flhc,lh,QGH,smois,charn,msang,scurx,scury,s2p,s2b) &
+    !$acc copyin(lu_index) &
+    !$acc copyin(qi0,rr0,rf0,rrf0,dtu0,dtv0,u0,v0) &
+    !$acc copyin(rho,rr,rf,prs,o30,zir)  &
+    !$acc copyin(flag) &
+    !$acc copyin(pi0) &
+    !$acc copyin(ug,vg) &
+    !$acc copyin(tke_myj,xkzh,xkzq,xkzm) &
+    !$acc copyin(xfref,xhref,yfref,yhref,dvdr) &
+    !$acc copyin(qpten,qtten,qvten,qcten,qa,q3d,qten,kmh,kmv,khh,khv,tkea,tke3d,tketen) &
+    !$acc copyin(effc,effi,effs,effr,effg,effis,out2d,out3d) &  ! physics only 
+    !$acc copyin(rain,prate,p3a,p3o) & ! physics only
+    !$acc copyin(qbudget,asq,bsq) &
+    !$acc copyin(qavg,cavg,cloudvar,rho0s,pi0s,prs0s,rth0s,tst,qst,z0t,z0q,mznt) &
+    !$acc copyin(ppi,pp3d,ppten,sadv,ppx,tha) &
+    !$acc copyin(thten1,thterm) &
+    !$acc copyin(glw,gsw) &
+    !$acc copyin(ulspg,vlspg) &
+    !$acc copyin(savg,pavg,uavg,vavg,thavg) &
+    !$acc copyin(lsnudge_u, lsnudge_v) &
+    !$acc copyin(dt) &
+    !$acc copyin(reqs_s,reqs_u,reqs_p3, &
+    !$acc   reqs_v,reqs_w,reqs_x,reqs_y,reqs_s,reqs_p2,reqs_z) &
+    !$acc copyin(rru,ua,u3d,uten,uten1,rrv,va,v3d,th3d,phi2,vten,vten1,rrw,wa,w3d,wten,wten1) &
+    !$acc copy(pdata_locind)
 
     if(timestats.ge.1) time_H2D=time_H2D+mytime()
 
@@ -2972,6 +3003,8 @@
 
         if(timestats.ge.1) time_misc=time_misc+mytime()
 
+
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
 #ifdef _NVTX
         call nvtxStartRange("solve1 ",id=0)
 #endif
@@ -3149,6 +3182,7 @@
 #ifdef _NVTX
         call nvtxEndRange
 #endif
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
       !print *,'cm1: after call to solve2'
       !$acc compare(dum1)
 
@@ -3181,6 +3215,7 @@
 #endif
 
       ENDIF
+      !print *,'cm1: (ngzy,ngz): ',ngxy,ngz 
 !$acc compare(qbudget)
 
 

--- a/src/comm.F
+++ b/src/comm.F
@@ -13936,9 +13936,8 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
       integer, intent(in) :: comm
       logical, parameter :: Debug = .FALSE.
       integer :: i,j
-      !$acc data present (s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32, &
-      !$acc               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2, &
-      !$acc               reqs_s)
+      !$acc declare present(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32) &
+      !$acc         present(n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2)
 
 if(Debug) print *, "prepcorners3_GPU: Im called"
 
@@ -13973,9 +13972,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       ENDIF
-
-      !$acc end data
-
+      !!$acc update device(s)
       end subroutine prepcorners3_GPU
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/constants.F
+++ b/src/constants.F
@@ -8,12 +8,10 @@
             cpdcv,rovcp,rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1,       &
             cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi,lv1,lv2,ls1,ls2,  &
             rhow,c_e1,c_e2,c_s,rcs,earth_radius,govtwo,mw,ms,surften,ion,os,ru
-
-!$acc declare create(g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp,cpdcv,rovcp, &
-!$acc                rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1, &
-!$acc                cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi, &
-!$acc                lv1,lv2,ls1,ls2,rhow,c_e1,c_e2,c_s,rcs,govtwo, &
-!$acc                earth_radius,govtwo,surften,mw,ms,ion,os,ru)
+!$acc declare create(g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp) &
+!$acc create(cpdcv,rovcp,rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1) &
+!$acc create(cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi,lv1,lv2,ls1,ls2) &
+!$acc create(rhow,c_e1,c_e2,c_s,rcs,earth_radius,govtwo,surften,mw,ms,ion,os,ru)
 
       !----------------
 
@@ -179,11 +177,11 @@
       c_s = ( c_m * c_m * c_m / ( c_e1 + c_e2 ) )**0.25   ! Smagorinsky constant
       rcs = 1.0/c_s
 
-!$acc update device(g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp,cpdcv,rovcp, &
-!$acc               rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1, &
-!$acc               cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi, &
-!$acc               lv1,lv2,ls1,ls2,rhow,c_e1,c_e2,c_s,rcs,govtwo, &
-!$acc               earth_radius,govtwo,surften,ms,mw,ion,os,ru)
+!$acc update device(g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp) &
+!$acc device(cpdcv,rovcp,rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1) &
+!$acc device(cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi,lv1,lv2,ls1,ls2) &
+!$acc device(rhow,c_e1,c_e2,c_s,rcs,earth_radius,govtwo,surften,ms,mw,ion,os,ru)
+
 
       end subroutine set_constants
 

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -1,12 +1,5 @@
 #ifdef _B4B
 
-#define _B4B07F
-#define _B4B08F
-#define _B4B09F
-#define _B4B10F
-#define _B4B11F
-#define _B4B12F
-
 #define _B4B16R
 #define _B4B19R
 #define _B4B21R
@@ -3463,11 +3456,7 @@
         varunit(nvar) = 'K'
 
       if( ptype.eq.0 )then
-#ifdef _B4B07F
-        !$acc update host(th0,th3d,pi0,pp3d,q3d,prs)
-#else
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,tx,qx,px,tlcl,ee)
-#endif
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -3482,11 +3471,7 @@
         enddo
         enddo
       else
-#ifdef _B4B07F
-        !$acc update host(th0,th3d,pi0,pp3d,q3d,prs)
-#else
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,tx,qx,px,tlcl,ee)
-#endif
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -3505,9 +3490,6 @@
         enddo
         enddo
       endif
-#ifdef _B4B07F
-      !$acc update device(dum1)
-#endif
 
         call getavg3d(dum1,savg)
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
@@ -3523,11 +3505,7 @@
         vardesc(nvar) = 'relative humidity (wrt liquid)'
         varunit(nvar) = 'nondimensional'
      
-#ifdef _B4B08F
-        !$acc update host(q3d,prs,th,pi0,pp3d)
-#else
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
-#endif
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -3535,9 +3513,6 @@
         enddo
         enddo
         enddo
-#ifdef _B4B08F
-        !$acc update device(dum1)
-#endif
         call getavg3d(dum1,savg)
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 
@@ -3551,11 +3526,7 @@
         varname(nvar) = 'rhi'
         vardesc(nvar) = 'relative humidity (wrt ice)'
         varunit(nvar) = 'nondimensional'
-#ifdef _B4B09F
-        !$acc update host(q3d,prs,th,pi0,pp3d)
-#else
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
-#endif
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -3563,9 +3534,6 @@
         enddo
         enddo
         enddo
-#ifdef _B4B09F
-        !$acc update device(dum1)
-#endif
         call getavg3d(dum1,savg)
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 
@@ -4408,11 +4376,7 @@
         varunit(nvar) = 'm'
         vargrid(nvar) = 'w'
 
-#ifdef _B4B10F
-        !$acc update host(ruh,rvh,rmf,zf,znt)
-#else
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
-#endif
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -4424,9 +4388,6 @@
         enddo
         enddo
         enddo
-#ifdef _B4B10F
-        !$acc update device(dum1)
-#endif
 
         call getavg3d(dum1,savg)
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
@@ -4726,17 +4687,10 @@
         vardesc(nvar) = 'analytic wind speed (neutral)'
         varunit(nvar) = 'm/s'
 
-#ifdef _B4B11F
-        !$acc update host(zh)
-#else
         !$acc parallel loop gang vector default(present) private(k)
-#endif
         do k=1,nk
           savg(k) = (ustbar/karman)*alog( (zh(1,1,k)+zntbar)/zntbar )
         enddo
-#ifdef _B4B11F
-        !$acc update device(savg)
-#endif
 
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 
@@ -4747,11 +4701,7 @@
         vardesc(nvar) = 'analytic wind speed'
         varunit(nvar) = 'm/s'
 
-#ifdef _B4B12F
-        !$acc update host(zh)
-#else
         !$acc parallel loop gang vector default(present) private(k,zeta,tpsim)
-#endif
         do k=1,nk
           if( abs(molbar).gt.1.0e-6 )then
             zeta = zh(1,1,k)/molbar
@@ -4762,9 +4712,6 @@
           savg(k) = (ustbar/karman)*( alog(zh(1,1,k)/zntbar) - tpsim )
           wspa(k) = savg(k)
         enddo
-#ifdef _B4B12F
-        !$acc update device(savg,wspa)
-#endif
 
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -1124,15 +1124,16 @@
     ziflag:  &
     IF( ( testcase.ge.1 .and. testcase.le.7 ) .or. testcase.eq.9 .or. testcase.eq.10 .or. testcase.eq.11 )THEN
 
+        !$acc parallel private(i,j,k,zi,tmax,dtdz) &
+        !$acc   reduction(min:zimin) &
+        !$acc   reduction(max:zimax)
         zimin =  1.0e30
         zimax = -1.0e30
-        !$acc parallel default(present) reduction(min:zimin) reduction(max:zimax)
-        !$acc loop gang vector collapse(2)
+        !$acc loop vector collapse(2)
         do j=1,nj
         do i=1,ni
           zi = 0.0
           tmax = 0.0
-          !$acc loop seq
           do k=nk,2,-1
             dtdz = (thv(i,j,k)-thv(i,j,k-1))*rdz*mf(i,j,k)
             if( dtdz .ge. tmax )then
@@ -1145,6 +1146,8 @@
           zimin = min( zimin , zi )
         enddo
         enddo
+!!!        print *,'zimin: ',zimin
+!!!        print *,'zimax: ',zimax
         !$acc end parallel
 
 #ifdef MPI
@@ -1167,6 +1170,8 @@
 
       !c-c-c-c-c-c-c-c-c-c
 
+      !JMD need to verify that zimin is still incorrect
+      !JMD-BUG:  for some reason zimin is still not set properly 
       nvar = nvar+1
       varname(nvar) = 'zimin'
       vardesc(nvar) = 'minimum value of zi'
@@ -1577,81 +1582,68 @@
         qcrit(k) = min( 1.0e-5 , 0.01*rslf(pavg(k),thavg(k)*((pavg(k)*rp00)**rovcp)) )
       enddo
 
+      !$acc parallel default(present) private(i,j,k)
+      do k=nk,1,-1
         ! use minimum of 1.0e-5 and 1% of saturation wrt liquid (using last known t,p)
         !qcrit(k) = min( 1.0e-5 , 0.01*rslf(pavg(k),thavg(k)*((pavg(k)*rp00)**rovcp)) )
         if( nqc.ge.1 )then
-          !$acc parallel default(present)
-          !$acc loop gang vector collapse(3)
-          do k=nk,1,-1
-             do j=1,nj
-                do i=1,ni
-                   if( q3d(i,j,k,nqc).ge.qcrit(k) ) dum1(i,j,1) = zh(i,j,k)
-                end do
-             end do
-          end do
-          !$acc end parallel
+          !$acc loop gang vector collapse(2)
+          do j=1,nj
+          do i=1,ni
+            if( q3d(i,j,k,nqc).ge.qcrit(k) ) dum1(i,j,1) = zh(i,j,k)
+          enddo
+          enddo
         endif
         if( nqr.ge.1 )then
-          !$acc parallel default(present)
-          !$acc loop gang vector collapse(3)
-          do k=nk,1,-1
-             do j=1,nj
-                do i=1,ni
-                   if( q3d(i,j,k,nqr).ge.qcrit(k) ) dum1(i,j,2) = zh(i,j,k)
-                end do
-             end do
-          end do
-          !$acc end parallel
+          !$acc loop gang vector collapse(2)
+          do j=1,nj
+          do i=1,ni
+            if( q3d(i,j,k,nqr).ge.qcrit(k) ) dum1(i,j,2) = zh(i,j,k)
+          enddo
+          enddo
         endif
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(3)
-        do k=nk,1,-1
-           do j=1,nj
-              do i=1,ni
-                 if( ql(i,j,k).ge.qcrit(k) ) dum1(i,j,3) = zh(i,j,k)
-              end do
-           end do
-        end do
-        !$acc end parallel
+        !$acc loop gang vector collapse(2)
+        do j=1,nj
+        do i=1,ni
+          if( ql(i,j,k).ge.qcrit(k) ) dum1(i,j,3) = zh(i,j,k)
+        enddo
+        enddo
         if( iice.eq.1 )then
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(3)
-        do k=nk,1,-1
-           do j=1,nj
-              do i=1,ni
-                 if( qice(i,j,k).ge.qcrit(k) ) dum1(i,j,4) = zh(i,j,k)
-              end do
-           end do
-        end do
-        !$acc end parallel
+        !$acc loop gang vector collapse(2)
+        do j=1,nj
+        do i=1,ni
+          if( qice(i,j,k).ge.qcrit(k) ) dum1(i,j,4) = zh(i,j,k)
+        enddo
+        enddo
         endif
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(3)
-        do k=nk,1,-1
-           do j=1,nj
-              do i=1,ni
-                 if( (ql(i,j,k)+qice(i,j,k)).ge.qcrit(k) ) dum1(i,j,5) = zh(i,j,k)
-              end do
-           end do
-        end do
-        !$acc end parallel
+        !$acc loop gang vector collapse(2)
+        do j=1,nj
+        do i=1,ni
+          if( (ql(i,j,k)+qice(i,j,k)).ge.qcrit(k) ) dum1(i,j,5) = zh(i,j,k)
+        enddo
+        enddo
+      enddo
+      !$acc end parallel
 
+      !$acc parallel default(present) private(i,j) &
+      !$acc   reduction(+:qcfrac,qrfrac,qlfrac,qifrac,qtfrac)
       qcfrac = 0.0
       qrfrac = 0.0
       qlfrac = 0.0
       qifrac = 0.0
       qtfrac = 0.0
-      !$acc parallel default(present) reduction(+:qcfrac,qrfrac,qlfrac,qifrac,qtfrac)
-      !$acc loop gang vector collapse(2) reduction(+:qcfrac,qrfrac,qlfrac,qifrac,qtfrac)
+
+      !$acc loop gang vector collapse(2) &
+      !$acc   reduction(+:qcfrac,qrfrac,qlfrac,qifrac,qtfrac)
       do j=1,nj
-         do i=1,ni
-            if( dum1(i,j,1).gt.0.01*zh(1,1,1) ) qcfrac = qcfrac+1.0
-            if( dum1(i,j,2).gt.0.01*zh(1,1,1) ) qrfrac = qrfrac+1.0
-            if( dum1(i,j,3).gt.0.01*zh(1,1,1) ) qlfrac = qlfrac+1.0
-            if( dum1(i,j,4).gt.0.01*zh(1,1,1) ) qifrac = qifrac+1.0
-            if( dum1(i,j,5).gt.0.01*zh(1,1,1) ) qtfrac = qtfrac+1.0
-         end do
-      end do
+      do i=1,ni
+        if( dum1(i,j,1).gt.0.01*zh(1,1,1) ) qcfrac = qcfrac+1.0
+        if( dum1(i,j,2).gt.0.01*zh(1,1,1) ) qrfrac = qrfrac+1.0
+        if( dum1(i,j,3).gt.0.01*zh(1,1,1) ) qlfrac = qlfrac+1.0
+        if( dum1(i,j,4).gt.0.01*zh(1,1,1) ) qifrac = qifrac+1.0
+        if( dum1(i,j,5).gt.0.01*zh(1,1,1) ) qtfrac = qtfrac+1.0
+      enddo
+      enddo
       !$acc end parallel
 
 #ifdef MPI

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -1,13 +1,5 @@
 #ifdef _B4B
 
-#define _B4B01F
-#define _B4B02F
-#define _B4B03F
-#define _B4B04F
-#define _B4B05F
-
-#define _B4B06
-
 #define _B4B07F
 #define _B4B08F
 #define _B4B09F
@@ -1373,27 +1365,17 @@
           enddo
         endif
       enddo
-#ifdef _B4B01F
-      !$acc update host(dum1(1:ni,1:nj,5),rho,prs,th,pi0,pp3d,rmh)
-#else
       !$acc parallel default(present) private(i,j)
       !$acc loop seq
-#endif
       do k=1,nk
-#ifndef _B4B01F
         !$acc loop gang vector collapse(2)
-#endif
         do j=1,nj
         do i=1,ni
           dum1(i,j,5) = dum1(i,j,5) + rho(i,j,k)*rslf(prs(i,j,k),th(i,j,k)*(pi0(i,j,k)+pp3d(i,j,k)))*dz*rmh(i,j,k)
         enddo
         enddo
       enddo
-#ifdef _B4B01F
-      !$acc update device(dum1(1:ni,1:nj,5))
-#else
       !$acc end parallel
-#endif
 
       do k=1,nk
         IF( iice.eq.1 )THEN
@@ -1601,18 +1583,11 @@
       enddo
       enddo
 
-#ifdef _B4B02F
-      !$acc update host(pavg,thavg)
-#else
       !$acc parallel loop gang vector default(present) private(i,j,k)
-#endif
       do k=1,nk
         ! use minimum of 1.0e-5 and 1% of saturation wrt liquid (using last known t,p)
         qcrit(k) = min( 1.0e-5 , 0.01*rslf(pavg(k),thavg(k)*((pavg(k)*rp00)**rovcp)) )
       enddo
-#ifdef _B4B02F
-      !$acc update device(qcrit)
-#endif
 
       !$acc parallel default(present) private(i,j,k)
       do k=nk,1,-1
@@ -3351,19 +3326,12 @@
         varunit(nvar) = 'n.d.'
 
       if( imoist.eq.1 )then
-#ifdef _B4B03F
-        !$acc update host(psfc,tsk)
-#else
         !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
-#endif
         do j=1,nj
         do i=1,ni
           tmpqsfc(i,j) = rslf(psfc(i,j),tsk(i,j))
         enddo
         enddo
-#ifdef _B4B03F
-        !$acc update device(tmpqsfc)    
-#endif
         !...
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
@@ -3405,11 +3373,7 @@
 
     !PORTME
     if( nloop.eq.1 )then
-#ifdef _B4B04F
-      !$acc update host(th0,th3d,dum2,tsk,psfc,tmpqsfc,thflux,qvflux,ust,govthv,hpbl)
-#else
       !$acc parallel loop gang vector collapse(2) default(present) private(i,j,thvx)
-#endif
       do j=1,nj
       do i=1,ni
         thvx = (th0(i,j,1)+th3d(i,j,1))*(1.0+repsm1*dum2(i,j,1))
@@ -3417,16 +3381,9 @@
         thv1(i,j) = thvx
       enddo
       enddo
-#ifdef _B4B04F
-      !$acc update device(thvx,thvsfc,thv1)
-#endif
     else
-#ifdef _B4B05F
-      !$acc update host(th0,th3d,dum2,tsk,psfc,tmpqsfc,thflux,qvflux,ust,govthv,hpbl)
-#else
       !$acc parallel loop gang vector collapse(2) default(present) &
       !$acc private(i,j,thvx,thf1,thf2,thvflux,ws,gamfac,tmpprt)
-#endif
       do j=1,nj
       do i=1,ni
         thvx = (th0(i,j,1)+th3d(i,j,1))*(1.0+repsm1*dum2(i,j,1))
@@ -3443,17 +3400,10 @@
         thv1(i,j) = thvx + tmpprt
       enddo
       enddo
-#ifdef _B4B05F
-      !$acc update device(thvx,thf1,thf2,thvflux,ws,gamfac,tmpprt,thv1)
-#endif
     endif
 
-#ifdef _B4B06
-      !$acc update host(u3d,v3d,zh,th0,th3d,dum2,tsk,psfc,tmpqsfc,thflux,qvflux,ust,govthv,hpbl)
-#else
       !$acc parallel loop gang vector collapse(3) default(present) &
       !$acc private(i,j,k,thvx,ubar,vbar)
-#endif
       do k=1,nk
       do j=1,nj
       do i=1,ni
@@ -3464,9 +3414,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B06
-      !$acc update device(dum1)
-#endif
 
     ENDDO  hloop
 

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -9688,7 +9688,7 @@
         vargrid(nvar) = '2'
 
         savg2d = 0.0
-        !$acc parallel loop gang vector reduction(max:savg2d)
+        !$acc parallel loop gang vector default(present) reduction(max:savg2d) 
         do k=2,nk
           savg2d = max( savg2d , dble(wvar(k)) )
         enddo
@@ -10667,26 +10667,15 @@
 
     integer :: i,j
 
-    !JMD Need to double check following bit of code.  We should be able to move 
-    !JMD calculation to the GPU
-#ifdef _B4B28R
-    !$acc update host(s2d)
-    savg2d = 0.0
-#else
     savg2d = 0.0
     !$acc parallel default(present) private(i,j) reduction(+:savg2d)
     !$acc loop gang vector collapse(2) reduction(+:savg2d)
-#endif
     do j=1,nj
     do i=1,ni
       savg2d = savg2d+s2d(i,j)
     enddo
     enddo
-#ifdef _B4B28R
-    !$acc update device(savg2d)
-#else
     !$acc end parallel
-#endif
 
 #ifdef MPI
     call MPI_ALLREDUCE(MPI_IN_PLACE,savg2d,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
@@ -10695,6 +10684,7 @@
     savg2d = savg2d/dble(nx*ny)
 
     end subroutine getavg2d
+
 
 
     !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -102,63 +102,56 @@
       integer :: tmp_flag
 #endif
 
-      call reinit_random_seed
+      !$acc declare present(rho,prs,qa,wa,sigma)
 
+      !integer :: nip1
+
+      !JMD no idea why these values hae not already been set previously
+      !$acc update device(ib,jb,kb,ie,je,ke)
+      !!$acc compare(wten,thten)
+      !KLUDGE-JMD
+      call reinit_random_seed
+      !print *,'droplet_driver: point #1'
 !----------------------------------------------------------------------
 !  apply bottom/top boundary conditions:
 !  [Note:  for u,v the array index (i,j,0) means the surface, ie z=0]
 !     (for the parcel subroutines only!)
-
-      !$acc data create(ta)
+      !$acc data create(ta) copyin(ngz,ngxy)
+      !print *,'droplet_driver: {ngxy,ngxy}: ',ngxy,ngz
+!$omp parallel do default(shared) private(i,j)
+!$acc parallel loop gang vector default(present) private(i,j)
+  DO j=jb,je+1
 
     IF(bbc.eq.1)THEN
       ! free slip ... extrapolate:
-      !$acc parallel loop gang vector collapse(2) default(present)
-      do j=jb,je
-         do i=ib,ie+1
-            ua(i,j,0) = cgs1*ua(i,j,1)+cgs2*ua(i,j,2)+cgs3*ua(i,j,3)
-         end do
-      end do
-      !$acc end parallel
-      !$acc parallel loop gang vector collapse(2) default(present)
-      do j=jb,je+1
-         do i=ib,ie
-            va(i,j,0) = cgs1*va(i,j,1)+cgs2*va(i,j,2)+cgs3*va(i,j,3)
-         end do
-      end do
-      !$acc end parallel
+      IF(j.le.je)THEN
+      do i=ib,ie+1
+        ua(i,j,0) = cgs1*ua(i,j,1)+cgs2*ua(i,j,2)+cgs3*ua(i,j,3)
+      enddo
+      ENDIF
+      do i=ib,ie
+        va(i,j,0) = cgs1*va(i,j,1)+cgs2*va(i,j,2)+cgs3*va(i,j,3)
+      enddo
     ELSEIF(bbc.eq.2)THEN
       ! no slip:
       if( imove.eq.1 )then
-        !$acc parallel loop gang vector collapse(2) default(present)
-        do j=jb,je
-           do i=ib,ie+1
-              ua(i,j,0) = 0.0 - umove
-           end do
-        end do
-        !$acc end parallel
-        !$acc parallel loop gang vector collapse(2) default(present)
-        do j=jb,je+1
-           do i=ib,ie
-              va(i,j,0) = 0.0 - vmove
-           end do
-        end do
-        !$acc end parallel
+        IF(j.le.je)THEN
+        do i=ib,ie+1
+          ua(i,j,0) = 0.0 - umove
+        enddo
+        ENDIF
+        do i=ib,ie
+          va(i,j,0) = 0.0 - vmove
+        enddo
       else
-        !$acc parallel loop gang vector collapse(2) default(present)
-        do j=jb,je
-           do i=ib,ie+1
-              ua(i,j,0) = 0.0
-           end do
-        end do
-        !$acc end parallel
-        !$acc parallel loop gang vector collapse(2) default(present)
-        do j=jb,je+1
-           do i=ib,ie
-              va(i,j,0) = 0.0
-           end do
-        end do
-        !$acc end parallel
+        IF(j.le.je)THEN
+        do i=ib,ie+1
+          ua(i,j,0) = 0.0
+        enddo
+        ENDIF
+        do i=ib,ie
+          va(i,j,0) = 0.0
+        enddo
       endif
     ELSEIF(bbc.eq.3)THEN
       ! u,v near sfc are determined below using log-layer equations
@@ -168,51 +161,56 @@
 
     IF(tbc.eq.1)THEN
       ! free slip ... extrapolate:
-      !$acc parallel loop gang vector collapse(2) default(present)
-      do j=jb,je
-         do i=ib,ie+1
-            ua(i,j,nk+1) = cgt1*ua(i,j,nk)+cgt2*ua(i,j,nk-1)+cgt3*ua(i,j,nk-2)
-         end do
-      end do
-      !$acc end parallel
-      !$acc parallel loop gang vector collapse(2) default(present)
-      do j=jb,je+1
-         do i=ib,ie
-            va(i,j,nk+1) = cgt1*va(i,j,nk)+cgt2*va(i,j,nk-1)+cgt3*va(i,j,nk-2)
-         end do
-      end do
-      !$acc end parallel
+      IF(j.le.je)THEN
+      do i=ib,ie+1
+        ua(i,j,nk+1) = cgt1*ua(i,j,nk)+cgt2*ua(i,j,nk-1)+cgt3*ua(i,j,nk-2)
+      enddo
+      ENDIF
+      do i=ib,ie
+        va(i,j,nk+1) = cgt1*va(i,j,nk)+cgt2*va(i,j,nk-1)+cgt3*va(i,j,nk-2)
+      enddo
     ELSEIF(tbc.eq.2)THEN
       ! no slip:
-      !$acc parallel loop gang vector collapse(2) default(present)
-      do j=jb,je
-         do i=ib,ie+1
-            ua(i,j,nk+1) = 0.0
-         end do
-      end do
-      !$acc end parallel
-      !$acc parallel loop gang vector collapse(2) default(present)
-      do j=jb,je+1
-         do i=ib,ie
-            va(i,j,nk+1) = 0.0
-         end do
-      end do
-      !$acc end parallel
+      IF(j.le.je)THEN
+      do i=ib,ie+1
+        ua(i,j,nk+1) = 0.0
+      enddo
+      ENDIF
+      do i=ib,ie
+        va(i,j,nk+1) = 0.0
+      enddo
     ENDIF
 
 !----------
 
-    !$acc parallel loop gang vector collapse(2) default(present)
-    do j=jb,je
-       do i=ib,ie
-          wa(i,j,nk+1) = 0.0
-       end do
-    end do
-    !$acc end parallel
+      IF(j.le.je)THEN
+      do i=ib,ie
+        wa(i,j,nk+1) = 0.0
+      enddo
+      ENDIF
 
+
+    !NEED SCALARS
+    
+
+  ENDDO
+
+
+  !!$acc compare(pi0,th_in,th0,ppa)
   !Compute temperature for interpolation
-
   !$acc parallel default(present) private(i,j,k)
+
+   
+  !JMD zero out the prevent PCAST errors
+  !!$acc loop gang vector collapse(3)
+  !do k=kb,ke
+  !do j=jb,je
+  !do i=ib,ie
+  !   ta(i,j,k)=0.0
+  !enddo
+  !enddo
+  !enddo
+
   !$acc loop gang vector collapse(3)
   do k=kb,ke
     do j=jb,je
@@ -227,6 +225,8 @@
   enddo
   !$acc end parallel
 
+  !!$acc compare(qa,ta,pi0,th_in,th0,ppa)
+  !stop 'droplet_driver: after first compare'
   ! GHB 210714:
     call prepcorners3_GPU( ta,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,1)
@@ -236,6 +236,12 @@
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,1)
     call prepcorners3_GPU(qa(ib,jb,kb,nqv),sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,1)
+    !$acc compare(rho)
+    !!$acc compare(qa,ta,pi0,th_in,th0,ppa)
+    !!$acc compare(sigma)
+!  print *, 'droplet_driver: after call to prepcorners'
+
+
 
 !----------------------------------------------------------------------
 !  Loop through all parcels:  if you have it, update it's properties
@@ -254,8 +260,17 @@
     !$acc host(pdata,xf,yf,zf,zh,sigma,sigmaf, &
     !$acc      ua,va,wa,qa,ta,rho,prs,znt,qten,thten,zs)
 #else
+    !$acc compare(pdata)
+    !JMD no idea why these values hae not already been set previously
+    !$acc update device(ngxy,ngz)
     !JMD WARNING: Loop does not yet match CPU version.
-    !$acc parallel default(present)
+    !$acc parallel &
+    !$acc default(present) &
+    !$acc private(i,j,k,x3d,y3d,z3d,sig3d,iflag,jflag,kflag,nrkp,rhoval, &
+    !$acc     rhop0,taup0,Nup,&
+    !$acc     dvpdt1,dvpdt2,dvpdt3,drpdt,dtpdt,dmvdt,dV,ix,iy,iz,xv,yv,zv,wtx,wty,wtz,wtt, &
+    !$acc     esl,part_grav1,part_grav2,part_grav3,rp0)
+    !$acc compare(ngxy,ngz)
     !$acc loop gang vector 
 #endif
     nploop:  &
@@ -277,6 +292,7 @@
   haveit1:  &
   IF( x3d.ge.xf(1) .and. x3d.le.xf(ni+1) .and.  &
       y3d.ge.yf(1) .and. y3d.le.yf(nj+1) )THEN
+
     IF(nx.eq.1)THEN
       iflag = 1
     ELSE
@@ -290,6 +306,7 @@
       ! cm1r19:
       call find_horizontal_location_index (pdata_locind(np,2), y3d, jb, je+1, yf, nj+1, jflag)  
     ENDIF
+
   ELSE     ! re-initialize x/y/z location index array if a parcel is not on this process
     pdata_locind(np,1) = undefined_index
     pdata_locind(np,2) = undefined_index
@@ -344,6 +361,7 @@
       drpdt    = pdata(np,prrp)
       dmvdt    = rhow*4.0/3.0*pi*pdata(np,prrp)**3
 
+
       !idropmethod = 0 !RK2 for droplet time integration
       idropmethod = 1 !Implicit backward Euler for droplet time integration
 
@@ -355,13 +373,16 @@
 
       call BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000)
 
+
       ENDIF dropmethod
 
 
       ENDIF dropalive1
       
+
     dropalive2:  &
     IF (pdata(np,pract).gt.0.0) THEN
+
 
 !-----------------------------------------------------
 !  Now perform the two-way coupling based on the changes in droplet momentum,
@@ -460,17 +481,18 @@
 
       dmvdt = (rhow*4.0/3.0*pi*pdata(np,prrp)**3-dmvdt)/dt
 
+
       !Volume where the droplet finds itself
       dV = (xh(iflag+1)-xh(iflag))*   &
            (yh(jflag+1)-yh(jflag))*   &
            (zh(iflag,jflag,kflag+1)-zh(iflag,jflag,kflag))
 
       !Loop over all nodes surrounding droplet
-      !$acc loop seq
+      !!$acc loop seq
       do i=0,1
-      !$acc loop seq
+      !!$acc loop seq
       do j=0,1
-      !$acc loop seq
+      !!$acc loop seq
       do k=0,1
 
         ix = iflag+i
@@ -504,6 +526,7 @@
       enddo
 
     ENDIF dropalive2
+
 
 !-----------------------------------------------------
 !  Account for boundary conditions (if necessary)
@@ -546,7 +569,6 @@
       ELSE
 
         ! set to really small number (so we can use the allreduce command below)
-
         pdata(np,prx) = -1.0e30
         pdata(np,pry) = -1.0e30
         if( .not. terrain_flag )then
@@ -562,12 +584,12 @@
         pdata(np,prms) = -1.0e30
         pdata(np,prmult) = -1.0e30
         pdata(np,pract) = -1.0e30
-
 #endif
 
       ENDIF  myparcel
 
     ENDDO  nploop
+    !print *,'droplet_driver: after the nploop'
 #ifdef _B4B01F
     !$acc update device(pdata,qten,thten)
 #else
@@ -577,7 +599,9 @@
 !----------------------------------------------------------------------
 !  communicate data  (for MPI runs)
 
+     !$acc compare(pdata)
 #ifdef MPI
+      !print *,'droplet_driver: before call to MPI_ALLREDUCE'
       !$acc update host(pdata)
       !!$acc host_data use_device(pdata)
       if( .not. terrain_flag )then
@@ -590,7 +614,10 @@
         call MPI_ALLREDUCE(MPI_IN_PLACE,pdata,npvars*nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
       endif
       !$acc update device(pdata)
+      !$acc compare(pdata)
+      !stop 'droplet_driver: after call to MPI_ALLREDUCE'
       if(timestats.ge.1) time_droplet_reduce=time_droplet_reduce+mytime()
+     
 #endif
 
 
@@ -619,7 +646,6 @@
       end subroutine droplet_driver
 
       subroutine rk2_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug)
-      !$acc routine seq
       use input
       use constants
       use bc_module
@@ -674,20 +700,48 @@
       !Unique to rk2_integration
       integer :: nrkp
 
+
       dt2 = dt/2.0      
 
       !HERE print *,'before rkloop np: ',np
       !$acc loop seq
       rkloop:  DO nrkp = 1,2
 
+
        call interpolate_to_parcel(np,nrkp,pdata_locind,iflag,jflag,kflag,x3d,y3d,z3d,sig3d,uval,vval,wval,tval,qval,rhoval,prsval,xh,xf,yh,yf,zh,zf,zs,znt,sigma,sigmaf,ua,va,wa,ta,qa,rho,prs,sigdot)
 
+       !qval = 0.008807098199749
+       !tval = 282.3
+       !uval = 0.0
+       !vval = 0.0
+       !wval = 0.0
+
+      if(np==TROUBLE) then 
+        print *,'before eslf: tval: ',tval 
+      endif
       estar = eslf(prsval,tval)  !Saturation vapor pressure based on interpolated temp,pressure
       lhv=lv1-lv2*tval
+
 
 !-----------------------------------------------------
 !  Update droplet position, velocity, etc.
 !-----------------------------------------------------
+      if(np==TROUBLE) then 
+        !print *,'before: pdata(np,prrp): ',pdata(np,prrp)
+        !print *,'before: pdata(np,prms): ',pdata(np,prms)
+        !print *,'before: pdata(np,prtp): ',pdata(np,prtp)
+        print *,'after eslf: tval: ',tval 
+        !print *,'prsval: ',prsval
+        !print *,'lv1: ',lv1
+        !print *,'lv2: ',lv2
+        !print *,'ru: ',ru
+        !print *,'ms: ',ms
+        !print *,'mw: ',mw
+        !print *,'ion: ',ion
+        !print *,'os: ',os
+        !print *,'surften: ',surften
+      endif
+
 
       ! RK2 scheme:
       IF(nrkp.eq.1)THEN
@@ -925,18 +979,16 @@
       pdata(np,pry)=y3d
       if( .not. terrain_flag )then
         pdata(np,prz)=z3d
+        pdata_locind(np,3) = undefined_index
       else
         pdata(np,prsig)=sig3d
+        pdata_locind(np,3) = undefined_index
       endif
-      if (pdata_locind(np,1) .eq. undefined_index .or. &
-          pdata_locind(np,2) .eq. undefined_index) then
-          pdata_locind(np,3) = undefined_index
-      end if
+
 
       end subroutine rk2_integration
 
       subroutine BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000)
-      !$acc routine seq
       use input
       use constants
       use bc_module
@@ -944,6 +996,7 @@
       use misclibs
       use parcel_module
       use cm1libs , only : eslf
+      use ieee_arithmetic
 
       implicit none
 
@@ -1005,7 +1058,9 @@
        !vval = 0.0
        !wval = 0.0
 
-       estar = eslf(prsval,tval)  !Saturation humidity based on interpolated temp,pressure
+      estar = eslf(prsval,tval)  !Saturation humidity based on interpolated temp,pressure
+
+
 
 !-----------------------------------------------------
 !  Update droplet position, velocity, etc.
@@ -1069,27 +1124,34 @@
          rt_start(2) = 1.0
       end if
 
+
       call gauss_newton_2d(diffnorm,dt_nondim,taup_scale,rt_start,rt_zeros,flag,prsval,rhoval,tval,qval,pdata(np,prtp),pdata(np,prms),pdata(np,prrp),np)
+
 
       if (flag==1) then
          num100 = num100+1
+
+
          call LV_solver(diffnorm,dt_nondim,taup_scale,rt_start,rt_zeros,flag,prsval,rhoval,tval,qval,pdata(np,prtp),pdata(np,prms),pdata(np,prrp),np)
+
       end if
 
       if (flag==1) num1000 = num1000+1
 
       !In rare cases the nonlinear solvers fail to converge
-      if ( (rt_zeros(1) .ne. rt_zeros(1)) .OR. &
-           (rt_zeros(2) .ne. rt_zeros(2)) .OR. &
-           (rt_zeros(2) .lt. 0) ) then
+      if (ieee_is_nan(rt_zeros(1)) .OR.  ieee_is_nan(rt_zeros(2)) .OR. rt_zeros(2)<0) then
+
          !If this happens keep radius unchanged and temp equal to surrounding
          rt_zeros(1) = 1.0
          rt_zeros(2) = tval/pdata(np,prtp)
+
       end if
 
       !Now redimsionalize
       pdata(np,prrp) = rt_zeros(1)*pdata(np,prrp)
       pdata(np,prtp) = rt_zeros(2)*pdata(np,prtp)
+
+
 
       !Finally, take care of particle BCs
 
@@ -1128,23 +1190,21 @@
         pdata_locind(np,2) = undefined_index
       endif
 
+
       pdata(np,prx)=x3d
       pdata(np,pry)=y3d
       if( .not. terrain_flag )then
         pdata(np,prz)=z3d
+        pdata_locind(np,3) = undefined_index
       else
         pdata(np,prsig)=sig3d
+        pdata_locind(np,3) = undefined_index
       endif
 
-      if (pdata_locind(np,1) .eq. undefined_index .or. &
-          pdata_locind(np,2) .eq. undefined_index) then
-          pdata_locind(np,3) = undefined_index
-      end if
 
       end subroutine BE_integration
 
       subroutine interpolate_to_parcel(np,nrkp,pdata_locind,iflag,jflag,kflag,x3d,y3d,z3d,sig3d,uval,vval,wval,tval,qval,rhoval,prsval,xh,xf,yh,yf,zh,zf,zs,znt,sigma,sigmaf,ua,va,wa,ta,qa,rho,prs,sigdot)
-      !$acc routine seq
       use input
       use constants
       use parcel_module
@@ -1202,19 +1262,57 @@
 
         kflag = 1
 ! JS - jflag could be negative somehow, which will break
-!        the find_vertical_location_index subroutine and 
-!        lead to invalid access to zf(iflag,jflag,kflag);
-!        revert to the old implementation
+!        the find_vertical_location_index subroutine;
+!        use the original interface but with the 
+!        pdata_locind(:,3) here
+!    - z3d could be NaN somehow, reset kflag = 1 to be 
+!        consistent with the original implementation
+#ifdef _VERIFY_FIND_LOC
+        tmp_flag = kflag
+#endif
+        kflag = max (kflag, pdata_locind(np,3) - location_offset - 1)
+        if ( z3d .ne. z3d ) kflag = 1
         if( .not. terrain_flag )then
+          if ( z3d.lt.zf(iflag,jflag,kflag) ) then
+            kflag = 1
+          end if
           do while( z3d.gt.zf(iflag,jflag,kflag+1) )
             kflag = kflag+1
           enddo
+          pdata_locind(np,3) = kflag
+#ifdef _VERIFY_FIND_LOC
+          do while( z3d.gt.zf(iflag,jflag,tmp_flag+1) )
+            tmp_flag = tmp_flag+1
+          enddo
+          if ( kflag .ne. tmp_flag ) then
+            print *, "z3d = ", z3d, ", old scheme finds ", zf(iflag,jflag,tmp_flag+1), ", new scheme finds ", zf(iflag,jflag,kflag+1)
+            print *, "original search scheme finds z index = ", tmp_flag, ", new search scheme finds z index = ", kflag
+            stop "Failed verification test: z index is not the same..."
+          else
+            print *, "Pass the verification test for z index..."
+          end if
+#endif
         else
+          if ( sig3d.lt.sigmaf(kflag) ) then
+            kflag = 1
+          end if
           do while( sig3d.gt.sigmaf(kflag+1) )
             kflag = kflag+1
           enddo
+          pdata_locind(np,3) = kflag
+#ifdef _VERIFY_FIND_LOC
+          do while( sig3d.gt.sigmaf(tmp_flag+1) )
+            tmp_flag = tmp_flag+1
+          enddo
+          if ( kflag .ne. tmp_flag ) then
+            print *, "original search scheme finds z index = ", tmp_flag, ", new search scheme finds z index = ", kflag
+            stop "Failed verification test: z index is not the same..."
+          else
+            print *, "Pass the verification test for z index..."
+          end if
+#endif
         endif
-        pdata_locind(np,3) = kflag
+
 
 !JMD-debug
 !----------------------------------------------------------------------
@@ -1654,8 +1752,7 @@
 #endif
 
       ! Sanity check:
-      ! - If input z location is outside the z range, return directly
-
+      ! - If input x/y location is outside the x/y range, return directly
       if ( loc .lt. dsize(lb) .or. loc .gt. dsize(ub) ) return
 
       if ( loc_ind .ne. undefined_index ) then 
@@ -1714,7 +1811,6 @@
       end subroutine find_vertical_location_index
 
       subroutine rad_solver2(guess,mflag,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
-      !$acc routine seq
       use constants
       use cm1libs , only : eslf
       implicit none
@@ -1764,6 +1860,7 @@
 
       subroutine gauss_newton_2d(diffnorm,dt_nondim,taup_scale,rt_start,rt_zeros,flag,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
         !$acc routine seq
+        use ieee_arithmetic
 
         implicit none
 
@@ -1782,71 +1879,59 @@
         flag = 0
         error = 1.e-8
 
-        v1(1) = rt_start(1)
-        v1(2) = rt_start(2)
+        v1 = rt_start
         fv2 = (/1., 1./)
         coeff = 0.1
+        do while ((sqrt(dot_product(fv2, fv2)) > error) .AND. (iterations<1000))
 
-        do while ((sqrt(fv2(1)*fv2(1)+fv2(2)*fv2(2)) > error) .AND. (iterations<1000))
 
                 iterations = iterations + 1
 
                 call ie_vrt_nd(diffnorm,v1(1),v1(2),fv1,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
                 call jacob_approx_2d(diffnorm,v1(1),v1(2),dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-                fancy(1,1) = J(1,1)*J(1,1)+J(2,1)*J(2,1)
-                fancy(1,2) = J(1,1)*J(1,2)+J(2,1)*J(2,2)
-                fancy(2,1) = J(1,2)*J(1,1)+J(2,2)*J(2,1)
-                fancy(2,2) = J(1,2)*J(1,2)+J(2,2)*J(2,2)
+                fancy = matmul(transpose(J),J)
 
                 call inverse_finder_2d(fancy, inv)
 
-                finalJ(1,1) = inv(1,1)*J(1,1)+inv(1,2)*J(1,2)
-                finalJ(1,2) = inv(1,1)*J(2,1)+inv(1,2)*J(2,2)
-                finalJ(2,1) = inv(2,1)*J(1,1)+inv(2,2)*J(1,2)
-                finalJ(2,2) = inv(2,1)*J(2,1)+inv(2,2)*J(2,2)
+                finalJ = matmul(inv, transpose(J))
 
-                correct(1) = finalJ(1,1)*fv1(1)+finalJ(1,2)*fv1(2)
-                correct(2) = finalJ(2,1)*fv1(1)+finalJ(2,2)*fv1(2)
-
-                rt_zeros(1) = v1(1) - correct(1)
-                rt_zeros(2) = v1(2) - correct(2)
+                correct = matmul(finalJ,fv1)
+                rt_zeros = v1 - correct
 
                 call ie_vrt_nd(diffnorm,v1(1),v1(2),temp1,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
                 call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),temp2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-                diff = sqrt(temp1(1)*temp1(1)+temp1(2)*temp1(2))-sqrt(temp2(1)*temp2(1)+temp2(2)*temp2(2))
 
-                if (sqrt(correct(1)*correct(1)+correct(2)*correct(2))<error) then
+                diff = sqrt(dot_product(temp1,temp1))-sqrt(dot_product(temp2,temp2))
+
+                if (sqrt(dot_product(correct,correct))<error) then
                         EXIT
                 end if
 
                 relax = 1.0
                 counts = 0
 
-                do while ((diff<0) .OR. (rt_zeros(1)<0) .OR. (rt_zeros(2)<0) .OR. (rt_zeros(1) .ne. rt_zeros(1)))
-                   counts = counts + 1
-                   coeff = 0.5
-                   relax = relax * coeff
-                   rt_zeros(1) = v1(1)-(finalJ(1,1)*fv1(1)+finalJ(1,2)*fv1(2))*relax
-                   rt_zeros(2) = v1(2)-(finalJ(2,1)*fv1(1)+finalJ(2,2)*fv1(2))*relax
-                   call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),temp2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
-                   diff = sqrt(temp1(1)*temp1(1)+temp1(2)*temp1(2))-sqrt(temp2(1)*temp2(1)+temp2(2)*temp2(2))
+               do while ((diff<0).OR.(rt_zeros(1)<0) .OR. (rt_zeros(2)<0) .OR. ieee_is_nan(rt_zeros(1)))
+                        counts = counts + 1
+                        coeff = 0.5
+                        relax = relax * coeff
+                        rt_zeros = v1-matmul(finalJ,fv1)*relax
+                        call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),temp2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+                        diff = sqrt(dot_product(temp1,temp1))-sqrt(dot_product(temp2,temp2))
 
-                   if (counts>10) EXIT
+                        if (counts>10) EXIT
                 end do
 
-                v1(1) = rt_zeros(1)
-                v1(2) = rt_zeros(2)
+                v1 = rt_zeros
 
                 call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),fv2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
         end do
       if (iterations == 100) flag = 1
-      if ((rt_zeros(1) .ne. rt_zeros(1)) .OR. rt_zeros(1)<0 .OR. (rt_zeros(2) .ne. rt_zeros(2)) .OR. rt_zeros(2)<0) flag = 1
+      if (ieee_is_nan(rt_zeros(1)) .OR. rt_zeros(1)<0 .OR. ieee_is_nan(rt_zeros(2)) .OR. rt_zeros(2)<0) flag = 1
 
       end subroutine gauss_newton_2d
-
       subroutine LV_solver(diffnorm,dt_nondim,taup_scale,rt_start,rt_zeros,flag,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
         !$acc routine seq
         implicit none
@@ -1865,64 +1950,53 @@
 
         error = 1.0e-8
 
+        ! I = reshape((/1, 0, 0, 1/),shape(I))
         I = reshape((/1, 0, 0, 1/),(/2,2/))
         iterations = 0
         flag = 0
-        v1(1) = rt_start(1)
-        v1(2) = rt_start(2)
+        v1 = rt_start
         fv2 = (/1., 1./)
 
         lambda = 0.001
         lup = 2.0
         ldown = 2.0
 
-        do while ((sqrt(fv2(1)*fv2(1)+fv2(2)*fv2(2)) > error) .AND. (iterations<1000))
+        do while ((sqrt(dot_product(fv2, fv2)) > error) .AND. (iterations<1000))
 
         iterations = iterations + 1
-
         call jacob_approx_2d(diffnorm,v1(1),v1(2),dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+
         call ie_vrt_nd(diffnorm,v1(1),v1(2),fv1,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-        g(1,1) = J(1,1)*J(1,1)+J(2,1)*J(2,1)+lambda*I(1,1)
-        g(1,2) = J(1,1)*J(1,2)+J(2,1)*J(2,2)+lambda*I(1,2)
-        g(2,1) = J(1,2)*J(1,1)+J(2,2)*J(2,1)+lambda*I(2,1)
-        g(2,2) = J(1,2)*J(1,2)+J(2,2)*J(2,2)+lambda*I(2,2)
-
-        gradC(1) = J(1,1)*fv1(1)+J(2,1)*fv1(2)
-        gradC(2) = J(1,2)*fv1(1)+J(2,2)*fv1(2)
-
-        C(1) = 0.5*fv1(1)*fv1(1)
-        C(2) = 0.5*fv1(2)*fv1(2)
+        g = matmul(transpose(J),J)+lambda*I
+        gradC = matmul(transpose(J),fv1)
+        C = 0.5*fv1*fv1
 
         call inverse_finder_2d(g, invg)
-        correct(1) = invg(1,1)*gradC(1)+invg(1,2)*gradC(2)
-        correct(2) = invg(2,1)*gradC(1)+invg(2,2)*gradC(2)
-        if (sqrt(correct(1)*correct(1)+correct(2)*correct(2)) < error) then
-           EXIT
+        correct = matmul(invg, gradC)
+        if (sqrt(dot_product(correct,correct)) < error) then
+                EXIT
         end if
 
-        rt_zeros(1) = v1(1) - correct(1)
-        rt_zeros(2) = v1(2) - correct(2)
+        rt_zeros = v1 - correct
         call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),fv2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
-        newC(1) = 0.5*fv2(1)*fv2(1)
-        newC(2) = 0.5*fv2(2)*fv2(2)
-
-        if (sqrt(newC(1)*newC(1)+newC(2)*newC(2))<sqrt(C(1)*C(1)+C(2)*C(2))) then
-           v1(1) = rt_zeros(1)
-           v1(2) = rt_zeros(2)
-           lambda = lambda/ldown
+        newC = 0.5*fv2*fv2
+         
+        if (sqrt(dot_product(newC,newC))<sqrt(dot_product(C,C))) then
+                v1 = rt_zeros
+                lambda = lambda/ldown
         else
-           lambda = lambda*lup
+                lambda = lambda*lup
         end if
 
         end do
 
         if (iterations==1000) then
-           flag = 1
+                flag = 1
         end if
 
         if (rt_zeros(1) < 0 .OR. rt_zeros(2) < 0) then
-           flag = 1
+                flag = 1
         end if
 
       end subroutine LV_solver
@@ -1936,13 +2010,12 @@
 
         det = C(1, 1) * C(2, 2) - C(1, 2) * C(2, 1)
 
+        ! invC = reshape((/C(2, 2), -C(2,1), -C(1, 2), C(1, 1)/),shape(invC))
         invC = reshape((/C(2, 2), -C(2,1), -C(1, 2), C(1, 1)/),(/2,2/))
         invC = (1./det)*invC
 
       end subroutine inverse_finder_2d
-
       subroutine jacob_approx_2d(diffnorm,rnext,tnext,dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
-        !$acc routine seq
         implicit none
         integer :: n
 
@@ -1958,28 +2031,24 @@
 
         call ie_vrt_nd(diffnorm,rnext,tnext,rt_output,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-        xper(1) = ynext(1)
-        xper(2) = ynext(2)
-        xper2(1) = ynext(1)
-        xper2(2) = ynext(2)
+        xper = ynext
+        xper2 = ynext
 
         do n=1, 2
-           xper(n) = xper(n) + diff
-           xper2(n) = xper2(n) - diff
-           call ie_vrt_nd(diffnorm,xper(1),xper(2),fxper,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+                xper(n) = xper(n) + diff
+                xper2(n) = xper2(n) - diff
+                call ie_vrt_nd(diffnorm,xper(1),xper(2),fxper,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-           call ie_vrt_nd(diffnorm,xper2(1),xper2(2),fxper2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+                call ie_vrt_nd(diffnorm,xper2(1),xper2(2),fxper2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
 
-           J(1,n) = (fxper(1)-rt_output(1))/diff
-           J(2,n) = (fxper(2)-rt_output(2))/diff
-           xper(n) = ynext(n)
-           xper2(n) = ynext(n)
+                J(:, n) = (fxper-rt_output)/diff
+                xper(n) = ynext(n)
+                xper2(n) = ynext(n)
         end do
 
-      end subroutine jacob_approx_2d
 
+      end subroutine jacob_approx_2d
       subroutine ie_vrt_nd(diffnorm,tempr,tempt,rt_output,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
-      !$acc routine seq
       use constants
       use input
       use cm1libs , only : eslf
@@ -1992,10 +2061,12 @@
       real :: esa,dnext,rhop,Rep,taup,rprime,Tprime,qstr,Shp,Nup,VolP,lhv
       real :: Tnext,rnext
 
+
         ! quantities come in already non-dimensionalized, so must be converted back;
         rnext = tempr*radius
         Tnext = tempt*Tp
         dnext = rnext*2.0
+
 
         esa = eslf(prsval,tval)
         VolP = (4.0/3.0)*pi*rnext**3
@@ -2008,13 +2079,16 @@
 
         lhv=lv1-lv2*tval
 
+
         !!! Humidity !!!
         qstr = (mw/(ru*Tnext*rhoval))*esa*exp(((lhv*mw/ru)*((1.0/tval)-(1.0/Tnext))) + ((2.0*mw*surften)/(ru*rhow*rnext*Tnext)) - ((ion*os*m_s*(mw/ms))/(VolP*rhop-m_s)))
         !!!!!!!!!!!!!!!!!!
 
+
         !!! Radius !!!
         rprime = (1.0/9.0)*(Shp/sc_num)*(rhop/rhow)*(rnext/taup)*(qval - qstr)
         rprime = rprime*(taup_scale/radius)
+
 
         !!! Temperature !!!
         Tprime = -(1.0/3.0)*(Nup/pr_num)*(cp/cpl)*(rhop/rhow)/taup*(Tnext-tval) + 3.0*lhv/(rnext*cpl)*rprime*(radius/taup_scale)
@@ -2023,7 +2097,10 @@
         rT_output(1) = rnext/radius - 1.0  - dt_nondim*rprime
         rT_output(2) = Tnext/Tp - 1.0  - dt_nondim*Tprime
 
+
       end subroutine ie_vrt_nd
+
+
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/init_terrain.F
+++ b/src/init_terrain.F
@@ -178,7 +178,6 @@
 
         zt = maxz
         rzt = 1.0/maxz
-        !$acc update device (zt,rzt)
 
         if(dowr) write(outfile,*)
         do k=1,nk+1

--- a/src/input.F
+++ b/src/input.F
@@ -160,18 +160,23 @@
               bl_mynn_cloudmix,bl_mynn_mixqt,initflag,spp_pbl,bl_mynn_output, &
               nutk,nvtk,nwtk
 
-!$acc declare create(nqs1,nqs2,nqr,nqi,nqs,nqg,nnci,nncc, &
-!$acc                ptype,psolver,ngxy,ngz,nx,ny,nz,axisymm, &
-!$acc                nparcels,npvals,npvars,ni,nj,nk,nip1,njp1, &
-!$acc                nkm1,nkp1,ib,ie,jb,je,kb,ke,terrain_flag, &
-!$acc                numq,imoist,imove,nqv,bbc,tbc,prx,pry,prz, &
-!$acc                pru,prv,prw,prth,prt,prprs,prtime,prpt1, &
-!$acc                prpt2,prqv,prq1,prq2,prnc1,prnc2,prkm,prkh, &
-!$acc                prtke,prdbz,prb,prvpg,przv,prrho,prqsl,prqsi, &
-!$acc                prznt,prust,przs,prsig,prvpx,prvpy,prvpz,prrp, &
-!$acc                prms,prtp,prmult,pract,ntwk,imp,jmp,kmp,kmt, &
-!$acc                rmp,cmp,vd_vadv,ibw,ibe,ibs,ibn,nodex,nodey, &
-!$acc                myi,myj)
+!$acc declare create(nqs1,nqs2)
+!$acc declare create(nqr,nqi,nqs,nqg,nnci,nncc)
+!$acc declare create(ptype,psolver)
+!$acc declare create(ngxy,ngz)
+!$acc declare create(nx,ny,nz)
+!$acc declare create(axisymm)
+!$acc declare create(nparcels,npvals,npvars)
+!$acc declare create(ni,nj,nk)
+!$acc declare create(nip1,njp1,nkm1,nkp1)
+!$acc declare create(ib,ie,jb,je,kb,ke)
+!$acc declare create(terrain_flag,numq)
+!$acc declare create(imoist,imove,nqv,bbc,tbc)
+!$acc declare create(prx,pry,prz,pru,prv,prw,prth,prt,prprs,prtime)           &
+!$acc         create(prpt1,prpt2,prqv,prq1,prq2,prnc1,prnc2,prkm,prkh,prtke)  &
+!$acc         create(prdbz,prb,prvpg,przv,prrho,prqsl,prqsi,prznt,prust,przs) &
+!$acc         create(prsig,prvpx,prvpy,prvpz,prrp,prms,prtp,prmult,pract)
+!$acc declare create(ntwk)
 !-----------------------------------------------------------------------
 
       real dx,dy,dz,dtl,timax,run_time,                                       &
@@ -207,12 +212,18 @@
            base_pbot,base_ptop,base_thbot,base_thtop,base_qvbot,base_qvtop,   &
            base_tbot,base_ttop,base_pibot,base_pitop
 
-!$acc declare create(dx,dy,dz,dtl,timax,run_time,tapfrq,rstfrq,    &
-!$acc                statfrq,prclfrq,diagfrq,kdiff2,kdiff6,fcor,   &
-!$acc                alph,kdiv,wbc,ebc,sbc,nbc,rdx,rdy,rdz,minx,   &
-!$acc                maxx,miny,maxy,cflmax,ksmax,zt,rzt,umove,     &
-!$acc                vmove,viscosity,pr_num,sc_num,maxz,cgs1,cgs2, &
-!$acc                cgs3,cgt1,cgt2,cgt3)
+!$acc declare create(dx,dy,dz,dtl,timax,run_time)
+!$acc declare create(tapfrq,rstfrq,statfrq,prclfrq,diagfrq)
+!$acc declare create(kdiff2,kdiff6,fcor,alph,kdiv)
+!$acc declare create(wbc,ebc,sbc,nbc)
+!$acc declare create(rdx,rdy,rdz)
+!$acc declare create(minx,maxx)
+!$acc declare create(miny,maxy)
+!$acc declare create(cflmax,ksmax)
+!$acc declare create(zt,rzt)
+!$acc declare create(umove,vmove)
+!$acc declare create(viscosity,pr_num,sc_num)
+!$acc declare create(maxz)
 !-----------------------------------------------------------------------
 
       character(len=maxstring) :: string

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3690,9 +3690,11 @@
       !$acc end parallel
 #endif
  
+#ifdef _B4B07R
       tmass=0.0d0
-#ifndef _B4B07R
+#else
       !$acc parallel default(present) reduction(+:tmass)
+      tmass=0.0d0
       !$acc loop gang vector reduction(+:tmass)
 #endif
       do k=1,nk

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3244,21 +3244,24 @@
         stop 1112
       endif
 
+      !$acc parallel default(present) private(k) reduction(max:fmax)
       fmax=-99999999.
-      !$acc parallel default(present) reduction(max:fmax)
-      !$acc loop gang vector reduction(max:fmax)
+      !$acc loop private(k) reduction(max:fmax)
       do k=2,nk
-         fmax = max( fmax , ks(k) )
-      end do
-      !$acc end parallel
-      ksmax = fmax
+        fmax = max( fmax , ks(k) )
+      enddo
 
+      ksmax = fmax
+      !$acc end parallel
       !$acc end data
 
 #ifdef MPI
-      call MPI_IALLREDUCE(MPI_IN_PLACE,ksmax,1,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,reqk,ierr)
+#ifndef _B4B04R
+      !$acc update host(ksmax)
 #endif
+      call MPI_IALLREDUCE(MPI_IN_PLACE,ksmax,1,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,reqk,ierr)
       !$acc update device(ksmax)
+#endif
 
       if(ksmax.ge.0.50) then 
          stopit=.true.
@@ -3304,66 +3307,75 @@
 !JMD-FIXME
 !!$acc update host(nstat,rstat,dt,uh,vh,mf,kmh,kmv,khh,khv)
 
-!$acc data copyout (ksh,ksv,imaxth,jmaxth,kmaxth,imaxtv,jmaxtv,kmaxtv) &
-!$acc      copyin (khh,vh,uh,mf)
+!$acc data create(imaxth,jmaxth,kmaxth,imaxtv,jmaxtv,kmaxtv,ksh,ksv,mmax,nmax)
 
       dtdx=dt*rdx*rdx
       dtdy=dt*rdy*rdy
       dtdz=dt*rdz*rdz
 
+!$acc parallel loop gang vector default(present) private(k)
+      do k=2,nk
+        ksh(k)=-99999.0
+        ksv(k)=-99999.0
+      enddo
+
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k,tem)
-
-!$acc parallel default(present) reduction(max:maxksh,maxksv)
-!$acc loop gang reduction(max:maxksh,maxksv)
+!$acc parallel default(present) private(i,j,k,tem) reduction(max:maxksh) reduction(max:maxksv)
       do k=2,nk
-         maxksh = -99999.0
-         maxksv = -99999.0
-!$acc loop vector collapse(2) reduction(max:maxksh,maxksv)
-         do j=1,nj
-            do i=1,ni
-               tem = khh(i,j,k)*dtdx*uh(i)*uh(i)
-               maxksh=max(tem,maxksh)
+        maxksh = -99999.0
+        maxksv = -99999.0
+!$acc loop collapse(2) private(i,j,k,tem) reduction(max:maxksh) reduction(max:maxksv)
+        do j=1,nj
+        do i=1,ni
+          tem = khh(i,j,k)*dtdx*uh(i)*uh(i)
+          maxksh=max(tem,maxksh)
 
-               tem = khh(i,j,k)*dtdy*vh(j)*vh(j)
-               maxksh=max(tem,maxksh)
+          tem = khh(i,j,k)*dtdy*vh(j)*vh(j)
+          maxksh=max(tem,maxksh)
 
-               tem = khv(i,j,k)*dtdz*mf(i,j,k)*mf(i,j,k)
-               maxksv=max(tem,maxksv)
-            end do
-         end do
-         ksh(k)=maxksh
-         ksv(k)=maxksv
-      end do
+          tem = khv(i,j,k)*dtdz*mf(i,j,k)*mf(i,j,k)
+          maxksv=max(tem,maxksv)
+        enddo
+        enddo
+        ksh(k)=maxksh
+        ksv(k)=maxksv
+      enddo
 !$acc end parallel
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k,tem)
-!$acc parallel loop gang vector collapse(3) default(present)
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,tem)
       do k=2,nk
-         do j=1,nj
-            do i=1,ni
-               tem = khh(i,j,k)*dtdx*uh(i)*uh(i)
-               if( tem.eq.ksh(k) )then
-                 imaxth(k)=i
-                 jmaxth(k)=j
-                 kmaxth(k)=k
-               end if
-               tem = khh(i,j,k)*dtdy*vh(j)*vh(j)
-               if( tem.eq.ksh(k) )then
-                 imaxth(k)=i
-                 jmaxth(k)=j
-                 kmaxth(k)=k
-               end if
-               tem = khv(i,j,k)*dtdz*mf(i,j,k)*mf(i,j,k)
-               if( tem.eq.ksv(k) )then
-                 imaxtv(k)=i
-                 jmaxtv(k)=j
-                 kmaxtv(k)=k
-               endif
-            end do
-         end do
-      end do
+        do j=1,nj
+        do i=1,ni
+!!!          tem = max( abs(kmh(i,j,k))*dtdx*uh(i)*uh(i) ,   &
+!!!                     abs(khh(i,j,k))*dtdx*uh(i)*uh(i) )
+          tem = khh(i,j,k)*dtdx*uh(i)*uh(i)
+          if( tem.eq.ksh(k) )then
+            imaxth(k)=i
+            jmaxth(k)=j
+            kmaxth(k)=k
+          endif
+!!!          tem = max( abs(kmh(i,j,k))*dtdy*vh(j)*vh(j) ,   &
+!!!                     abs(khh(i,j,k))*dtdy*vh(j)*vh(j) )
+          tem = khh(i,j,k)*dtdy*vh(j)*vh(j)
+          if( tem.eq.ksh(k) )then
+            imaxth(k)=i
+            jmaxth(k)=j
+            kmaxth(k)=k
+          endif
+!!!          tem = max( abs(kmv(i,j,k))*dtdz*mf(i,j,k)*mf(i,j,k) ,   &
+!!!                     abs(khv(i,j,k))*dtdz*mf(i,j,k)*mf(i,j,k) )
+          tem = khv(i,j,k)*dtdz*mf(i,j,k)*mf(i,j,k)
+          if( tem.eq.ksv(k) )then
+            imaxtv(k)=i
+            jmaxtv(k)=j
+            kmaxtv(k)=k
+          endif
+        enddo
+        enddo
+      enddo
 
       fhmax=-99999999.
       fvmax=-99999999.
@@ -3373,20 +3385,20 @@
       imaxv=1
       jmaxv=1
       kmaxv=1
-      !$acc parallel loop gang vector default(present)
+      !$acc parallel loop gang vector default(present) private(k)
       do k=2,nk
-         if(ksh(k).gt.fhmax)then
-           fhmax=ksh(k)
-           imaxh=imaxth(k)
-           jmaxh=jmaxth(k)
-           kmaxh=kmaxth(k)
-         endif
-         if(ksv(k).gt.fvmax)then
-           fvmax=ksv(k)
-           imaxv=imaxtv(k)
-           jmaxv=jmaxtv(k)
-           kmaxv=kmaxtv(k)
-         endif
+        if(ksh(k).gt.fhmax)then
+          fhmax=ksh(k)
+          imaxh=imaxth(k)
+          jmaxh=jmaxth(k)
+          kmaxh=kmaxth(k)
+        endif
+        if(ksv(k).gt.fvmax)then
+          fvmax=ksv(k)
+          imaxv=imaxtv(k)
+          jmaxv=jmaxtv(k)
+          kmaxv=kmaxtv(k)
+        endif
       enddo
 
       if( cm1setup.eq.2 .and. horizturb.eq.0 )then

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -1,6 +1,5 @@
 #ifdef _B4B
 
-#undef _B4B03F
 #undef _B4B01R
 
 !JMD-expensive
@@ -2591,16 +2590,12 @@
 
 ! Reference:  Bryan, 2008, MWR, p. 5239
 
-!$omp parallel do default(shared)  &
-!$omp private(i,j,k,n,tx,cpm)
-#ifdef _B4B03F
-            !$acc update host(zh,th0,tha,pi0,ppi,qa,prs,rh,the) 
-#else
-            !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,n,tx,cpm)
-#endif
-      do k=1,nk
+      !$omp parallel do default(shared) private(i,j,k,n,tx,cpm)
+      !$acc parallel loop gang vector collapse(2) default(present) private(i,j,k,tx,cpm)
       do j=1,nj
       do i=1,ni
+      !$acc loop seq
+      do k=1,nk
         if(zh(i,j,k).le.10000.)then
           tx=(th0(i,j,k)+tha(i,j,k))*(pi0(i,j,k)+ppi(i,j,k))
           cpm=cp
@@ -2614,9 +2609,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B03F
-      !$acc update device(the)
-#endif
 
       if(timestats.ge.1) time_stat=time_stat+mytime()
 

--- a/src/mp_driver.F
+++ b/src/mp_driver.F
@@ -1,6 +1,3 @@
-#ifdef _B4B
-#undef _B4B01F
-#endif
   MODULE mp_driver_module
 
              !------  Microphysics Driver ------!
@@ -543,11 +540,7 @@
           ! Get final values for th3d,pp3d,prs:
           ! Note:  dum1 stores temperature, thten stores old temperature:
           IF( eqtset.eq.2 )THEN
-#ifdef _B4B01F
-            !$acc update host(dum1,thten,q3d,qten,rho,pi0,th0)
-#else
             !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
-#endif
             !$omp parallel do default(shared) private(i,j,k)
             do k=1,nk
             do j=1,nj
@@ -561,9 +554,6 @@
             enddo
             enddo
             enddo
-#ifdef _B4B01F
-            !$acc update device(prs,pp3d,th3d)
-#endif
           ELSE
             !$omp parallel do default(shared) private(i,j,k)
             !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)

--- a/src/param.F
+++ b/src/param.F
@@ -5334,7 +5334,6 @@
 
         nvdiag = nvdiag+1
         vd_vadv = nvdiag
-        !$acc update device (vd_vadv)
 
         if( cm1setup.ge.1 .or. ipbl.ge.1 )then
           nvdiag = nvdiag+1
@@ -6230,14 +6229,12 @@
       if(dowr) write(outfile,*) '    prmult   = ',prmult
       if(dowr) write(outfile,*) '    pract    = ',pract
       if(dowr) write(outfile,*)
-
-      !$acc update device (nparcels,npvals,npvars,prx,pry,prz,pru, &
-      !$acc                prv,prw,prtime,prth,prt,prprs,prpt1, &
-      !$acc                prpt2,prqv,prq1,prq2,prnc1,prnc2,prkm, &
-      !$acc                prkh,prtke,prdbz,prb,prvpg,przv,prrho, &
-      !$acc                prqsl,prqsi,prznt,prust,przs,prsig, &
-      !$acc                prvpx,prvpy,prvpz,prrp,prms,prtp, &
-      !$acc                prmult,pract)
+      !$acc update device(nparcels,npvals,npvars,prx,pry,prz,pru,prv,prw) &
+      !$acc device(prtime,prth,prt,prprs,prpt1,prpt2,prqv,prq1,prq2,prnc1) &
+      !$acc device(prnc2,prkm,prkh,prtke,prdbz,prb,prvpg,przv,prrho,prqsl) &
+      !$acc device(prqsi,prznt,prust,przs,prsig,prvpx,prvpy,prvpz,prrp,prms) &
+      !$acc device(prtp,prmult,pract)
+      
 
 !--------------------------------------------------------------
 !  Get identity
@@ -6411,8 +6408,6 @@
         ibn=1
       endif
 #endif
-
-      !$acc update device (ibw,ibe,ibs,ibn)
 
 !--------------------------------------------------------------
 
@@ -8702,8 +8697,6 @@
       if(dowr) write(outfile,*) '  ---------------------------------- '
 
   ENDDO
-
-  !$acc update device (cgs1,cgs2,cgs3,cgt1,cgt2,cgt3)
 
 !--------------------------------------------------------------
 !  cm1r18:  Set ghost points for zh

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -42,9 +42,12 @@
       real :: wsp,wlast,var,rznt,usave,vsave,ssave
       logical :: convergeFail
 
-      !$acc declare present(xh,za,xland,u1,v1,s1,u10,v10,s10, &
-      !$acc                 znt,ust,cd,ch,cq)
-
+      !$acc declare &
+      !$acc present(xh,za,xland) &
+      !$acc present(u1,v1,s1) &
+      !$acc present(u10,v10,s10) &
+      !$acc present(znt,ust,cd,ch,cq) &
+      !$acc present(avgsfcu,avgsfcv,avgsfcs,avgsfct)
 !-----------------------------------------------------------------------
 !
 !  This subroutine determines several important variables at the surface

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -1,17 +1,9 @@
 #ifdef _B4B
 
-#undef _B4B01F
-#undef _B4B02F
-#undef _B4B03F
-#undef _B4B04F
-#undef _B4B05F
-#undef _B4B07F
-#undef _B4B11F
-
 #define _B4B06R
 #define _B4B08R
 #define _B4B09R
-#define _B4B10
+#define _B4B10R
 #endif
   MODULE sfcphys_module
 
@@ -116,11 +108,7 @@
     ! specify z0 (roughness length):
     ! note:  set znt array in "init_surface.F"
 
-#ifdef _B4B01F
-    !$acc update host(za,znt,u1,v1,s1)
-#else
     !$acc parallel loop gang vector collapse(2) default(present) private(i,j,var,rznt)
-#endif
     !$omp parallel do default(shared) private(i,j,var,rznt)
     do j=j1,j2
     do i=i1,i2
@@ -133,17 +121,10 @@
       ust(i,j) = max( s1(i,j)*karman/alog(za(i,j)*rznt) , 1.0e-6 )
     enddo
     enddo
-#ifdef _B4B01F
-    !$acc update device(cd,u10,v10,s10,ust)
-#endif
 
   ELSEIF( set_ust.eq.1 )THEN  sfc_options
       ! specify ustar (friction velocity):
-#ifdef _B4B01F
-    !$acc update host(za,u1,v1,s1)
-#else
     !$acc parallel loop gang vector collapse(2) default(present) private(i,j,var,rznt)
-#endif
     !$omp parallel do default(shared) private(i,j,var,rznt)
     do j=j1,j2
     do i=i1,i2
@@ -157,9 +138,6 @@
       s10(i,j) = s1(i,j)*var
     enddo
     enddo
-#ifdef _B4B01F
-    !$acc update device(znt,cd,u10,v10,s10,ust)
-#endif
 
   ELSEIF( cecd.eq.1 )THEN  sfc_options
     ! specify Cd (drag coefficient):
@@ -189,11 +167,7 @@
     ! Cd,z0,ust are functions of 10-m windspeed over water ... need to iterate:
     convergeFail = .false.
     !$omp parallel do default(shared) private(i,j,wlast,n,var,rznt)
-#ifdef _B4B11F
-    !$acc update host(xland,znt,za,s1,u1,v1)
-#else
     !$acc parallel loop gang vector collapse(2) default(present) private(i,j,wlast,n,var,rznt)
-#endif
     do j=j1,j2
     do i=i1,i2
       IF(xland(i,j).gt.1.5)THEN
@@ -249,9 +223,6 @@
       ust(i,j) = max( s1(i,j)*karman/alog((za(i,j)+znt(i,j))*rznt) , 1.0e-6 )
     enddo
     enddo
-#ifdef _B4B11F
-    !$acc update device(s10,cd,u10,v10,ust,znt)
-#endif
     !print *,'getcecd: before convergeFail check' 
     if(convergeFail) then 
       call stopcm1
@@ -417,29 +388,18 @@
 
     !  sensible heat flux:
     !$omp parallel do default(shared) private(i,j,pisfc)
-#ifdef _B4B02F
-    !$acc update host(psfc,ch,s10,tsk,th0,tha)
-#else
     !$acc parallel loop gang vector  default(present) private(i,j,pisfc)
-#endif
     DO j=1,nj
       do i=1,ni
         pisfc = (psfc(i,j)*rp00)**rovcp
         thflux(i,j)=ch(i,j)*s10(i,j)*(tsk(i,j)/pisfc-th0(i,j,1)-tha(i,j,1))
       enddo
     ENDDO
-#ifdef _B4B02F
-    !$acc update device(thflux)
-#endif
 
     !  latent heat flux:
     IF(imoist.eq.1)THEN
       !$omp parallel do default(shared) private(i,j,pisfc,qvsat)
-#ifdef _B4B03F
-      !$acc update host(psfc,tsk,qva,s10,cq,mavail)
-#else
       !$acc parallel loop gang vector default(present) private(i,j,pisfc,qvsat)
-#endif
       DO j=1,nj
         do i=1,ni
           qvsat=rslf(psfc(i,j),tsk(i,j))
@@ -448,9 +408,6 @@
         enddo
       ENDDO
     ENDIF
-#ifdef _B4B03F
-    !$acc update device(qsfc,qvflux)
-#endif
 
   ENDIF  setting_flux
 
@@ -492,11 +449,7 @@
       ! (VanZanten et al 2011, JAMES)
 
   
-#ifdef _B4B04F
-      !$acc update host(psfc,s1,tsk,th0,tha)
-#else
       !$acc parallel loop gang vector default(present) private(i,j,pisfc,qvsat)
-#endif
       !$omp parallel do default(shared) private(i,j,pisfc,qvsat)
       DO j=1,nj
         do i=1,ni
@@ -504,15 +457,8 @@
           thflux(i,j) = 0.001094*s1(i,j)*(tsk(i,j)/pisfc-th0(i,j,1)-tha(i,j,1))
         enddo
       ENDDO
-#ifdef _B4B04F
-      !$acc update device(thflux)
-#endif
       IF(imoist.eq.1)THEN
-#ifdef _B4B05F
-        !$acc update host(psfc,tsk,s1,qva,mavail)
-#else
         !$acc parallel loop gang vector default(present) private(i,j,pisfc,qvsat)
-#endif
         !$omp parallel do default(shared) private(i,j,pisfc,qvsat)
         DO j=1,nj
           do i=1,ni
@@ -521,9 +467,6 @@
             qvflux(i,j) = 0.001133*s1(i,j)*(qvsat-qva(i,j,1))*mavail(i,j)
           enddo
         ENDDO 
-#ifdef _B4B05F
-        !$acc update device(qvflux,qsfc)
-#endif
       ENDIF
 
     ELSEIF( testcase.eq.11 )THEN
@@ -638,13 +581,9 @@
       EP1 = rv/rd - 1.0
 
       ! surface layer diagnostics:
-#ifdef _B4B07F
-      !$acc update host(psfc,tsk,th0,tha,qa,qsfc,znt,za,qvflux,hpbl,dsxy,s1,wspd,thflux,rf,cd,th2)
-#else
       !$acc parallel loop gang vector collapse(2) default(present)   &
       !$acc private(i,j,pisfc,thgb,thx,thvx,tskv,govrth,dthvdz,vconv,vsgd,   &
       !$acc dthvm,val,fluxc,rznt)
-#endif      
       !$omp parallel do default(shared)   &
       !$omp private(i,j,pisfc,thgb,thx,thvx,tskv,govrth,dthvdz,vconv,vsgd,   &
       !$omp dthvm,val,fluxc,rznt)
@@ -696,9 +635,6 @@
         t2(i,j) = th2(i,j)*pisfc
       enddo
       enddo
-#ifdef _B4B07F
-      !$acc update device(gz1oz0,qsfc,wspd,br,hfx,qfx,cda,psim,psih,zol,mol,fm,fh,th2,q2,t2)
-#endif
 
       if(timestats.ge.1) time_sfcphys=time_sfcphys+mytime()
       end subroutine sfcdiags
@@ -1219,7 +1155,7 @@
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfct,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
 #endif
 
-#ifndef _B4B10
+#ifndef _B4B10R
       !$acc parallel 
 #endif
       temd = 1.0/dble(nx*ny)
@@ -1227,7 +1163,7 @@
       avgsfcv = avgsfcv*temd
       avgsfcs = avgsfcs*temd
       avgsfct = avgsfct*temd
-#ifndef _B4B10
+#ifndef _B4B10R
       !$acc end parallel
 #else
       !$acc update device(avgsfcu,avgsfcv,avgsfcs,avgsfct)

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -1,6 +1,4 @@
 #ifdef _B4B
-#undef _B4B01F
-#undef _B4B02F
 #define _B4B03R
 #endif
   MODULE solve1_module
@@ -1787,11 +1785,7 @@
         rdt = 1.0/dt
         tem = 0.0001*tsmall
         IF(imoist.eq.1)THEN
-#ifdef _B4B01F
-          !$acc update host(thten1,qten,tha,qa,rho,th0,pi0,ppi)
-#else
           !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,pinew,thnew,qvnew)
-#endif
           !$omp parallel do default(shared) private(i,j,k,pinew,thnew,qvnew)
           do k=1,nk
           do j=1,nj
@@ -1811,9 +1805,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B01F
-          !$acc update device(ppten)
-#endif
           if( ptype.ge.1 )then
             ! use diabatic tendencies from last timestep as a good estimate:
             !$omp parallel do default(shared)  &
@@ -1831,13 +1822,7 @@
             enddo
           endif
         ELSE
-#ifdef _B4B02F
-          !$acc update host(thten1,tha,rho,th0,pi0,ppi)
-#else
-          !$acc data copyin(tem,dt,rd,rp00,rddcv,rdt)
-          !non-B4B
           !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,pinew,thnew)
-#endif
           !$omp parallel do default(shared) private(i,j,k,pinew,thnew,qvnew)
           do k=1,nk
           do j=1,nj
@@ -1856,11 +1841,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B02F
-          !$acc update device(ppten)
-#else
-          !$acc end data
-#endif
         ENDIF  ! endif for moist/dry
       ENDIF    ! endif for eqtset 1/2
 

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -1,10 +1,5 @@
 #ifdef _B4B
 
-#define _B4B01F
-#define _B4B02F
-#define _B4B03F
-#define _B4B04F
-
 #define _B4B05RF
 #define _B4B06R
 
@@ -1706,12 +1701,7 @@
         ENDIF
 
         IF( nrk.eq.nrkmax .or. (idiff.ge.1 .and. difforder.eq.6) )THEN
-#ifdef _B4B01F
-          !$acc update host(pi0,pp3d,th0,th3d,pp3d,q3d)    
-#else
-          !non-B4B01
           !$acc parallel loop gang vector collapse(3) private(i,j,k)
-#endif
           !$omp parallel do default(shared) private(i,j,k)
           do k=1,nk
           do j=1,nj
@@ -1723,20 +1713,12 @@
           enddo
           enddo
           enddo
-#ifdef _B4B01F
-          !$acc update device(prs,rho)
-#endif
         ENDIF
 
       ELSE
 
         IF( nrk.eq.nrkmax .or. (idiff.ge.1 .and. difforder.eq.6) )THEN
-#ifdef _B4B02F
-          !$acc update host(pi0,pp3d,th0,th3d,pp3d)    
-#else
-          !non-B4B02
           !$acc parallel loop gang vector collapse(3) private(i,j,k)
-#endif
           !$omp parallel do default(shared) private(i,j,k)
           do k=1,nk
           do j=1,nj
@@ -1747,9 +1729,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B02F
-          !$acc update device(prs,rho)
-#endif
         ENDIF
 
       ENDIF
@@ -2175,12 +2154,7 @@
 !!!        if( myid.eq.0 ) print *,'  temd,tem = ',temd,tem
 
         IF( imoist.eq.1 )THEN
-#ifdef _B4B03F
-          !$acc update host(pi0,pp3d,th0,th3d,pp3d,prs,q3d)    
-#else
-          !non-B4B03
           !$acc parallel loop gang vector collapse(3) private(i,j,k)
-#endif
           !$omp parallel do default(shared) private(i,j,k)
           do k=1,nk
           do j=1,nj
@@ -2193,16 +2167,8 @@
           enddo
           enddo
           enddo
-#ifdef _B4B03F
-          !$acc update device(rho,prs,pp3d)
-#endif
         ELSE
-#ifdef _B4B04F
-          !$acc update host(pi0,pp3d,th0,th3d,pp3d,prs)    
-#else
-          !non-B4B04
           !$acc parallel loop gang vector collapse(3)  private(i,j,k)
-#endif
           !$omp parallel do default(shared) private(i,j,k)
           do k=1,nk
           do j=1,nj
@@ -2214,9 +2180,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B04F
-          !$acc update device(rho,prs,pp3d)
-#endif
         ENDIF
 
       ENDIF  pscheck2

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -75,15 +75,19 @@
 
 !---------------------------------------------------------------------
 
+    print *,'sounde: nsound: ',nsound
     IF( nrkmax.eq.3 )THEN
       if(nrk.eq.1)then
 !!!        nloop=1
 !!!        dts=dt/3.
         nloop=nint(float(nsound)/3.0)
-        dts=dt/(nloop*3.0)
+!        print *,'sounde: denominator: ', float(nloop)*3.0
+!        print *,'sounde: numerator: ', dt
+        dts=dt/(float(nloop)*3.0)
+!        print *,'sounde: dts: ', dts
         if( dts.gt.(dt/nsound) )then
           nloop=nloop+1
-          dts=dt/(nloop*3.0)
+          dts=dt/(float(nloop)*3.0)
         endif
       elseif(nrk.eq.2)then
         nloop=0.5*nsound

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -1,7 +1,3 @@
-#ifdef _B4B
-#undef _B4B01F
-#undef _B4B02F
-#endif
   MODULE statpack_module
 
   implicit none
@@ -351,12 +347,7 @@
       IF(imoist.eq.1)THEN
 
         if(stat_rh.eq.1 .or. stat_the.eq.1)then
-          ! non-B4B  due to presence of exp in rslf()
-#ifdef _B4B01F
-          !$acc update host(prs,th0,tha,pi0,ppi,qa)
-#else
           !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,qvs)
-#endif
           !$omp parallel do default(shared) private(i,j,k,qvs)
           do k=1,nk
           do j=1,nj
@@ -367,9 +358,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B01F
-          !$acc update device(dum2)
-#endif
         endif
 
         if(stat_rh.eq.1)then
@@ -377,13 +365,8 @@
         endif
 
         if(iice.eq.1 .and. stat_rhi.eq.1)then
-!$omp parallel do default(shared)  &
-!$omp private(i,j,k,qvs)
-#ifdef _B4B02F
-          !$acc update host(prs,th0,tha,pi0,ppi,qa)
-#else
+          !$omp parallel do default(shared) private(i,j,k,qvs)
           !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,qvs)
-#endif
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -393,9 +376,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B02F
-          !$acc update device(dum3)
-#endif
           call maxmin(ni,nj,nk,dum3,nstat,rstat,kmin,kmax,'RHIMAX','RHIMIN')
         endif
 

--- a/src/testcase_simple_phys.F
+++ b/src/testcase_simple_phys.F
@@ -1,6 +1,5 @@
 #ifdef _B4B
 #define _B4B01R
-#undef _B4B04F
 #define _B4B05R   
 #endif
   MODULE simple_phys_module
@@ -499,16 +498,9 @@
 !!!        print *
 !!!      endif
 
-#ifdef _B4B04F
-      !$acc update host(dum1,dum2,rho0,ql,zf,zir)
-#else
-      !non-B4B due to EXP and PWR functions
       !$acc parallel default(present) private(i,j,k,fr1,fr2,fr3)
-#endif
       do k=nk+1,1,-1
-#ifndef _B4B04F
       !$acc loop gang vector collapse(2)
-#endif
       do j=1,nj
       do i=1,ni
         dum1(i,j,k) = dum1(i,j,min(nk+1,k+1))  &
@@ -525,11 +517,7 @@
       enddo
       enddo
       enddo
-#ifdef _B4B04F
-      !$acc update device(frad,dum1) 
-#else
       !$acc end parallel
-#endif
       stop 'simplerad: at the end of the subroutine'
       end subroutine simplerad
 

--- a/src/turb.F
+++ b/src/turb.F
@@ -1,14 +1,6 @@
 #ifdef _B4B
 
-#define _B4B01F
-#define _B4B02F
-#define _B4B03F
-#define _B4B04F
-#define _B4B05F
-#define _B4B08F
-
 !JMD-changes answers
-#define _B4B06F
 #define _B4B07R
 #define _B4B09R
 #define _B4B10R
@@ -658,11 +650,7 @@
           call getcecd(xh,u1,v1,s1,ppten(ib,jb,1),u10,v10,s10,xland,znt,ust,cd,ch,cq,avgsfcu,avgsfcv,avgsfcs,avgsfct)
 
           if( tbc.eq.3 )then
-#ifdef _B4B01F
-            !$acc update host(ugr,vgr,zf,zh) 
-#else
             !$acc parallel loop gang vector collapse(2) default(present) 
-#endif
             do j=1,nj
             do i=1,ni
               ut(i,j) = 0.5*( ugr(i,j,nk) + ugr(i+1,j,nk) )
@@ -671,10 +659,7 @@
               ustt(i,j) = max( st(i,j)*karman/alog((zf(i,j,nk+1)-zh(i,j,nk))/cnst_znt) , 1.0e-6 )
             enddo
             enddo
-#ifdef _B4B01F
-            !$acc update device(ut,vt,st,ustt)
-#endif
-            stop 'sfc_and_turb: after setting of ut,vt,st,ustt'
+            !stop 'sfc_and_turb: after setting of ut,vt,st,ustt'
           endif
 
 
@@ -919,19 +904,12 @@
                      ids=1  ,ide=ni+1 , jds= 1 ,jde= 1   , kds=1  ,kde=nk+1 ,                                   &
                      ims=ib ,ime=ie   , jms= 1 ,jme= 1   , kms=kb ,kme=ke ,                                     &
                      its=1  ,ite=ni   , jts= 1 ,jte= 1   , kts=1  ,kte=nk  )
-#ifdef _B4B02F
-          !$acc update host(br,ppten,znt)
-#else
           !$acc parallel loop gang vector default(present) private(i)
-#endif
           do i=1,ni
             br(i,j) = max( -10.0 , br(i,j) )
             br(i,j) = min(  10.0 , br(i,j) )
             gz1oz0(I,J)=ALOG(ppten(i,j,1)/znt(i,j))
           enddo
-#ifdef _B4B02F
-          !$acc update device(br,gz1oz0)
-#endif
 
         enddo
         endif
@@ -2440,12 +2418,7 @@
 
       ! single length scale:  appropriate if dx,dy are nearly the same as dz
 
-#ifdef _B4B03F
-      !$acc update host(csz,ruh,rvh,rmf,tkea,nm,dissten,ce1z,ce2z,cmz,kmh,khh)
-#else
-      !non-B4B: due to use of PWR function 
       !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,prinv,rcs)
-#endif
       !$omp parallel do default(shared) private(i,j,k,prinv,rcs)
       do k=2,nk
       do j=1,nj
@@ -2495,20 +2468,13 @@
       enddo
       enddo
       enddo
-#ifdef _B4B03F
-      !$acc update device(grdscl,rgrdscl,lenscl,tk,dissten,kmh,kmv,khh,khv)
-#endif
 
     ELSEIF(tconfig.eq.2)THEN
 
       ! two length scales:  one for horizontal, one for vertical
 
       !$omp parallel do default(shared) private(i,j,k,prinv,rcs)
-#ifdef _B4B03F
-      !$acc update host(grdscl,rgrdscl,lenscl,tk,dissten,kmh,kmv,khh,khv)
-#else
       !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,prinv,rcs)
-#endif
       do k=2,nk
       do j=1,nj
       do i=1,ni
@@ -2558,9 +2524,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B03F
-      !$acc update device(grdscl,rgrdscl,lenscl,tk,dissten,kmh,kmv,khh,khv)
-#endif
 
     ENDIF
      
@@ -4737,12 +4700,7 @@
 
     IF(imoist.eq.0)then
 
-#ifdef _B4B04F
-      !$acc update host(th0,th,mf)
-#else
-      !non-B4B
       !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
-#endif
       !$omp parallel do default(shared) private(i,j,k)
       do k=2,nk
       do j=1,nj
@@ -4752,9 +4710,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B04F
-      !$acc update device(nm)
-#endif
 
 ! GHB, 220308 ... comment out this stop 
 !!!      stop 'calcnm: after first loop'
@@ -4854,16 +4809,11 @@
       enddo
       enddo
 
-#ifdef _B4B05F
-      !$acc update host(thv,mf,c1,c2,prs,t,qt,qvci,qt)
-#else
-      !non-B4B
       !$acc parallel loop gang vector collapse(3) default(present) &
       !$acc private(i,j,k,pavg,tavg,qtavg,qvciavg) &
       !$acc private(qvs,ql,qi,qv,qvsl,qvsi)  &
       !$acc private(cpml,lh,drdt,gamma) &
       !$acc private(rtt1,rtt2,ff,nmi,nml)
-#endif
       do k=2,nk
       do j=1,nj
       do i=1,ni
@@ -4941,9 +4891,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B05F
-      !$acc update device(nm,iamsat)
-#endif
       stop 'calcnm: point #2'
 
     ELSE  icecheck
@@ -4959,12 +4906,8 @@
       enddo
       enddo
       enddo
-#ifdef _B4B06F
-      !$acc update host(qt,mf,c1,c2,prs,t,qt,qvci)
-#else
       !$acc parallel loop gang vector collapse(3) default(present) &
       !$acc private(i,j,k,pavg,tavg,qtavg,qvciavg,qvs,ql,qv,cpml,lh,drdt,gamma)
-#endif
       do k=2,nk
       do j=1,nj
       do i=1,ni
@@ -4993,12 +4936,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B06F
-    !$acc update device(t,thv,nm,iamsat)
-#else
-    !$acc end parallel
-#endif
-      !stop 'calcnm: point #3'
 
     ENDIF  icecheck
 
@@ -5501,17 +5438,10 @@
 
 
         !print *,'t2pcode: point #3'
-#ifndef _B4B08F
         !$acc parallel loop gang vector default(present) private(k)
-#endif
         do k=1,(ntwk+1)
           wspa(k) = (ustbar/karman)*alog( sngl(zh(1,1,k)/zntbar) )
         enddo
-#ifdef _B4B08F
-        !$acc update device(wspa)
-#else
-        !$acc end parallel
-#endif
 
     !-------------------------------------------
 

--- a/src/turb.F
+++ b/src/turb.F
@@ -2527,7 +2527,8 @@
 
     ENDIF
      
-    !$acc update host (grdscl)
+
+
     if( nstep.eq.0 .and. myid.eq.0 )then
       print *
       print *,'  zf,grdscl:'


### PR DESCRIPTION
This commit eliminates a number of code blocks that are designed to produce B4B answers between the CPU and GPU versions of the code.  In particular, it focuses on code blocks that contain math intrinsic functions that have previously caused numerical differences.  Recently a flag has been added to the NVHPC compiler 'math_uniform' that provides a math intrinsic function calculations on the GPU that reproduces the CPU version.   