### PR TITLE
Eliminate B4B attempt #2

### DIFF
--- a/run/namelist.baseline.dx=40m.short
+++ b/run/namelist.baseline.dx=40m.short
@@ -19,8 +19,8 @@
  run_time =  -999.9,
  tapfrq =   900.0,
  rstfrq = 10800.0,
- statfrq =  60.0,
- prclfrq =   60.0,
+ statfrq =   1.0,
+ prclfrq =   1.0,
  /
 
  &param2

--- a/src/Makefile
+++ b/src/Makefile
@@ -78,7 +78,7 @@ ifeq (${FC},nvfortran)
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${DEBUG_L},true)
          OPTS    += -g -O0
-         # DM      += -D_B4B
+         DM      += -D_B4B
     else
          OPTS    += -g -O2
     endif
@@ -124,7 +124,7 @@ ifeq (${FC},pgf90)
         ifeq (${DEBUG_L},true)
             OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Mnofma
         else
-            OPTS += -acc -gpu=cc70,lineinfo,math_uniform -Mpcast -Minfo=accel -Mnofma
+            OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel -Mnofma
         endif
         DM       += -D_OPENACC
     endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -78,9 +78,9 @@ ifeq (${FC},nvfortran)
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${DEBUG_L},true)
          OPTS    += -g -O0
-         DM      += -D_B4B
+         # DM      += -D_B4B
     else
-         OPTS    += -O2
+         OPTS    += -g -O2
     endif
     ifeq (${USE_DOUBLE_L},true)
          OPTS    += -r8
@@ -94,7 +94,7 @@ ifeq (${FC},nvfortran)
         ifeq (${DEBUG_L},true)
             OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Mnofma
         else
-            OPTS += -acc -gpu=cc70,lineinfo,math_uniform -Mpcast -Minfo=accel
+            OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel -Mnofma
         endif
         DM       += -D_OPENACC
     endif
@@ -124,7 +124,7 @@ ifeq (${FC},pgf90)
         ifeq (${DEBUG_L},true)
             OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform -Mnofma
         else
-            OPTS += -acc -gpu=cc70,lineinfo,math_uniform -Mpcast -Minfo=accel
+            OPTS += -acc -gpu=cc70,lineinfo,math_uniform -Mpcast -Minfo=accel -Mnofma
         endif
         DM       += -D_OPENACC
     endif
@@ -138,7 +138,7 @@ endif
 #  Intel compiler
 #-----------------------------------------------------------------------------
 ifeq (${FC},ifort)
-    OPTS         += -g -O3 -xHost -ip -assume byterecl -fp-model precise -ftz -init=snan,arrays -traceback
+    OPTS         += -g -O3 -xHost -ip -assume byterecl -fp-model precise -ftz -init=snan,arrays -traceback -no-fma
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${USE_OPENMP_L},true)
         OPTS     += -qopenmp

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -3779,10 +3779,7 @@
       if(iprcl.eq.1)then
       IF( doprclout )THEN
       
-#ifdef _OPENACC
-!        stop 'ERROR: parcel_interp not supported in OpenACC'
-#endif
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
+        !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
         call     parcel_interp(dt,mtime,xh,uh,ruh,xf,uf,yh,vh,rvh,yf,vf, &
                                zh,mh,rmh,zf,mf,zntmp,ust,c1,c2,        &
                                zs,sigma,sigmaf,rds,gz,                 &
@@ -3796,13 +3793,7 @@
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p, &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2)
 
-#if 0
-#endif
-       !stop 'cm1: after call to parcel_interp'
-!#ifdef _OPENACC
-!        stop 'ERROR: parcel_write not supported in OpenACC'
-!#endif
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
+        !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 
         call     parcel_write(prec,rtime,qname,name_prcl,desc_prcl,unit_prcl,pdata,ploc)
         prec = prec+1

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -581,9 +581,9 @@
       nkm1 = nk-1
       !$acc update device(nip1,njp1,nkp1,nkm1,ni,nj,nk,nparcels, &
       !$acc               npvals,terrain_flag,numq,bbc,tbc, &
-      !$acc               viscosity,pr_num,sc_num,prvpx,prvpy, &
-      !$acc               prvpz,prrp,prms,prtp,prx,pry,prsig,prz, &
-      !$acc               pract,nodex,nodey)
+      !$acc               pr_num,sc_num,prvpx,prvpy,prvpz,prrp, &
+      !$acc               prms,prtp,prx,pry,prsig,prz,pract, &
+      !$acc               nodex,nodey)
 
       nimax = ni
       njmax = nj

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -1,12 +1,5 @@
 #ifdef _B4B
 
-#define _B4B07F
-#define _B4B08F
-#define _B4B09F
-#define _B4B10F
-#define _B4B11F
-#define _B4B12F
-
 #define _B4B16R
 #define _B4B19R
 #define _B4B21R
@@ -3463,11 +3456,7 @@
         varunit(nvar) = 'K'
 
       if( ptype.eq.0 )then
-#ifdef _B4B07F
-        !$acc update host(th0,th3d,pi0,pp3d,q3d,prs)
-#else
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,tx,qx,px,tlcl,ee)
-#endif
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -3482,11 +3471,7 @@
         enddo
         enddo
       else
-#ifdef _B4B07F
-        !$acc update host(th0,th3d,pi0,pp3d,q3d,prs)
-#else
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,tx,qx,px,tlcl,ee)
-#endif
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -3505,9 +3490,6 @@
         enddo
         enddo
       endif
-#ifdef _B4B07F
-      !$acc update device(dum1)
-#endif
 
         call getavg3d(dum1,savg)
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
@@ -3523,11 +3505,7 @@
         vardesc(nvar) = 'relative humidity (wrt liquid)'
         varunit(nvar) = 'nondimensional'
      
-#ifdef _B4B08F
-        !$acc update host(q3d,prs,th,pi0,pp3d)
-#else
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
-#endif
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -3535,9 +3513,6 @@
         enddo
         enddo
         enddo
-#ifdef _B4B08F
-        !$acc update device(dum1)
-#endif
         call getavg3d(dum1,savg)
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 
@@ -3551,11 +3526,7 @@
         varname(nvar) = 'rhi'
         vardesc(nvar) = 'relative humidity (wrt ice)'
         varunit(nvar) = 'nondimensional'
-#ifdef _B4B09F
-        !$acc update host(q3d,prs,th,pi0,pp3d)
-#else
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
-#endif
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -3563,9 +3534,6 @@
         enddo
         enddo
         enddo
-#ifdef _B4B09F
-        !$acc update device(dum1)
-#endif
         call getavg3d(dum1,savg)
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 
@@ -4408,11 +4376,7 @@
         varunit(nvar) = 'm'
         vargrid(nvar) = 'w'
 
-#ifdef _B4B10F
-        !$acc update host(ruh,rvh,rmf,zf,znt)
-#else
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
-#endif
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -4424,9 +4388,6 @@
         enddo
         enddo
         enddo
-#ifdef _B4B10F
-        !$acc update device(dum1)
-#endif
 
         call getavg3d(dum1,savg)
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
@@ -4726,17 +4687,10 @@
         vardesc(nvar) = 'analytic wind speed (neutral)'
         varunit(nvar) = 'm/s'
 
-#ifdef _B4B11F
-        !$acc update host(zh)
-#else
         !$acc parallel loop gang vector default(present) private(k)
-#endif
         do k=1,nk
           savg(k) = (ustbar/karman)*alog( (zh(1,1,k)+zntbar)/zntbar )
         enddo
-#ifdef _B4B11F
-        !$acc update device(savg)
-#endif
 
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 
@@ -4747,11 +4701,7 @@
         vardesc(nvar) = 'analytic wind speed'
         varunit(nvar) = 'm/s'
 
-#ifdef _B4B12F
-        !$acc update host(zh)
-#else
         !$acc parallel loop gang vector default(present) private(k,zeta,tpsim)
-#endif
         do k=1,nk
           if( abs(molbar).gt.1.0e-6 )then
             zeta = zh(1,1,k)/molbar
@@ -4762,9 +4712,6 @@
           savg(k) = (ustbar/karman)*( alog(zh(1,1,k)/zntbar) - tpsim )
           wspa(k) = savg(k)
         enddo
-#ifdef _B4B12F
-        !$acc update device(savg,wspa)
-#endif
 
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -1,13 +1,5 @@
 #ifdef _B4B
 
-#define _B4B01F
-#define _B4B02F
-#define _B4B03F
-#define _B4B04F
-#define _B4B05F
-
-#define _B4B06
-
 #define _B4B07F
 #define _B4B08F
 #define _B4B09F
@@ -1373,27 +1365,17 @@
           enddo
         endif
       enddo
-#ifdef _B4B01F
-      !$acc update host(dum1(1:ni,1:nj,5),rho,prs,th,pi0,pp3d,rmh)
-#else
       !$acc parallel default(present) private(i,j)
       !$acc loop seq
-#endif
       do k=1,nk
-#ifndef _B4B01F
         !$acc loop gang vector collapse(2)
-#endif
         do j=1,nj
         do i=1,ni
           dum1(i,j,5) = dum1(i,j,5) + rho(i,j,k)*rslf(prs(i,j,k),th(i,j,k)*(pi0(i,j,k)+pp3d(i,j,k)))*dz*rmh(i,j,k)
         enddo
         enddo
       enddo
-#ifdef _B4B01F
-      !$acc update device(dum1(1:ni,1:nj,5))
-#else
       !$acc end parallel
-#endif
 
       do k=1,nk
         IF( iice.eq.1 )THEN
@@ -1601,18 +1583,11 @@
       enddo
       enddo
 
-#ifdef _B4B02F
-      !$acc update host(pavg,thavg)
-#else
       !$acc parallel loop gang vector default(present) private(i,j,k)
-#endif
       do k=1,nk
         ! use minimum of 1.0e-5 and 1% of saturation wrt liquid (using last known t,p)
         qcrit(k) = min( 1.0e-5 , 0.01*rslf(pavg(k),thavg(k)*((pavg(k)*rp00)**rovcp)) )
       enddo
-#ifdef _B4B02F
-      !$acc update device(qcrit)
-#endif
 
       !$acc parallel default(present) private(i,j,k)
       do k=nk,1,-1
@@ -3351,19 +3326,12 @@
         varunit(nvar) = 'n.d.'
 
       if( imoist.eq.1 )then
-#ifdef _B4B03F
-        !$acc update host(psfc,tsk)
-#else
         !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
-#endif
         do j=1,nj
         do i=1,ni
           tmpqsfc(i,j) = rslf(psfc(i,j),tsk(i,j))
         enddo
         enddo
-#ifdef _B4B03F
-        !$acc update device(tmpqsfc)    
-#endif
         !...
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
@@ -3405,11 +3373,7 @@
 
     !PORTME
     if( nloop.eq.1 )then
-#ifdef _B4B04F
-      !$acc update host(th0,th3d,dum2,tsk,psfc,tmpqsfc,thflux,qvflux,ust,govthv,hpbl)
-#else
       !$acc parallel loop gang vector collapse(2) default(present) private(i,j,thvx)
-#endif
       do j=1,nj
       do i=1,ni
         thvx = (th0(i,j,1)+th3d(i,j,1))*(1.0+repsm1*dum2(i,j,1))
@@ -3417,16 +3381,9 @@
         thv1(i,j) = thvx
       enddo
       enddo
-#ifdef _B4B04F
-      !$acc update device(thvx,thvsfc,thv1)
-#endif
     else
-#ifdef _B4B05F
-      !$acc update host(th0,th3d,dum2,tsk,psfc,tmpqsfc,thflux,qvflux,ust,govthv,hpbl)
-#else
       !$acc parallel loop gang vector collapse(2) default(present) &
       !$acc private(i,j,thvx,thf1,thf2,thvflux,ws,gamfac,tmpprt)
-#endif
       do j=1,nj
       do i=1,ni
         thvx = (th0(i,j,1)+th3d(i,j,1))*(1.0+repsm1*dum2(i,j,1))
@@ -3443,17 +3400,10 @@
         thv1(i,j) = thvx + tmpprt
       enddo
       enddo
-#ifdef _B4B05F
-      !$acc update device(thvx,thf1,thf2,thvflux,ws,gamfac,tmpprt,thv1)
-#endif
     endif
 
-#ifdef _B4B06
-      !$acc update host(u3d,v3d,zh,th0,th3d,dum2,tsk,psfc,tmpqsfc,thflux,qvflux,ust,govthv,hpbl)
-#else
       !$acc parallel loop gang vector collapse(3) default(present) &
       !$acc private(i,j,k,thvx,ubar,vbar)
-#endif
       do k=1,nk
       do j=1,nj
       do i=1,ni
@@ -3464,9 +3414,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B06
-      !$acc update device(dum1)
-#endif
 
     ENDDO  hloop
 

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -9688,7 +9688,7 @@
         vargrid(nvar) = '2'
 
         savg2d = 0.0
-        !$acc parallel loop gang vector reduction(max:savg2d)
+        !$acc parallel loop gang vector default(present) reduction(max:savg2d) 
         do k=2,nk
           savg2d = max( savg2d , dble(wvar(k)) )
         enddo
@@ -10667,26 +10667,15 @@
 
     integer :: i,j
 
-    !JMD Need to double check following bit of code.  We should be able to move 
-    !JMD calculation to the GPU
-#ifdef _B4B28R
-    !$acc update host(s2d)
-    savg2d = 0.0
-#else
     savg2d = 0.0
     !$acc parallel default(present) private(i,j) reduction(+:savg2d)
     !$acc loop gang vector collapse(2) reduction(+:savg2d)
-#endif
     do j=1,nj
     do i=1,ni
       savg2d = savg2d+s2d(i,j)
     enddo
     enddo
-#ifdef _B4B28R
-    !$acc update device(savg2d)
-#else
     !$acc end parallel
-#endif
 
 #ifdef MPI
     call MPI_ALLREDUCE(MPI_IN_PLACE,savg2d,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
@@ -10695,6 +10684,7 @@
     savg2d = savg2d/dble(nx*ny)
 
     end subroutine getavg2d
+
 
 
     !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3690,9 +3690,11 @@
       !$acc end parallel
 #endif
  
+#ifdef _B4B07R
       tmass=0.0d0
-#ifndef _B4B07R
+#else
       !$acc parallel default(present) reduction(+:tmass)
+      tmass=0.0d0
       !$acc loop gang vector reduction(+:tmass)
 #endif
       do k=1,nk

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -1,6 +1,5 @@
 #ifdef _B4B
 
-#undef _B4B03F
 #undef _B4B01R
 
 !JMD-expensive
@@ -2591,16 +2590,12 @@
 
 ! Reference:  Bryan, 2008, MWR, p. 5239
 
-!$omp parallel do default(shared)  &
-!$omp private(i,j,k,n,tx,cpm)
-#ifdef _B4B03F
-            !$acc update host(zh,th0,tha,pi0,ppi,qa,prs,rh,the) 
-#else
-            !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,n,tx,cpm)
-#endif
-      do k=1,nk
+      !$omp parallel do default(shared) private(i,j,k,n,tx,cpm)
+      !$acc parallel loop gang vector collapse(2) default(present) private(i,j,k,tx,cpm)
       do j=1,nj
       do i=1,ni
+      !$acc loop seq
+      do k=1,nk
         if(zh(i,j,k).le.10000.)then
           tx=(th0(i,j,k)+tha(i,j,k))*(pi0(i,j,k)+ppi(i,j,k))
           cpm=cp
@@ -2614,9 +2609,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B03F
-      !$acc update device(the)
-#endif
 
       if(timestats.ge.1) time_stat=time_stat+mytime()
 

--- a/src/mp_driver.F
+++ b/src/mp_driver.F
@@ -1,6 +1,3 @@
-#ifdef _B4B
-#undef _B4B01F
-#endif
   MODULE mp_driver_module
 
              !------  Microphysics Driver ------!
@@ -543,11 +540,7 @@
           ! Get final values for th3d,pp3d,prs:
           ! Note:  dum1 stores temperature, thten stores old temperature:
           IF( eqtset.eq.2 )THEN
-#ifdef _B4B01F
-            !$acc update host(dum1,thten,q3d,qten,rho,pi0,th0)
-#else
             !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
-#endif
             !$omp parallel do default(shared) private(i,j,k)
             do k=1,nk
             do j=1,nj
@@ -561,9 +554,6 @@
             enddo
             enddo
             enddo
-#ifdef _B4B01F
-            !$acc update device(prs,pp3d,th3d)
-#endif
           ELSE
             !$omp parallel do default(shared) private(i,j,k)
             !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -1,17 +1,9 @@
 #ifdef _B4B
 
-#undef _B4B01F
-#undef _B4B02F
-#undef _B4B03F
-#undef _B4B04F
-#undef _B4B05F
-#undef _B4B07F
-#undef _B4B11F
-
 #define _B4B06R
 #define _B4B08R
 #define _B4B09R
-#define _B4B10
+#define _B4B10R
 #endif
   MODULE sfcphys_module
 
@@ -116,11 +108,7 @@
     ! specify z0 (roughness length):
     ! note:  set znt array in "init_surface.F"
 
-#ifdef _B4B01F
-    !$acc update host(za,znt,u1,v1,s1)
-#else
     !$acc parallel loop gang vector collapse(2) default(present) private(i,j,var,rznt)
-#endif
     !$omp parallel do default(shared) private(i,j,var,rznt)
     do j=j1,j2
     do i=i1,i2
@@ -133,17 +121,10 @@
       ust(i,j) = max( s1(i,j)*karman/alog(za(i,j)*rznt) , 1.0e-6 )
     enddo
     enddo
-#ifdef _B4B01F
-    !$acc update device(cd,u10,v10,s10,ust)
-#endif
 
   ELSEIF( set_ust.eq.1 )THEN  sfc_options
       ! specify ustar (friction velocity):
-#ifdef _B4B01F
-    !$acc update host(za,u1,v1,s1)
-#else
     !$acc parallel loop gang vector collapse(2) default(present) private(i,j,var,rznt)
-#endif
     !$omp parallel do default(shared) private(i,j,var,rznt)
     do j=j1,j2
     do i=i1,i2
@@ -157,9 +138,6 @@
       s10(i,j) = s1(i,j)*var
     enddo
     enddo
-#ifdef _B4B01F
-    !$acc update device(znt,cd,u10,v10,s10,ust)
-#endif
 
   ELSEIF( cecd.eq.1 )THEN  sfc_options
     ! specify Cd (drag coefficient):
@@ -189,11 +167,7 @@
     ! Cd,z0,ust are functions of 10-m windspeed over water ... need to iterate:
     convergeFail = .false.
     !$omp parallel do default(shared) private(i,j,wlast,n,var,rznt)
-#ifdef _B4B11F
-    !$acc update host(xland,znt,za,s1,u1,v1)
-#else
     !$acc parallel loop gang vector collapse(2) default(present) private(i,j,wlast,n,var,rznt)
-#endif
     do j=j1,j2
     do i=i1,i2
       IF(xland(i,j).gt.1.5)THEN
@@ -249,9 +223,6 @@
       ust(i,j) = max( s1(i,j)*karman/alog((za(i,j)+znt(i,j))*rznt) , 1.0e-6 )
     enddo
     enddo
-#ifdef _B4B11F
-    !$acc update device(s10,cd,u10,v10,ust,znt)
-#endif
     !print *,'getcecd: before convergeFail check' 
     if(convergeFail) then 
       call stopcm1
@@ -417,29 +388,18 @@
 
     !  sensible heat flux:
     !$omp parallel do default(shared) private(i,j,pisfc)
-#ifdef _B4B02F
-    !$acc update host(psfc,ch,s10,tsk,th0,tha)
-#else
     !$acc parallel loop gang vector  default(present) private(i,j,pisfc)
-#endif
     DO j=1,nj
       do i=1,ni
         pisfc = (psfc(i,j)*rp00)**rovcp
         thflux(i,j)=ch(i,j)*s10(i,j)*(tsk(i,j)/pisfc-th0(i,j,1)-tha(i,j,1))
       enddo
     ENDDO
-#ifdef _B4B02F
-    !$acc update device(thflux)
-#endif
 
     !  latent heat flux:
     IF(imoist.eq.1)THEN
       !$omp parallel do default(shared) private(i,j,pisfc,qvsat)
-#ifdef _B4B03F
-      !$acc update host(psfc,tsk,qva,s10,cq,mavail)
-#else
       !$acc parallel loop gang vector default(present) private(i,j,pisfc,qvsat)
-#endif
       DO j=1,nj
         do i=1,ni
           qvsat=rslf(psfc(i,j),tsk(i,j))
@@ -448,9 +408,6 @@
         enddo
       ENDDO
     ENDIF
-#ifdef _B4B03F
-    !$acc update device(qsfc,qvflux)
-#endif
 
   ENDIF  setting_flux
 
@@ -492,11 +449,7 @@
       ! (VanZanten et al 2011, JAMES)
 
   
-#ifdef _B4B04F
-      !$acc update host(psfc,s1,tsk,th0,tha)
-#else
       !$acc parallel loop gang vector default(present) private(i,j,pisfc,qvsat)
-#endif
       !$omp parallel do default(shared) private(i,j,pisfc,qvsat)
       DO j=1,nj
         do i=1,ni
@@ -504,15 +457,8 @@
           thflux(i,j) = 0.001094*s1(i,j)*(tsk(i,j)/pisfc-th0(i,j,1)-tha(i,j,1))
         enddo
       ENDDO
-#ifdef _B4B04F
-      !$acc update device(thflux)
-#endif
       IF(imoist.eq.1)THEN
-#ifdef _B4B05F
-        !$acc update host(psfc,tsk,s1,qva,mavail)
-#else
         !$acc parallel loop gang vector default(present) private(i,j,pisfc,qvsat)
-#endif
         !$omp parallel do default(shared) private(i,j,pisfc,qvsat)
         DO j=1,nj
           do i=1,ni
@@ -521,9 +467,6 @@
             qvflux(i,j) = 0.001133*s1(i,j)*(qvsat-qva(i,j,1))*mavail(i,j)
           enddo
         ENDDO 
-#ifdef _B4B05F
-        !$acc update device(qvflux,qsfc)
-#endif
       ENDIF
 
     ELSEIF( testcase.eq.11 )THEN
@@ -638,13 +581,9 @@
       EP1 = rv/rd - 1.0
 
       ! surface layer diagnostics:
-#ifdef _B4B07F
-      !$acc update host(psfc,tsk,th0,tha,qa,qsfc,znt,za,qvflux,hpbl,dsxy,s1,wspd,thflux,rf,cd,th2)
-#else
       !$acc parallel loop gang vector collapse(2) default(present)   &
       !$acc private(i,j,pisfc,thgb,thx,thvx,tskv,govrth,dthvdz,vconv,vsgd,   &
       !$acc dthvm,val,fluxc,rznt)
-#endif      
       !$omp parallel do default(shared)   &
       !$omp private(i,j,pisfc,thgb,thx,thvx,tskv,govrth,dthvdz,vconv,vsgd,   &
       !$omp dthvm,val,fluxc,rznt)
@@ -696,9 +635,6 @@
         t2(i,j) = th2(i,j)*pisfc
       enddo
       enddo
-#ifdef _B4B07F
-      !$acc update device(gz1oz0,qsfc,wspd,br,hfx,qfx,cda,psim,psih,zol,mol,fm,fh,th2,q2,t2)
-#endif
 
       if(timestats.ge.1) time_sfcphys=time_sfcphys+mytime()
       end subroutine sfcdiags
@@ -1219,7 +1155,7 @@
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfct,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
 #endif
 
-#ifndef _B4B10
+#ifndef _B4B10R
       !$acc parallel 
 #endif
       temd = 1.0/dble(nx*ny)
@@ -1227,7 +1163,7 @@
       avgsfcv = avgsfcv*temd
       avgsfcs = avgsfcs*temd
       avgsfct = avgsfct*temd
-#ifndef _B4B10
+#ifndef _B4B10R
       !$acc end parallel
 #else
       !$acc update device(avgsfcu,avgsfcv,avgsfcs,avgsfct)

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -1,6 +1,4 @@
 #ifdef _B4B
-#undef _B4B01F
-#undef _B4B02F
 #define _B4B03R
 #endif
   MODULE solve1_module
@@ -1787,11 +1785,7 @@
         rdt = 1.0/dt
         tem = 0.0001*tsmall
         IF(imoist.eq.1)THEN
-#ifdef _B4B01F
-          !$acc update host(thten1,qten,tha,qa,rho,th0,pi0,ppi)
-#else
           !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,pinew,thnew,qvnew)
-#endif
           !$omp parallel do default(shared) private(i,j,k,pinew,thnew,qvnew)
           do k=1,nk
           do j=1,nj
@@ -1811,9 +1805,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B01F
-          !$acc update device(ppten)
-#endif
           if( ptype.ge.1 )then
             ! use diabatic tendencies from last timestep as a good estimate:
             !$omp parallel do default(shared)  &
@@ -1831,13 +1822,7 @@
             enddo
           endif
         ELSE
-#ifdef _B4B02F
-          !$acc update host(thten1,tha,rho,th0,pi0,ppi)
-#else
-          !$acc data copyin(tem,dt,rd,rp00,rddcv,rdt)
-          !non-B4B
           !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,pinew,thnew)
-#endif
           !$omp parallel do default(shared) private(i,j,k,pinew,thnew,qvnew)
           do k=1,nk
           do j=1,nj
@@ -1856,11 +1841,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B02F
-          !$acc update device(ppten)
-#else
-          !$acc end data
-#endif
         ENDIF  ! endif for moist/dry
       ENDIF    ! endif for eqtset 1/2
 

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -1,10 +1,5 @@
 #ifdef _B4B
 
-#define _B4B01F
-#define _B4B02F
-#define _B4B03F
-#define _B4B04F
-
 #define _B4B05RF
 #define _B4B06R
 
@@ -1706,12 +1701,7 @@
         ENDIF
 
         IF( nrk.eq.nrkmax .or. (idiff.ge.1 .and. difforder.eq.6) )THEN
-#ifdef _B4B01F
-          !$acc update host(pi0,pp3d,th0,th3d,pp3d,q3d)    
-#else
-          !non-B4B01
           !$acc parallel loop gang vector collapse(3) private(i,j,k)
-#endif
           !$omp parallel do default(shared) private(i,j,k)
           do k=1,nk
           do j=1,nj
@@ -1723,20 +1713,12 @@
           enddo
           enddo
           enddo
-#ifdef _B4B01F
-          !$acc update device(prs,rho)
-#endif
         ENDIF
 
       ELSE
 
         IF( nrk.eq.nrkmax .or. (idiff.ge.1 .and. difforder.eq.6) )THEN
-#ifdef _B4B02F
-          !$acc update host(pi0,pp3d,th0,th3d,pp3d)    
-#else
-          !non-B4B02
           !$acc parallel loop gang vector collapse(3) private(i,j,k)
-#endif
           !$omp parallel do default(shared) private(i,j,k)
           do k=1,nk
           do j=1,nj
@@ -1747,9 +1729,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B02F
-          !$acc update device(prs,rho)
-#endif
         ENDIF
 
       ENDIF
@@ -2175,12 +2154,7 @@
 !!!        if( myid.eq.0 ) print *,'  temd,tem = ',temd,tem
 
         IF( imoist.eq.1 )THEN
-#ifdef _B4B03F
-          !$acc update host(pi0,pp3d,th0,th3d,pp3d,prs,q3d)    
-#else
-          !non-B4B03
           !$acc parallel loop gang vector collapse(3) private(i,j,k)
-#endif
           !$omp parallel do default(shared) private(i,j,k)
           do k=1,nk
           do j=1,nj
@@ -2193,16 +2167,8 @@
           enddo
           enddo
           enddo
-#ifdef _B4B03F
-          !$acc update device(rho,prs,pp3d)
-#endif
         ELSE
-#ifdef _B4B04F
-          !$acc update host(pi0,pp3d,th0,th3d,pp3d,prs)    
-#else
-          !non-B4B04
           !$acc parallel loop gang vector collapse(3)  private(i,j,k)
-#endif
           !$omp parallel do default(shared) private(i,j,k)
           do k=1,nk
           do j=1,nj
@@ -2214,9 +2180,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B04F
-          !$acc update device(rho,prs,pp3d)
-#endif
         ENDIF
 
       ENDIF  pscheck2

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -75,16 +75,12 @@
 
 !---------------------------------------------------------------------
 
-    print *,'sounde: nsound: ',nsound
     IF( nrkmax.eq.3 )THEN
       if(nrk.eq.1)then
 !!!        nloop=1
 !!!        dts=dt/3.
         nloop=nint(float(nsound)/3.0)
-!        print *,'sounde: denominator: ', float(nloop)*3.0
-!        print *,'sounde: numerator: ', dt
         dts=dt/(float(nloop)*3.0)
-!        print *,'sounde: dts: ', dts
         if( dts.gt.(dt/nsound) )then
           nloop=nloop+1
           dts=dt/(float(nloop)*3.0)

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -75,15 +75,19 @@
 
 !---------------------------------------------------------------------
 
+    print *,'sounde: nsound: ',nsound
     IF( nrkmax.eq.3 )THEN
       if(nrk.eq.1)then
 !!!        nloop=1
 !!!        dts=dt/3.
         nloop=nint(float(nsound)/3.0)
-        dts=dt/(nloop*3.0)
+!        print *,'sounde: denominator: ', float(nloop)*3.0
+!        print *,'sounde: numerator: ', dt
+        dts=dt/(float(nloop)*3.0)
+!        print *,'sounde: dts: ', dts
         if( dts.gt.(dt/nsound) )then
           nloop=nloop+1
-          dts=dt/(nloop*3.0)
+          dts=dt/(float(nloop)*3.0)
         endif
       elseif(nrk.eq.2)then
         nloop=0.5*nsound

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -1,7 +1,3 @@
-#ifdef _B4B
-#undef _B4B01F
-#undef _B4B02F
-#endif
   MODULE statpack_module
 
   implicit none
@@ -351,12 +347,7 @@
       IF(imoist.eq.1)THEN
 
         if(stat_rh.eq.1 .or. stat_the.eq.1)then
-          ! non-B4B  due to presence of exp in rslf()
-#ifdef _B4B01F
-          !$acc update host(prs,th0,tha,pi0,ppi,qa)
-#else
           !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,qvs)
-#endif
           !$omp parallel do default(shared) private(i,j,k,qvs)
           do k=1,nk
           do j=1,nj
@@ -367,9 +358,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B01F
-          !$acc update device(dum2)
-#endif
         endif
 
         if(stat_rh.eq.1)then
@@ -377,13 +365,8 @@
         endif
 
         if(iice.eq.1 .and. stat_rhi.eq.1)then
-!$omp parallel do default(shared)  &
-!$omp private(i,j,k,qvs)
-#ifdef _B4B02F
-          !$acc update host(prs,th0,tha,pi0,ppi,qa)
-#else
+          !$omp parallel do default(shared) private(i,j,k,qvs)
           !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,qvs)
-#endif
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -393,9 +376,6 @@
           enddo
           enddo
           enddo
-#ifdef _B4B02F
-          !$acc update device(dum3)
-#endif
           call maxmin(ni,nj,nk,dum3,nstat,rstat,kmin,kmax,'RHIMAX','RHIMIN')
         endif
 

--- a/src/testcase_simple_phys.F
+++ b/src/testcase_simple_phys.F
@@ -1,6 +1,5 @@
 #ifdef _B4B
 #define _B4B01R
-#undef _B4B04F
 #define _B4B05R   
 #endif
   MODULE simple_phys_module
@@ -499,16 +498,9 @@
 !!!        print *
 !!!      endif
 
-#ifdef _B4B04F
-      !$acc update host(dum1,dum2,rho0,ql,zf,zir)
-#else
-      !non-B4B due to EXP and PWR functions
       !$acc parallel default(present) private(i,j,k,fr1,fr2,fr3)
-#endif
       do k=nk+1,1,-1
-#ifndef _B4B04F
       !$acc loop gang vector collapse(2)
-#endif
       do j=1,nj
       do i=1,ni
         dum1(i,j,k) = dum1(i,j,min(nk+1,k+1))  &
@@ -525,11 +517,7 @@
       enddo
       enddo
       enddo
-#ifdef _B4B04F
-      !$acc update device(frad,dum1) 
-#else
       !$acc end parallel
-#endif
       stop 'simplerad: at the end of the subroutine'
       end subroutine simplerad
 

--- a/src/turb.F
+++ b/src/turb.F
@@ -1,14 +1,6 @@
 #ifdef _B4B
 
-#define _B4B01F
-#define _B4B02F
-#define _B4B03F
-#define _B4B04F
-#define _B4B05F
-#define _B4B08F
-
 !JMD-changes answers
-#define _B4B06F
 #define _B4B07R
 #define _B4B09R
 #define _B4B10R
@@ -658,11 +650,7 @@
           call getcecd(xh,u1,v1,s1,ppten(ib,jb,1),u10,v10,s10,xland,znt,ust,cd,ch,cq,avgsfcu,avgsfcv,avgsfcs,avgsfct)
 
           if( tbc.eq.3 )then
-#ifdef _B4B01F
-            !$acc update host(ugr,vgr,zf,zh) 
-#else
             !$acc parallel loop gang vector collapse(2) default(present) 
-#endif
             do j=1,nj
             do i=1,ni
               ut(i,j) = 0.5*( ugr(i,j,nk) + ugr(i+1,j,nk) )
@@ -671,10 +659,7 @@
               ustt(i,j) = max( st(i,j)*karman/alog((zf(i,j,nk+1)-zh(i,j,nk))/cnst_znt) , 1.0e-6 )
             enddo
             enddo
-#ifdef _B4B01F
-            !$acc update device(ut,vt,st,ustt)
-#endif
-            stop 'sfc_and_turb: after setting of ut,vt,st,ustt'
+            !stop 'sfc_and_turb: after setting of ut,vt,st,ustt'
           endif
 
 
@@ -919,19 +904,12 @@
                      ids=1  ,ide=ni+1 , jds= 1 ,jde= 1   , kds=1  ,kde=nk+1 ,                                   &
                      ims=ib ,ime=ie   , jms= 1 ,jme= 1   , kms=kb ,kme=ke ,                                     &
                      its=1  ,ite=ni   , jts= 1 ,jte= 1   , kts=1  ,kte=nk  )
-#ifdef _B4B02F
-          !$acc update host(br,ppten,znt)
-#else
           !$acc parallel loop gang vector default(present) private(i)
-#endif
           do i=1,ni
             br(i,j) = max( -10.0 , br(i,j) )
             br(i,j) = min(  10.0 , br(i,j) )
             gz1oz0(I,J)=ALOG(ppten(i,j,1)/znt(i,j))
           enddo
-#ifdef _B4B02F
-          !$acc update device(br,gz1oz0)
-#endif
 
         enddo
         endif
@@ -2440,12 +2418,7 @@
 
       ! single length scale:  appropriate if dx,dy are nearly the same as dz
 
-#ifdef _B4B03F
-      !$acc update host(csz,ruh,rvh,rmf,tkea,nm,dissten,ce1z,ce2z,cmz,kmh,khh)
-#else
-      !non-B4B: due to use of PWR function 
       !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,prinv,rcs)
-#endif
       !$omp parallel do default(shared) private(i,j,k,prinv,rcs)
       do k=2,nk
       do j=1,nj
@@ -2495,20 +2468,13 @@
       enddo
       enddo
       enddo
-#ifdef _B4B03F
-      !$acc update device(grdscl,rgrdscl,lenscl,tk,dissten,kmh,kmv,khh,khv)
-#endif
 
     ELSEIF(tconfig.eq.2)THEN
 
       ! two length scales:  one for horizontal, one for vertical
 
       !$omp parallel do default(shared) private(i,j,k,prinv,rcs)
-#ifdef _B4B03F
-      !$acc update host(grdscl,rgrdscl,lenscl,tk,dissten,kmh,kmv,khh,khv)
-#else
       !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,prinv,rcs)
-#endif
       do k=2,nk
       do j=1,nj
       do i=1,ni
@@ -2558,9 +2524,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B03F
-      !$acc update device(grdscl,rgrdscl,lenscl,tk,dissten,kmh,kmv,khh,khv)
-#endif
 
     ENDIF
      
@@ -4737,12 +4700,7 @@
 
     IF(imoist.eq.0)then
 
-#ifdef _B4B04F
-      !$acc update host(th0,th,mf)
-#else
-      !non-B4B
       !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
-#endif
       !$omp parallel do default(shared) private(i,j,k)
       do k=2,nk
       do j=1,nj
@@ -4752,9 +4710,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B04F
-      !$acc update device(nm)
-#endif
 
 ! GHB, 220308 ... comment out this stop 
 !!!      stop 'calcnm: after first loop'
@@ -4854,16 +4809,11 @@
       enddo
       enddo
 
-#ifdef _B4B05F
-      !$acc update host(thv,mf,c1,c2,prs,t,qt,qvci,qt)
-#else
-      !non-B4B
       !$acc parallel loop gang vector collapse(3) default(present) &
       !$acc private(i,j,k,pavg,tavg,qtavg,qvciavg) &
       !$acc private(qvs,ql,qi,qv,qvsl,qvsi)  &
       !$acc private(cpml,lh,drdt,gamma) &
       !$acc private(rtt1,rtt2,ff,nmi,nml)
-#endif
       do k=2,nk
       do j=1,nj
       do i=1,ni
@@ -4941,9 +4891,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B05F
-      !$acc update device(nm,iamsat)
-#endif
       stop 'calcnm: point #2'
 
     ELSE  icecheck
@@ -4959,12 +4906,8 @@
       enddo
       enddo
       enddo
-#ifdef _B4B06F
-      !$acc update host(qt,mf,c1,c2,prs,t,qt,qvci)
-#else
       !$acc parallel loop gang vector collapse(3) default(present) &
       !$acc private(i,j,k,pavg,tavg,qtavg,qvciavg,qvs,ql,qv,cpml,lh,drdt,gamma)
-#endif
       do k=2,nk
       do j=1,nj
       do i=1,ni
@@ -4993,12 +4936,6 @@
       enddo
       enddo
       enddo
-#ifdef _B4B06F
-    !$acc update device(t,thv,nm,iamsat)
-#else
-    !$acc end parallel
-#endif
-      !stop 'calcnm: point #3'
 
     ENDIF  icecheck
 
@@ -5501,17 +5438,10 @@
 
 
         !print *,'t2pcode: point #3'
-#ifndef _B4B08F
         !$acc parallel loop gang vector default(present) private(k)
-#endif
         do k=1,(ntwk+1)
           wspa(k) = (ustbar/karman)*alog( sngl(zh(1,1,k)/zntbar) )
         enddo
-#ifdef _B4B08F
-        !$acc update device(wspa)
-#else
-        !$acc end parallel
-#endif
 
     !-------------------------------------------
 

--- a/src/turb.F
+++ b/src/turb.F
@@ -659,7 +659,6 @@
               ustt(i,j) = max( st(i,j)*karman/alog((zf(i,j,nk+1)-zh(i,j,nk))/cnst_znt) , 1.0e-6 )
             enddo
             enddo
-            !stop 'sfc_and_turb: after setting of ut,vt,st,ustt'
           endif
 
 


### PR DESCRIPTION
This commit eliminates a number of code blocks that are designed to produce B4B answers between the CPU and GPU versions of the code. In particular, it focuses on code blocks that contain math intrinsic functions that have previously caused numerical differences. Recently a flag has been added to the NVHPC compiler 'math_uniform' that provides a math intrinsic function calculations on the GPU that reproduces the CPU version.