### PR TITLE
Open acc reduction cleanup

### DIFF
--- a/src/droplet.F
+++ b/src/droplet.F
@@ -2,8 +2,6 @@
 #define PITER 1048576
 #ifdef _B4B
 #undef _B4B01F
-#undef _B4B02F
-#undef _B4B03F
 #endif
   MODULE droplet_module
 

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3670,11 +3670,9 @@
       !$acc end parallel
 #endif
  
-#ifdef _B4B07R
       tmass=0.0d0
-#else
+#ifndef _B4B07R
       !$acc parallel default(present) reduction(+:tmass)
-      tmass=0.0d0
       !$acc loop gang vector reduction(+:tmass)
 #endif
       do k=1,nk
@@ -3683,6 +3681,7 @@
 #ifndef _B4B07R
       !$acc end parallel
 #endif
+
 
 #ifdef MPI
       var=0.0d0

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -2,8 +2,6 @@
 
 #define _B4B06R
 #define _B4B08R
-#define _B4B09R
-#define _B4B10R
 #endif
   MODULE sfcphys_module
 
@@ -1117,14 +1115,14 @@
 
 !-----------------------------------------------------------------------
 
-#ifndef _B4B08R
-      !$acc parallel default(present) &
-      !$acc reduction(+:avgsfcu,avgsfcv,avgsfcs,avgsfct)
-#endif
       avgsfcu = 0.0
       avgsfcv = 0.0
       avgsfcs = 0.0
       avgsfct = 0.0
+#ifndef _B4B08R
+      !$acc parallel default(present) &
+      !$acc reduction(+:avgsfcu,avgsfcv,avgsfcs,avgsfct)
+#endif
 #ifdef _B4B08R
       !$acc update host(u1,v1,s1,t1)
 #else
@@ -1150,21 +1148,21 @@
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfcv,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfcs,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfct,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
+      !$acc update device(avgsfcu,avgsfcv,avgsfcs,avgsfct)
 #endif
 
-#ifndef _B4B10R
+      !JMD FIXME
+      !JMD Don't quite understand what is going on here.  THese are scalar
+      !JMD values and should be located in the CPU memory.  For some reason if I
+      !JMD remove the acc parallel directive the GPU results are further away from
+      !JMD the CPU results.
       !$acc parallel 
-#endif
       temd = 1.0/dble(nx*ny)
       avgsfcu = avgsfcu*temd
       avgsfcv = avgsfcv*temd
       avgsfcs = avgsfcs*temd
       avgsfct = avgsfct*temd
-#ifndef _B4B10R
       !$acc end parallel
-#else
-      !$acc update device(avgsfcu,avgsfcv,avgsfcs,avgsfct)
-#endif
 
       if(timestats.ge.1) time_sfcphys=time_sfcphys+mytime()
 

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -984,6 +984,7 @@
       !  budget calculations:
       if(dosfcflx.and.imoist.eq.1)then
         !JMD-FIXME review the indexing in this loop 
+        qtmp =0.0
         !$acc data create(budarray)
         !$omp parallel do default(shared) private(i,j,delpi,delth,delqv,delt,n)
         !$acc parallel loop gang vector collapse(2) default(present) &
@@ -1028,7 +1029,6 @@
         !$acc parallel default(present) reduction(+:budtmp,qtmp)
 #endif
 
-        qtmp =0.0
 #ifndef _B4B03R
         !$acc loop gang reduction(+:budtmp) reduction(+:qtmp)
 #endif

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -1,6 +1,5 @@
 #ifdef _B4B
 
-#define _B4B05RF
 #define _B4B06R
 
 #endif
@@ -1744,7 +1743,7 @@
 #ifdef _B4B06R
         !$acc update host(rho,ruh,rvh,rmh,pi0,pp3d,xf)
 #else
-        !$acc parallel private(tmp1,tmp2) reduction(+:tmp1,tmp2)
+        !$acc parallel reduction(+:tmp1,tmp2)
 #endif
         IF( axisymm.eq.0 )THEN
 #ifndef _B4B06R
@@ -2127,17 +2126,9 @@
         call mpi_wait(reqp2,mpi_status_ignore,ierr)
         !$acc update device(dumk3,dumk4)
 #endif
-#ifdef _B4B05RF
-        !$acc update host(dumk3,dumk4)
-#else
-        !$acc parallel reduction(+:temq1,temq2)
-#endif
-
         temq1 = 0.0
         temq2 = 0.0
-#ifndef _B4B05RF
-        !$acc loop vector reduction(+:temq1,temq2)
-#endif 
+        !$acc parallel loop vector reduction(+:temq1,temq2)
         do k=1,nk
           temq1 = temq1 + dumk3(k)
           temq2 = temq2 + dumk4(k)
@@ -2147,9 +2138,6 @@
         p2 = temq2
 
         tem = ( (mass1/mass2)**rddcv - 1.0d0 )*p2/(nx*ny*nz)
-#ifndef _B4B05RF
-        !$acc end parallel
-#endif
 
 !!!        if( myid.eq.0 ) print *,'  temd,tem = ',temd,tem
 

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -81,13 +81,6 @@
       double precision, dimension(numq) :: afoo,bfoo
 #endif
 
-!  !$acc update &
-!  !$acc   host(qbudget,asq,bsq,xh,rxh,uh,ruh,xf,uf,yh,vh,rvh,vf, &
-!  !$acc     zh,mh,rmh,zf,mf,zs,rgzu,rgzv,rds,sigma,rdsf,sigmaf, &
-!  !$acc     pi0,rho0,thv0,th0,qv0,dum1,dum2,dum3,dum4,dum5,rho,prs, &
-!  !$acc     u0,ua,v0,va,wa,ppi,tha,qa,vq,kmh,kmv,khh,khv,tkea,qke, &
-!  !$acc     tke_myj,xkzh,xkzq,xkzm,pta,u10,v10,hpbl,prate)      
-           
 !-----------------------------------------------------------------------
 #ifdef MPI
       !$acc data create(afoo,bfoo,cfoo)
@@ -284,9 +277,6 @@
       if( sgsmodel.ge.1 .or. ipbl.eq.2 )then
         if(stat_km.eq.1) call maxmin(ni,nj,nk+1,kmv,nstat,rstat,kmin,kmax,'KMVMAX','KMVMIN')
       endif
-        !JMD Probably should remove this update host(khh) call
-        !!$acc update host(khh)
-        !print *,'maxval(khh): ',maxval(khh)
         if(stat_kh.eq.1) call maxmin(ni,nj,nkp1,khh,nstat,rstat,kmin,kmax,'KHHMAX','KHHMIN')
       if( sgsmodel.ge.1 .or. ipbl.eq.2 )then
         if(stat_kh.eq.1) call maxmin(ni,nj,nk+1,khv,nstat,rstat,kmin,kmax,'KHVMAX','KHVMIN')
@@ -670,10 +660,7 @@
 
 #ifdef NETCDF
     ELSEIF(output_format.eq.2)THEN
-
-!#ifdef _OPENACC
       call writestat_nc(nrec,rtime,nstat,rstat,qname,budname,name_stat,desc_stat,unit_stat)
-!#endif
 #endif
 
 !-----------------------------------------------------------------------
@@ -683,11 +670,6 @@
   ENDIF
 
   ENDIF  dostats
-!  !$acc update &
-!  !$acc   device(qbudget,asq,bsq, &
-!  !$acc     dum1,dum2,dum3,dum4,dum5) &
-!  !$acc     u0,ua,v0,va,wa,ppi,tha,qa,vq,kmh,kmv,khh,khv,tkea,qke, &
-!  !$acc     tke_myj,xkzh,xkzq,xkzm,pta,u10,v10,hpbl,prate)
 
       end subroutine statpack
 

--- a/src/turb.F
+++ b/src/turb.F
@@ -4762,8 +4762,6 @@
       enddo
       ENDIF
 
-      !JMD
-      !JMD!$acc data copyin(numq,nqv,nql1,nql2,nqs1,nqs2,iice)
       DO n=1,numq
         IF( (n.eq.nqv) .or.                                 &
             (n.ge.nql1.and.n.le.nql2) .or.                  &
@@ -4779,7 +4777,6 @@
           enddo
         ENDIF
       ENDDO
-      !JMD!$acc end data
 
       k = 1
 

--- a/src/turb.F
+++ b/src/turb.F
@@ -5383,14 +5383,8 @@
 
     !-------------------------------------------
 
-        !!$acc data copyin(arf1,arf2) &
-        !!$acc copyin(ust,u1,v1,s1,rf,mf) &
-        !!$acc copyin(kmh,kmv) &
-        !!$acc copyin(ugr,vgr) &
-        !!$acc copy(stau,dum1,dum2,t13,t23)
         call     sfcstress(xf,rxf,arf1,arf2,ust,stau,u1,v1,s1,rf,mf,dum1,dum2,  &
                         kmh,kmv,s13,s23,ua,ugr,va,vgr,avgsfcu,avgsfcv,avgsfcs)
-        !!$acc end data
 
     !-------------------------------------------
     !  surface vars:

--- a/src/turb.F
+++ b/src/turb.F
@@ -5398,18 +5398,9 @@
     !-------------------------------------------
     !  surface vars:
 
-        !print *,'t2pcode: point #1'
-#ifdef _B4B07R
-        !$acc update host(s13,s23,rf,zntmp)
-#else
-        !$acc parallel default(present) private(i,j) reduction(+:ustbar,zntbar)
-#endif
         ustbar = 0.0
         zntbar = 0.0
-
-#ifndef _B4B07R
-        !$acc loop vector collapse(2) reduction(+:ustbar,zntbar)
-#endif
+        !$acc parallel loop vector collapse(2) default(present) reduction(+:ustbar,zntbar)
         do j=1,nj
         do i=1,ni
 !!!          ustbar = ustbar + ust(i,j)
@@ -5419,10 +5410,7 @@
           zntbar = zntbar + zntmp(i,j)
         enddo
         enddo
-#ifndef _B4B07R
-        !$acc end parallel
-#endif
-        !print *,'t2pcode: point #2'
+
 #ifdef MPI
         !Reductions are on the host anyway  
         call MPI_ALLREDUCE(MPI_IN_PLACE,ustbar,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)


### PR DESCRIPTION
This fixes a number of OpenACC reduction clause bugs.   While the GPU results are closer to the CPU.  There are still differences, especially with the OpenACC+MPI implementation.