### PR TITLE
Open acc reduction cleanup

### DIFF
--- a/src/bc.F
+++ b/src/bc.F
@@ -2039,6 +2039,7 @@
 !$omp private(j,k)
           do k=1,nk+1
           do j=nj+1,nj+ngxy
+            w(i,j,k)=w(i,nj,k)
           enddo
           enddo
         endif

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2672,7 +2672,6 @@
 #endif
           endif
           if(myid.eq.0) print *,'cm1: ksmax: ',ksmax
-          !stop 'cm1: after call to calcflquick'
           stopit = .false.
           ndt  = 0
           adt  = 0.0
@@ -2813,7 +2812,7 @@
 !$acc              xfref,xhref,yfref,yhref,dvdr,qpten,qtten, &
 !$acc              qvten,qcten,qa,q3d,qten,kmh,kmv,khh,khv,tkea, &
 !$acc              tke3d,tketen,effc,effi,effs,effr,effg,effis, &
-!$acc              out2d,out3d,rain,prate,p3a,p3o,asq, &
+!$acc              out2d,out3d,rain,prate,p3a,p3o, &
 !$acc              qavg,cavg,cloudvar,rho0s,pi0s,prs0s,rth0s, &
 !$acc              tst,qst,z0t,z0q,mznt,ppi,pp3d,ppten,sadv,ppx, &
 !$acc              tha,thten1,thterm,glw,gsw,ulspg,vlspg,savg,pavg, &
@@ -2828,13 +2827,10 @@
     !c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c!
     timeloop:  &
     DO WHILE( mtime.lt.timax )
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 
       !print *,'cm1: at the top of the do-while loop'
-      !$acc compare(dum1)
       ifsolve:  &
       if( dosolve )then
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 
         ! call solve, integrate model one time step:
         nstep = nstep + 1
@@ -2975,9 +2971,6 @@
 #ifdef _NVTX
         call nvtxStartRange("solve1 ",id=0)
 #endif
-        !$acc compare(rho,tha)
-        !$acc compare(khh,khv)
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
         ! solve1: pre-RK terms
         ! (tendencies held fixed during Runge-Kutta integration and acoustic sub-stepping)
         call     solve1(nstep,rbufsz,num_soil_layers,                  &
@@ -3049,26 +3042,18 @@
                    dowriteout,dorad,getdbz,getvt,dotdwrite,          &
                    dotbud,doqbud,doubud,dovbud,dowbud,donudge,       &
                    doazimwrite,dorestart)
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6,dum7,dum8,epsd2)
-!$acc compare(rru,rrv)
-!$acc compare(khh,khv)
         ! end_solve1
        ! stop 'cm1: after solve1' 
-!$acc compare(tha)
 #ifdef _NVTX
         call nvtxEndRange
 #endif
        !print *,'cm1: after solve1'
-       !$acc compare(dum1)
        !call flush(6)
 
 #ifdef _NVTX
         call nvtxStartRange("solve2",id=1)
 #endif
        !print *,'cm1: before solve2'
-        !$acc compare(rho)
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
-!$acc compare(ust,u1,v1,s1)
         ! solve2: RK loop and pressure solver
         ! (advection, buoyancy, pressure gradient)
         call     solve2(nstep,rbufsz,num_soil_layers,                  &
@@ -3141,14 +3126,10 @@
                    dotbud,doqbud,doubud,dovbud,dowbud,               &
                    doazimwrite,dorestart)
         ! end_solve2
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6,epsd2)
-!$acc compare(khh,khv)
-!$acc compare(tha)
 #ifdef _NVTX
         call nvtxEndRange
 #endif
       !print *,'cm1: after call to solve2'
-      !$acc compare(dum1)
 
       IF(imoist.eq.1)THEN
 
@@ -3159,7 +3140,6 @@
         call nvtxStartRange("mp_driver",id=2)
 #endif
 
-      !$acc compare(rho,q3d)
       if( ptype.eq.0 )then
         ! qv only:
         call pdefq2_GPU(    0.0,asq(1),ruh,rvh,rmh,rho,q3d(ib,jb,kb,1))
@@ -3184,14 +3164,11 @@
 #ifdef _NVTX
         call nvtxStartRange("solve3",id=3)
 #endif
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
         if(timestats.ge.1) time_nvtx=time_nvtx+mytime()
         ! solve3: finish primary dynamical solver
         ! (finish comms, update arrays, move surface)
 
 !print *,'cm1: before call to solve3'
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
-!$acc compare(ust,u1,v1,s1)
 
         call     solve3(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
@@ -3261,17 +3238,11 @@
                    dotbud,doqbud,doubud,dovbud,dowbud,donudge,       &
                    doazimwrite,dorestart,pdata_locind)
         ! end_solve3
-        !stop 'cm1: after call to solve3'
-!$acc compare(khh,khv)
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6,epsd2)
-!$acc compare(tha,rru,rrv)
 #ifdef _NVTX
         call nvtxEndRange
 #endif
 
 !print *,'cm1: after call to solve3'
-!$acc compare(rho)
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 
 
 
@@ -3292,7 +3263,6 @@
 
       endif  ifsolve
       
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 
 
       !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -3320,13 +3290,11 @@
         ENDIF
 
       ENDIF
-      !$acc compare(dum1,dum2)
 
 
       !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       !cc   radiation  ccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 
 
       IF( radopt.ge.1 .and. dorad )THEN
@@ -3363,7 +3331,6 @@
 #endif
 
       ENDIF
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 
       !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       !cc   Prepare turbulence vars for next time step   cccccccccccccccccc
@@ -3381,13 +3348,10 @@
 
       update_sfc = .true.
       if( startup .or. restarted ) update_sfc = .false.
-      !$acc compare(dum1,dum2)
 
 #ifdef _NVTX
         call nvtxStartRange("srf_and_turb",id=5)
 #endif
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
-!$acc compare(ust,u1,v1,s1)
       call sfc_and_turb(getsfc,getpbl,nstep,dt,dosfcflx,cloudvar,qbudget, &
                    avgsfcu,avgsfcv,avgsfcs,avgsfct,                  &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,  &
@@ -3439,14 +3403,9 @@
                    flag  ,out2d,out3d,rtime,update_sfc,dotbud,dotdwrite,restarted,  &
                    dowriteout,doazimwrite)
         ! end_sfc_and_turb
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6,epsd2)
-!$acc compare(khh,khv)
 #ifdef _NVTX
       call nvtxEndRange()
 #endif
-      !$acc compare(dum1,dum2)
-      !$acc compare(rho) 
-      !stop 'cm1: after call to sfc_and_turb'
 
       IF( (idiff.ge.1).and.(difforder.eq.2) )THEN
         !  get stress terms for explicit diffusion scheme:
@@ -3535,7 +3494,6 @@
                           ua,va,wa,ppi,tha,qa,qten,kmh,kmv,khh,khv,tkea,qke,  &
                           tke_myj,xkzh,xkzq,xkzm,                             &
                           pta,u10,v10,hpbl,prate,reset,nstatout)
-        !stop 'after call to statpack'
 !#endif
         nrec = nrec + 1
         nstatout = nstatout + 1
@@ -3698,7 +3656,6 @@
                         bndy,kbdy,hflxw,hflxe,hflxs,hflxn,                                     &
                         nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,myi1p,myi2p,myj1p,myj2p)
                         ! end_writeout
-                        !stop 'cm1: after call to writout'
 !#endif
                         
           if(n.eq.1)then
@@ -3738,7 +3695,6 @@
       if(iprcl.eq.1)then
       IF( doprclout )THEN
       
-        !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
         call     parcel_interp(dt,mtime,xh,uh,ruh,xf,uf,yh,vh,rvh,yf,vf, &
                                zh,mh,rmh,zf,mf,zntmp,ust,c1,c2,        &
                                zs,sigma,sigmaf,rds,gz,                 &
@@ -3752,7 +3708,6 @@
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p, &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2)
 
-        !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 
         call     parcel_write(prec,rtime,qname,name_prcl,desc_prcl,unit_prcl,pdata,ploc)
         prec = prec+1
@@ -3787,7 +3742,6 @@
 #ifdef _NVTX
         call nvtxStartRange("domaindiag",id=7)
 #endif
-        !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6,dum7,dum8)
         call   domaindiag(nstep,mtime,nwritet,trecs,trecw,qname,qunit,dt,dosfcflx, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,            &
                    yh,vh,rvh,yf,vf,rvf,                                        &
@@ -3845,7 +3799,6 @@
         call nvtxEndRange()
 #endif
 
-      !stop 'cm1: after call to domaindiag'
 
 
       endif
@@ -3862,7 +3815,6 @@
 #ifdef _OPENACC
         stop 'ERROR: azimavg not supported in OpenACC'
 #endif
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
         call   azimavg(nstep,mtime,nwritea,arecs,arecw,qname,dt,dosfcflx,      &
                    icrs,icenter,jcenter,xcenter,ycenter,                       &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,            &
@@ -3888,7 +3840,6 @@
                    tdiag,qdiag,udiag,vdiag,wdiag,pdiag,out2d,out3d,getdbz,getvt, &
                    dat1(1,1),dat2(1,1),dat3(1,1,1),                            &
                    sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,flag)
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
         ! end_azimavg
         nwritea = nwritea+1
         if(azimavgfrq.gt.0.0)then
@@ -3918,7 +3869,6 @@
 #ifdef _OPENACC
         stop 'ERROR: writeout_hifrq not supported in OpenACC'
 #endif
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
         call   writeout_hifrq(                                                 &
                    nstep,mtime,nwriteh,qname,dt,dosfcflx,                      &
                    icrs,icenter,jcenter,xcenter,ycenter,                       &
@@ -3949,7 +3899,6 @@
                    myi1p,myi2p,myj1p,myj2p,kbdy,bndy,                          &
                    sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,flag,               &
                    dat1(1,1),dat2(1,1),dat3(1,1,1),reqt,reqs_s)
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
         ! end hifrq
 
         nwriteh = nwriteh+1
@@ -3987,8 +3936,6 @@
 #ifdef _OPENACC
         print *,'ERROR: write_restart not supported in OpenACC'
 #endif
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
-!$acc compare(kw1,kw2,ke1,ke2,ks1,ks2,kn1,kn2,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
         call     write_restart(nstep,srec,sirec,urec,vrec,wrec,nrec,mrec,prec,      &
                                trecs,trecw,arecs,arecw,                             &
                                nwrite,nwritet,nwritea,nwriteh,nrst,nstatout,        &
@@ -4025,8 +3972,6 @@
                                icenter,jcenter,xcenter,ycenter,adaptmovetim,mvrec,nwritemv,ug,vg, &
                                gamk,kmw,u1b,v1b,cmz,csz,ce1z,ce2z,                  &
                                dum1,dat1,dat2,dat3,reqt,myi1p,myi2p,myj1p,myj2p)
-!$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
-!$acc compare(kw1,kw2,ke1,ke2,ks1,ks2,kn1,kn2,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
           ! end_write_restart
         if(myid.eq.0) print *,'  next rsttim = ',rsttim
         IF( nrst.eq.0 )THEN

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2814,7 +2814,7 @@
 !$acc              qvten,qcten,qa,q3d,qten,kmh,kmv,khh,khv,tkea, &
 !$acc              tke3d,tketen,effc,effi,effs,effr,effg,effis, &
 !$acc              out2d,out3d,rain,prate,p3a,p3o,asq, &
-!$acc              bsq,qavg,cavg,cloudvar,rho0s,pi0s,prs0s,rth0s, &
+!$acc              qavg,cavg,cloudvar,rho0s,pi0s,prs0s,rth0s, &
 !$acc              tst,qst,z0t,z0q,mznt,ppi,pp3d,ppten,sadv,ppx, &
 !$acc              tha,thten1,thterm,glw,gsw,ulspg,vlspg,savg,pavg, &
 !$acc              uavg,vavg,thavg,lsnudge_u,lsnudge_v,reqs_s, &

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -1653,7 +1653,7 @@
       allocate(  bud2(nj) )
       bud2 = 0.0
       allocate( qbudget(nbudget) )
-      qbudget   = 0.0
+      qbudget = 0.0
       allocate(    asq(numq) )
       asq = 0.0
       allocate(    bsq(numq) )

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -82,7 +82,6 @@
       logical, dimension(maxvars) :: cmpr_output
       character(len=40), dimension(maxvars) :: name_stat,desc_stat,unit_stat
       character(len=40), dimension(maxvars) :: name_prcl,desc_prcl,unit_prcl
-      double precision :: qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10 
       double precision, dimension(:), allocatable :: bud,bud2
       double precision, dimension(:), allocatable :: qbudget
       double precision, dimension(:), allocatable :: asq,bsq
@@ -1655,16 +1654,6 @@
       bud2 = 0.0
       allocate( qbudget(nbudget) )
       qbudget   = 0.0
-      qbudget1  = 0.0
-      qbudget2  = 0.0
-      qbudget3  = 0.0
-      qbudget4  = 0.0
-      qbudget5  = 0.0
-      qbudget6  = 0.0
-      qbudget7  = 0.0
-      qbudget8  = 0.0
-      qbudget9  = 0.0
-      qbudget10 = 0.0
       allocate(    asq(numq) )
       asq = 0.0
       allocate(    bsq(numq) )
@@ -2515,16 +2504,6 @@
                               gamk,kmw,u1b,v1b,cmz,csz,ce1z,ce2z,                  &
                               dum1,dat1,dat2,dat3,reqt,myi1p,myi2p,myj1p,myj2p,restarted,restart_prcl)
           ! end_read_restart
-        qbudget1 = qbudget(1)
-        qbudget2 = qbudget(2)
-        qbudget3 = qbudget(3)
-        qbudget4 = qbudget(4)
-        qbudget5 = qbudget(5)
-        qbudget6 = qbudget(6)
-        qbudget7 = qbudget(7)
-        qbudget8 = qbudget(8)
-        qbudget9 = qbudget(9)
-        qbudget10= qbudget(10)
         !  In case user wants to change values on a restart:
         IF( restart_reset_frqtim )THEN 
           if( statfrq.gt.1.0e-6 ) stattim = mtime + statfrq
@@ -3003,7 +2982,7 @@
         ! (tendencies held fixed during Runge-Kutta integration and acoustic sub-stepping)
         call     solve1(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,qbudget8,qbudget9,qbudget10,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,xhref,yfref,yhref,dumk1,dumk2,rds,sigma,rdsf,sigmaf, &
@@ -3094,7 +3073,7 @@
         ! (advection, buoyancy, pressure gradient)
         call     solve2(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,qbudget8,qbudget9,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,xhref,yfref,yhref,dumk1,dumk2,rds,sigma,rdsf,sigmaf, &
@@ -3185,8 +3164,7 @@
         ! qv only:
         call pdefq2_GPU(    0.0,asq(1),ruh,rvh,rmh,rho,q3d(ib,jb,kb,1))
       else
-        call   mp_driver(nstep,dt,qbudget,qbudget1,qbudget2,qbudget3,qbudget4,qbudget5, &
-                         qbudget6,qbudget7,qbudget8,qbudget9,asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,  &
+        call   mp_driver(nstep,dt,qbudget,asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,  &
                          mh,rmh,c1,c2,zh,mf,rmf,zf,rain,prate,pi0,th0,rho0,prs0,qv0,   &
                          rho,prs,dum1,dum2,dum3,dum4,dum5,dum6,dum7,dum8,  &
                          w3d,ppi,pp3d,ppten,sten,tha,th3d,thten,qa,q3d,qten,   &
@@ -3217,7 +3195,7 @@
 
         call     solve3(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,bud,bud2,qbudget,qbudget8,qbudget9,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,bud,bud2,qbudget,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,yfref,dumk1,dumk2,rds,sigma,rdsf,sigmaf,     &
@@ -3410,7 +3388,7 @@
 #endif
 !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 !$acc compare(ust,u1,v1,s1)
-      call sfc_and_turb(getsfc,getpbl,nstep,dt,dosfcflx,cloudvar,qbudget,qbudget8,qbudget9,   &
+      call sfc_and_turb(getsfc,getpbl,nstep,dt,dosfcflx,cloudvar,qbudget, &
                    avgsfcu,avgsfcv,avgsfcs,avgsfct,                  &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,  &
                    yh,vh,rvh,yf,vf,rvf,                              &
@@ -3548,8 +3526,7 @@
         ENDIF
 !#if 0
         call     statpack(mtime,nrec,ndt,dt,dtlast,rtime,adt,acfl,cloudvar,   &
-                          qname,budname,qbudget,qbudget1,qbudget2,qbudget3,   &
-                          qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10,asq,bsq,                      &
+                          qname,budname,qbudget,asq,bsq,                      &
                           name_stat,desc_stat,unit_stat,                      &
                           xh,rxh,uh,ruh,xf,uf,yh,vh,rvh,vf,zh,mh,rmh,zf,mf,   &
                           zs,rgzu,rgzv,rds,sigma,rdsf,sigmaf,                 &
@@ -4019,7 +3996,7 @@
                                avgsfcu,avgsfcv,avgsfcs,avgsfct,                     &
                                dt,dtlast,mtime,ndt,adt,acfl,dbldt,mass1,            &
                                stattim,taptim,rsttim,radtim,prcltim,                &
-                               qbudget,qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10,asq,bsq,qname,                               &
+                               qbudget,asq,bsq,qname,                               &
                                xfref,yfref,zh,zf,sigma,sigmaf,zs,                   &
                                th0,prs0,pi0,rho0,qv0,u0,v0,                         &
                                rain,sws,svs,sps,srs,sgs,sus,shs,                    &

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -82,6 +82,7 @@
       logical, dimension(maxvars) :: cmpr_output
       character(len=40), dimension(maxvars) :: name_stat,desc_stat,unit_stat
       character(len=40), dimension(maxvars) :: name_prcl,desc_prcl,unit_prcl
+      double precision :: qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10 
       double precision, dimension(:), allocatable :: bud,bud2
       double precision, dimension(:), allocatable :: qbudget
       double precision, dimension(:), allocatable :: asq,bsq
@@ -1653,7 +1654,17 @@
       allocate(  bud2(nj) )
       bud2 = 0.0
       allocate( qbudget(nbudget) )
-      qbudget = 0.0
+      qbudget   = 0.0
+      qbudget1  = 0.0
+      qbudget2  = 0.0
+      qbudget3  = 0.0
+      qbudget4  = 0.0
+      qbudget5  = 0.0
+      qbudget6  = 0.0
+      qbudget7  = 0.0
+      qbudget8  = 0.0
+      qbudget9  = 0.0
+      qbudget10 = 0.0
       allocate(    asq(numq) )
       asq = 0.0
       allocate(    bsq(numq) )
@@ -2504,6 +2515,16 @@
                               gamk,kmw,u1b,v1b,cmz,csz,ce1z,ce2z,                  &
                               dum1,dat1,dat2,dat3,reqt,myi1p,myi2p,myj1p,myj2p,restarted,restart_prcl)
           ! end_read_restart
+        qbudget1 = qbudget(1)
+        qbudget2 = qbudget(2)
+        qbudget3 = qbudget(3)
+        qbudget4 = qbudget(4)
+        qbudget5 = qbudget(5)
+        qbudget6 = qbudget(6)
+        qbudget7 = qbudget(7)
+        qbudget8 = qbudget(8)
+        qbudget9 = qbudget(9)
+        qbudget10= qbudget(10)
         !  In case user wants to change values on a restart:
         IF( restart_reset_frqtim )THEN 
           if( statfrq.gt.1.0e-6 ) stattim = mtime + statfrq
@@ -2813,7 +2834,7 @@
 !$acc              xfref,xhref,yfref,yhref,dvdr,qpten,qtten, &
 !$acc              qvten,qcten,qa,q3d,qten,kmh,kmv,khh,khv,tkea, &
 !$acc              tke3d,tketen,effc,effi,effs,effr,effg,effis, &
-!$acc              out2d,out3d,rain,prate,p3a,p3o,qbudget,asq, &
+!$acc              out2d,out3d,rain,prate,p3a,p3o,asq, &
 !$acc              bsq,qavg,cavg,cloudvar,rho0s,pi0s,prs0s,rth0s, &
 !$acc              tst,qst,z0t,z0q,mznt,ppi,pp3d,ppten,sadv,ppx, &
 !$acc              tha,thten1,thterm,glw,gsw,ulspg,vlspg,savg,pavg, &
@@ -2982,7 +3003,7 @@
         ! (tendencies held fixed during Runge-Kutta integration and acoustic sub-stepping)
         call     solve1(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,qbudget8,qbudget9,qbudget10,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,xhref,yfref,yhref,dumk1,dumk2,rds,sigma,rdsf,sigmaf, &
@@ -3050,7 +3071,6 @@
                    dotbud,doqbud,doubud,dovbud,dowbud,donudge,       &
                    doazimwrite,dorestart)
 !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6,dum7,dum8,epsd2)
-!$acc compare(qbudget)
 !$acc compare(rru,rrv)
 !$acc compare(khh,khv)
         ! end_solve1
@@ -3074,7 +3094,7 @@
         ! (advection, buoyancy, pressure gradient)
         call     solve2(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,qbudget8,qbudget9,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,xhref,yfref,yhref,dumk1,dumk2,rds,sigma,rdsf,sigmaf, &
@@ -3145,7 +3165,6 @@
 !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6,epsd2)
 !$acc compare(khh,khv)
 !$acc compare(tha)
-!$acc compare(qbudget)
 #ifdef _NVTX
         call nvtxEndRange
 #endif
@@ -3166,7 +3185,8 @@
         ! qv only:
         call pdefq2_GPU(    0.0,asq(1),ruh,rvh,rmh,rho,q3d(ib,jb,kb,1))
       else
-        call   mp_driver(nstep,dt,qbudget,asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,  &
+        call   mp_driver(nstep,dt,qbudget,qbudget1,qbudget2,qbudget3,qbudget4,qbudget5, &
+                         qbudget6,qbudget7,qbudget8,qbudget9,asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,  &
                          mh,rmh,c1,c2,zh,mf,rmf,zf,rain,prate,pi0,th0,rho0,prs0,qv0,   &
                          rho,prs,dum1,dum2,dum3,dum4,dum5,dum6,dum7,dum8,  &
                          w3d,ppi,pp3d,ppten,sten,tha,th3d,thten,qa,q3d,qten,   &
@@ -3181,7 +3201,6 @@
 #endif
 
       ENDIF
-!$acc compare(qbudget)
 
 
 #ifdef _NVTX
@@ -3198,7 +3217,7 @@
 
         call     solve3(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,bud,bud2,qbudget,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,bud,bud2,qbudget,qbudget8,qbudget9,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,yfref,dumk1,dumk2,rds,sigma,rdsf,sigmaf,     &
@@ -3268,7 +3287,6 @@
 !$acc compare(khh,khv)
 !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6,epsd2)
 !$acc compare(tha,rru,rrv)
-!$acc compare(qbudget)
 #ifdef _NVTX
         call nvtxEndRange
 #endif
@@ -3392,7 +3410,7 @@
 #endif
 !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6)
 !$acc compare(ust,u1,v1,s1)
-      call sfc_and_turb(getsfc,getpbl,nstep,dt,dosfcflx,cloudvar,qbudget,   &
+      call sfc_and_turb(getsfc,getpbl,nstep,dt,dosfcflx,cloudvar,qbudget,qbudget8,qbudget9,   &
                    avgsfcu,avgsfcv,avgsfcs,avgsfct,                  &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,  &
                    yh,vh,rvh,yf,vf,rvf,                              &
@@ -3444,7 +3462,6 @@
                    dowriteout,doazimwrite)
         ! end_sfc_and_turb
 !$acc compare(dum1,dum2,dum3,dum4,dum5,dum6,epsd2)
-!$acc compare(qbudget)
 !$acc compare(khh,khv)
 #ifdef _NVTX
       call nvtxEndRange()
@@ -3531,7 +3548,8 @@
         ENDIF
 !#if 0
         call     statpack(mtime,nrec,ndt,dt,dtlast,rtime,adt,acfl,cloudvar,   &
-                          qname,budname,qbudget,asq,bsq,                      &
+                          qname,budname,qbudget,qbudget1,qbudget2,qbudget3,   &
+                          qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10,asq,bsq,                      &
                           name_stat,desc_stat,unit_stat,                      &
                           xh,rxh,uh,ruh,xf,uf,yh,vh,rvh,vf,zh,mh,rmh,zf,mf,   &
                           zs,rgzu,rgzv,rds,sigma,rdsf,sigmaf,                 &
@@ -3542,7 +3560,6 @@
                           pta,u10,v10,hpbl,prate,reset,nstatout)
         !stop 'after call to statpack'
 !#endif
-!$acc compare(qbudget)
         nrec = nrec + 1
         nstatout = nstatout + 1
         if( statfrq.gt.0.0 .and. ( .not. restarted ) )then
@@ -4002,7 +4019,7 @@
                                avgsfcu,avgsfcv,avgsfcs,avgsfct,                     &
                                dt,dtlast,mtime,ndt,adt,acfl,dbldt,mass1,            &
                                stattim,taptim,rsttim,radtim,prcltim,                &
-                               qbudget,asq,bsq,qname,                               &
+                               qbudget,qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10,asq,bsq,qname,                               &
                                xfref,yfref,zh,zf,sigma,sigmaf,zs,                   &
                                th0,prs0,pi0,rho0,qv0,u0,v0,                         &
                                rain,sws,svs,sps,srs,sgs,sus,shs,                    &

--- a/src/comm.F
+++ b/src/comm.F
@@ -9130,9 +9130,9 @@
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
 #else
+        !$acc update host(south)
         call mpi_isend(south,cs1sn,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
-        !$acc update host(south)
 #endif
       endif
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -609,10 +609,6 @@
 !
 !----------------------------------------------------------------------
       !$acc end data
-      !!$acc compare(pdata(1:50,1:npvals))
-      !!$acc compare(pdata)
-      !!$acc compare(qten,thten)
-      !stop 'droplet_driver: at the end subroutine'
 
       end subroutine droplet_driver
 

--- a/src/kessler.F
+++ b/src/kessler.F
@@ -389,6 +389,7 @@
       real :: esl,qvs,qvnew,qcnew,cvml,rm,lhv,tlast,dqv
       real :: converge,t1,d1,tem,ql,qi,rdt
       double precision :: dum
+      double precision :: bud1tmp,bud2tmp
       double precision, dimension(nk) :: bud1,bud2
       logical :: doit
 
@@ -415,141 +416,147 @@
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k,n,tnew,pnew,esl,qvs,qvnew,qcnew,cvml,rm,lhv,   &
 !$omp tlast,dqv,t1,d1,tem,ql,qi,doit)
-      !$acc parallel default(present) private(i,j,k,n,tnew,pnew,esl,qvs,qvnew,qcnew,cvml,rm,lhv,tlast,dqv,t1,d1,tem,ql,qi,doit) 
-      !$acc loop gang vector 
+      !$acc parallel default(present) reduction(+:bud1tmp,bud2tmp) reduction(max:nmax) &
+      !$acc private(i,j,k,n,tnew,pnew,esl,qvs,qvnew,qcnew,cvml,rm,lhv,tlast,dqv,t1,d1,tem,ql,qi,doit) 
+      !$acc loop gang 
       do k=1,nk
-      bud1(k)=0.0d0
-      bud2(k)=0.0d0
-      !$acc loop gang vector collapse(2)
-      do j=1,nj
-      do i=1,ni
+        bud1tmp=0.0d0
+        bud2tmp=0.0d0
+        !$acc loop vector collapse(2) reduction(+:bud1tmp,bud2tmp) reduction(max:nmax)
+        do j=1,nj
+        do i=1,ni
 
-        tnew=(th0(i,j,k)+th3d(i,j,k))*(pi0(i,j,k)+pp3d(i,j,k))
-        esl=611.2*exp( 17.67 * ( tnew - 273.15 ) / ( tnew - 29.65 ) )
-        ! 171023 (fix for very cold temps):
-        esl = min( esl , prs(i,j,k)*0.5 )
-        qvs=eps*esl/(prs(i,j,k)-esl)
+          tnew=(th0(i,j,k)+th3d(i,j,k))*(pi0(i,j,k)+pp3d(i,j,k))
+          esl=611.2*exp( 17.67 * ( tnew - 273.15 ) / ( tnew - 29.65 ) )
+          ! 171023 (fix for very cold temps):
+          esl = min( esl , prs(i,j,k)*0.5 )
+          qvs=eps*esl/(prs(i,j,k)-esl)
 
-        IF(q3d(i,j,k,nqc).gt.1.0e-12 .or. q3d(i,j,k,nqv).gt.qvs)THEN
+          IF(q3d(i,j,k,nqc).gt.1.0e-12 .or. q3d(i,j,k,nqv).gt.qvs)THEN
 
-          qvnew=q3d(i,j,k,nqv)
-          qcnew=q3d(i,j,k,nqc)
-          ql=0.0
-          qi=0.0
-          do n=nql1,nql2
-            ql=ql+q3d(i,j,k,n)
-          enddo
-          if(iice.eq.1)then
-            do n=nqs1,nqs2
-              qi=qi+q3d(i,j,k,n)
+            qvnew=q3d(i,j,k,nqv)
+            qcnew=q3d(i,j,k,nqc)
+            ql=0.0
+            qi=0.0
+            !$acc loop seq
+            do n=nql1,nql2
+              ql=ql+q3d(i,j,k,n)
             enddo
-          endif
-          ql=max(0.0,ql)
-          qi=max(0.0,qi)
-          cvml=cv+cvv*qvnew+cpl*ql+cpi*qi
-          lhv=lv1-lv2*tnew
-
-          t1=(lhv-rv*tnew)/cvml
-          d1=t1*17.67*243.5
-
-          n=0
-          tlast=tnew
-          doit=.true.
-
-          do while( doit )
-            n=n+1
-            dqv=(qvs-qvnew)/(1.0+d1*qvs/((tnew-29.65)**2) )
-            dqv=min(dqv,qcnew)
-            if(  (qvnew+dqv).lt.1.0e-20 ) dqv=1.0e-20-qvnew
-
-            qvnew=qvnew+dqv
-            qcnew=qcnew-dqv
-            tnew=tnew-dqv*t1
-            pnew=rho(i,j,k)*(rd+rv*qvnew)*tnew
-
-            doit = .false.
-            if( abs(tnew-tlast).gt.converge )then
-              tlast=tnew
-              esl=611.2*exp( 17.67 * ( tnew - 273.15 ) / ( tnew - 29.65 ) )
-              ! 171023 (fix for very cold temps):
-              esl = min( esl , prs(i,j,k)*0.5 )
-              qvs=eps*esl/(pnew-esl)
-              doit = .true.
+            if(iice.eq.1)then
+              !$acc loop seq
+              do n=nqs1,nqs2
+                qi=qi+q3d(i,j,k,n)
+              enddo
             endif
+            ql=max(0.0,ql)
+            qi=max(0.0,qi)
+            cvml=cv+cvv*qvnew+cpl*ql+cpi*qi
+            lhv=lv1-lv2*tnew
 
-            if(n.gt.50) print *,'  satadj:',myid,n,tnew,pnew
-            if(n.eq.100)then
-              print *,'  infinite loop!'
-              print *,'  i,j,k=',i,j,k
-              iflag=1
-              doit=.false.
-            endif
+            t1=(lhv-rv*tnew)/cvml
+            d1=t1*17.67*243.5
 
-          enddo
+            n=0
+            tlast=tnew
+            doit=.true.
 
-          tem=ruh(i)*rvh(j)*rmh(i,j,k)
+            do while( doit )
+              n=n+1
+              dqv=(qvs-qvnew)/(1.0+d1*qvs/((tnew-29.65)**2) )
+              dqv=min(dqv,qcnew)
+              if(  (qvnew+dqv).lt.1.0e-20 ) dqv=1.0e-20-qvnew
 
-          bud1(k)=bud1(k)+rr(i,j,k)*max(qcnew-q3d(i,j,k,nqc),0.0)*tem
-          bud2(k)=bud2(k)+rr(i,j,k)*max(qvnew-q3d(i,j,k,nqv),0.0)*tem
+              qvnew=qvnew+dqv
+              qcnew=qcnew-dqv
+              tnew=tnew-dqv*t1
+              pnew=rho(i,j,k)*(rd+rv*qvnew)*tnew
 
-          prs(i,j,k) = pnew
-          pp3d(i,j,k) = (pnew*rp00)**rovcp - pi0(i,j,k)
-          th3d(i,j,k) = tnew/(pi0(i,j,k)+pp3d(i,j,k))-th0(i,j,k)
-          q3d(i,j,k,nqc) = qcnew
-          q3d(i,j,k,nqv) = qvnew
+              doit = .false.
+              if( abs(tnew-tlast).gt.converge )then
+                tlast=tnew
+                esl=611.2*exp( 17.67 * ( tnew - 273.15 ) / ( tnew - 29.65 ) )
+                ! 171023 (fix for very cold temps):
+                esl = min( esl , prs(i,j,k)*0.5 )
+                qvs=eps*esl/(pnew-esl)
+                doit = .true.
+              endif
 
-          nmax=max(n,nmax)
+              if(n.gt.50) print *,'  satadj:',myid,n,tnew,pnew
+              if(n.eq.100)then
+                print *,'  infinite loop!'
+                print *,'  i,j,k=',i,j,k
+                iflag=1
+                doit=.false.
+              endif
 
-        ENDIF
+            enddo
+
+            tem=ruh(i)*rvh(j)*rmh(i,j,k)
+
+            bud1tmp=bud1tmp+rr(i,j,k)*max(qcnew-q3d(i,j,k,nqc),0.0)*tem
+            bud2tmp=bud2tmp+rr(i,j,k)*max(qvnew-q3d(i,j,k,nqv),0.0)*tem
+
+            prs(i,j,k) = pnew
+            pp3d(i,j,k) = (pnew*rp00)**rovcp - pi0(i,j,k)
+            th3d(i,j,k) = tnew/(pi0(i,j,k)+pp3d(i,j,k))-th0(i,j,k)
+            q3d(i,j,k,nqc) = qcnew
+            q3d(i,j,k,nqv) = qvnew
+
+            nmax=max(n,nmax)
+
+          ENDIF
 
 
+        enddo
+        enddo
+        bud1(k)=bud1tmp
+        bud2(k)=bud2tmp
       enddo
-      enddo
-      enddo
-!$acc end parallel
+      !$acc end parallel
 
     ELSE
 
       nmax=1
 
-!$omp parallel do default(shared)  &
-!$omp private(i,j,k,qvnew,qcnew,tnew,esl,qvs,lhv,dqv,tem,rm)
-      !$acc parallel default(present) private(i,j,k,qvnew,qcnew,tnew,esl,qvs,lhv,dqv,tem,rm) 
-      !$acc loop gang vector 
+      !$omp parallel do default(shared) private(i,j,k,qvnew,qcnew,tnew,esl,qvs,lhv,dqv,tem,rm)
+      !$acc parallel default(present) private(i,j,k,qvnew,qcnew,tnew,esl,qvs,lhv,dqv,tem,rm) reduction(+:bud1tmp,bud2tmp)
+      !$acc loop gang
       do k=1,nk
-      bud1(k)=0.0d0
-      bud2(k)=0.0d0
-      !$acc loop gang vector collapse(2)
-      do j=1,nj
-      do i=1,ni
+        bud1tmp=0.0d0
+        bud2tmp=0.0d0
+        !$acc loop vector collapse(2) reduction(+:bud1tmp,bud2tmp)
+        do j=1,nj
+        do i=1,ni
 
-        qvnew=q3d(i,j,k,nqv)
-        qcnew=q3d(i,j,k,nqc)
-        tnew=(th0(i,j,k)+th3d(i,j,k))*(pi0(i,j,k)+pp3d(i,j,k))
-        esl=611.2*exp( 17.67 * ( tnew - 273.15 ) / ( tnew - 29.65 ) )
-        ! 171023 (fix for very cold temps):
-        esl = min( esl , prs(i,j,k)*0.5 )
-        qvs=eps*esl/(prs(i,j,k)-esl)
-        lhv=lv1-lv2*tnew
+          qvnew=q3d(i,j,k,nqv)
+          qcnew=q3d(i,j,k,nqc)
+          tnew=(th0(i,j,k)+th3d(i,j,k))*(pi0(i,j,k)+pp3d(i,j,k))
+          esl=611.2*exp( 17.67 * ( tnew - 273.15 ) / ( tnew - 29.65 ) )
+          ! 171023 (fix for very cold temps):
+          esl = min( esl , prs(i,j,k)*0.5 )
+          qvs=eps*esl/(prs(i,j,k)-esl)
+          lhv=lv1-lv2*tnew
 !!!        dqv=(qvs-qvnew)/(1.0+lhv*qvs*4097.8531/(cp*((tnew-35.86)**2)))
-        dqv=(qvs-qvnew)/(1.0+lhv*qvs*17.67*243.5/(cp*((tnew-29.65)**2)))
-        if(  (qvnew+dqv).lt.1.0e-20 ) dqv=1.0e-20-qvnew
-        dqv=min(dqv,max(0.0,qcnew))
+          dqv=(qvs-qvnew)/(1.0+lhv*qvs*17.67*243.5/(cp*((tnew-29.65)**2)))
+          if(  (qvnew+dqv).lt.1.0e-20 ) dqv=1.0e-20-qvnew
+          dqv=min(dqv,max(0.0,qcnew))
 
-        qvnew=qvnew+dqv
-        qcnew=qcnew-dqv
-        tem=ruh(i)*rvh(j)*rmh(i,j,k)
-        bud1(k)=bud1(k)+rr(i,j,k)*max(qcnew-q3d(i,j,k,nqc),0.0)*tem
-        bud2(k)=bud2(k)+rr(i,j,k)*max(qvnew-q3d(i,j,k,nqv),0.0)*tem
+          qvnew=qvnew+dqv
+          qcnew=qcnew-dqv
+          tem=ruh(i)*rvh(j)*rmh(i,j,k)
+          bud1tmp=bud1tmp+rr(i,j,k)*max(qcnew-q3d(i,j,k,nqc),0.0)*tem
+          bud2tmp=bud2tmp+rr(i,j,k)*max(qvnew-q3d(i,j,k,nqv),0.0)*tem
 
-        th3d(i,j,k)=th3d(i,j,k)-dqv*( lhv/(cp*(pi0(i,j,k)+pp3d(i,j,k))) )
-        q3d(i,j,k,nqc)=qcnew
-        q3d(i,j,k,nqv)=qvnew
-        rho(i,j,k)=prs(i,j,k)   &
+          th3d(i,j,k)=th3d(i,j,k)-dqv*( lhv/(cp*(pi0(i,j,k)+pp3d(i,j,k))) )
+          q3d(i,j,k,nqc)=qcnew
+          q3d(i,j,k,nqv)=qvnew
+          rho(i,j,k)=prs(i,j,k)   &
              /(rd*(th0(i,j,k)+th3d(i,j,k))*(pi0(i,j,k)+pp3d(i,j,k))*(1.0+qvnew*reps))
 
-      enddo
-      enddo
+        enddo
+        enddo
+        bud1(k)=bud1tmp
+        bud2(k)=bud2tmp
       enddo
       !$acc end parallel
 
@@ -756,9 +763,11 @@
     do j=1,nj
       bud(j)=0.0d0
     enddo
-    !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,n,nr) 
+    !JMD FIXME:  The following loop looks excessively complex
+    !$acc parallel loop gang vector collapse(2) default(present) private(i,j,k,n,nr) 
     do j=1,nj
     do i=1,ni
+      !$acc loop seq
       do k=1,nk
         if (k==1) crmax = 0.0
         crmax = max( crmax , vq(i,j,k)*dt*rdz*mh(i,j,k) )
@@ -790,6 +799,7 @@
     enddo
     !$acc end parallel
 
+    !JMD FIXME:  This loop looks incorrect. what is going on with the n-loop 
     !$acc parallel default(present) private(i,j,k,ll,n)
     !$acc loop gang vector collapse(3) 
     do k=1,nk
@@ -803,14 +813,16 @@
       enddo
     enddo
     enddo
-
     !$acc end parallel
+
+    !JMD FIXME:  This loop looks incorrect. what is going on with the n-loop 
     !$acc parallel default(present) private(i,j,n,ll,nr)
     !$acc loop gang vector collapse(3)
     do nr=1,nrain
     do j=1,nj
     do i=1,ni
     ll = nfall(i,j)
+    !$acc loop seq
     do n=1,ll
           rain(i,j,nr)=rain(i,j,nr)+0.1*dtfall(i,j)*rq(i,j,1)
                                 ! mult by 100 cm/m  (convert from m to cm)
@@ -820,6 +832,8 @@
     enddo
     enddo
     !$acc end parallel
+    !JMD FIXME:  This loop looks incorrect. what is going on with the n-loop 
+    !JMD FIXME:  This loop needs a reduction clause due to the bud(j)
     !$acc parallel default(present) private(i,j,ll,n)
     !$acc loop gang vector collapse(2) 
     do j=1,nj

--- a/src/maxmin.F
+++ b/src/maxmin.F
@@ -207,4 +207,94 @@
 
       end subroutine maxmin2d
 
+      subroutine maxmin2dhalo(izz,jzz,f,amax,amin)
+      use input
+#ifdef MPI
+      use mpi
+#endif
+      implicit none
+
+      integer :: izz,jzz
+      real, dimension(1-ngxy:izz+ngxy,1-ngxy:jzz+ngxy) :: f
+      character(len=6) :: amax,amin
+
+!-----------------------------------------------------------------------
+
+      integer :: i,j
+      integer :: imax,jmax,imin,jmin
+      integer, dimension(jzz) :: imaxt,jmaxt,imint,jmint
+      real, dimension(jzz) :: tmax,tmin
+      real :: fmax,fmin,rmax,rmin
+      real :: tmaxt,tmint
+      integer :: loc
+      real, dimension(2) :: mmax,nmax,mmin,nmin
+      integer :: foundmax,foundmin
+
+!-----------------------------------------------------------------------
+      imin=1
+      imax=1
+      jmin=1
+      jmax=1
+      fmax = -1.e30
+      fmin =  1.e30
+
+      !$acc parallel default(present) private(i,j) &
+      !$acc    reduction(min:fmin) reduction(max:fmax)
+      !$acc loop gang vector collapse(2)
+      do j=1-ngxy,jzz+ngxy
+      do i=1-ngxy,izz+ngxy
+        fmax = max(f(i,j),fmax)
+        fmin = min(f(i,j),fmin)
+        if(f(i,j).eq.fmax)then
+          imax=i
+          jmax=j
+        endif
+        if(f(i,j).eq.fmin)then
+          imin=i
+          jmin=j
+        endif
+      enddo
+      enddo
+      !$acc end parallel
+
+#ifdef MPI
+      mmax(1)=fmax
+      mmax(2)=myid
+      call MPI_ALLREDUCE(mmax,nmax,1,MPI_2REAL,MPI_MAXLOC,   &
+                         MPI_COMM_WORLD,ierr)
+      loc=nint(nmax(2))
+      imax=imax+(myi1-1)
+      jmax=jmax+(myj1-1)
+      call MPI_BCAST(imax,1,MPI_INTEGER,loc,MPI_COMM_WORLD,ierr)
+      call MPI_BCAST(jmax,1,MPI_INTEGER,loc,MPI_COMM_WORLD,ierr)
+
+      mmin(1)=fmin
+      mmin(2)=myid
+      call MPI_ALLREDUCE(mmin,nmin,1,MPI_2REAL,MPI_MINLOC,   &
+                         MPI_COMM_WORLD,ierr)
+      loc=nint(nmin(2))
+      imin=imin+(myi1-1)
+      jmin=jmin+(myj1-1)
+      call MPI_BCAST(imin,1,MPI_INTEGER,loc,MPI_COMM_WORLD,ierr)
+      call MPI_BCAST(jmin,1,MPI_INTEGER,loc,MPI_COMM_WORLD,ierr)
+
+      fmax=nmax(1)
+      fmin=nmin(1)
+
+    if(myid.eq.0)then
+#endif
+      write(6,100) amax,fmax,imax,jmax,1,    &
+                   amin,fmin,imin,jmin,1
+100   format(2x,'stat:: ',a6,':',1x,g13.6,i5,i5,i5,    &
+             4x,a6,':',1x,g13.6,i5,i5,i5)
+
+#ifdef MPI
+    endif
+#endif
+
+      if(timestats.ge.1) time_stat=time_stat+mytime()
+
+      end subroutine maxmin2dhalo
+
+
   END MODULE maxmin_module

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -2868,7 +2868,6 @@
  
       end subroutine vertvort
 
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -3043,6 +3042,186 @@
 !$acc end data
 
       end subroutine calccfl
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+ 
+      subroutine calccfl_fold(nstat,rstat,dt,acfl,uh,vh,mh,ua,va,wa,writeit)
+      use input
+      use constants
+#ifdef MPI
+      use mpi
+#endif
+      implicit none
+
+      integer nstat
+      real, dimension(stat_out) :: rstat
+      real :: dt
+      double precision :: acfl
+      real, intent(in), dimension(ib:ie) :: uh
+      real, intent(in), dimension(jb:je) :: vh
+      real, intent(in), dimension(ib:ie,jb:je,kb:ke) :: mh
+      real, dimension(ib:ie+1,jb:je,kb:ke) :: ua
+      real, dimension(ib:ie,jb:je+1,kb:ke) :: va
+      real, dimension(ib:ie,jb:je,kb:ke+1) :: wa
+      integer :: writeit
+ 
+      integer i,j,k,index
+      integer imax,jmax,kmax
+      integer imaxt(ni*nj),jmaxt(ni*nj),kmaxt(ni*nj)
+      real dtdx,dtdy,dtdz,cfl(ni*nj),fmax
+      real :: wsp
+      integer :: loc
+      integer RANGE, PAIRS
+      real, dimension(2) :: mmax,nmax
+
+!$acc data create(imaxt,jmaxt,kmaxt,cfl,mmax,nmax)
+
+      dtdx=0.5*dt*rdx
+      dtdy=0.5*dt*rdy
+      dtdz=0.5*dt*rdz
+
+      cfl = -1.0
+      imaxt = 0
+      jmaxt = 0
+      kmaxt = 0
+
+      if(nx.gt.1.and.ny.gt.1)then
+!! Each thread runs a serial loop and finds the max from that "stripe".
+!! We'd really want to split the second dimension between the parallel &
+!! serial loops so we can fill the SM's with threads but not oversubscribe.
+!$omp parallel do default(shared)  &
+!$omp private(i,j,k,wsp)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,j,k,wsp)
+        do j=1,nj
+        do i=1,ni
+!$acc loop seq private(index)
+        do k=1,nk
+          wsp = sqrt( ( ((ua(i,j,k)+ua(i+1,j,k))*dtdx*uh(i))**2     &
+                       +((va(i,j,k)+va(i,j+1,k))*dtdy*vh(j))**2 )   &
+                       +((wa(i,j,k)+wa(i,j,k+1))*dtdz*mh(i,j,k))**2 )
+          index=j*ni+i
+          if( wsp.gt.cfl(index) )then
+            cfl(index) = wsp
+            imaxt(index)=i
+            jmaxt(index)=j
+            kmaxt(index)=k
+          endif
+        enddo
+        enddo
+        enddo
+      elseif(nx.gt.1)then
+!$omp parallel do default(shared)  &
+!$omp private(i,j,k,wsp)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,j,k,wsp)
+        do j=1,nj
+        do i=1,ni
+!$acc loop seq private(index)
+        do k=1,nk
+          wsp = sqrt( ((ua(i,j,k)+ua(i+1,j,k))*dtdx*uh(i))**2     &
+                     +((wa(i,j,k)+wa(i,j,k+1))*dtdz*mh(i,j,k))**2 )
+          index=j*ni+i
+          if( wsp.gt.cfl(index) )then
+            cfl(index) = wsp
+            imaxt(index)=i
+            jmaxt(index)=j
+            kmaxt(index)=k
+          endif
+        enddo
+        enddo
+        enddo
+      elseif(axisymm.eq.0.and.ny.gt.1)then
+!$omp parallel do default(shared)  &
+!$omp private(i,j,k,wsp)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,j,k,wsp)
+        do j=1,nj
+        do i=1,ni
+!$acc loop seq private(index)
+        do k=1,nk
+          wsp = sqrt( ((va(i,j,k)+va(i,j+1,k))*dtdy*vh(j))**2     &
+                     +((wa(i,j,k)+wa(i,j,k+1))*dtdz*mh(i,j,k))**2 )
+          index=j*ni+i
+          if( wsp.gt.cfl(index) )then
+            cfl(index) = wsp
+            imaxt(index)=i
+            jmaxt(index)=j
+            kmaxt(index)=k
+          endif
+        enddo
+        enddo
+        enddo
+      endif
+
+!! Using a serial loop here so all the data is sync'd between consecutive kernel
+!calls.
+!! The RANGE = PAIRS or (PAIRS+1) as a way to manage odd numbers.
+      PAIRS=ni*nj/2           !! Round down.
+      RANGE=(ni*nj+1)/2       !! Round up.
+      do while ( RANGE > 1 )
+!! Now fold the 2-d array with half the threads each time.
+!$acc parallel loop gang vector private(i)
+        do i=1,PAIRS
+          if ( cfl(i) .le. cfl(RANGE)) then
+             cfl(i)=cfl(RANGE+i)
+             imaxt(i)=imaxt(RANGE+i)
+             jmaxt(i)=jmaxt(RANGE+i)
+             kmaxt(i)=kmaxt(RANGE+i)
+          endif
+        enddo
+        PAIRS=RANGE/2
+        RANGE=(RANGE+1)/2
+!! May need some kind of sync-barrier here.
+      enddo
+
+      fmax=cfl(1)
+      imax=imaxt(1)
+      jmax=jmaxt(1)
+      kmax=kmaxt(1)
+
+#ifdef MPI
+      mmax(1)=fmax
+      mmax(2)=myid
+      call MPI_ALLREDUCE(mmax,nmax,1,MPI_2REAL,MPI_MAXLOC,   &
+                         MPI_COMM_WORLD,ierr)
+      !!$acc update device(mmax)
+      loc=nint(nmax(2))
+      imax=imax+(myi1-1)
+      jmax=jmax+(myj1-1)
+      call MPI_BCAST(imax,1,MPI_INTEGER,loc,MPI_COMM_WORLD,ierr)
+      call MPI_BCAST(jmax,1,MPI_INTEGER,loc,MPI_COMM_WORLD,ierr)
+      call MPI_BCAST(kmax,1,MPI_INTEGER,loc,MPI_COMM_WORLD,ierr)
+      !!$acc update device(imax,jmax,kmax)
+      fmax=nmax(1)
+      if(myid.eq.0)then
+#endif
+
+    IF(writeit.eq.1)THEN
+      nstat = nstat + 1
+      IF( adapt_dt.eq.1 )THEN
+        write(6,100) 'CFLMAX',sngl(acfl),imax,jmax,kmax
+        rstat(nstat) = sngl(acfl)
+      ELSE
+        write(6,100) 'CFLMAX',fmax,imax,jmax,kmax
+        rstat(nstat) = fmax
+      ENDIF
+100   format(2x,'stat:: ',a6,':',1x,f13.6,i5,i5,i5)
+    ENDIF
+
+#ifdef MPI
+      endif
+#endif
+
+
+      print *,'calccfl: fmax is: ',fmax
+      if(fmax.ge.1.50) stopit=.true.
+ 
+      if(timestats.ge.1) time_stat=time_stat+mytime()
+
+!$acc end data
+
+      end subroutine calccfl_fold
 
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -1270,12 +1270,12 @@
 !----------------------------------------------------------------------
 
       !print *,'pdefq2_GPU: pdscheme: ',pdscheme
-      !$acc data create(budj,budk)
+!      !$acc data create(budj,budk)
       !tem = dx*dy*dz
       IF(pdscheme.eq.1)THEN
 
         !$omp parallel do default(shared) private(i,j,k,t1,t2,t3,a1,a2)
-        !$acc parallel default(present) private(i,j,k) copy(asq) &
+        !$acc parallel default(present) private(i,j,k) &
         !$acc reduction(+:a1,t1,t2) reduction(+:a2) reduction(+:asq)
         !$acc loop gang collapse(2)
         do j=1,nj
@@ -1309,7 +1309,7 @@
 
         !$omp parallel do default(shared) private(i,j,k,a1,a2)
         !$acc parallel default(present) private(i,j,k,a1,a2) reduction(+:budt,asq)
-        !$acc loop gang
+        !$acc loop gang reduction(+:asq)
         do k=1,nk
           budt=0.0d0
           !$acc loop vector collapse(2) reduction(+:budt)
@@ -1333,7 +1333,7 @@
         !$acc end parallel
 
       ENDIF
-      !$acc end data
+!      !$acc end data
 
 !----------------------------------------------------------------------
 
@@ -3134,7 +3134,6 @@
 #endif
 
       if(cflmax.ge.1.50) stopit=.true.
-          !stop 'calcflquick: end of subroutine'
 
 
       if(timestats.ge.1) time_cflq=time_cflq+mytime()
@@ -3716,8 +3715,8 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
+ 
+ 
       subroutine totq(nstat,rstat,ruh,rvh,rmh,q,rho,aname)
       use input
       use constants
@@ -3976,19 +3975,22 @@
       double precision :: tmu,tmv,tmw,qtot,var,tem
       double precision, dimension(nk) :: foo1,foo2,foo3
       double precision :: foot1,foot2,foot3
+      double precision :: qltmp,vrtmp
 
       tmu=0.0d0
       tmv=0.0d0
       tmw=0.0d0
+      qltmp=0.0d0
+      vrtmp=0.0d0
 
 #ifdef _B4B09R
       !$acc update host(qv,ql,qi,ruh,rvh,rmh,ua,va,wa,vr,rho)
 #else
-      !$acc parallel default(present) private(i,j,k,qtot,tem) reduction(+:tmu,tmv,tmw)
+      !$acc parallel default(present) private(i,j,k,qtot,tem) reduction(+:tmu,tmv,tmw,qltmp,vrtmp)
 #endif
       !$omp parallel do default(shared) private(i,j,k,qtot,tem)
 #ifndef _B4B09R
-      !$acc loop vector collapse(3) reduction(+:tmu,tmv,tmw)
+      !$acc loop vector collapse(3) reduction(+:tmu,tmv,tmw,qltmp,vrtmp)
 #endif
       do k=1,nk
         do j=1,nj
@@ -4002,6 +4004,8 @@
           tmw=tmw   &
                 +rho(i,j,k)*tem*(1.0+qtot)*( 0.5*(wa(i,j,k)+wa(i,j,k+1)) )   &
                 -rho(i,j,k)*tem*ql(i,j,k)*vr(i,j,k)
+          qltmp = qltmp+ql(i,j,k)
+          vrtmp = vrtmp+vr(i,j,k)
         enddo
         enddo
       enddo
@@ -4014,6 +4018,8 @@
       tmu=tmu*(dx*dy*dz)
       tmv=tmv*(dx*dy*dz)
       tmw=tmw*(dx*dy*dz)
+      vrtmp=vrtmp*(dx*dy*dz)
+      qltmp=qltmp*(dx*dy*dz)
       
 
 #ifdef MPI
@@ -4021,20 +4027,35 @@
       call MPI_REDUCE(tmu,var,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                       MPI_COMM_WORLD,ierr)
       tmu=var
+
       var=0.0d0
       call MPI_REDUCE(tmv,var,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                       MPI_COMM_WORLD,ierr)
       tmv=var
+
       var=0.0d0
       call MPI_REDUCE(tmw,var,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                       MPI_COMM_WORLD,ierr)
       tmw=var
+
+      var=0.0d0
+      call MPI_REDUCE(qltmp,var,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      qltmp=var
+
+      var=0.0d0
+      call MPI_REDUCE(vrtmp,var,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      vrtmp=var
+
       if(myid.eq.0)then
 #endif
  
       write(6,100) 'TMU   ',tmu
       write(6,100) 'TMV   ',tmv
       write(6,100) 'TMW   ',tmw
+      write(6,100) 'QL   ',qltmp
+      write(6,100) 'VR   ',vrtmp
 100   format(2x,'stat:: ',a6,':',1x,e13.6)
  
       nstat = nstat + 1

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3102,7 +3102,7 @@
           wsp = sqrt( ( ((ua(i,j,k)+ua(i+1,j,k))*dtdx*uh(i))**2     &
                        +((va(i,j,k)+va(i,j+1,k))*dtdy*vh(j))**2 )   &
                        +((wa(i,j,k)+wa(i,j,k+1))*dtdz*mh(i,j,k))**2 )
-          index=j*ni+i
+          index=(j-1)*ni+i
           if( wsp.gt.cfl(index) )then
             cfl(index) = wsp
             imaxt(index)=i
@@ -3122,7 +3122,7 @@
         do k=1,nk
           wsp = sqrt( ((ua(i,j,k)+ua(i+1,j,k))*dtdx*uh(i))**2     &
                      +((wa(i,j,k)+wa(i,j,k+1))*dtdz*mh(i,j,k))**2 )
-          index=j*ni+i
+          index=(j-1)*ni+i
           if( wsp.gt.cfl(index) )then
             cfl(index) = wsp
             imaxt(index)=i
@@ -3142,7 +3142,7 @@
         do k=1,nk
           wsp = sqrt( ((va(i,j,k)+va(i,j+1,k))*dtdy*vh(j))**2     &
                      +((wa(i,j,k)+wa(i,j,k+1))*dtdz*mh(i,j,k))**2 )
-          index=j*ni+i
+          index=(j-1)*ni+i
           if( wsp.gt.cfl(index) )then
             cfl(index) = wsp
             imaxt(index)=i

--- a/src/mp_driver.F
+++ b/src/mp_driver.F
@@ -159,7 +159,7 @@
 
     if(ptype.ne.5 .and. ptype .ne. 6) then 
       !$acc update &
-      !$acc host(asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
+      !$acc host(asq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
       !$acc      mf,rmf,zf,rain,prate,pi0,th0,rho0,prs0,qv0,rho,prs,dum1,dum2, &
       !$acc      dum3,dum4,dum5,dum6,dum7,dum8,w3d,ppi,pp3d,ppten,sten,tha,    &
       !$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
@@ -625,7 +625,7 @@
 
         ELSEIF(ptype.eq.6)THEN
           !!$acc update &
-          !!$acc host(asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
+          !!$acc host(asq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
           !!$acc      mf,rmf,zf,rain,prate,pi0,th0,rho0,prs0,qv0,rho,prs,dum1,dum2, &
           !!$acc      dum3,dum4,dum5,dum6,dum7,dum8,w3d,ppi,pp3d,ppten,sten,tha,    &
           !!$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
@@ -697,7 +697,7 @@
             enddo
           ENDIF
           !!$acc update &
-         !!$acc device(asq,bsq,rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
+         !!$acc device(asq,rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
           !!$acc      dum6,dum7,dum8,ppi,pp3d,ppten,sten,tha,    &
           !!$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
           !!$acc      dum2d5,effc,effi,effs,effr,effg,effis,tdiag,qdiag,out2d,out3d) 
@@ -1359,7 +1359,7 @@
     !print *,'ptype: ',ptype
     if(ptype.ne.5 .and. ptype .ne.6) then 
       !$acc update &
-      !$acc device(asq,bsq,rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
+      !$acc device(asq,rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
       !$acc      dum6,dum7,dum8,ppi,pp3d,ppten,sten,tha,    &
       !$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
       !$acc      dum2d5,effc,effi,effs,effr,effg,effis,tdiag,qdiag,out2d,out3d) 

--- a/src/mp_driver.F
+++ b/src/mp_driver.F
@@ -159,7 +159,7 @@
 
     if(ptype.ne.5 .and. ptype .ne. 6) then 
       !$acc update &
-      !$acc host(asq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
+      !$acc host(xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
       !$acc      mf,rmf,zf,rain,prate,pi0,th0,rho0,prs0,qv0,rho,prs,dum1,dum2, &
       !$acc      dum3,dum4,dum5,dum6,dum7,dum8,w3d,ppi,pp3d,ppten,sten,tha,    &
       !$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
@@ -625,7 +625,7 @@
 
         ELSEIF(ptype.eq.6)THEN
           !!$acc update &
-          !!$acc host(asq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
+          !!$acc host(xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
           !!$acc      mf,rmf,zf,rain,prate,pi0,th0,rho0,prs0,qv0,rho,prs,dum1,dum2, &
           !!$acc      dum3,dum4,dum5,dum6,dum7,dum8,w3d,ppi,pp3d,ppten,sten,tha,    &
           !!$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
@@ -679,7 +679,6 @@
           endif
           call fallout_GPU(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,2),qten(ib,jb,kb,2))
-          !stop 'mp_driver: after call to fallout_GPU'
           call satadj_GPU(4,dt,qbudget(1),qbudget(2),ruh,rvh,rmh,pi0,th0,   &
                       rho,dum3,pp3d,prs,th3d,q3d)
 
@@ -697,12 +696,11 @@
             enddo
           ENDIF
           !!$acc update &
-         !!$acc device(asq,rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
+         !!$acc device(rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
           !!$acc      dum6,dum7,dum8,ppi,pp3d,ppten,sten,tha,    &
           !!$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
           !!$acc      dum2d5,effc,effi,effs,effr,effg,effis,tdiag,qdiag,out2d,out3d) 
           if(timestats.ge.1) time_phys_H2D=time_phys_H2D+mytime()
-          !stop 'mp_driver: at the end of ptype==6'
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !  Ziegler/Mansell (NSSL) two-moment scheme
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -1359,7 +1357,7 @@
     !print *,'ptype: ',ptype
     if(ptype.ne.5 .and. ptype .ne.6) then 
       !$acc update &
-      !$acc device(asq,rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
+      !$acc device(rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
       !$acc      dum6,dum7,dum8,ppi,pp3d,ppten,sten,tha,    &
       !$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
       !$acc      dum2d5,effc,effi,effs,effr,effg,effis,tdiag,qdiag,out2d,out3d) 

--- a/src/mp_driver.F
+++ b/src/mp_driver.F
@@ -14,7 +14,7 @@
   !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-    subroutine mp_driver(nstep,dt,qbudget,qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,  &
+    subroutine mp_driver(nstep,dt,qbudget,asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,  &
                          mh,rmh,c1,c2,zh,mf,rmf,zf,rain,prate,pi0,th0,rho0,prs0,qv0,   &
                          rho,prs,dum1,dum2,dum3,dum4,dum5,dum6,dum7,dum8,  &
                          w3d,ppi,pp3d,ppten,sten,tha,th3d,thten,qa,q3d,qten,  &
@@ -41,7 +41,6 @@
     integer, intent(in) :: nstep
     real, intent(inout) :: dt
     double precision, intent(inout), dimension(nbudget) :: qbudget
-    double precision, intent(inout) :: qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9
     double precision, intent(inout), dimension(numq) :: asq,bsq
     real, intent(in), dimension(ib:ie) :: xh,ruh
     real, intent(in), dimension(ib:ie+1) :: xf,ruf
@@ -186,7 +185,7 @@
           call pdefq( qsmall,asq(2),ruh,rvh,rmh,rho,q3d(ib,jb,kb,2))
           call pdefq( qsmall,asq(3),ruh,rvh,rmh,rho,q3d(ib,jb,kb,3))
           call k_fallout(rho,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
-          call geterain(dt,cpl,lv1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
+          call geterain(dt,cpl,lv1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
           if(efall.ge.1)then
             call getcvm(dum2,q3d)
             call getefall(1,cpl,mf,dum1,dum2,dum4,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
@@ -216,12 +215,12 @@
               enddo
             endif
           endif
-          call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
-          call kessler(dt,qbudget3,qbudget4,qbudget5,ruh,rvh,rmh,pi0,th0,dum1,   &
+          call kessler(dt,qbudget(3),qbudget(4),qbudget(5),ruh,rvh,rmh,pi0,th0,dum1,   &
                        rho,dum3,pp3d,th3d,prs,                            &
                        q3d(ib,jb,kb,nqv),q3d(ib,jb,kb,2),q3d(ib,jb,kb,3))
-          call satadj(4,dt,qbudget1,qbudget2,ruh,rvh,rmh,pi0,th0,   &
+          call satadj(4,dt,qbudget(1),qbudget(2),ruh,rvh,rmh,pi0,th0,   &
                       rho,dum3,pp3d,prs,th3d,q3d)
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -236,19 +235,19 @@
           call pdefq( qsmall,asq(4),ruh,rvh,rmh,rho,q3d(ib,jb,kb,4))
           call pdefq( qsmall,asq(5),ruh,rvh,rmh,rho,q3d(ib,jb,kb,5))
           call pdefq( qsmall,asq(6),ruh,rvh,rmh,rho,q3d(ib,jb,kb,6))
-          call goddard(dt,qbudget3,qbudget4,qbudget5,ruh,rvh,rmh,pi0,th0,             &
+          call goddard(dt,qbudget(3),qbudget(4),qbudget(5),ruh,rvh,rmh,pi0,th0,             &
                        rho,dum3,prs,pp3d,th3d,                            &
      q3d(ib,jb,kb,1), q3d(ib,jb,kb,2),q3d(ib,jb,kb,3),qten(ib,jb,kb,3),   &
      q3d(ib,jb,kb,4),qten(ib,jb,kb,4),q3d(ib,jb,kb,5),qten(ib,jb,kb,5),   &
      q3d(ib,jb,kb,6),qten(ib,jb,kb,6))
-          call satadj_ice(4,dt,qbudget1,qbudget2,ruh,rvh,rmh,pi0,th0,     &
+          call satadj_ice(4,dt,qbudget(1),qbudget(2),ruh,rvh,rmh,pi0,th0,     &
                           rho,dum3,pp3d,prs,th3d,                     &
               q3d(ib,jb,kb,1),q3d(ib,jb,kb,2),q3d(ib,jb,kb,3),   &
               q3d(ib,jb,kb,4),q3d(ib,jb,kb,5),q3d(ib,jb,kb,6))
-          call geterain(dt,cpl,lv1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
-          call geterain(dt,cpi,ls1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,4),qten(ib,jb,kb,4))
-          call geterain(dt,cpi,ls1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,5),qten(ib,jb,kb,5))
-          call geterain(dt,cpi,ls1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,6),qten(ib,jb,kb,6))
+          call geterain(dt,cpl,lv1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
+          call geterain(dt,cpi,ls1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,4),qten(ib,jb,kb,4))
+          call geterain(dt,cpi,ls1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,5),qten(ib,jb,kb,5))
+          call geterain(dt,cpi,ls1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,6),qten(ib,jb,kb,6))
           if(efall.ge.1)then
             call getcvm(dum2,q3d)
             call getefall(1,cpl,mf,dum1,dum2,dum4,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
@@ -281,13 +280,13 @@
               enddo
             endif
           endif
-          call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
-          call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,4),qten(ib,jb,kb,4))
-          call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,5),qten(ib,jb,kb,5))
-          call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,6),qten(ib,jb,kb,6))
           if(getdbz) call calcdbz(rho,q3d(ib,jb,kb,3),q3d(ib,jb,kb,5),q3d(ib,jb,kb,6),  &
                                   qdiag(ibdq,jbdq,kbdq,qd_dbz))
@@ -347,8 +346,8 @@
                   re_cloud=dum6, re_ice=dum7, re_snow=dum8,                  &
                   has_reqc=has_reqc, has_reqi=has_reqi, has_reqs=has_reqs,   &
                   nrain=nrain,dx=dx, dy=dy, cm1dz=dz,                        &
-                  tcond=qbudget1,tevac=qbudget2,                         &
-                  tevar=qbudget5,train=qbudget6,                         &
+                  tcond=qbudget(1),tevac=qbudget(2),                         &
+                  tevar=qbudget(5),train=qbudget(6),                         &
                   ruh=ruh,rvh=rvh,rmh=rmh,rr=dum3,rain=rain,prate=prate,     &
                   ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d, &
                   nout3d=nout3d,out3d=out3d,eqtset=eqtset,                   &
@@ -418,7 +417,7 @@
           call lfo_ice_drive(dt, mf, pi0, prs0, pp3d, prs, th0, th3d,    &
                              qv0, rho0, q3d, qten, dum1)
           do n=2,numq
-            call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+            call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                          q3d(ib,jb,kb,n),qten(ib,jb,kb,n))
           enddo
 
@@ -480,7 +479,7 @@
                           q3d(ib,jb,kb,10),ppten,                             &
                                prs,rho,dt,dum4,w3d,rain,prate,                &
                           effc,effi,effs,effr,effg,effis,                     &
-                          qbudget1,qbudget2,qbudget5,qbudget6,        &
+                          qbudget(1),qbudget(2),qbudget(5),qbudget(6),        &
                           ruh,rvh,rmh,dum3,getdbz,                            &
                           qten(ib,jb,kb,nqc),qten(ib,jb,kb,nqr),qten(ib,jb,kb,nqi),  &
                           qten(ib,jb,kb,nqs),qten(ib,jb,kb,nqg),getvt,dorad,  &
@@ -648,7 +647,7 @@
           enddo
           enddo
           enddo
-          call geterain_GPU(dt,cpl,lv1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,2),qten(ib,jb,kb,2))
+          call geterain_GPU(dt,cpl,lv1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,2),qten(ib,jb,kb,2))
           if( efall.ge.1 .and. v_t.gt.1.0e-6 )then
             call getcvm_GPU(dum2,q3d)
             call getefall_GPU(1,cpl,mf,dum1,dum2,dum4,q3d(ib,jb,kb,2),qten(ib,jb,kb,2))
@@ -678,10 +677,10 @@
               enddo
             endif
           endif
-          call fallout_GPU(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout_GPU(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,2),qten(ib,jb,kb,2))
           !stop 'mp_driver: after call to fallout_GPU'
-          call satadj_GPU(4,dt,qbudget1,qbudget2,ruh,rvh,rmh,pi0,th0,   &
+          call satadj_GPU(4,dt,qbudget(1),qbudget(2),ruh,rvh,rmh,pi0,th0,   &
                       rho,dum3,pp3d,prs,th3d,q3d)
 
           IF( v_t.lt.(-0.0001) )THEN
@@ -764,10 +763,10 @@
                               dbz = qdiag(ibdq,jbdq,kbdq,qd_dbz), &
                               ruh = ruh, rvh = rvh, rmh = rmh, &
                               dx = dx, dy = dy,              &
-                              tcond = qbudget1,            &
-                              tevac = qbudget2,            &
-                              tevar = qbudget5,            &
-                              train = qbudget6,            &
+                              tcond = qbudget(1),            &
+                              tevac = qbudget(2),            &
+                              tevar = qbudget(5),            &
+                              train = qbudget(6),            &
                               rr    = dum3,                  &
                               diagflag = getdbz,                  &
                   ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d, &
@@ -806,10 +805,10 @@
                               dbz = qdiag(ibdq,jbdq,kbdq,qd_dbz), &
                               ruh = ruh, rvh = rvh, rmh = rmh, &
                               dx = dx, dy = dy,              &
-                              tcond = qbudget1,            &
-                              tevac = qbudget2,            &
-                              tevar = qbudget5,            &
-                              train = qbudget6,            &
+                              tcond = qbudget(1),            &
+                              tevac = qbudget(2),            &
+                              tevar = qbudget(5),            &
+                              train = qbudget(6),            &
                               rr    = dum3,                  &
                               diagflag = getdbz,             &
                   ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d, &
@@ -838,10 +837,10 @@
                               dbz = qdiag(ibdq,jbdq,kbdq,qd_dbz), &
                               ruh = ruh, rvh = rvh, rmh = rmh, &
                               dx = dx, dy = dy,              &
-                              tcond = qbudget1,            &
-                              tevac = qbudget2,            &
-                              tevar = qbudget5,            &
-                              train = qbudget6,            &
+                              tcond = qbudget(1),            &
+                              tevac = qbudget(2),            &
+                              tevar = qbudget(5),            &
+                              train = qbudget(6),            &
                               rr    = dum3,                  &
                               diagflag = getdbz,                  &
                   ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d, &
@@ -1006,12 +1005,12 @@
             if( axisymm.eq.1 )then
               do i=1,ni
                 prate(i,j) = p3a(i,1,22)*rdt
-                qbudget6 = qbudget6 + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy*dum3(i,j,1)/rho(i,j,1)
+                qbudget(6) = qbudget(6) + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy*dum3(i,j,1)/rho(i,j,1)
               enddo
             else
               do i=1,ni
                 prate(i,j) = p3a(i,1,22)*rdt
-                qbudget6 = qbudget6 + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy
+                qbudget(6) = qbudget(6) + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy
               enddo
             endif
 
@@ -1159,12 +1158,12 @@
             if( axisymm.eq.1 )then
               do i=1,ni
                 prate(i,j) = p3a(i,1,22)*rdt
-                qbudget6 = qbudget6 + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy*dum3(i,j,1)/rho(i,j,1)
+                qbudget(6) = qbudget(6) + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy*dum3(i,j,1)/rho(i,j,1)
               enddo
             else
               do i=1,ni
                 prate(i,j) = p3a(i,1,22)*rdt
-                qbudget6 = qbudget6 + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy
+                qbudget(6) = qbudget(6) + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy
               enddo
             endif
 
@@ -1277,7 +1276,7 @@
 !               q3d(ib,jb,kb,13), q3d(ib,jb,kb,14), q3d(ib,jb,kb,15), q3d(ib,jb,kb,16)
 
 !          write(6,*) ni, nk, nj, ib, ie, jb, je, kb, ke, rain(ib,jb,1),dum5(ib,jb,1)
-!          write(6,*) nrain, dx, dy, dz, qbudget1, qbudget2, qbudget5, qbudget6
+!          write(6,*) nrain, dx, dy, dz, qbudget(1), qbudget(2), qbudget(5), qbudget(6)
 !          write(6,*)  ruh(1), rvh(1), rmh(1,1,1), dum3(1,1,1), rain(1,1,1), prate(1,1)
 
 !               ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d, &
@@ -1310,8 +1309,8 @@
        diag_vmi3d_2=p3o(1,1,1, 5), diag_di3d_2=p3o(1,1,1, 6), diag_rhopo3d_2=p3o(1,1,1, 7), diag_phii3d_2=p3o(1,1,1, 8), &
        diag_vmi3d_3=p3o(1,1,1, 9), diag_di3d_3=p3o(1,1,1,10), diag_rhopo3d_3=p3o(1,1,1,11), diag_phii3d_3=p3o(1,1,1,12), &
                nrain=nrain,dx=dx, dy=dy, cm1dz=dz,                        &
-               tcond=qbudget1,tevac=qbudget2,                         &
-               tevar=qbudget5,train=qbudget6,                         &
+               tcond=qbudget(1),tevac=qbudget(2),                         &
+               tevar=qbudget(5),train=qbudget(6),                         &
                ruh=ruh,rvh=rvh,rmh=rmh,rr=dum3,rain=rain,prate=prate,     &
                ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d,eqtset=eqtset, &
                nout3d=nout3d,out3d=out3d,dowr=dowr,outfile=outfile,getdbz=getdbz,dorad=dorad)

--- a/src/mp_driver.F
+++ b/src/mp_driver.F
@@ -14,7 +14,7 @@
   !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-    subroutine mp_driver(nstep,dt,qbudget,asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,  &
+    subroutine mp_driver(nstep,dt,qbudget,qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,  &
                          mh,rmh,c1,c2,zh,mf,rmf,zf,rain,prate,pi0,th0,rho0,prs0,qv0,   &
                          rho,prs,dum1,dum2,dum3,dum4,dum5,dum6,dum7,dum8,  &
                          w3d,ppi,pp3d,ppten,sten,tha,th3d,thten,qa,q3d,qten,  &
@@ -41,6 +41,7 @@
     integer, intent(in) :: nstep
     real, intent(inout) :: dt
     double precision, intent(inout), dimension(nbudget) :: qbudget
+    double precision, intent(inout) :: qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9
     double precision, intent(inout), dimension(numq) :: asq,bsq
     real, intent(in), dimension(ib:ie) :: xh,ruh
     real, intent(in), dimension(ib:ie+1) :: xf,ruf
@@ -159,7 +160,7 @@
 
     if(ptype.ne.5 .and. ptype .ne. 6) then 
       !$acc update &
-      !$acc host(qbudget,asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
+      !$acc host(asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
       !$acc      mf,rmf,zf,rain,prate,pi0,th0,rho0,prs0,qv0,rho,prs,dum1,dum2, &
       !$acc      dum3,dum4,dum5,dum6,dum7,dum8,w3d,ppi,pp3d,ppten,sten,tha,    &
       !$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
@@ -185,7 +186,7 @@
           call pdefq( qsmall,asq(2),ruh,rvh,rmh,rho,q3d(ib,jb,kb,2))
           call pdefq( qsmall,asq(3),ruh,rvh,rmh,rho,q3d(ib,jb,kb,3))
           call k_fallout(rho,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
-          call geterain(dt,cpl,lv1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
+          call geterain(dt,cpl,lv1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
           if(efall.ge.1)then
             call getcvm(dum2,q3d)
             call getefall(1,cpl,mf,dum1,dum2,dum4,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
@@ -215,12 +216,12 @@
               enddo
             endif
           endif
-          call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
-          call kessler(dt,qbudget(3),qbudget(4),qbudget(5),ruh,rvh,rmh,pi0,th0,dum1,   &
+          call kessler(dt,qbudget3,qbudget4,qbudget5,ruh,rvh,rmh,pi0,th0,dum1,   &
                        rho,dum3,pp3d,th3d,prs,                            &
                        q3d(ib,jb,kb,nqv),q3d(ib,jb,kb,2),q3d(ib,jb,kb,3))
-          call satadj(4,dt,qbudget(1),qbudget(2),ruh,rvh,rmh,pi0,th0,   &
+          call satadj(4,dt,qbudget1,qbudget2,ruh,rvh,rmh,pi0,th0,   &
                       rho,dum3,pp3d,prs,th3d,q3d)
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -235,19 +236,19 @@
           call pdefq( qsmall,asq(4),ruh,rvh,rmh,rho,q3d(ib,jb,kb,4))
           call pdefq( qsmall,asq(5),ruh,rvh,rmh,rho,q3d(ib,jb,kb,5))
           call pdefq( qsmall,asq(6),ruh,rvh,rmh,rho,q3d(ib,jb,kb,6))
-          call goddard(dt,qbudget(3),qbudget(4),qbudget(5),ruh,rvh,rmh,pi0,th0,             &
+          call goddard(dt,qbudget3,qbudget4,qbudget5,ruh,rvh,rmh,pi0,th0,             &
                        rho,dum3,prs,pp3d,th3d,                            &
      q3d(ib,jb,kb,1), q3d(ib,jb,kb,2),q3d(ib,jb,kb,3),qten(ib,jb,kb,3),   &
      q3d(ib,jb,kb,4),qten(ib,jb,kb,4),q3d(ib,jb,kb,5),qten(ib,jb,kb,5),   &
      q3d(ib,jb,kb,6),qten(ib,jb,kb,6))
-          call satadj_ice(4,dt,qbudget(1),qbudget(2),ruh,rvh,rmh,pi0,th0,     &
+          call satadj_ice(4,dt,qbudget1,qbudget2,ruh,rvh,rmh,pi0,th0,     &
                           rho,dum3,pp3d,prs,th3d,                     &
               q3d(ib,jb,kb,1),q3d(ib,jb,kb,2),q3d(ib,jb,kb,3),   &
               q3d(ib,jb,kb,4),q3d(ib,jb,kb,5),q3d(ib,jb,kb,6))
-          call geterain(dt,cpl,lv1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
-          call geterain(dt,cpi,ls1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,4),qten(ib,jb,kb,4))
-          call geterain(dt,cpi,ls1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,5),qten(ib,jb,kb,5))
-          call geterain(dt,cpi,ls1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,6),qten(ib,jb,kb,6))
+          call geterain(dt,cpl,lv1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
+          call geterain(dt,cpi,ls1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,4),qten(ib,jb,kb,4))
+          call geterain(dt,cpi,ls1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,5),qten(ib,jb,kb,5))
+          call geterain(dt,cpi,ls1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,6),qten(ib,jb,kb,6))
           if(efall.ge.1)then
             call getcvm(dum2,q3d)
             call getefall(1,cpl,mf,dum1,dum2,dum4,q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
@@ -280,13 +281,13 @@
               enddo
             endif
           endif
-          call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,3),qten(ib,jb,kb,3))
-          call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,4),qten(ib,jb,kb,4))
-          call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,5),qten(ib,jb,kb,5))
-          call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,6),qten(ib,jb,kb,6))
           if(getdbz) call calcdbz(rho,q3d(ib,jb,kb,3),q3d(ib,jb,kb,5),q3d(ib,jb,kb,6),  &
                                   qdiag(ibdq,jbdq,kbdq,qd_dbz))
@@ -346,8 +347,8 @@
                   re_cloud=dum6, re_ice=dum7, re_snow=dum8,                  &
                   has_reqc=has_reqc, has_reqi=has_reqi, has_reqs=has_reqs,   &
                   nrain=nrain,dx=dx, dy=dy, cm1dz=dz,                        &
-                  tcond=qbudget(1),tevac=qbudget(2),                         &
-                  tevar=qbudget(5),train=qbudget(6),                         &
+                  tcond=qbudget1,tevac=qbudget2,                         &
+                  tevar=qbudget5,train=qbudget6,                         &
                   ruh=ruh,rvh=rvh,rmh=rmh,rr=dum3,rain=rain,prate=prate,     &
                   ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d, &
                   nout3d=nout3d,out3d=out3d,eqtset=eqtset,                   &
@@ -417,7 +418,7 @@
           call lfo_ice_drive(dt, mf, pi0, prs0, pp3d, prs, th0, th3d,    &
                              qv0, rho0, q3d, qten, dum1)
           do n=2,numq
-            call fallout(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+            call fallout(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                          q3d(ib,jb,kb,n),qten(ib,jb,kb,n))
           enddo
 
@@ -467,7 +468,7 @@
           ENDIF
           ! cm1r17:  get fall velocities (store in qten array)
           !$acc update &
-          !$acc host(qbudget,ruh,rvh,rmh,  &
+          !$acc host(ruh,rvh,rmh,  &
           !$acc      rain,prate,rho,prs,dum1,&
           !$acc      dum3,dum4,dum5,w3d,ppten,    &
           !$acc      q3d,qten,effc,effi,effs,effr,effg,effis,tdiag,qdiag,out3d) 
@@ -479,14 +480,14 @@
                           q3d(ib,jb,kb,10),ppten,                             &
                                prs,rho,dt,dum4,w3d,rain,prate,                &
                           effc,effi,effs,effr,effg,effis,                     &
-                          qbudget(1),qbudget(2),qbudget(5),qbudget(6),        &
+                          qbudget1,qbudget2,qbudget5,qbudget6,        &
                           ruh,rvh,rmh,dum3,getdbz,                            &
                           qten(ib,jb,kb,nqc),qten(ib,jb,kb,nqr),qten(ib,jb,kb,nqi),  &
                           qten(ib,jb,kb,nqs),qten(ib,jb,kb,nqg),getvt,dorad,  &
                           dotbud,doqbud,tdiag,qdiag,out3d)
           if(timestats.ge.1) time_microphy=time_microphy+mytime()
           !$acc update &
-          !$acc device(qbudget,rain,prate,rho,prs,dum1,dum3,dum4,dum5,ppten,   &
+          !$acc device(rain,prate,rho,prs,dum1,dum3,dum4,dum5,ppten,   &
           !$acc      q3d,qten,effc,effi,effs,effr,effg,effis,tdiag,qdiag,out3d) 
           if(timestats.ge.1) time_phys_H2D=time_phys_H2D+mytime()
           IF(numq.eq.11)THEN
@@ -625,7 +626,7 @@
 
         ELSEIF(ptype.eq.6)THEN
           !!$acc update &
-          !!$acc host(qbudget,asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
+          !!$acc host(asq,bsq,xh,ruh,xf,ruf,yh,rvh,yf,rvf,mh,rmh,c1,c2,zh,  &
           !!$acc      mf,rmf,zf,rain,prate,pi0,th0,rho0,prs0,qv0,rho,prs,dum1,dum2, &
           !!$acc      dum3,dum4,dum5,dum6,dum7,dum8,w3d,ppi,pp3d,ppten,sten,tha,    &
           !!$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
@@ -647,7 +648,7 @@
           enddo
           enddo
           enddo
-          call geterain_GPU(dt,cpl,lv1,qbudget(7),ruh,rvh,dum1,dum3,q3d(ib,jb,kb,2),qten(ib,jb,kb,2))
+          call geterain_GPU(dt,cpl,lv1,qbudget7,ruh,rvh,dum1,dum3,q3d(ib,jb,kb,2),qten(ib,jb,kb,2))
           if( efall.ge.1 .and. v_t.gt.1.0e-6 )then
             call getcvm_GPU(dum2,q3d)
             call getefall_GPU(1,cpl,mf,dum1,dum2,dum4,q3d(ib,jb,kb,2),qten(ib,jb,kb,2))
@@ -677,10 +678,10 @@
               enddo
             endif
           endif
-          call fallout_GPU(dt,qbudget(6),ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
+          call fallout_GPU(dt,qbudget6,ruh,rvh,zh,mh,mf,rain,prate,dum3,rho,   &
                        q3d(ib,jb,kb,2),qten(ib,jb,kb,2))
           !stop 'mp_driver: after call to fallout_GPU'
-          call satadj_GPU(4,dt,qbudget(1),qbudget(2),ruh,rvh,rmh,pi0,th0,   &
+          call satadj_GPU(4,dt,qbudget1,qbudget2,ruh,rvh,rmh,pi0,th0,   &
                       rho,dum3,pp3d,prs,th3d,q3d)
 
           IF( v_t.lt.(-0.0001) )THEN
@@ -697,7 +698,7 @@
             enddo
           ENDIF
           !!$acc update &
-         !!$acc device(qbudget,asq,bsq,rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
+         !!$acc device(asq,bsq,rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
           !!$acc      dum6,dum7,dum8,ppi,pp3d,ppten,sten,tha,    &
           !!$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
           !!$acc      dum2d5,effc,effi,effs,effr,effg,effis,tdiag,qdiag,out2d,out3d) 
@@ -763,10 +764,10 @@
                               dbz = qdiag(ibdq,jbdq,kbdq,qd_dbz), &
                               ruh = ruh, rvh = rvh, rmh = rmh, &
                               dx = dx, dy = dy,              &
-                              tcond = qbudget(1),            &
-                              tevac = qbudget(2),            &
-                              tevar = qbudget(5),            &
-                              train = qbudget(6),            &
+                              tcond = qbudget1,            &
+                              tevac = qbudget2,            &
+                              tevar = qbudget5,            &
+                              train = qbudget6,            &
                               rr    = dum3,                  &
                               diagflag = getdbz,                  &
                   ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d, &
@@ -805,10 +806,10 @@
                               dbz = qdiag(ibdq,jbdq,kbdq,qd_dbz), &
                               ruh = ruh, rvh = rvh, rmh = rmh, &
                               dx = dx, dy = dy,              &
-                              tcond = qbudget(1),            &
-                              tevac = qbudget(2),            &
-                              tevar = qbudget(5),            &
-                              train = qbudget(6),            &
+                              tcond = qbudget1,            &
+                              tevac = qbudget2,            &
+                              tevar = qbudget5,            &
+                              train = qbudget6,            &
                               rr    = dum3,                  &
                               diagflag = getdbz,             &
                   ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d, &
@@ -837,10 +838,10 @@
                               dbz = qdiag(ibdq,jbdq,kbdq,qd_dbz), &
                               ruh = ruh, rvh = rvh, rmh = rmh, &
                               dx = dx, dy = dy,              &
-                              tcond = qbudget(1),            &
-                              tevac = qbudget(2),            &
-                              tevar = qbudget(5),            &
-                              train = qbudget(6),            &
+                              tcond = qbudget1,            &
+                              tevac = qbudget2,            &
+                              tevar = qbudget5,            &
+                              train = qbudget6,            &
                               rr    = dum3,                  &
                               diagflag = getdbz,                  &
                   ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d, &
@@ -1005,12 +1006,12 @@
             if( axisymm.eq.1 )then
               do i=1,ni
                 prate(i,j) = p3a(i,1,22)*rdt
-                qbudget(6) = qbudget(6) + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy*dum3(i,j,1)/rho(i,j,1)
+                qbudget6 = qbudget6 + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy*dum3(i,j,1)/rho(i,j,1)
               enddo
             else
               do i=1,ni
                 prate(i,j) = p3a(i,1,22)*rdt
-                qbudget(6) = qbudget(6) + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy
+                qbudget6 = qbudget6 + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy
               enddo
             endif
 
@@ -1158,12 +1159,12 @@
             if( axisymm.eq.1 )then
               do i=1,ni
                 prate(i,j) = p3a(i,1,22)*rdt
-                qbudget(6) = qbudget(6) + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy*dum3(i,j,1)/rho(i,j,1)
+                qbudget6 = qbudget6 + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy*dum3(i,j,1)/rho(i,j,1)
               enddo
             else
               do i=1,ni
                 prate(i,j) = p3a(i,1,22)*rdt
-                qbudget(6) = qbudget(6) + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy
+                qbudget6 = qbudget6 + p3a(i,1,22)*ruh(i)*rvh(j)*dx*dy
               enddo
             endif
 
@@ -1276,7 +1277,7 @@
 !               q3d(ib,jb,kb,13), q3d(ib,jb,kb,14), q3d(ib,jb,kb,15), q3d(ib,jb,kb,16)
 
 !          write(6,*) ni, nk, nj, ib, ie, jb, je, kb, ke, rain(ib,jb,1),dum5(ib,jb,1)
-!          write(6,*) nrain, dx, dy, dz, qbudget(1), qbudget(2), qbudget(5), qbudget(6)
+!          write(6,*) nrain, dx, dy, dz, qbudget1, qbudget2, qbudget5, qbudget6
 !          write(6,*)  ruh(1), rvh(1), rmh(1,1,1), dum3(1,1,1), rain(1,1,1), prate(1,1)
 
 !               ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d, &
@@ -1309,8 +1310,8 @@
        diag_vmi3d_2=p3o(1,1,1, 5), diag_di3d_2=p3o(1,1,1, 6), diag_rhopo3d_2=p3o(1,1,1, 7), diag_phii3d_2=p3o(1,1,1, 8), &
        diag_vmi3d_3=p3o(1,1,1, 9), diag_di3d_3=p3o(1,1,1,10), diag_rhopo3d_3=p3o(1,1,1,11), diag_phii3d_3=p3o(1,1,1,12), &
                nrain=nrain,dx=dx, dy=dy, cm1dz=dz,                        &
-               tcond=qbudget(1),tevac=qbudget(2),                         &
-               tevar=qbudget(5),train=qbudget(6),                         &
+               tcond=qbudget1,tevac=qbudget2,                         &
+               tevar=qbudget5,train=qbudget6,                         &
                ruh=ruh,rvh=rvh,rmh=rmh,rr=dum3,rain=rain,prate=prate,     &
                ib3d=ib3d,ie3d=ie3d,jb3d=jb3d,je3d=je3d,kb3d=kb3d,ke3d=ke3d,eqtset=eqtset, &
                nout3d=nout3d,out3d=out3d,dowr=dowr,outfile=outfile,getdbz=getdbz,dorad=dorad)
@@ -1359,7 +1360,7 @@
     !print *,'ptype: ',ptype
     if(ptype.ne.5 .and. ptype .ne.6) then 
       !$acc update &
-      !$acc device(qbudget,asq,bsq,rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
+      !$acc device(asq,bsq,rain,prate,rho,prs,dum1,dum2,dum3,dum4,dum5,  &
       !$acc      dum6,dum7,dum8,ppi,pp3d,ppten,sten,tha,    &
       !$acc      th3d,thten,qa,q3d,qten,p3a,p3o,dum2d1,dum2d2,dum2d3,dum2d4,   &
       !$acc      dum2d5,effc,effi,effs,effr,effg,effis,tdiag,qdiag,out2d,out3d) 

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -787,7 +787,6 @@
       enddo
       enddo
     endif
-    !$acc compare(qt)
       IF(iice.eq.1)THEN
         do n=nqs1,nqs2
         !$omp parallel do default(shared) private(i,j,k)
@@ -813,7 +812,6 @@
         enddo
         enddo
       ENDIF
-      !$acc compare(th,t)
       IF( prb.ge.1 .or. prvpg.ge.1 )THEN
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
@@ -826,7 +824,6 @@
         enddo
         enddo
         enddo
-        !$acc compare(dum7)
       ENDIF
       IF( prvpg.ge.1 )THEN
         !$omp parallel do default(shared) private(i,j,k)
@@ -838,7 +835,6 @@
         enddo
         enddo
         enddo
-        !$acc compare(dum8)
       ENDIF
 
 
@@ -857,7 +853,6 @@
         enddo
         enddo
        enddo
-       !$acc compare(th,t)
       ENDIF
       IF( prb.ge.1 .or. prvpg.ge.1 )THEN
        !$omp parallel do default(shared) private(i,j,k)
@@ -869,7 +864,6 @@
         enddo
         enddo
        enddo
-       !$acc compare(dum7)
       ENDIF
       IF( prvpg.ge.1 )THEN
        !$omp parallel do default(shared) private(i,j,k)
@@ -881,7 +875,6 @@
         enddo
         enddo
        enddo
-       !$acc compare(dum8)
       ENDIF
 
 
@@ -902,7 +895,6 @@
       !!$acc update device(buoy)
       call    prepcornert_GPU(buoy,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,1)
-      !$acc compare(buoy)
       !!$acc update host(buoy)
 
       !$omp parallel do default(shared) private(i,j)
@@ -917,7 +909,6 @@
                                      /(  zf(i,j,nk  )-  zf(i,j,nk-1))
       enddo
       enddo
-      !$acc compare(buoy)
     ENDIF
     IF( prvpg.ge.1 )THEN
     if( .not. terrain_flag )then
@@ -932,7 +923,6 @@
       enddo
       enddo
       enddo
-      !$acc compare(vpg)
     else
       !$omp parallel do default(shared) private(i,j,k)
       !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,tem1)
@@ -945,7 +935,6 @@
       enddo
       enddo
       enddo
-      !$acc compare(vpg)
     endif
       if(timestats.ge.1) time_parceli=time_parceli+mytime()
       !!$acc update device(vpg)
@@ -978,7 +967,6 @@
       call bcw2_GPU(w3d)
       !!$acc update host(u3d,v3d,w3d)
 #endif
-      !$acc compare(u3d,v3d,w3d)
 
 !----------------------------------------------------------------------
 !  apply bottom/top boundary conditions:
@@ -1001,7 +989,6 @@
         v3d(i,j,0) = cgs1*v3d(i,j,1)+cgs2*v3d(i,j,2)+cgs3*v3d(i,j,3)
       enddo
     ENDDO
-    !$acc compare(u3d,v3d)
   ELSEIF(bbc.eq.2)THEN
     ! no slip:
     if( imove.eq.1 )then
@@ -1017,7 +1004,6 @@
           v3d(i,j,0) = 0.0 - vmove
         enddo
        ENDDO
-    !$acc compare(u3d,v3d)
     else
       !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
       DO j=jb,je
@@ -1067,7 +1053,6 @@
       enddo
     ENDDO
   ENDIF
-    !$acc compare(u3d,v3d)
 
 !----------
 
@@ -1086,14 +1071,12 @@
         call prepcorners_GPU(th ,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
         !!$acc update host(th)
-        !$acc compare(th)
       endif
       !print *,'parcel_interp: point #2'
       if( prt.ge.1 )then
         !!$acc update device(t)
         call prepcorners_GPU(t  ,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
-        !$acc compare(t)
         !!$acc update host(t)
       endif
       !print *,'parcel_interp: point #3'
@@ -1102,7 +1085,6 @@
         call prepcorners_GPU(prs,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
         !!$acc update host(prs)
-        !$acc compare(prs)
       endif
       !print *,'parcel_interp: point #4'
       if( prrho.ge.1 )then
@@ -1110,7 +1092,6 @@
         call prepcorners_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
         !!$acc update host(rho)
-        !$acc compare(rho)
       endif
       !print *,'parcel_interp: point #5'
       if(prpt1.ge.1)then
@@ -1120,7 +1101,6 @@
                                             pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,0)
         enddo
         !!$acc update host(pt3d)
-        !$acc compare(pt3d)
       endif
       !print *,'parcel_interp: point #6'
       !!$acc update device(q3d)
@@ -1135,7 +1115,6 @@
                                            pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,0)
         enddo
       endif
-      !$acc compare(q3d)
       !!$acc update host(q3d)
       !print *,'parcel_interp: point #8'
       !!$acc update device(kmh,kmv)
@@ -1145,7 +1124,6 @@
         call prepcornert_GPU(kmv,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,0)
       endif
-      !$acc compare(kmh,kmv)
       !!$acc update host(kmh,kmv)
       !print *,'parcel_interp: point #9'
       !!$acc update device(khh,khv)
@@ -1155,7 +1133,6 @@
         call prepcornert_GPU(khv,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,0)
       endif
-      !$acc compare(khh,khv)
       !!$acc update host(khh,khv)
       !print *,'parcel_interp: point #10'
       !!$acc update device(tke3d)
@@ -1163,7 +1140,6 @@
         call prepcornert_GPU(tke3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,0)
       endif
-      !$acc compare(tke3d)
       !!$acc update host(tke3d)
       !print *,'parcel_interp: point #11'
       !!$acc update device(qdiag)
@@ -1173,7 +1149,6 @@
                              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
       endif
       !!$acc update host(qdiag)
-      !$acc compare(qdiag)
 
 !----------------------------------------------------------------------
 
@@ -1222,7 +1197,6 @@
                             pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
       !!$acc update host(dum2)
     ENDIF
-    !$acc compare(dum1,dum2)
     !  print *,'parcel_interp: point #13'
 
 !----------------------------------------------------------------------
@@ -1245,13 +1219,11 @@
       enddo
 
     ENDIF
-    !$acc compare(zv)
     !HERE print *,'parcel_interp: before nploop2'
 !----------------------------------------------------------------------
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !----------------------------------------------------------------------
 !  Loop through all parcels:  if you have it, get interpolated info:
-    !stop 'parcel_interp: before nploop2'
     !PORTME
     !$acc parallel loop gang vector default(present) &
     !$acc   private(x3d,y3d,z3d,i,j,k,n,iflag,jflag,kflag, &
@@ -1788,7 +1760,6 @@
       ENDIF  myprcl
 
     ENDDO  nploop2
-    !$acc compare(pdata)
     if(timestats.ge.1) time_parceli=time_parceli+mytime()
 
 !----------------------------------------------------------------------
@@ -1807,7 +1778,6 @@
 #endif
 !----------------------------------------------------------------------
 
-      !stop 'parcel_interp: at the end of the subroutine'
 
       end subroutine parcel_interp
 

--- a/src/restart.F
+++ b/src/restart.F
@@ -14,7 +14,7 @@
                                avgsfcu,avgsfcv,avgsfcs,avgsfct,                     &
                                dt,dtlast,mtime,ndt,adt,acfl,dbldt,mass1,            &
                                stattim,taptim,rsttim,radtim,prcltim,                &
-                               qbudget,qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10,asq,bsq,qname,                               &
+                               qbudget,asq,bsq,qname,                               &
                                xfref,yfref,zh,zf,sigma,sigmaf,zs,                   &
                                th0,prs0,pi0,rho0,qv0,u0,v0,                         &
                                rain,sws,svs,sps,srs,sgs,sus,shs,                    &
@@ -70,7 +70,6 @@
       double precision, intent(in) :: mass1
       double precision, intent(in) :: mtime,stattim,taptim,rsttim,radtim,prcltim
       double precision, intent(inout), dimension(nbudget) :: qbudget
-      double precision, intent(inout) :: qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10
       double precision, intent(inout), dimension(numq) :: asq,bsq
       character(len=3), intent(in), dimension(maxq) :: qname
       real, intent(in), dimension(1-ngxy:nx+ngxy+1) :: xfref
@@ -513,84 +512,6 @@
         enddo
       else
         qbudget = 0.0
-      endif
-
-      call MPI_REDUCE(qbudget1,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget(1)=qbudget1
-      else
-        qbudget(1) = 0.0
-      endif
-
-      call MPI_REDUCE(qbudget2,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget(2)=qbudget2
-      else
-        qbudget(2) = 0.0
-      endif
-
-      call MPI_REDUCE(qbudget3,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget(3)=qbudget3
-      else
-        qbudget(3) = 0.0
-      endif
-
-      call MPI_REDUCE(qbudget4,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget(4)=qbudget4
-      else
-        qbudget(4) = 0.0
-      endif
-
-      call MPI_REDUCE(qbudget5,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget(5)=qbudget5
-      else
-        qbudget(5) = 0.0
-      endif
-
-      call MPI_REDUCE(qbudget6,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget(6)=qbudget6
-      else
-        qbudget(6) = 0.0
-      endif
-
-      call MPI_REDUCE(qbudget7,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget(7)=qbudget7
-      else
-        qbudget(7) = 0.0
-      endif
-      call MPI_REDUCE(qbudget8,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget(8)=qbudget8
-      else
-        qbudget(8) = 0.0
-      endif
-
-      call MPI_REDUCE(qbudget9,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget(9)=qbudget9
-      else
-        qbudget(9) = 0.0
-      endif
-      call MPI_REDUCE(qbudget10,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget(10)=qbudget10
-      else
-        qbudget(10) = 0.0
       endif
 
       if( imoist.eq.1 )then

--- a/src/restart.F
+++ b/src/restart.F
@@ -14,7 +14,7 @@
                                avgsfcu,avgsfcv,avgsfcs,avgsfct,                     &
                                dt,dtlast,mtime,ndt,adt,acfl,dbldt,mass1,            &
                                stattim,taptim,rsttim,radtim,prcltim,                &
-                               qbudget,asq,bsq,qname,                               &
+                               qbudget,qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10,asq,bsq,qname,                               &
                                xfref,yfref,zh,zf,sigma,sigmaf,zs,                   &
                                th0,prs0,pi0,rho0,qv0,u0,v0,                         &
                                rain,sws,svs,sps,srs,sgs,sus,shs,                    &
@@ -70,6 +70,7 @@
       double precision, intent(in) :: mass1
       double precision, intent(in) :: mtime,stattim,taptim,rsttim,radtim,prcltim
       double precision, intent(inout), dimension(nbudget) :: qbudget
+      double precision, intent(inout) :: qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10
       double precision, intent(inout), dimension(numq) :: asq,bsq
       character(len=3), intent(in), dimension(maxq) :: qname
       real, intent(in), dimension(1-ngxy:nx+ngxy+1) :: xfref
@@ -146,6 +147,7 @@
       integer :: proc,index,count,req1,req2,req3,reqp
       double precision, dimension(nbudget) :: cfoo
       double precision, dimension(numq) :: afoo,bfoo
+      double precision :: tfoo
 #endif
 #ifdef NETCDF
       integer :: varid,ncstatus
@@ -503,7 +505,7 @@
 !-----------------------------------------------------------------------
 #ifdef MPI
       cfoo = 0.0
-      call MPI_REDUCE(qbudget(1),cfoo(1),nbudget,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+      call MPI_REDUCE(qbudget,cfoo,nbudget,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                       MPI_COMM_WORLD,ierr)
       if( myid.eq.0 )then
         do n=1,nbudget
@@ -512,6 +514,85 @@
       else
         qbudget = 0.0
       endif
+
+      call MPI_REDUCE(qbudget1,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget(1)=qbudget1
+      else
+        qbudget(1) = 0.0
+      endif
+
+      call MPI_REDUCE(qbudget2,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget(2)=qbudget2
+      else
+        qbudget(2) = 0.0
+      endif
+
+      call MPI_REDUCE(qbudget3,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget(3)=qbudget3
+      else
+        qbudget(3) = 0.0
+      endif
+
+      call MPI_REDUCE(qbudget4,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget(4)=qbudget4
+      else
+        qbudget(4) = 0.0
+      endif
+
+      call MPI_REDUCE(qbudget5,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget(5)=qbudget5
+      else
+        qbudget(5) = 0.0
+      endif
+
+      call MPI_REDUCE(qbudget6,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget(6)=qbudget6
+      else
+        qbudget(6) = 0.0
+      endif
+
+      call MPI_REDUCE(qbudget7,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget(7)=qbudget7
+      else
+        qbudget(7) = 0.0
+      endif
+      call MPI_REDUCE(qbudget8,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget(8)=qbudget8
+      else
+        qbudget(8) = 0.0
+      endif
+
+      call MPI_REDUCE(qbudget9,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget(9)=qbudget9
+      else
+        qbudget(9) = 0.0
+      endif
+      call MPI_REDUCE(qbudget10,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget(10)=qbudget10
+      else
+        qbudget(10) = 0.0
+      endif
+
       if( imoist.eq.1 )then
         afoo = 0.0
         call MPI_REDUCE(asq(1),afoo(1),numq,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &

--- a/src/restart.F
+++ b/src/restart.F
@@ -146,7 +146,6 @@
       integer :: proc,index,count,req1,req2,req3,reqp
       double precision, dimension(nbudget) :: cfoo
       double precision, dimension(numq) :: afoo,bfoo
-      double precision :: tfoo
 #endif
 #ifdef NETCDF
       integer :: varid,ncstatus

--- a/src/restart.F
+++ b/src/restart.F
@@ -516,7 +516,7 @@
 
       if( imoist.eq.1 )then
         afoo = 0.0
-        call MPI_REDUCE(asq(1),afoo(1),numq,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+        call MPI_REDUCE(asq,afoo,numq,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                         MPI_COMM_WORLD,ierr)
         if( myid.eq.0 )then
           do n=1,numq
@@ -526,7 +526,7 @@
           asq = 0.0
         endif
         bfoo = 0.0
-        call MPI_REDUCE(bsq(1),bfoo(1),numq,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+        call MPI_REDUCE(bsq,bfoo,numq,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                         MPI_COMM_WORLD,ierr)
         if( myid.eq.0 )then
           do n=1,numq

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -1148,7 +1148,7 @@
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfcv,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfcs,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfct,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-      !$acc update device(avgsfcu,avgsfcv,avgsfcs,avgsfct)
+      !!$acc update device(avgsfcu,avgsfcv,avgsfcs,avgsfct)
 #endif
 
       !JMD FIXME
@@ -1156,13 +1156,13 @@
       !JMD values and should be located in the CPU memory.  For some reason if I
       !JMD remove the acc parallel directive the GPU results are further away from
       !JMD the CPU results.
-      !$acc parallel 
+      !!$acc parallel 
       temd = 1.0/dble(nx*ny)
       avgsfcu = avgsfcu*temd
       avgsfcv = avgsfcv*temd
       avgsfcs = avgsfcs*temd
       avgsfct = avgsfct*temd
-      !$acc end parallel
+      !!$acc end parallel
 
       if(timestats.ge.1) time_sfcphys=time_sfcphys+mytime()
 

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -341,7 +341,7 @@
 
       !$acc declare &
       !$acc present(ruh,rvh,ch,th0,tsk,mavail,s1,rf,tha,qva,s10, &
-      !$acc         thflux,qvflux,qbsfc,qsfc)
+      !$acc         thflux,qvflux,qsfc)
 !-----------------------------------------------------------------------
 !
 !  This subroutine calculates surface fluxes of heat and moisture.

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -1148,21 +1148,13 @@
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfcv,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfcs,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,avgsfct,1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-      !!$acc update device(avgsfcu,avgsfcv,avgsfcs,avgsfct)
 #endif
 
-      !JMD FIXME
-      !JMD Don't quite understand what is going on here.  THese are scalar
-      !JMD values and should be located in the CPU memory.  For some reason if I
-      !JMD remove the acc parallel directive the GPU results are further away from
-      !JMD the CPU results.
-      !!$acc parallel 
       temd = 1.0/dble(nx*ny)
       avgsfcu = avgsfcu*temd
       avgsfcv = avgsfcv*temd
       avgsfcs = avgsfcs*temd
       avgsfct = avgsfct*temd
-      !!$acc end parallel
 
       if(timestats.ge.1) time_sfcphys=time_sfcphys+mytime()
 

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -79,7 +79,7 @@
 
       subroutine solve1(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,qbudget8,qbudget9,qbudget10,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,xhref,yfref,yhref,dumk1,dumk2,rds,sigma,rdsf,sigmaf, &
@@ -180,6 +180,7 @@
       double precision, intent(inout), dimension(nk) :: bud
       double precision, intent(inout), dimension(nj) :: bud2
       double precision, intent(inout), dimension(nbudget) :: qbudget
+      double precision :: qbudget8,qbudget9,qbudget10
       double precision, intent(inout), dimension(numq) :: asq,bsq
       real, intent(in), dimension(ib:ie) :: xh,rxh,arh1,arh2,uh,ruh
       real, intent(in), dimension(ib:ie+1) :: xf,rxf,arf1,arf2,uf,ruf
@@ -361,7 +362,7 @@
       !$acc present(m11,m12,m13,m22,m23,m33) &
       !$acc present(kmw,u1b,v1b) &
       !$acc present(tauh,tauf,taus) &
-      !$acc present(bud2,qbudget) &
+      !$acc present(bud2) &
       !$acc present(ufrc,vfrc,thfrc,qvfrc) &
       !$acc present(t11,t12,t13,t22,t23,t33) &
       !$acc present(thflux,qvflux) &
@@ -1024,7 +1025,7 @@
         enddo
         enddo
 #ifdef _B4B03R
-        !$acc update host(budarray,qbudget)
+        !$acc update host(budarray)
 #else
         !$acc parallel default(present) reduction(+:budtmp,qtmp)
 #endif
@@ -1043,12 +1044,11 @@
           bud2(j)=budtmp
           qtmp = qtmp + dt*dx*dy*dz*bud2(j)
         enddo
-        qbudget(9) = qtmp;
-#ifdef _B4B03R
-        !$acc update device(qbudget)
-#else
+#ifndef _B4B03R
         !$acc end parallel
 #endif
+        qbudget(9) = qtmp;
+        qbudget9=qtmp
         !$acc end data
         if(timestats.ge.1) time_misc09=time_misc09+mytime()
       endif
@@ -1157,29 +1157,33 @@
         tem0 = dt*dx*dy*dz
         !FIXME
         !$omp parallel do default(shared) private(i,j,k,thrad,prad)
-        !$acc parallel loop gang vector default(present) private(i,j,k,thrad,prad)
+        !$acc parallel default(present) private(i,j,k,thrad,prad) reduction(+:budtmp)
+        !$acc loop gang
         do k=1,nk
-        bud(k)=0.0d0
-        do j=1,nj
-        do i=1,ni
-          ! NOTE:  thrad is a POTENTIAL TEMPERATURE tendency
-          thrad = -tha(i,j,k)/(12.0*3600.0)
-          if( tha(i,j,k).gt. 1.0 ) thrad = -1.0/(12.0*3600.0)
-          if( tha(i,j,k).lt.-1.0 ) thrad =  1.0/(12.0*3600.0)
-          thten1(i,j,k)=thten1(i,j,k)+thrad
-          ! associated pressure tendency:
-          prad = (pi0(i,j,k)+ppi(i,j,k))*rddcv*thrad/(th0(i,j,k)+tha(i,j,k))
-          ! budget:
-          bud(k) = bud(k) + dum1(i,j,k)*dum2(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)*( &
+          budtmp=0.0d0
+          !$acc loop vector reduction(+:budtmp)
+          do j=1,nj
+          do i=1,ni
+            ! NOTE:  thrad is a POTENTIAL TEMPERATURE tendency
+            thrad = -tha(i,j,k)/(12.0*3600.0)
+            if( tha(i,j,k).gt. 1.0 ) thrad = -1.0/(12.0*3600.0)
+            if( tha(i,j,k).lt.-1.0 ) thrad =  1.0/(12.0*3600.0)
+            thten1(i,j,k)=thten1(i,j,k)+thrad
+            ! associated pressure tendency:
+            prad = (pi0(i,j,k)+ppi(i,j,k))*rddcv*thrad/(th0(i,j,k)+tha(i,j,k))
+            ! budget:
+            budtmp = budtmp + dum1(i,j,k)*dum2(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)*( &
                             thrad*(pi0(i,j,k)+ppi(i,j,k))    &
                            + prad*(th0(i,j,k)+tha(i,j,k)) )
+          enddo
+          enddo
+          bud(k) = budtmp
         enddo
-        enddo
-        enddo
+        !$acc end parallel
         !FIXME
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) private(k) reduction(+:qbudget10)
         do k=1,nk
-          qbudget(10) = qbudget(10) + tem0*bud(k)
+          qbudget10 = qbudget10 + tem0*bud(k)
         enddo
         if( dotbud .and. td_rad.ge.1 )then
           !$omp parallel do default(shared) private(i,j,k)

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -79,7 +79,7 @@
 
       subroutine solve1(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,qbudget8,qbudget9,qbudget10,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,xhref,yfref,yhref,dumk1,dumk2,rds,sigma,rdsf,sigmaf, &
@@ -180,7 +180,6 @@
       double precision, intent(inout), dimension(nk) :: bud
       double precision, intent(inout), dimension(nj) :: bud2
       double precision, intent(inout), dimension(nbudget) :: qbudget
-      double precision :: qbudget8,qbudget9,qbudget10
       double precision, intent(inout), dimension(numq) :: asq,bsq
       real, intent(in), dimension(ib:ie) :: xh,rxh,arh1,arh2,uh,ruh
       real, intent(in), dimension(ib:ie+1) :: xf,rxf,arf1,arf2,uf,ruf
@@ -1048,7 +1047,6 @@
         !$acc end parallel
 #endif
         qbudget(9) = qtmp;
-        qbudget9=qtmp
         !$acc end data
         if(timestats.ge.1) time_misc09=time_misc09+mytime()
       endif
@@ -1181,10 +1179,12 @@
         enddo
         !$acc end parallel
         !FIXME
-        !$acc parallel loop gang vector default(present) private(k) reduction(+:qbudget10)
+        budtmp=qbudget(10)
+        !$acc parallel loop gang vector default(present) private(k) reduction(+:budtmp)
         do k=1,nk
-          qbudget10 = qbudget10 + tem0*bud(k)
+          budtmp = budtmp + tem0*bud(k)
         enddo
+        qbudget(10)=budtmp
         if( dotbud .and. td_rad.ge.1 )then
           !$omp parallel do default(shared) private(i,j,k)
           !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -1250,9 +1250,9 @@
 
         get_time_avg = .false.
 
-      text1='sv2.15'
-      text2='sv2.15'
-      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+      !text1='sv2.15'
+      !text2='sv2.15'
+      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
         IF(psolver.eq.1)THEN
 
@@ -1352,9 +1352,9 @@
                         pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
 
         ENDIF
-      text1='sv2.16'
-      text2='sv2.16'
-      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+      !text1='sv2.16'
+      !text2='sv2.16'
+      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
 !--------------------------------------------------------------------
 !  Update v for axisymmetric model simulations:
@@ -1459,9 +1459,9 @@
 !  For Bryan-Fritsch equation set, compute 3d divergence.
 !     Store in T11 array.
 
-      text1='sv2.17'
-      text2='sv2.17'
-      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+      !text1='sv2.17'
+      !text2='sv2.17'
+      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
     IF( imoist.eq.1 .and. eqtset.eq.2 )THEN
       if( get_time_avg )then
         ! cm1r19:  rru,rrv,rrw store small-step-avg velocities
@@ -1472,9 +1472,9 @@
                         rds,rdsf,sigma,sigmaf,gz,rgzu,rgzv,dzdx,dzdy)
       endif
     ENDIF
-      text1='sv2.18'
-      text2='sv2.18'
-      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+      !text1='sv2.18'
+      !text2='sv2.18'
+      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
 !--------------------------------------------------------------------
 
@@ -1836,9 +1836,9 @@
 !  bcs and comms:
 
       !print *,'solve2: point #19'
-      text1='sv2.19'
-      text2='sv2.19'
-      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+      !text1='sv2.19'
+      !text2='sv2.19'
+      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
       call bcu_GPU(u3d)
 #ifdef MPI

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -154,6 +154,7 @@
       use bc_module
       use comm_module
       use adv_module
+      use maxmin_module
       use adv_routines , only : movesfc
       use sound_module
       use sounde_module
@@ -347,6 +348,8 @@
 #ifdef MPI
       integer :: reqp1,reqp2
 #endif
+      character(len=6) :: text1,text2
+
        !$acc declare create(dumk3,dumk4)
        !$acc declare &
        !$acc present(xh,rxh,arh1,arh2,uh,ruh,arf1,arf2) &
@@ -552,7 +555,6 @@
             enddo
             enddo
             enddo
-            !stop 'solve2: after call to eqtset==1 loop'
 
           ENDIF
 
@@ -595,6 +597,9 @@
         enddo
         if(timestats.ge.1) time_misc14=time_misc14+mytime()
         !print *,'solve2: point #2'
+      text1='sv2.5'
+      text2='sv2.5'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 !--------------------------------------------------------------------
         IF(nrk.ge.2)THEN
 #ifdef MPI
@@ -610,6 +615,9 @@
             call bc2d_GPU(w3d(ib,jb,1))
           endif
         ENDIF
+      text1='sv2.6'
+      text2='sv2.6'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
         !print *,'solve2: point #27'
 !--------------------------------------------------------------------
 !  Get rru,rrv,rrw,divx
@@ -1023,6 +1031,9 @@
         ENDIF
 #endif
         !print *,'solve2: point #7'
+      text1='sv2.7'
+      text2='sv2.7'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 !--------------------------------------------------------------------
 !  advection:
           call advu(nrk   ,arh1,arh2,uh,xf,rxf,arf1,arf2,uf,vh,gz,rgz,gzu,mh,rho0,rr0,rf0,rrf0,dum1,dum2,dum3,dum4,dum5,dum6,dum7,divx, &
@@ -1034,6 +1045,9 @@
                       rru,rrv,rrw,w3d  ,wten,rds,rdsf,c1,c2,rho,dttmp,               &
                       dowbud ,wdiag,hadvordrv,vadvordrv,advwenov,bndy,kbdy,uf,vf,u3d,v3d,hflxw,hflxe,hflxs,hflxn)
 
+      text1='sv2.8'
+      text2='sv2.8'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 !--------------------------------------------------------------------
 !  Buoyancy
 
@@ -1236,6 +1250,9 @@
 
         get_time_avg = .false.
 
+      text1='sv2.15'
+      text2='sv2.15'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
         IF(psolver.eq.1)THEN
 
@@ -1257,7 +1274,7 @@
 
         ELSEIF( psolver.eq.2 .or. psolver.eq.7 )THEN
           get_time_avg = .true.
-          !print *,'solve2: before call to sounde'
+          print *,'solve2: before call to sounde'
           call   sounde(dt,xh,arh1,arh2,uh,ruh,xf,uf,yh,vh,rvh,yf,vf,     &
                         rds,sigma,rdsf,sigmaf,zh,mh,rmh,c1,c2,mf,zf,      &
                         pi0,rho0,rr0,rf0,rrf0,th0,rth0,thv0,zs,           &
@@ -1273,7 +1290,7 @@
                         t11,t22   ,nrk,dttmp,rtime,mtime,get_time_avg,    &
                         bndy,kbdy,                                        &
                         pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-          !print *,'solve2: after call to sounde'
+          print *,'solve2: after call to sounde'
         ELSEIF(psolver.eq.3)THEN
 
           
@@ -1335,7 +1352,9 @@
                         pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
 
         ENDIF
-      !stop 'solve2: after solver_block'
+      text1='sv2.16'
+      text2='sv2.16'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
 !--------------------------------------------------------------------
 !  Update v for axisymmetric model simulations:
@@ -1440,6 +1459,9 @@
 !  For Bryan-Fritsch equation set, compute 3d divergence.
 !     Store in T11 array.
 
+      text1='sv2.17'
+      text2='sv2.17'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
     IF( imoist.eq.1 .and. eqtset.eq.2 )THEN
       if( get_time_avg )then
         ! cm1r19:  rru,rrv,rrw store small-step-avg velocities
@@ -1450,6 +1472,9 @@
                         rds,rdsf,sigma,sigmaf,gz,rgzu,rgzv,dzdx,dzdy)
       endif
     ENDIF
+      text1='sv2.18'
+      text2='sv2.18'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
 !--------------------------------------------------------------------
 
@@ -1554,7 +1579,6 @@
                    dotbud,ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,tdiag,td_hadv,td_vadv,td_lsw, &
                    td_hidiff,td_vidiff,td_hediff,wprof,dumk1,dumk2,hadvordrs,vadvordrs,kbdy,bndy,hflxw,hflxe,hflxs,hflxn,out3d)
       !print *,'solve2: point #14.1'
-      !stop 'solve2: point #14.1'
 
       !$omp parallel do default(shared) private(i,j,k)
       !$acc parallel loop gang vector collapse(3) private(i,j,k)
@@ -1608,7 +1632,6 @@
       endif
 #endif
         !print *,'solve2: point #16'
-        !stop 'solve2: after point #16'
 
       ! Note: epsilon = 1.0e-18
 !!!      weps = 0.01*epsilon
@@ -1813,6 +1836,10 @@
 !  bcs and comms:
 
       !print *,'solve2: point #19'
+      text1='sv2.19'
+      text2='sv2.19'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+
       call bcu_GPU(u3d)
 #ifdef MPI
       call comm_3u_start_GPU(u3d,uw31,uw32,ue31,ue32,   &
@@ -1867,6 +1894,9 @@
         ENDIF
       ENDIF
       !print *,'solve2: point #20'
+      text1='sv2.20'
+      text2='sv2.20'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
 !--------------------------------------------------------------------
 !  TKE advection
@@ -1892,7 +1922,6 @@
         ENDIF
 #endif
       !print *,'solve2: point #20.1'
-      !stop 'solve2: point #20.1'
 
         if( dotdwrite .and. kd_adv.ge.1 )then
         if( nrk.eq.nrkmax )then
@@ -2193,7 +2222,6 @@
 ! RK loop end
 
       ENDDO  rkloop
-      !stop 'solve2: after rkloop'
 
 !CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 !CC   End of RK section   CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -81,7 +81,7 @@
 
       subroutine solve2(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,qbudget8,qbudget9,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,xhref,yfref,yhref,dumk1,dumk2,rds,sigma,rdsf,sigmaf, &
@@ -185,7 +185,6 @@
       double precision, intent(inout), dimension(nk) :: bud
       double precision, intent(inout), dimension(nj) :: bud2
       double precision, intent(inout), dimension(nbudget) :: qbudget
-      double precision :: qbudget8,qbudget9
       double precision, intent(inout), dimension(numq) :: asq,bsq
       real, intent(in), dimension(ib:ie) :: xh,rxh,arh1,arh2,uh,ruh
       real, intent(in), dimension(ib:ie+1) :: xf,rxf,arf1,arf2,uf,ruf

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -81,7 +81,7 @@
 
       subroutine solve2(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,qmag,bud,bud2,qbudget,qbudget8,qbudget9,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,xhref,yfref,yhref,dumk1,dumk2,rds,sigma,rdsf,sigmaf, &
@@ -185,6 +185,7 @@
       double precision, intent(inout), dimension(nk) :: bud
       double precision, intent(inout), dimension(nj) :: bud2
       double precision, intent(inout), dimension(nbudget) :: qbudget
+      double precision :: qbudget8,qbudget9
       double precision, intent(inout), dimension(numq) :: asq,bsq
       real, intent(in), dimension(ib:ie) :: xh,rxh,arh1,arh2,uh,ruh
       real, intent(in), dimension(ib:ie+1) :: xf,rxf,arf1,arf2,uf,ruf

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -76,7 +76,7 @@
 
       subroutine solve3(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,bud,bud2,qbudget,qbudget8,qbudget9,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,bud,bud2,qbudget,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,yfref,dumk1,dumk2,rds,sigma,rdsf,sigmaf,    &
@@ -173,7 +173,6 @@
       double precision, intent(inout), dimension(nk) :: bud
       double precision, intent(inout), dimension(nj) :: bud2
       double precision, intent(inout), dimension(nbudget) :: qbudget
-      double precision, intent(inout) :: qbudget8,qbudget9
       double precision, intent(inout), dimension(numq) :: asq,bsq
       real, intent(in), dimension(ib:ie) :: xh,rxh,arh1,arh2,uh,ruh
       real, intent(in), dimension(ib:ie+1) :: xf,rxf,arf1,arf2,uf,ruf

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -76,7 +76,7 @@
 
       subroutine solve3(nstep,rbufsz,num_soil_layers,                  &
                    dt,dtlast,mtime,dbldt,mass1,mass2,                 &
-                   dosfcflx,cloudvar,rhovar,bud,bud2,qbudget,asq,bsq, &
+                   dosfcflx,cloudvar,rhovar,bud,bud2,qbudget,qbudget8,qbudget9,asq,bsq, &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,   &
                    yh,vh,rvh,yf,vf,rvf,                               &
                    xfref,yfref,dumk1,dumk2,rds,sigma,rdsf,sigmaf,    &
@@ -173,6 +173,7 @@
       double precision, intent(inout), dimension(nk) :: bud
       double precision, intent(inout), dimension(nj) :: bud2
       double precision, intent(inout), dimension(nbudget) :: qbudget
+      double precision, intent(inout) :: qbudget8,qbudget9
       double precision, intent(inout), dimension(numq) :: asq,bsq
       real, intent(in), dimension(ib:ie) :: xh,rxh,arh1,arh2,uh,ruh
       real, intent(in), dimension(ib:ie+1) :: xf,rxf,arf1,arf2,uf,ruf

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -146,6 +146,7 @@
       use constants
       use bc_module
       use comm_module
+      use maxmin_module
       use adv_routines, only : movesfc
       use misclibs
       use parcel_module, only : parcel_driver
@@ -325,6 +326,7 @@
 #ifdef MPI
       integer :: reqp1,reqp2
 #endif
+      character(len=20) :: text1,text2
 
 !--------------------------------------------------------------------
       !$acc declare present(rrw)
@@ -528,6 +530,10 @@
         !-----
       endif
 
+      !text1='slv3.5'
+      !text2='slv3.5'
+      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+
 #ifdef MPI
       call comm_3u_end_GPU(u3d,uw31,uw32,ue31,ue32,   &
                            us31,us32,un31,un32,reqs_u)
@@ -538,6 +544,9 @@
 #endif
 
       !print *,'solve3: point #7'
+      !text1='slv3.6'
+      !text2='slv3.6'
+      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 #ifdef MPI
       if(   sgsmodel.eq.5 .or. sgsmodel.eq.6 )then
         call getcorneru_GPU(u3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
@@ -549,6 +558,9 @@
       endif
 #endif
       !print *,'solve3: point #8'
+      !text1='slv3.7'
+      !text2='slv3.7'
+      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
       if(terrain_flag)then
         call bcwsfc(gz,dzdx,dzdy,u3d,v3d,w3d)
@@ -634,6 +646,9 @@
         ENDIF
         if(timestats.ge.1) time_parcels=time_parcels+mytime()
         ! bc/comms:
+      !text1='slv3.8'
+      !text2='slv3.8'
+      !call maxmin2dhalo(ni,nj,rrw(ib,jb,13),text1,text2)
         call bcu_GPU(rru)
 #ifdef MPI
         call comm_3u_start_GPU(rru,uw31,uw32,ue31,ue32,us31,us32,un31,un32,reqs_u)
@@ -648,6 +663,10 @@
 #endif
       ENDIF
       !print *,'solve3: point #9'
+      !text1='slv3.9'
+      !text2='slv3.9'
+      !call maxmin2dhalo(ni,nj,rrw(ib,jb,13),text1,text2)
+
 
 !----------
 !  Diagnostics (infrequent):

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -293,9 +293,9 @@
                                ps1,ps2,pn1,pn2,reqs_p)
         endif
 #endif
-      text1='snd.1b'
-      text2='snd.1b'
-      call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
+      !text1='snd.1b'
+      !text2='snd.1b'
+      !call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
       !$acc compare(ppd)
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -312,27 +312,21 @@
         tem1 = rdx*cp*0.5
         tem2 = rdy*cp*0.5
 
-        print *,'HOST: sounde: before loop: cp: ',cp
-        print *,'HOST: sounde: before loop: rdy: ',rdy
-        !$acc parallel
-        print *,'DEVICE: sounde: before loop: cp: ',cp
-        print *,'DEVICE: sounde: before loop: rdy: ',rdy
-        !$acc end parallel
-        text1='snd.1j'
-        text2='snd.1j'
-        call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
-        text1='snd.1k'
-        text2='snd.1k'
-        call maxmin2dhalo(ni,nj,dtv(ib,jb),text1,text2)
-        text1='snd.1m'
-        text2='snd.1m'
-        call maxmin2dhalo(ni,nj+1,vten(ib,jb,13),text1,text2)
-        text1='snd.1n'
-        text2='snd.1n'
-        call maxmin2dhalo(ni,nj,thv(ib,jb,13),text1,text2)
-        text1='snd.1x'
-        text2='snd.1x'
-        call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
+        !text1='snd.1j'
+        !text2='snd.1j'
+        !call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
+        !text1='snd.1k'
+        !text2='snd.1k'
+        !call maxmin2dhalo(ni,nj,dtv(ib,jb),text1,text2)
+        !text1='snd.1m'
+        !text2='snd.1m'
+        !call maxmin2dhalo(ni,nj+1,vten(ib,jb,13),text1,text2)
+        !text1='snd.1n'
+        !text2='snd.1n'
+        !call maxmin2dhalo(ni,nj,thv(ib,jb,13),text1,text2)
+        !text1='snd.1x'
+        !text2='snd.1x'
+        !call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
 
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
@@ -348,9 +342,9 @@
           enddo
           enddo
         enddo
-        text1='snd.1h'
-        text2='snd.1h'
-        call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
+        !text1='snd.1h'
+        !text2='snd.1h'
+        !call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
 
         IF( do_ib )THEN
           call zero_out_uv(bndy,kbdy,u3d,v3d)
@@ -578,18 +572,18 @@
           call get_wnudge(mtime,dts,xh,yh,zf,w3d,dum1)
         ENDIF
       ENDIF
-      text1='snd.2a'
-      text2='snd.2a'
-      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
-      text1='snd.2b'
-      text2='snd.2b'
-      call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
-      text1='snd.2c'
-      text2='snd.2c'
-      call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
-      text1='snd.2e'
-      text2='snd.2e'
-      call maxmin2dhalo(ni,nj,wten(ib,jb,13),text1,text2)
+      !text1='snd.2a'
+      !text2='snd.2a'
+      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+      !text1='snd.2b'
+      !text2='snd.2b'
+      !call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
+      !text1='snd.2c'
+      !text2='snd.2c'
+      !call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
+      !text1='snd.2e'
+      !text2='snd.2e'
+      !call maxmin2dhalo(ni,nj,wten(ib,jb,13),text1,text2)
 
   !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
@@ -824,42 +818,39 @@
       IF(.not.terrain_flag)THEN
         ! Cartesian grid, without terrain:
 
-        text1='snd.5a'
-        text2='snd.5a'
-        call maxmin2dhalo(ni,nj,pp3d(ib,jb,13),text1,text2)
+        !text1='snd.5a'
+        !text2='snd.5a'
+        !call maxmin2dhalo(ni,nj,pp3d(ib,jb,13),text1,text2)
 #if 0
 #endif
-        print *,'temx,temy: ',temx,temy
-        print *,'kdiv: ',kdiv
-        print *,'smeps: ',smeps
-        text1='snd.5c'
-        text2='snd.5c'
-        call maxmin2dhalo(ni,nj,ppterm(ib,jb,13),text1,text2)
-        text1='snd.5d'
-        text2='snd.5d'
-        call maxmin2dhalo(ni,nj,piadv(ib,jb,13),text1,text2)
-        text1='snd.5e'
-        text2='snd.5e'
-        call maxmin2dhalo(ni,nj,pk1(ib,jb,13),text1,text2)
-        text1='snd.5f'
-        text2='snd.5f'
-        call maxmin2dhalo(ni,nj,pk2(ib,jb,13),text1,text2)
-        text1='snd.5g'
-        text2='snd.5g'
-        call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
-        text1='snd.5h'
-        text2='snd.5h'
-        call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
-        text1='snd.5i'
-        text2='snd.5i'
-        call maxmin2dhalo(ni+1,nj,u3d(ib,jb,13),text1,text2)
-        text1='snd.5j'
-        text2='snd.5j'
-        call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
-        text1='snd.5k'
-        text2='snd.5k'
-        call maxmin2dhalo(ni,nj+1,mh(ib,jb,13),text1,text2)
-        print *,'mh(1,1,13): ',mh(1,1,13)
+        !text1='snd.5c'
+        !text2='snd.5c'
+        !call maxmin2dhalo(ni,nj,ppterm(ib,jb,13),text1,text2)
+        !text1='snd.5d'
+        !text2='snd.5d'
+        !call maxmin2dhalo(ni,nj,piadv(ib,jb,13),text1,text2)
+        !text1='snd.5e'
+        !text2='snd.5e'
+        !call maxmin2dhalo(ni,nj,pk1(ib,jb,13),text1,text2)
+        !text1='snd.5f'
+        !text2='snd.5f'
+        !call maxmin2dhalo(ni,nj,pk2(ib,jb,13),text1,text2)
+        !text1='snd.5g'
+        !text2='snd.5g'
+        !call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
+        !text1='snd.5h'
+        !text2='snd.5h'
+        !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+        !text1='snd.5i'
+        !text2='snd.5i'
+        !call maxmin2dhalo(ni+1,nj,u3d(ib,jb,13),text1,text2)
+        !text1='snd.5j'
+        !text2='snd.5j'
+        !call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
+        !text1='snd.5k'
+        !text2='snd.5k'
+        !call maxmin2dhalo(ni,nj+1,mh(ib,jb,13),text1,text2)
+        !print *,'mh(1,1,13): ',mh(1,1,13)
 
         !$omp parallel do default(shared)   &
         !$omp private(i,j,k,div,delp)
@@ -886,15 +877,15 @@
         enddo
         enddo
         enddo
-      text1='snd.6a'
-      text2='snd.6a'
-      call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
-      text1='snd.6b'
-      text2='snd.6b'
-      call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
-      text1='snd.6c'
-      text2='snd.6c'
-      call maxmin2dhalo(ni,nj,pp3d(ib,jb,13),text1,text2)
+      !text1='snd.6a'
+      !text2='snd.6a'
+      !call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
+      !text1='snd.6b'
+      !text2='snd.6b'
+      !call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
+      !text1='snd.6c'
+      !text2='snd.6c'
+      !call maxmin2dhalo(ni,nj,pp3d(ib,jb,13),text1,text2)
 
       ELSE
         ! Cartesian grid, with terrain:

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -27,6 +27,7 @@
       use misclibs , only : convinitu,convinitv,get_wnudge
       use bc_module
       use comm_module
+      use maxmin_module
       use ib_module
       implicit none
 
@@ -72,6 +73,7 @@
       real :: tem,tem1,tem2,tem3,tem4,r1,r2,rr1,rr2,dts,delp
 
       real :: temx,temy,u1,u2,v1,v2,w1,w2,ww,div,tavg,c1a,c1b,c2a,c2b,p1,p2,p3,p4
+      character (len=6) :: text1,text2
 
 !---------------------------------------------------------------------
 
@@ -96,7 +98,7 @@
       stop 97393
     ENDIF
 
-!!!      print *,'  nloop,dts,dttmp = ',nloop,dts,nloop*dts
+    !JMD print *,'  nloop,dts,dttmp = ',nloop,dts,nloop*dts
 
       !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
       do j=1,nj+1
@@ -240,11 +242,8 @@
 !-----
 
         if(irbc.eq.2)then
- 
           if(ibw.eq.1 .or. ibe.eq.1) call radbcew(radbcw,radbce,u3d)
- 
           if(ibs.eq.1 .or. ibn.eq.1) call radbcns(radbcs,radbcn,v3d)
- 
         endif
 
 !-----------------------------------------------------------------------
@@ -267,7 +266,6 @@
 
 !-----
 
-      !print *,'sounde: before openbc: N:= ',N
       IF(axisymm.eq.0)THEN
         IF(sbc.eq.2.and.ibs.eq.1)THEN
           ! south open bc tendency:
@@ -282,8 +280,6 @@
           call restrict_openbc_sn(ruh,rmh,rho0,v3d)
         ENDIF
       ENDIF
-      !print *,'sounde: after openbc: N:= ',N
-      !stop 'sounde: after openbc'
 
 !-----------------------------------------------------------------------
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -297,6 +293,10 @@
                                ps1,ps2,pn1,pn2,reqs_p)
         endif
 #endif
+      text1='snd.1b'
+      text2='snd.1b'
+      call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
+      !$acc compare(ppd)
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !  psolver = 2
@@ -312,7 +312,27 @@
         tem1 = rdx*cp*0.5
         tem2 = rdy*cp*0.5
 
-        !print *,'sounde: before loop'
+        print *,'HOST: sounde: before loop: cp: ',cp
+        print *,'HOST: sounde: before loop: rdy: ',rdy
+        !$acc parallel
+        print *,'DEVICE: sounde: before loop: cp: ',cp
+        print *,'DEVICE: sounde: before loop: rdy: ',rdy
+        !$acc end parallel
+        text1='snd.1j'
+        text2='snd.1j'
+        call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
+        text1='snd.1k'
+        text2='snd.1k'
+        call maxmin2dhalo(ni,nj,dtv(ib,jb),text1,text2)
+        text1='snd.1m'
+        text2='snd.1m'
+        call maxmin2dhalo(ni,nj+1,vten(ib,jb,13),text1,text2)
+        text1='snd.1n'
+        text2='snd.1n'
+        call maxmin2dhalo(ni,nj,thv(ib,jb,13),text1,text2)
+        text1='snd.1x'
+        text2='snd.1x'
+        call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
 
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
@@ -328,6 +348,9 @@
           enddo
           enddo
         enddo
+        text1='snd.1h'
+        text2='snd.1h'
+        call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
 
         IF( do_ib )THEN
           call zero_out_uv(bndy,kbdy,u3d,v3d)
@@ -555,6 +578,18 @@
           call get_wnudge(mtime,dts,xh,yh,zf,w3d,dum1)
         ENDIF
       ENDIF
+      text1='snd.2a'
+      text2='snd.2a'
+      call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+      text1='snd.2b'
+      text2='snd.2b'
+      call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
+      text1='snd.2c'
+      text2='snd.2c'
+      call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
+      text1='snd.2e'
+      text2='snd.2e'
+      call maxmin2dhalo(ni,nj,wten(ib,jb,13),text1,text2)
 
   !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
@@ -789,6 +824,43 @@
       IF(.not.terrain_flag)THEN
         ! Cartesian grid, without terrain:
 
+        text1='snd.5a'
+        text2='snd.5a'
+        call maxmin2dhalo(ni,nj,pp3d(ib,jb,13),text1,text2)
+#if 0
+#endif
+        print *,'temx,temy: ',temx,temy
+        print *,'kdiv: ',kdiv
+        print *,'smeps: ',smeps
+        text1='snd.5c'
+        text2='snd.5c'
+        call maxmin2dhalo(ni,nj,ppterm(ib,jb,13),text1,text2)
+        text1='snd.5d'
+        text2='snd.5d'
+        call maxmin2dhalo(ni,nj,piadv(ib,jb,13),text1,text2)
+        text1='snd.5e'
+        text2='snd.5e'
+        call maxmin2dhalo(ni,nj,pk1(ib,jb,13),text1,text2)
+        text1='snd.5f'
+        text2='snd.5f'
+        call maxmin2dhalo(ni,nj,pk2(ib,jb,13),text1,text2)
+        text1='snd.5g'
+        text2='snd.5g'
+        call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
+        text1='snd.5h'
+        text2='snd.5h'
+        call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
+        text1='snd.5i'
+        text2='snd.5i'
+        call maxmin2dhalo(ni+1,nj,u3d(ib,jb,13),text1,text2)
+        text1='snd.5j'
+        text2='snd.5j'
+        call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
+        text1='snd.5k'
+        text2='snd.5k'
+        call maxmin2dhalo(ni,nj+1,mh(ib,jb,13),text1,text2)
+        print *,'mh(1,1,13): ',mh(1,1,13)
+
         !$omp parallel do default(shared)   &
         !$omp private(i,j,k,div,delp)
         !$acc parallel loop gang vector collapse(3) default(present) &
@@ -814,6 +886,15 @@
         enddo
         enddo
         enddo
+      text1='snd.6a'
+      text2='snd.6a'
+      call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
+      text1='snd.6b'
+      text2='snd.6b'
+      call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
+      text1='snd.6c'
+      text2='snd.6c'
+      call maxmin2dhalo(ni,nj,pp3d(ib,jb,13),text1,text2)
 
       ELSE
         ! Cartesian grid, with terrain:
@@ -1044,7 +1125,6 @@
       ENDIF
       if(timestats.ge.1) time_sound=time_sound+mytime()
 
-      !stop 'sounde: at the end of the subroutine'
 
       end subroutine sounde
 

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -472,7 +472,7 @@
       IF( bbc.eq.3 .and. sfcmodel.ge.1 )THEN
         call maxmin2d(ni,nj,hpbl(ibl,jbl),nstat,rstat,'HPBLMX','HPBLMN')
       ENDIF
-      !JMD-KLUDGE if(stat_cfl.eq.1) call calccfl(nstat,rstat,dt,acfl,uh,vh,mh,ua,va,wa,1)
+      if(stat_cfl.eq.1) call calccfl_fold(nstat,rstat,dt,acfl,uh,vh,mh,ua,va,wa,1)
 
       if(stat_cfl.eq.1.and.(sgsmodel.ge.1.or.ipbl.eq.2.or.horizturb.eq.1)) call calcksmax(nstat,rstat,dt,uh,vh,mf,kmh,kmv,khh,khv)
 

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -8,7 +8,7 @@
   CONTAINS
 
       subroutine statpack(mtime,nrec,ndt,dt,dtlast,rtime,adt,acfl,cloudvar,   &
-                          qname,budname,qbudget,asq,bsq,                      &
+                          qname,budname,qbudget,qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10,asq,bsq,                &
                           name_stat,desc_stat,unit_stat,                      &
                           xh,rxh,uh,ruh,xf,uf,yh,vh,rvh,vf,zh,mh,rmh,zf,mf,   &
                           zs,rgzu,rgzv,rds,sigma,rdsf,sigmaf,                 &
@@ -40,6 +40,7 @@
       character(len=3), dimension(maxq) :: qname
       character(len=6), dimension(maxq) :: budname
       double precision, dimension(nbudget) :: qbudget
+      double precision :: qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10
       double precision, dimension(numq) :: asq,bsq
       character(len=40), intent(in), dimension(maxvars) :: name_stat,desc_stat,unit_stat
       real, intent(in), dimension(ib:ie) :: xh,rxh,uh,ruh
@@ -79,14 +80,15 @@
 #ifdef MPI
       double precision, dimension(nbudget) :: cfoo
       double precision, dimension(numq) :: afoo,bfoo
+      double precision :: tfoo
 #endif
 
 !-----------------------------------------------------------------------
 #ifdef MPI
       !$acc data create(afoo,bfoo,cfoo)
       cfoo = 0.0
-      !$acc update host(qbudget,asq,bsq)
-      call MPI_REDUCE(qbudget(1),cfoo(1),nbudget,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+      !$acc update host(asq,bsq)
+      call MPI_REDUCE(qbudget,cfoo,nbudget,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                       MPI_COMM_WORLD,ierr)
       if( myid.eq.0 )then
         do n=1,nbudget
@@ -94,6 +96,77 @@
         enddo
       else
         qbudget = 0.0
+      endif
+      call MPI_REDUCE(qbudget1,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget1=tfoo
+      else
+        qbudget1 = 0.0
+      endif
+      call MPI_REDUCE(qbudget2,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget2=tfoo
+      else
+        qbudget2 = 0.0
+      endif
+      call MPI_REDUCE(qbudget3,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget3=tfoo
+      else
+        qbudget3 = 0.0
+      endif
+      call MPI_REDUCE(qbudget4,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget4=tfoo
+      else
+        qbudget4 = 0.0
+      endif
+      call MPI_REDUCE(qbudget5,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget5=tfoo
+      else
+        qbudget5 = 0.0
+      endif
+      call MPI_REDUCE(qbudget6,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget6=tfoo
+      else
+        qbudget6 = 0.0
+      endif
+      call MPI_REDUCE(qbudget7,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget7=tfoo
+      else
+        qbudget7 = 0.0
+      endif
+
+      call MPI_REDUCE(qbudget8,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget8=tfoo
+      else
+        qbudget8 = 0.0
+      endif
+      call MPI_REDUCE(qbudget9,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget9=tfoo
+      else
+        qbudget9 = 0.0
+      endif
+      call MPI_REDUCE(qbudget10,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+                      MPI_COMM_WORLD,ierr)
+      if( myid.eq.0 )then
+        qbudget10=tfoo
+      else
+        qbudget10 = 0.0
       endif
       if( imoist.eq.1 )then
         afoo = 0.0
@@ -117,7 +190,7 @@
           bsq = 0.0
         endif
       endif
-      !$acc update device(qbudget,asq,bsq)
+      !$acc update device(asq,bsq)
       !$acc end data
 #endif
 !-----------------------------------------------------------------------
@@ -512,7 +585,8 @@
         call getqli(qa,dum2,dum3)
 
         if(stat_tmois.eq.1)then
-          call totmois(nstat,rstat,qbudget(budrain),ruh,rvh,rmh,dum1,dum2,dum3,rho)
+          !JMD FIXME call totmois(nstat,rstat,qbudget(budrain),ruh,rvh,rmh,dum1,dum2,dum3,rho)
+          call totmois(nstat,rstat,qbudget6,ruh,rvh,rmh,dum1,dum2,dum3,rho)
         endif
 
         if(stat_qmass.eq.1)then
@@ -597,9 +671,31 @@
       if(myid.eq.0)then
 100     format(2x,'stat:: ',a6,':',1x,e13.6)
         do n=1,nbudget
-          write(6,100) budname(n),qbudget(n)
-          nstat = nstat + 1
-          rstat(nstat) = qbudget(n)
+          if(n == 1) then 
+            write(6,100) budname(n),qbudget1
+          elseif(n == 2) then 
+            write(6,100) budname(n),qbudget2
+          elseif(n == 3) then 
+            write(6,100) budname(n),qbudget3
+          elseif(n == 4) then 
+            write(6,100) budname(n),qbudget4
+          elseif(n == 5) then 
+            write(6,100) budname(n),qbudget5
+          elseif(n == 6) then 
+            write(6,100) budname(n),qbudget6
+          elseif(n == 7) then 
+            write(6,100) budname(n),qbudget7
+          elseif(n == 8) then 
+            write(6,100) budname(n),qbudget8
+          elseif(n == 9) then 
+            write(6,100) budname(n),qbudget9
+          elseif(n == 10) then 
+            write(6,100) budname(n),qbudget10
+          else
+            write(6,100) budname(n),qbudget(n)
+            nstat = nstat + 1
+            rstat(nstat) = qbudget(n)
+          endif
         enddo
       endif
       ENDIF

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -84,9 +84,7 @@
 
 !-----------------------------------------------------------------------
 #ifdef MPI
-      !$acc data create(afoo,bfoo,cfoo)
       cfoo = 0.0
-      !$acc update host(asq)
       call MPI_REDUCE(qbudget,cfoo,nbudget,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                       MPI_COMM_WORLD,ierr)
       if( myid.eq.0 )then
@@ -118,8 +116,6 @@
           bsq = 0.0
         endif
       endif
-      !$acc update device(asq)
-      !$acc end data
 #endif
 !-----------------------------------------------------------------------
 
@@ -177,6 +173,7 @@
               do while( sigmaf(nkm).gt.zlev .and. nkm.gt.1 )
                 nkm = nkm-1
               enddo
+              print *,'nkm: ',nkm
               ! dum1(i,j,1) = wa(i,j,nkm)+(wa(i,j,nkm+1)-wa(i,j,nkm))  &
               !                          *(         zlev-sigmaf(nkm))  &
               !                          /(sigmaf(nkm+1)-sigmaf(nkm))

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -79,7 +79,6 @@
 #ifdef MPI
       double precision, dimension(nbudget) :: cfoo
       double precision, dimension(numq) :: afoo,bfoo
-      double precision :: tfoo
 #endif
 
 !-----------------------------------------------------------------------

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -86,7 +86,7 @@
 #ifdef MPI
       !$acc data create(afoo,bfoo,cfoo)
       cfoo = 0.0
-      !$acc update host(asq,bsq)
+      !$acc update host(asq)
       call MPI_REDUCE(qbudget,cfoo,nbudget,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                       MPI_COMM_WORLD,ierr)
       if( myid.eq.0 )then
@@ -98,7 +98,7 @@
       endif
       if( imoist.eq.1 )then
         afoo = 0.0
-        call MPI_REDUCE(asq(1),afoo(1),numq,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+        call MPI_REDUCE(asq,afoo,numq,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                         MPI_COMM_WORLD,ierr)
         if( myid.eq.0 )then
           do n=1,numq
@@ -108,7 +108,7 @@
           asq = 0.0
         endif
         bfoo = 0.0
-        call MPI_REDUCE(bsq(1),bfoo(1),numq,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
+        call MPI_REDUCE(bsq,bfoo,numq,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
                         MPI_COMM_WORLD,ierr)
         if( myid.eq.0 )then
           do n=1,numq
@@ -118,7 +118,7 @@
           bsq = 0.0
         endif
       endif
-      !$acc update device(asq,bsq)
+      !$acc update device(asq)
       !$acc end data
 #endif
 !-----------------------------------------------------------------------

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -8,7 +8,7 @@
   CONTAINS
 
       subroutine statpack(mtime,nrec,ndt,dt,dtlast,rtime,adt,acfl,cloudvar,   &
-                          qname,budname,qbudget,qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10,asq,bsq,                &
+                          qname,budname,qbudget,asq,bsq,                      &
                           name_stat,desc_stat,unit_stat,                      &
                           xh,rxh,uh,ruh,xf,uf,yh,vh,rvh,vf,zh,mh,rmh,zf,mf,   &
                           zs,rgzu,rgzv,rds,sigma,rdsf,sigmaf,                 &
@@ -40,7 +40,6 @@
       character(len=3), dimension(maxq) :: qname
       character(len=6), dimension(maxq) :: budname
       double precision, dimension(nbudget) :: qbudget
-      double precision :: qbudget1,qbudget2,qbudget3,qbudget4,qbudget5,qbudget6,qbudget7,qbudget8,qbudget9,qbudget10
       double precision, dimension(numq) :: asq,bsq
       character(len=40), intent(in), dimension(maxvars) :: name_stat,desc_stat,unit_stat
       real, intent(in), dimension(ib:ie) :: xh,rxh,uh,ruh
@@ -96,77 +95,6 @@
         enddo
       else
         qbudget = 0.0
-      endif
-      call MPI_REDUCE(qbudget1,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget1=tfoo
-      else
-        qbudget1 = 0.0
-      endif
-      call MPI_REDUCE(qbudget2,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget2=tfoo
-      else
-        qbudget2 = 0.0
-      endif
-      call MPI_REDUCE(qbudget3,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget3=tfoo
-      else
-        qbudget3 = 0.0
-      endif
-      call MPI_REDUCE(qbudget4,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget4=tfoo
-      else
-        qbudget4 = 0.0
-      endif
-      call MPI_REDUCE(qbudget5,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget5=tfoo
-      else
-        qbudget5 = 0.0
-      endif
-      call MPI_REDUCE(qbudget6,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget6=tfoo
-      else
-        qbudget6 = 0.0
-      endif
-      call MPI_REDUCE(qbudget7,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget7=tfoo
-      else
-        qbudget7 = 0.0
-      endif
-
-      call MPI_REDUCE(qbudget8,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget8=tfoo
-      else
-        qbudget8 = 0.0
-      endif
-      call MPI_REDUCE(qbudget9,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget9=tfoo
-      else
-        qbudget9 = 0.0
-      endif
-      call MPI_REDUCE(qbudget10,tfoo,1,MPI_DOUBLE_PRECISION,MPI_SUM,0,  &
-                      MPI_COMM_WORLD,ierr)
-      if( myid.eq.0 )then
-        qbudget10=tfoo
-      else
-        qbudget10 = 0.0
       endif
       if( imoist.eq.1 )then
         afoo = 0.0
@@ -585,8 +513,7 @@
         call getqli(qa,dum2,dum3)
 
         if(stat_tmois.eq.1)then
-          !JMD FIXME call totmois(nstat,rstat,qbudget(budrain),ruh,rvh,rmh,dum1,dum2,dum3,rho)
-          call totmois(nstat,rstat,qbudget6,ruh,rvh,rmh,dum1,dum2,dum3,rho)
+          call totmois(nstat,rstat,qbudget(budrain),ruh,rvh,rmh,dum1,dum2,dum3,rho)
         endif
 
         if(stat_qmass.eq.1)then
@@ -671,31 +598,9 @@
       if(myid.eq.0)then
 100     format(2x,'stat:: ',a6,':',1x,e13.6)
         do n=1,nbudget
-          if(n == 1) then 
-            write(6,100) budname(n),qbudget1
-          elseif(n == 2) then 
-            write(6,100) budname(n),qbudget2
-          elseif(n == 3) then 
-            write(6,100) budname(n),qbudget3
-          elseif(n == 4) then 
-            write(6,100) budname(n),qbudget4
-          elseif(n == 5) then 
-            write(6,100) budname(n),qbudget5
-          elseif(n == 6) then 
-            write(6,100) budname(n),qbudget6
-          elseif(n == 7) then 
-            write(6,100) budname(n),qbudget7
-          elseif(n == 8) then 
-            write(6,100) budname(n),qbudget8
-          elseif(n == 9) then 
-            write(6,100) budname(n),qbudget9
-          elseif(n == 10) then 
-            write(6,100) budname(n),qbudget10
-          else
-            write(6,100) budname(n),qbudget(n)
-            nstat = nstat + 1
-            rstat(nstat) = qbudget(n)
-          endif
+          write(6,100) budname(n),qbudget(n)
+          nstat = nstat + 1
+          rstat(nstat) = qbudget(n)
         enddo
       endif
       ENDIF

--- a/src/turb.F
+++ b/src/turb.F
@@ -19,7 +19,7 @@
 
   CONTAINS
 
-      subroutine sfc_and_turb(getsfc,getpbl,nstep,dt,dosfcflx,cloudvar,qbudget,qbudget8,qbudget9,   &
+      subroutine sfc_and_turb(getsfc,getpbl,nstep,dt,dosfcflx,cloudvar,qbudget,  &
                    avgsfcu,avgsfcv,avgsfcs,avgsfct,                  &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,  &
                    yh,vh,rvh,yf,vf,rvf,                              &
@@ -104,7 +104,6 @@
       logical, intent(in) :: dosfcflx
       logical, intent(in), dimension(maxq) :: cloudvar
       double precision, intent(inout), dimension(nbudget) :: qbudget
-      double precision, intent(inout) :: qbudget8, qbudget9
       double precision, intent(inout) :: avgsfcu,avgsfcv,avgsfcs,avgsfct
       real, intent(in), dimension(ib:ie) :: xh,rxh,arh1,arh2,uh,ruh
       real, intent(in), dimension(ib:ie+1) :: xf,rxf,arf1,arf2,uf,ruf
@@ -665,7 +664,7 @@
           if(isfcflx.eq.1)then
             call sfcflux(dt,ruh,xf,rvh,pi0s,ch,cq,pi0,thv0,th0,rf0,tsk,thflux,qvflux,mavail, &
                          rho,rf,u1,v1,s1,ppi,tha,divx, &
-                         qbudget8,psfc,u10,v10,s10,qsfc,znt,rtime)
+                         qbudget(8),psfc,u10,v10,s10,qsfc,znt,rtime)
           endif
 
           ! get sfc diagnostics needed by pbl scheme:

--- a/src/turb.F
+++ b/src/turb.F
@@ -537,7 +537,6 @@
       endif
 
 !-----------------------------------------------------------------------
-    !$acc compare(ugr,vgr)
     if(timestats.ge.1) time_turb=time_turb+mytime()
 
     dosfc:  IF( getsfc )THEN
@@ -638,14 +637,12 @@
           enddo
          ENDIF
 
-        !$acc compare(ust,u1,v1,s1)
         IF( use_avg_sfc .and. ( sfcmodel.eq.1 .or. sfcmodel.eq.5 ) )THEN
             call getavgsfc(u1,v1,s1,t1,avgsfcu,avgsfcv,avgsfcs,avgsfct)
         ENDIF
 
         IF( sfcmodel.eq.1 )THEN
 
-          !$acc compare(ust,u1,v1,s1)
           call getcecd(xh,u1,v1,s1,ppten(ib,jb,1),u10,v10,s10,xland,znt,ust,cd,ch,cq,avgsfcu,avgsfcv,avgsfcs,avgsfct)
 
           if( tbc.eq.3 )then
@@ -672,7 +669,6 @@
                         xland,psfc,qsfc,u10,v10,hfx,qfx,cda,znt,gz1oz0,  &
                         psim,psih,br,zol,mol,hpbl,dsxy,th2,t2,q2,fm,fh,  &
                         zs,ppten(ib,jb,1),pi0s,pi0,th0,ppi,tha,rho,rf,divx)
-          !stop 'after call to sfcdiags'
           if( use_pbl )then
             !$omp parallel do default(shared) private(i,j)
             !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
@@ -1043,7 +1039,6 @@
 
   bbc3b:  &
   IF( bbc.eq.3 )THEN
-    !$acc compare(ust,u1,v1,s1)
     !-------------!
     call bc2d_GPU(ust)
 #ifdef MPI
@@ -1079,7 +1074,6 @@
   endif
     !-------------!
 
-    !$acc compare(ust,u1,v1,s1)
 #ifdef MPI
     !-------------!
     call comm_1s2d_end_GPU(ust,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
@@ -1109,14 +1103,12 @@
   endif
     !-------------!
 
-    !$acc compare(ust,u1,v1,s1)
     !-------------!
     call comm_2d_corner_GPU(ust)
     call comm_2d_corner_GPU(u1)
     call comm_2d_corner_GPU(v1)
     call comm_2d_corner_GPU(s1)
     call comm_2d_corner_GPU(znt)
-    !$acc compare(ust,u1,v1,s1)
   if( sfcmodel.eq.4 )then
     call comm_2d_corner_GPU(mznt)
   endif
@@ -1254,7 +1246,6 @@
                      dum1,dum2,ua,va,wa,t11,t12,t13,t22,t23,t33,gx,gy,rho,rr,rf)
 
       ENDIF
-    !$acc compare(dum1,dum2)
 
 !--------------------------------------
 !  LES subgrid models:
@@ -1267,7 +1258,6 @@
 !        print *,'ERROR: call to getgamk not supported in OpenACC'
 !#endif
         ! get gamk for two-part model:
-        !$acc compare(ust,u1,v1,s1)
         call     getgamk(dt,rtime,xf,rxf,c1,c2,zh,mh,zf,mf,rf0,rr0,rho0,rrf0,u0,v0,            &
                          uavg,vavg,savg,l2p,kmw,gamwall,gamk,s2p,s2b,t2pm1,t2pm2,t2pm3,t2pm4,cavg,  &
                          ua,va,wa,t11,t12,t13,t22,t23,t33,dum1,dum2,dum3,dum4,                 &
@@ -1276,7 +1266,6 @@
                          u1,v1,s1,u1b,v1b,                                                     &
                          avgsfcu,avgsfcv,avgsfcs,                                              &
                          sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s)
-    !$acc compare(dum1,dum2)
         ! update turbulence model "constants":
         !$acc parallel loop gang vector default(present) private(k)
         do k=1,nk+1
@@ -1293,7 +1282,6 @@
 
 
          ! Deardorff TKE: 
-        !$acc compare(ust)
         call tkekm(nstep,rtime,dt,ruh,rvh,rmh,zf,mf,rmf,zntmp,ust,ustt,rf,cmz,csz,ce1z,ce2z, &
                    nm,defv,defh,dum1,dum2,dum3,dum4,dum5,             &
                    kmh,kmv,khh,khv,tkea,lenscl,dissten,out3d,         &
@@ -1307,8 +1295,6 @@
                    kw1(1,1,4),kw2(1,1,4),ke1(1,1,4),ke2(1,1,4),       &
                    ks1(1,1,4),ks2(1,1,4),kn1(1,1,4),kn2(1,1,4))
 
-    !$acc compare(dum1,dum2)
-        !stop 'sfc_and_turb: after call to tkekm'
 
         if( do_ib )then
           !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
@@ -1324,13 +1310,11 @@
           enddo
           enddo
         endif
-        !$acc compare(ust,u1,v1,st)
         call     tkebc(tkea,kmh,kmv,khh,khv,zntmp,ust,ustt,          &
                        kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
                        ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),  &
                        kw1(1,1,2),kw2(1,1,2),ke1(1,1,2),ke2(1,1,2),  &
                        ks1(1,1,2),ks2(1,1,2),kn1(1,1,2),kn2(1,1,2))
-        !$acc compare(ust,u1,v1,st)
        
         !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
         do j=0,nj+1
@@ -1354,7 +1338,6 @@
                          ua ,va ,wa ,tkea ,nm,                     &
                          kw1,kw2,ke1,ke2,ks1,ks2,kn1,kn2,reqs_s,   &
                          nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-    !$acc compare(dum1,dum2)
         ENDIF
 
       ELSEIF(sgsmodel.eq.2)THEN
@@ -1388,7 +1371,6 @@
                          ua ,va ,wa ,tkea ,nm,                     &
                          kw1,kw2,ke1,ke2,ks1,ks2,kn1,kn2,reqs_s,   &
                          nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-    !$acc compare(dum1,dum2)
 
       ELSEIF( sgsmodel.eq.0 )THEN
 
@@ -1450,7 +1432,6 @@
 !#ifdef _OPENACC
 !            print *,'ERROR: call to t2pcode not supported in OpenACC'
 !#endif
-            !$acc compare(ust,u1,v1,st)
             call t2pcode(dt,rtime,xf,rxf,c1,c2,zh,mh,zf,mf,rf0,rr0,rho0,rrf0,u0,v0,            &
                          uavg,vavg,savg,l2p,kmw,gamwall,gamk,s2p,s2b,t2pm1,t2pm2,t2pm3,t2pm4,cavg,  &
                          ua,va,wa,t11,t12,t13,t22,t23,t33,dum1,dum2,dum3,dum4,                 &
@@ -1459,7 +1440,6 @@
                          u1,v1,s1,u1b,v1b,                                                     &
                          avgsfcu,avgsfcv,avgsfcs,                                              &
                          sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s)
-            !$acc compare(ust,u1,v1,st)
           else
             stop 54321
           endif
@@ -1471,7 +1451,6 @@
       !-------------
 
     ENDIF  les_sgs
-    !$acc compare(dum1,dum2)
 
 !--------------------------------------
 !  Simple Smagorinsky-like turbulence schemes:
@@ -1551,12 +1530,9 @@
 #endif
       endif
 
-        !$acc compare(ust,u1,v1,st)
         !  now, get turbulent stresses:
         call     gettau(xf,rxf,arf1,arf2,ust,stau,u1,v1,s1,ustt,ut,vt,st,rf,mf,dum1,dum2,dum3,dum4,dum5,dum6, &
                         kmh,kmv,t11,t12,t13,t22,t23,t33,ua,ugr,va,vgr,wa,avgsfcu,avgsfcv,avgsfcs,bndy,kbdy)
-    !$acc compare(dum1,dum2)
-    !stop 'sfc_and_turb: after gettau'
 
         if( do_ib )then
 #ifdef _OPENACC
@@ -1622,7 +1598,6 @@
           ENDIF
 
     ENDIF
-    !$acc compare(dum1,dum2)
 
 
 !-------------------------------------------------------------------
@@ -2583,7 +2558,6 @@
 #endif
 !--------------------------------------------------------------
 !   finished
-      !stop 'tkekm: at the end'      
       return
       end subroutine tkekm
 
@@ -3689,10 +3663,8 @@
 !--------------------------------------------------------------
 !  lower boundary conditions
 
-       !$acc compare(dum1,dum2,ust,u1,v1,s1,stau)
             call sfcstress(xf,rxf,arf1,arf2,ust,stau,u1,v1,s1,rf,mf,dum1,dum2,  &
                         kmh,kmv,t13,t23,ua,ugr,va,vgr,avgsfcu,avgsfcv,avgsfcs)
-       !$acc compare(dum1,dum2)
 !--------------------------------------------------------------
 !  upper boundary conditions
 
@@ -3898,7 +3870,6 @@
                            /( max(0.0001,avgsfcs*sqrt( avgsfcu**2 + avgsfcv**2 )) )
           enddo
           enddo
-          !$acc compare(dum1,dum2,ust,s1,u1,v1)
 
           !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
           do j=1,nj+1
@@ -5544,7 +5515,6 @@
     !$acc end data
    
       if(timestats.ge.1) time_turb=time_turb+mytime()
-      !stop 't2pcode: end of subroutine'
 
       end subroutine t2pcode
 
@@ -5676,7 +5646,6 @@
       call MPI_ALLREDUCE(MPI_IN_PLACE,cavg(1,2),nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       !$acc update device(cavg)
 #endif
-      !stop 'getgamk: point #2'
       !$acc parallel default(present) 
       temd = 1.0/dble(nx*ny)
 

--- a/src/turb.F
+++ b/src/turb.F
@@ -19,7 +19,7 @@
 
   CONTAINS
 
-      subroutine sfc_and_turb(getsfc,getpbl,nstep,dt,dosfcflx,cloudvar,qbudget,    &
+      subroutine sfc_and_turb(getsfc,getpbl,nstep,dt,dosfcflx,cloudvar,qbudget,qbudget8,qbudget9,   &
                    avgsfcu,avgsfcv,avgsfcs,avgsfct,                  &
                    xh,rxh,arh1,arh2,uh,ruh,xf,rxf,arf1,arf2,uf,ruf,  &
                    yh,vh,rvh,yf,vf,rvf,                              &
@@ -104,6 +104,7 @@
       logical, intent(in) :: dosfcflx
       logical, intent(in), dimension(maxq) :: cloudvar
       double precision, intent(inout), dimension(nbudget) :: qbudget
+      double precision, intent(inout) :: qbudget8, qbudget9
       double precision, intent(inout) :: avgsfcu,avgsfcv,avgsfcs,avgsfct
       real, intent(in), dimension(ib:ie) :: xh,rxh,arh1,arh2,uh,ruh
       real, intent(in), dimension(ib:ie+1) :: xf,rxf,arf1,arf2,uf,ruf
@@ -220,7 +221,7 @@
     !$acc declare &
     !$acc present(xh,uh,ruh,xf,arf1,arf2,uf,vh,rvh,vf,zh,mh,rmh,c1,c2,zf,mf,rmf,   &
     !$acc        pi0,rho0,th0,rf0,rrf0,zs,gx,gy,xland,u0,v0)                      &
-    !$acc present(qbudget,tsk,znt,zntmp,ust,stau,thflux,qvflux,cd,ch,cq,u1,v1,s1,t1, &
+    !$acc present(tsk,znt,zntmp,ust,stau,thflux,qvflux,cd,ch,cq,u1,v1,s1,t1, &
     !$acc      ustt,ut,vt,st,dum1,dum2,dum3,dum4,dum5,dum6,dum7,dum8,dum9,divx,   &
     !$acc      rho,rr,rf,prs,t11,t12,t13,t22,t23,t33,m11,m12,m13,m22,m23,m33,rru, &
     !$acc      rrv,rrw,ua,va,wa,ugr,vgr,ppi,ppten,sten,sadv,tha,thten,thten1,     &
@@ -642,7 +643,6 @@
         IF( use_avg_sfc .and. ( sfcmodel.eq.1 .or. sfcmodel.eq.5 ) )THEN
             call getavgsfc(u1,v1,s1,t1,avgsfcu,avgsfcv,avgsfcs,avgsfct)
         ENDIF
-        !$acc compare(avgsfcu,avgsfcv,avgsfcs,avgsfct)
 
         IF( sfcmodel.eq.1 )THEN
 
@@ -665,7 +665,7 @@
           if(isfcflx.eq.1)then
             call sfcflux(dt,ruh,xf,rvh,pi0s,ch,cq,pi0,thv0,th0,rf0,tsk,thflux,qvflux,mavail, &
                          rho,rf,u1,v1,s1,ppi,tha,divx, &
-                         qbudget(8),psfc,u10,v10,s10,qsfc,znt,rtime)
+                         qbudget8,psfc,u10,v10,s10,qsfc,znt,rtime)
           endif
 
           ! get sfc diagnostics needed by pbl scheme:
@@ -1552,7 +1552,7 @@
 #endif
       endif
 
-        !$acc compare(ust,u1,v1,st,avgsfcu,avgsfcv,avgsfcs)
+        !$acc compare(ust,u1,v1,st)
         !  now, get turbulent stresses:
         call     gettau(xf,rxf,arf1,arf2,ust,stau,u1,v1,s1,ustt,ut,vt,st,rf,mf,dum1,dum2,dum3,dum4,dum5,dum6, &
                         kmh,kmv,t11,t12,t13,t22,t23,t33,ua,ugr,va,vgr,wa,avgsfcu,avgsfcv,avgsfcs,bndy,kbdy)


### PR DESCRIPTION
This PR addresses several bugs associated with the placement of global integrals into GPU memory.  They were moved back to the CPU.  It eliminates a large number of '$acc compare' directives and some commented out stop statements used for debugging.  It did add a new routine used for debugging 'maxmin2dhalo' and added it to several locations in the code.