### PR TITLE
Bc cleanup

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -138,7 +138,7 @@ endif
 #  Intel compiler
 #-----------------------------------------------------------------------------
 ifeq (${FC},ifort)
-    OPTS         += -g -O2 -XhOst -ip -assume byterecl -fp-model precise -ftz -init=snan,arrays -traceback -no-fma
+    OPTS         += -g -O2 -xHost -ip -assume byterecl -fp-model precise -ftz -init=snan,arrays -traceback -no-fma
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${USE_OPENMP_L},true)
         OPTS     += -qopenmp

--- a/src/ib_module.F
+++ b/src/ib_module.F
@@ -31,7 +31,7 @@
 
     use input
     use constants
-    use bc_module, only: bc2d_GPU, bcs2_2d
+    use bc_module, only: bc2d_GPU, bcs2_2d_GPU
     use comm_module
 #ifdef MPI
     use mpi
@@ -197,8 +197,8 @@
                                south,newsouth,north,newnorth,reqs_p)
       call comm_2dew_end(zsfoo,west,newwest,east,neweast,reqs_p)
       call comm_2dns_end(zsfoo,south,newsouth,north,newnorth,reqs_p)
-      call bcs2_2d(zsfoo)
       !$acc data copy(zsfoo)
+      call bcs2_2d_GPU(zsfoo)
       call bc2d_GPU(zsfoo)
       !$acc end data
       call getcorner3_2d(zsfoo)

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -2137,6 +2137,9 @@
 !------------------------------------------------------------------
 
         IF( do_ib )THEN
+#ifdef _OPENACC
+          stop 'entering GPU resident compute region'
+#endif
           call zero_out_uv(bndy,kbdy,ua ,va )
           call zero_out_w(bndy,kbdy,wa )
           if( cm1setup.eq.1 .and. iusetke ) call zero_out_w(bndy,kbdy,tkea )

--- a/src/input.F
+++ b/src/input.F
@@ -40,6 +40,8 @@
               use_pbl,use_avg_sfc,dot2p,iusetke,do_adapt_move,                &
               bl_mynn_tkeadvect
 
+!$acc declare create(p2tchsws,p2tchsww,p2tchses,p2tchsee,p2tchnwn,p2tchnww,p2tchnen,p2tchnee)
+
 !-----------------------------------------------------------------------
 
       integer nx,ny,nz,nodex,nodey,ppnode,timeformat,timestats,               &
@@ -171,7 +173,7 @@
 !$acc                prznt,prust,przs,prsig,prvpx,prvpy,prvpz,prrp, &
 !$acc                prms,prtp,prmult,pract,ntwk,imp,jmp,kmp,kmt, &
 !$acc                rmp,cmp,ibw,ibe,ibs,ibn,nodex,nodey, &
-!$acc                myi,myj)
+!$acc                myi,myj,mdiff)
 !-----------------------------------------------------------------------
 
       real dx,dy,dz,dtl,timax,run_time,                                       &

--- a/src/param.F
+++ b/src/param.F
@@ -254,7 +254,7 @@
       call bcast_int(weno_order)
       call bcast_int(apmasscon)
       call bcast_int(idiff)
-      call bcast_int(mdiff)
+      call bcast_int(mdiff,device=.true.)
       call bcast_int(difforder)
       call bcast_int(imoist,device=.true.)
       call bcast_int(ipbl)
@@ -7934,6 +7934,7 @@
       if(dowr) write(outfile,*) '  p2tchnwn =',p2tchnwn
       if(dowr) write(outfile,*) '  p2tchnen =',p2tchnen
       if(dowr) write(outfile,*)
+      !$acc update device(p2tchsws,p2tchsww,p2tchses,p2tchsee,p2tchnwn,p2tchnww,p2tchnen,p2tchnee)
 #endif
 
 !CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -398,7 +398,6 @@
       else
         tqnudge = .false.
       endif
-      tqnudge = .false.
 
 
       timenudge = mtime+dt

--- a/src/turb.F
+++ b/src/turb.F
@@ -5734,7 +5734,9 @@
       s2b(k) = shravg
 
     enddo
+    !$acc end parallel
 
+    !$acc parallel
     gamk(1) = gamk(2)
     !$acc end parallel
     endif  doinggamk

--- a/src/turb.F
+++ b/src/turb.F
@@ -5350,7 +5350,7 @@
     doingt2p:  &
     if( t2pfac.ge.0.001 )then
 
-      if( myid.eq.0 ) print *,'  t2pfac = ',t2pfac
+      if( myid.eq.0 ) print *,'t2pcode:  t2pfac = ',t2pfac
 
     !-------------------------------------------
 
@@ -5647,10 +5647,9 @@
       call MPI_ALLREDUCE(MPI_IN_PLACE,cavg(1,2),nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       !$acc update device(cavg)
 #endif
-      !$acc parallel default(present) 
       temd = 1.0/dble(nx*ny)
 
-      !$acc loop gang vector
+      !$acc parallel loop gang vector default(present) 
       do k=1,nk
         uavg(k)  = cavg(k,1)*temd
         vavg(k)  = cavg(k,2)*temd
@@ -5660,7 +5659,6 @@
       enddo
 
       teme = 1.0/dble(nx*ny)
-      !$acc end parallel
 
 #ifdef _B4B11R
     !$acc update host(mf,c1,c2,t11,t22,t33,t12,t13,t23,rf)
@@ -5724,6 +5722,8 @@
     !$acc parallel private(k,shravg) 
     !$acc loop gang vector
     do k=2,ntwk
+      s13b = 0.5*(uavg(k)-uavg(k-1))*rdz*mf(1,1,k)
+      s23b = 0.5*(vavg(k)-vavg(k-1))*rdz*mf(1,1,k)
       spavg(k) = sqrt( spavg(k)*teme )
 
       shravg = sqrt( 4.0*( s13b**2 + s23b**2 ) )


### PR DESCRIPTION
Identified and fixed a race condition bug in the getgamk subroutine.  Note that this changed significantly improved correctness for when tqnudge is disabled.  We are now re-enabling tqnudge for further debugging work.

OpenACC versus Intel:
29 stat variables are identical.
54 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06

OpenACC+MPI versus Intel:
26 stat variables are identical.
57 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06
