### PR TITLE
Added the only clause to the input module in several acoustic solvers

### DIFF
--- a/src/anelp.F
+++ b/src/anelp.F
@@ -19,7 +19,11 @@
                        wa,w3d,wten,                                 &
                        ppi,pp3d,phi1,phi2,cfb,cfa,cfc,              &
                         d1, d2,pdt,lgbth,lgbph,rhs,trans,dttmp,nrk,rtime,mtime)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,rmp,imp,jmp,kmp, &
+          ibph,ieph,jbph,jeph,kbph,keph,ipb,ipe,jpb,jpe,kpb,kpe, &
+          ni,nj,nk,nsound,terrain_flag,rdx,rdy,rdz,axisymm,timestats,time_sound, &
+          mytime,irbc,ibw,ibe,ibs,ibn,wbc,ebc,sbc,nbc,roflux,convinit,convtime,nx,ny,myid, &
+          zdeep,lamx,lamy,xcent,ycent,aconv,wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge
       use bc_module, only: bcs_GPU, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -336,6 +336,7 @@
       iusetke = .false.
       ramp_up_turb = .false.
       do_adapt_move = .false.
+      !$acc update device(smeps)
 
       dorestart = .false.
       dowriteout = .false.

--- a/src/input.F
+++ b/src/input.F
@@ -214,7 +214,7 @@
 !$acc                alph,kdiv,rdx,rdy,rdz,minx,   &
 !$acc                maxx,miny,maxy,zt,rzt,umove,vmove,   &
 !$acc                viscosity,pr_num,sc_num,maxz,cgs1,cgs2, &
-!$acc                cgs3,cgt1,cgt2,cgt3,hurr_rad)
+!$acc                cgs3,cgt1,cgt2,cgt3,csound,hurr_rad,smeps)
 !-----------------------------------------------------------------------
 
       character(len=maxstring) :: string

--- a/src/param.F
+++ b/src/param.F
@@ -6459,6 +6459,7 @@
         if(dowr) write(outfile,*) 'csound=',csound
         if(dowr) write(outfile,*)
       endif
+      !$acc update device(csound)
 
       if(dowr) write(outfile,*)
       if(dowr) write(outfile,*) 'timeformat   =',timeformat

--- a/src/sound.F
+++ b/src/sound.F
@@ -22,7 +22,10 @@
                         thv,ppterm,nrk,dttmp,rtime,mtime,get_time_avg,    &
                         bndy,kbdy,                                        &
                         pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-      use input
+      use input, only: ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,rmp,imp,jmp,kmp, &
+          ni,nj,nk,nsound,psolver,terrain_flag,rdx,rdy,rdz,axisymm,timestats,time_sound, &
+          mytime,irbc,ibw,ibe,ibs,ibn,wbc,ebc,sbc,nbc,roflux,convinit,convtime,nx,ny,myid, &
+          zdeep,lamx,lamy,xcent,ycent,aconv,wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound,alph
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge
       use bc_module, only: bcs_GPU, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &

--- a/src/soundcb.F
+++ b/src/soundcb.F
@@ -22,7 +22,11 @@
                         thv,ppterm,nrk,dttmp,rtime,mtime,get_time_avg,    &
                         bndy,kbdy,                                        &
                         pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,rmp,imp,jmp,kmp, &
+          ibph,ieph,jbph,jeph,kbph,keph,ni,nj,nk,nsound,terrain_flag,rdx,rdy,rdz, &
+          axisymm,timestats,time_sound,mytime,irbc,ibw,ibe,ibs,ibn,wbc,ebc,sbc,nbc, &
+          roflux,convinit,convtime,nx,ny,myid,zdeep,lamx,lamy,xcent,ycent,aconv, &
+          wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge,getdiv
       use bc_module, only: bcs_GPU, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -22,7 +22,11 @@
                         thv,ppterm,nrk,dttmp,rtime,mtime,get_time_avg,    &
                         bndy,kbdy,                                        &
                         pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-      use input
+
+      use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,rmp,imp,jmp,kmp,         &
+          ni,nj,nk,nsound,psolver,terrain_flag,rdx,rdy,rdz,axisymm,timestats,time_sound,   &
+          mytime,irbc,ibw,ibe,ibs,ibn,wbc,ebc,sbc,nbc,roflux,convinit,convtime,nx,ny,myid, &
+          zdeep,lamx,lamy,xcent,ycent,aconv,wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge
       use bc_module, only: bcp, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &

--- a/src/soundns.F
+++ b/src/soundns.F
@@ -19,7 +19,10 @@
                          wa,w3d,wten,                                     &
                          ppi,pp3d,ppten,thv,ppterm,dttmp,nrk,rtime,mtime, &
                          bndy,kbdy)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,rmp,imp,jmp,kmp, &
+          ni,nj,nk,nsound,psolver,terrain_flag,rdx,rdy,rdz,axisymm,timestats,time_sound, &
+          mytime,irbc,ibw,ibe,ibs,ibn,wbc,ebc,sbc,nbc,roflux,convinit,convtime,nx,ny,myid, &
+          zdeep,lamx,lamy,xcent,ycent,aconv,wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge,getdiv
       use bc_module, only: radbcew,radbcns, restrict_openbc_we, restrict_openbc_sn, &


### PR DESCRIPTION
This PR adds the use of the FORTRAN only clause for the 'input' module in several acoustic solvers.  This change has allowed for the identification of two module variables (smeps, csound) that were potentially not set properly on the GPU.  While it does not appear to change answers.  

CPU versus GPU
29 stat variables are identical.
54 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06

CPU versus GPU+MPI
26 stat variables are identical.
57 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06
 