### PR TITLE
Add missing OpenACC reduction clause and improve coding style

### DIFF
--- a/src/adv.F
+++ b/src/adv.F
@@ -1913,7 +1913,7 @@
 
     IF( dolsw )THEN
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(2) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present)
       do k=1,nk
       do j=1,nj
       do i=1,ni+1

--- a/src/bc.F
+++ b/src/bc.F
@@ -2533,15 +2533,17 @@
         temout(k) = 0.0d0
         temin(k)  = 0.0d0
       enddo
+      !$acc end parallel
 
       if(wbc.eq.2.and.ibw.eq.1)then
         i=1
         !$omp parallel do default(shared) private(j,k,temp1,temp2)
-        !$acc parallel loop gang vector private(j,k,temp1,temp2)
+        !$acc parallel default(present) reduction(+:temp1,temp2)
+        !$acc loop gang
         do k=1,nk
           temp1 = temout(k)
           temp2 = temin(k)
-          !$acc loop reduction(+:temp1,temp2) 
+          !$acc loop vector reduction(+:temp1,temp2) 
           do j=1,nj
             temp1 = temp1 - min(0.0,rho0(1,j,k)*u3d(i,j,k)*rvh(j)*rmh(1,j,k))
             temp2 = temp2 + max(0.0,rho0(1,j,k)*u3d(i,j,k)*rvh(j)*rmh(1,j,k))
@@ -2554,20 +2556,13 @@
 
       if(ebc.eq.2.and.ibe.eq.1)then
         i=ni+1
-        !!$omp parallel do default(shared) private(j,k)
-        !do k=1,nk
-        !do j=1,nj
-        !  temout(k)=temout(k)+max(0.0,rho0(ni,j,k)*u3d(i,j,k)*rvh(j)*rmh(ni,j,k))
-        !  temin(k) =temin(k) -min(0.0,rho0(ni,j,k)*u3d(i,j,k)*rvh(j)*rmh(ni,j,k))
-        !enddo
-        !enddo
-
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector private(j,k,temp1,temp2)
+        !$acc parallel default(present) reduction(+:temp1,temp2)
+        !$acc loop gang
         do k=1,nk
           temp1 = temout(k)
           temp2 = temin(k)
-          !$acc loop reduction(+:temp1,temp2)
+          !$acc loop vector reduction(+:temp1,temp2)
           do j=1,nj
             temp1 = temp1 + max(0.0,rho0(ni,j,k)*u3d(i,j,k)*rvh(j)*rmh(ni,j,k))
             temp2 = temp2 - min(0.0,rho0(ni,j,k)*u3d(i,j,k)*rvh(j)*rmh(ni,j,k))
@@ -2613,6 +2608,7 @@
           endif
         enddo
         enddo
+        !$acc end parallel
       endif
 
       if(ebc.eq.2.and.ibe.eq.1)then
@@ -2627,6 +2623,7 @@
           endif
         enddo
         enddo
+        !$acc end parallel
       endif
 
       !$acc end data

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -10102,25 +10102,18 @@
 
   !----------------------
 
-    
-#ifndef _B4B21R
-    !$acc parallel default(present) private(i,j,k) reduction(+:vbart) reduction(+:vfrt,vfdt)
+    !$acc parallel default(present)
     !$acc loop gang vector
-#endif
     do k=1,nk
       vbar(k) = 0.0
     enddo
+    !$acc end parallel
 
-#ifdef _B4B21R
-    !$acc update host(dum3)
-#else
+    !$acc parallel default(present) reduction(+:vbart)
     !$acc loop gang
-#endif
     do k=2,nk
       vbart = 0.0d0
-#ifndef _B4B21R
       !$acc loop vector collapse(2) reduction(+:vbart)  
-#endif
       do j=1,nj
       do i=1,ni
         vbart = vbart+dum3(i,j,k)
@@ -10128,13 +10121,7 @@
       enddo
       vbar(k) = vbart
     enddo
-#ifdef _B4B21R
-    !$acc update device(vbar)
-#else
     !$acc end parallel
-#endif
-        !buh4
-    !stop 'domaindiag: point #1'
 
 #ifdef MPI
     !$acc update host(vbar)
@@ -10165,7 +10152,6 @@
           wbar = 0.5*(w3d(i,j,k)+w3d(i,j-1,k))
           vfrt = vfrt + wbar*(dum4(i,j,k)-vbar(k))
           vfdt = vfdt+ wbar*(dum3(i,j,k)-dum4(i,j,k))
-        !buh5
         enddo
         enddo
         vfr(k) = vfrt
@@ -10175,11 +10161,7 @@
 
     !-------------------------------------------------------
 
-#ifdef _B4B23R
-      !$acc update host(rf,m13,m23,t13,t23)
-#else
       !$acc parallel default(present) private(i,j,k) reduction(+:ufst,vfst)
-#endif
       if( cm1setup.ge.1 .or. ipbl.eq.2 )then
         if( sgsmodel.eq.5 .or. sgsmodel.eq.6 )then
           ! use mij:
@@ -10347,12 +10329,14 @@
 
   !----------------------
 
-    !$acc parallel default(present) reduction(+:sbart)
-    !$acc loop vector gang 
+    !$acc parallel default(present)
+    !$acc loop gang vector
     do k=1,nk+1
       sbar(k) = 0.0
     enddo
+    !$acc end parallel
 
+    !$acc parallel default(present) reduction(+:sbart)
     !$acc loop gang
     do k=2,nk
       sbart=0.d0
@@ -10365,7 +10349,6 @@
       sbar(k) = sbart
     enddo
     !$acc end parallel
-        !buh4
 
 #ifdef MPI
     !$acc update host(sbar)
@@ -10384,8 +10367,8 @@
 
   !----------------------
 
-    !$acc parallel default(present) private(i,j,k) reduction(+:sfrt,sfdt,sfst)
     !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel default(present) reduction(+:sfrt,sfdt)
     !$acc loop gang 
     do k=2,nk
       sfrt=0.0d0
@@ -10395,14 +10378,15 @@
       do i=1,ni
         sfrt = sfrt + w3d(i,j,k)*(dum4(i,j,k)-sbar(k))
         sfdt = sfdt + w3d(i,j,k)*(dum3(i,j,k)-dum4(i,j,k))
-        !buh5
       enddo
       enddo
       sfr(k) = sfrt
       sfd(k) = sfdt
     enddo
+    !$acc end parallel
 
     if( cm1setup.ge.1 .or. ipbl.eq.2 .or. cm1setup.eq.3 )then
+      !$acc parallel default(present) reduction(+:sfst)
       !$acc loop gang 
       do k=2,nk
         sfst=0.0d0
@@ -10414,13 +10398,15 @@
         enddo
         sfs(k) = sfst
       enddo
+      !$acc end parallel
     else
+      !$acc parallel default(present)
       !$acc loop gang vector
       do k=2,nk
         sfs(k) = 0.0d0
       enddo
+      !$acc end parallel
     endif
-    !$acc end parallel
 
       !-----------------------------
       ! 171122:  boundary conditions
@@ -10531,12 +10517,12 @@
       integer :: k
       real :: fb1,fb2
 
-        !$acc parallel default(present) private(k,fb1,fb2) reduction(+:wstar)
         wstar = 0.0
         fbmin = 1.0e30
         zfbmin = 0.0
 
-        !$acc loop vector reduction(+:wstar)
+        !$acc parallel default(present)
+        !$acc loop seq
         do k=1,nk
           if( k.eq.1 )then
             fb1 = g*( thfavg*rth0s(1,1) + repsm1*qvfavg )
@@ -10552,16 +10538,13 @@
           wstar = wstar + (zf(1,1,k+1)-zf(1,1,k))*0.5*(fb1+fb2)
 
           if( fb1.lt.fbmin )then
-            !$acc atomic write
             fbmin = fb1
-            !$acc atomic write
             zfbmin = zf(1,1,k)
           endif
-
         enddo
+        !$acc end parallel
         
         wstar = 2.5*(max(0.0d0,wstar)**(1.0/3.0))
-        !$acc end parallel
 
       end subroutine getwstar
 
@@ -10586,7 +10569,7 @@
     integer :: i,j
 
     savg2d = 0.0
-    !$acc parallel default(present) private(i,j) reduction(+:savg2d)
+    !$acc parallel default(present) reduction(+:savg2d)
     !$acc loop gang vector collapse(2) reduction(+:savg2d)
     do j=1,nj
     do i=1,ni
@@ -10635,12 +10618,14 @@
       k2 = min(nkm,nk+1)
     ENDIF
 
-    !$acc parallel default(present) reduction(+:stmp)
-    !$acc loop 
+    !$acc parallel default(present)
+    !$acc loop gang vector
     do k=1,nk+1
       savg(k) = 0.0
     enddo
+    !$acc end parallel
 
+    !$acc parallel default(present)
     !$acc loop gang
     do k=1,k2
       stmp = 0.0
@@ -10664,10 +10649,9 @@
     do k=1,k2
       savg(k) = savg(k)/dble(nx*ny)
     enddo
+    !$acc end parallel
 
     end subroutine getavg3d
-
-
 
     !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
     !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -10695,19 +10679,20 @@
     IF( present(nkm) )THEN
       k2 = min(nkm,nk+1)
     ENDIF
-    !$acc parallel default(present) private(i,j,k) reduction(max:temd)
+    !$acc parallel default(present)
     !$acc loop gang vector
     do k=1,nk+1
       savg(k) = -1.0e30
     enddo
+    !$acc end parallel
 
+    !$acc parallel default(present) reduction(max:temd)
     !$acc loop gang
     do k=1,k2
       temd = -1.0e30
       !$acc loop vector collapse(2) reduction(max:temd)
       do j=1,nj
       do i=1,ni
-        !savg(k) = max(savg(k),s(i,j,k))
         temd = max(temd,s(i,j,k))
       enddo
       enddo
@@ -10749,19 +10734,20 @@
     IF( present(nkm) )THEN
       k2 = min(nkm,nk+1)
     ENDIF
-    !$acc parallel default(present) reduction(min:temd)
+    !$acc parallel default(present)
     !$acc loop gang vector
     do k=1,nk+1
       savg(k) = 1.0e30
     enddo
+    !$acc end parallel
 
+    !$acc parallel default(present) reduction(min:temd)
     !$acc loop gang
     do k=1,k2
       temd = 1.0e30
       !$acc loop vector collapse(2) reduction(min:temd)
       do j=1,nj
       do i=1,ni
-        !savg(k) = min(savg(k),s(i,j,k))
         temd = min(temd,s(i,j,k))
       enddo
       enddo
@@ -10938,7 +10924,7 @@
     integer :: i,j,k
     !$acc declare present(rtkeb,utk,udiag,uavg)
 
-    !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+    !$acc parallel loop gang vector collapse(3) default(present)
     do k=1,nk
     do j=1,nj
     do i=1,ni
@@ -10954,7 +10940,7 @@
     enddo
     enddo
     enddo
-
+    !$acc end parallel
 
     if( myid.eq.0 ) print *,'  rtkeb_addu,udn = ',udn
 
@@ -10977,7 +10963,7 @@
     integer :: i,j,k
     !$acc declare present(rtkeb,vtk,vdiag,vavg)
 
-    !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+    !$acc parallel loop gang vector collapse(3) default(present)
     do k=1,nk
     do j=1,nj
     do i=1,ni
@@ -10993,6 +10979,7 @@
     enddo
     enddo
     enddo
+    !$acc end parallel
 
     if( myid.eq.0 ) print *,'  rtkeb_addv,vdn = ',vdn
 
@@ -11015,7 +11002,7 @@
     integer :: i,j,k
     !$acc declare present(rtkeb,wtk,wdiag,wavg)
 
-    !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+    !$acc parallel loop gang vector collapse(3) default(present)
     do k=1,nk
     do j=1,nj
     do i=1,ni
@@ -11028,6 +11015,7 @@
     enddo
     enddo
     enddo
+    !$acc end parallel
 
     if( myid.eq.0 ) print *,'  rtkeb_addw,wdn = ',wdn
 
@@ -11052,7 +11040,7 @@
     integer :: i,j,k
     !$acc declare present(uwb,utk,wtk,udiag,wdiag,u_avg,w_avg)
 
-    !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+    !$acc parallel loop gang vector collapse(3) default(present)
     do k=2,nk
     do j=1,nj
     do i=1,ni
@@ -11066,6 +11054,7 @@
     enddo
     enddo
     enddo
+    !$acc end parallel
 
     if( myid.eq.0 ) print *,'  uwb: udn,wdn = ',udn,wdn
 
@@ -11090,7 +11079,7 @@
     integer :: i,j,k
     !$acc declare present(vwb,vtk,wtk,vdiag,wdiag,v_avg,w_avg)
 
-    !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+    !$acc parallel loop gang vector collapse(3) default(present)
     do k=2,nk
     do j=1,nj
     do i=1,ni
@@ -11104,6 +11093,7 @@
     enddo
     enddo
     enddo
+    !$acc end parallel
 
     if( myid.eq.0 ) print *,'  vwb: vdn,wdn = ',vdn,wdn
 

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -5741,7 +5741,7 @@
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 
       !c-c-c-c-c-c-c-c-c-c
-#if 0
+#if 1 
         call     momentum_flux(u3d,v3d,w3d,t13,t23,m13,m23,rf,rf0,c1,c2,dum3,dum4,dum5,ufr,ufs,ufd,vfr,vfs,vfd)
 
         nvar = nvar+1
@@ -7120,7 +7120,6 @@
 
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 
-       stop 'domaindiag: ub_vturbr'
       !c-c-c-c-c-c-c-c-c-c
 
         nvar = nvar+1
@@ -10239,7 +10238,6 @@
 
       !$acc end data
 
-      stop 'momentum_flux: at the end'
       end subroutine momentum_flux
 
 

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -5741,7 +5741,7 @@
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 
       !c-c-c-c-c-c-c-c-c-c
-#if 1 
+
         call     momentum_flux(u3d,v3d,w3d,t13,t23,m13,m23,rf,rf0,c1,c2,dum3,dum4,dum5,ufr,ufs,ufd,vfr,vfs,vfd)
 
         nvar = nvar+1
@@ -7149,7 +7149,6 @@
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
 
       !c-c-c-c-c-c-c-c-c-c
-#endif
 
       if( ud_hadv.ge.1 )then
 

--- a/src/kessler.F
+++ b/src/kessler.F
@@ -565,13 +565,9 @@
     !$acc parallel
     IF(nrk.ge.nrkmax)THEN
       dum=dx*dy*dz
-      !$acc loop gang vector reduction(+:tcond)
+      !$acc loop gang vector reduction(+:tcond,tevac)
       do k=1,nk
         tcond=tcond+bud1(k)*dum
-      enddo
-
-      !$acc loop gang vector reduction(+:tevac)
-      do k=1,nk
         tevac=tevac+bud2(k)*dum
       enddo
     ENDIF
@@ -1017,8 +1013,8 @@
       !$acc data create(bud)
 
       !$omp parallel do default(shared) private(i,j)
-      !$acc parallel default(present) private(i,j) reduction(+:budt,erain)
-      !$acc loop gang
+      !$acc parallel default(present) reduction(+:budt,erain)
+      !$acc loop gang reduction(+:erain)
       do j=1,nj
         budt=0.0d0
         !$acc loop vector reduction(+:budt)
@@ -1026,10 +1022,6 @@
           budt=budt+dt*vr(i,j,1)*rr(i,j,1)*q3d(i,j,1)*(cpx*t(i,j,1)-lx1)*ruh(i)*rvh(j)
         enddo
         bud(j)=budt
-      enddo
-
-      !$acc loop vector reduction(+:erain)
-      do j=1,nj
         erain=erain+bud(j)*dx*dy
       enddo
       !$acc end parallel

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1154,6 +1154,7 @@
       enddo
       enddo
       enddo
+      !$acc end parallel
 
       if(timestats.ge.1) time_parceli=time_parceli+mytime()
 
@@ -1169,6 +1170,7 @@
       enddo
       enddo
       enddo
+      !$acc end parallel
 
       if(timestats.ge.1) time_parceli=time_parceli+mytime()
 
@@ -1194,7 +1196,7 @@
       enddo
       enddo
       enddo
-
+      !$acc end parallel
     ENDIF
     !HERE print *,'parcel_interp: before nploop2'
 !----------------------------------------------------------------------
@@ -1202,11 +1204,7 @@
 !----------------------------------------------------------------------
 !  Loop through all parcels:  if you have it, get interpolated info:
     !PORTME
-    !$acc parallel loop gang vector default(present) &
-    !$acc   private(x3d,y3d,z3d,i,j,k,n,iflag,jflag,kflag, &
-    !$acc       rx,ry,rz,rxu,ryv,rzw,rxs,rys,rzs, &
-    !$acc       w1,w2,w3,w4,w5,w6,w7,w8, &
-    !$acc       uval,vval,wval,z0,var,rznt)
+    !$acc parallel loop gang vector default(present)
     nploop2:  &
     DO np=1,nparcels
 


### PR DESCRIPTION
This PR further improves some coding styles and fixies  some reduction clauses for the GPU code.

Verification results:

CPU versus OpenACC GPU
29 stat variables are identical.
48 stat variables show a mean relative difference > 1e-06
6 stat variables show a mean relative difference <= 1e-06
four variables with maximum error: KSVMAX, KSHMAX, TMW, TKEMAX

CPU versus OpenACC GPU + MPI
26 stat variables are identical.
57 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06
four variables with maximum error: STHPMX, THPMAX, TMW, PPMAX

This is consistent with the current `gpu-opt` branch.