### PR TITLE
Input only mods #4

### DIFF
--- a/src/bc.F
+++ b/src/bc.F
@@ -360,7 +360,8 @@
 
 
       subroutine bcp(p)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc, &
+          ibw,ibe,ibs,ibn,ni,nj,nk,timestats,time_bc,mytime
       implicit none
 
       real, dimension(ib:ie,jb:je,kb:ke) :: p
@@ -855,7 +856,8 @@
 
 
       subroutine bcw(w,flag)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc,ngxy, &
+          ibw,ibe,ibs,ibn,ni,nj,nk,timestats,time_bc,mytime
       implicit none
 
       real, dimension(ib:ie,jb:je,kb:ke+1) :: w
@@ -1020,7 +1022,9 @@
 
 
       subroutine bcwsfc(gz,dzdx,dzdy,u,v,w)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ni,nj, &
+          timestats,time_bc,mytime
+
       implicit none
 
       real, intent(in), dimension(itb:ite,jtb:jte) :: gz
@@ -1057,7 +1061,8 @@
 
 
       subroutine bcs_tend_halo(s)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,wbc,ebc,sbc,nbc, &
+          time_bcst,timestats,mytime
       implicit none
 
       double precision, dimension(ib:ie,jb:je,kb:ke) :: s
@@ -1139,7 +1144,7 @@
 
 
       subroutine extrapbcs(s)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,nk,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
       implicit none
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
@@ -1297,7 +1302,9 @@
 
 
       subroutine bct2(t)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
+          ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
+          patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real t(ib:ie,jb:je,kb:ke+1)
@@ -1423,7 +1430,9 @@
 
 
       subroutine bct2_GPU(t)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
+          ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
+          patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real t(ib:ie,jb:je,kb:ke+1)
@@ -1548,7 +1557,9 @@
 
 
       subroutine bcu2_GPU(u)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
+          ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
+          patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real u(ib:ie+1,jb:je,kb:ke)
@@ -1675,7 +1686,9 @@
 
 
       subroutine bcv2_GPU(v)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
+          ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
+          patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real v(ib:ie,jb:je+1,kb:ke)
@@ -1929,7 +1942,9 @@
 
 
       subroutine bcw2_GPU(w)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
+          ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
+          patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real w(ib:ie,jb:je,kb:ke+1)
@@ -2056,7 +2071,9 @@
 
 
       subroutine bcs2_2d(s)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
+          ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
+          patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real s(ib:ie,jb:je)
@@ -2157,7 +2174,9 @@
 
 
       subroutine bcs2_2d_GPU(s)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
+          ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
+          patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real s(ib:ie,jb:je)
@@ -2267,7 +2286,8 @@
 
 
       subroutine radbcew(radbcw,radbce,ua)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc,ni,nj,nk, &
+          ibw,ibe,ibs,ibn,timestats,time_bc,mytime
       use constants
       implicit none
 
@@ -2322,7 +2342,9 @@
 
 
       subroutine radbcns(radbcs,radbcn,va)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc,ni,nj,nk, &
+          ibw,ibe,ibs,ibn,timestats,time_bc,mytime
+
       use constants
       implicit none
 
@@ -2377,7 +2399,9 @@
 
 
       subroutine radbcew4(ruf,radbcw,radbce,u1,u2,dt)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc,ni,nj,nk, &
+          ibw,ibe,ibs,ibn,dx,timestats,time_bc,mytime
+
       use constants
       implicit none
 
@@ -2441,7 +2465,8 @@
 
 
       subroutine radbcns4(rvf,radbcs,radbcn,v1,v2,dt)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc,ni,nj,nk, &
+          ibw,ibe,ibs,ibn,dy,timestats,time_bc,mytime
       use constants
       implicit none
 
@@ -2508,7 +2533,9 @@
 
 
       subroutine restrict_openbc_we(rvh,rmh,rho0,u3d)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk, &
+          wbc,ebc,sbc,nbc,ibw,ibe,ibs,ibn,time_bc, &
+          ierr,timestats,mytime
 #ifdef MPI
       use mpi
 #endif
@@ -2639,7 +2666,9 @@
 
 
       subroutine restrict_openbc_sn(ruh,rmh,rho0,v3d)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk, &
+          wbc,ebc,sbc,nbc,ibw,ibe,ibs,ibn,time_bc, &
+          ierr,timestats,mytime
 #ifdef MPI
       use mpi
 #endif
@@ -2740,7 +2769,8 @@
 
 
       subroutine ssopenbcw(uh,rds,sigma,rdsf,sigmaf,gz,rgzu,gx,radbcw,dum1,u3d,uten,dts)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,ni,nj,nk, &
+          cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,rdx,terrain_flag,timestats,time_bc,mytime
       implicit none
 
       real, intent(in),    dimension(ib:ie) :: uh
@@ -2825,7 +2855,8 @@
 
 
       subroutine ssopenbce(uh,rds,sigma,rdsf,sigmaf,gz,rgzu,gx,radbce,dum1,u3d,uten,dts)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,ni,nj,nk, &
+          cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,rdx,terrain_flag,timestats,time_bc,mytime
       implicit none
 
       real, intent(in),    dimension(ib:ie) :: uh
@@ -2910,7 +2941,8 @@
 
 
       subroutine ssopenbcs(vh,rds,sigma,rdsf,sigmaf,gz,rgzv,gy,radbcs,dum1,v3d,vten,dts)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,ni,nj,nk, &
+          cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,rdy,terrain_flag,timestats,time_bc,mytime
       implicit none
 
       real, intent(in),    dimension(jb:je) :: vh
@@ -2995,7 +3027,8 @@
 
 
       subroutine ssopenbcn(vh,rds,sigma,rdsf,sigmaf,gz,rgzv,gy,radbcn,dum1,v3d,vten,dts)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,ni,nj,nk, &
+          cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,rdy,terrain_flag,timestats,time_bc,mytime
       implicit none
 
       real, intent(in),    dimension(jb:je) :: vh
@@ -3077,7 +3110,8 @@
 !GPU================================================================================================
 
       subroutine bc2d_GPU(s)
-      use input
+      use input, only : ib,ie,jb,je,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
+          ibw,ibe,ibs,ibn,timestats,time_bc,mytime 
       implicit none
 
       real, dimension(ib:ie,jb:je) :: s
@@ -3241,7 +3275,8 @@
       end subroutine bc2d_GPU
 
       subroutine bcs(s)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
+          ibw,ibe,ibs,ibn,timestats,time_bc,mytime
       implicit none
 
       real, dimension(ib:ie,jb:je,kb:ke) :: s
@@ -3417,7 +3452,8 @@
       end subroutine bcs
 
       subroutine bcs_GPU(s)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
+          ibw,ibe,ibs,ibn,timestats,time_bcs,mytime
       implicit none
 
       real, dimension(ib:ie,jb:je,kb:ke) :: s
@@ -3631,7 +3667,8 @@
       end subroutine bcs_GPU
 
       subroutine bcu_GPU(u)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
+          ibw,ibe,ibs,ibn,timestats,time_bc,mytime
       implicit none
 
       real, dimension(ib:ie+1,jb:je,kb:ke) :: u
@@ -3849,7 +3886,8 @@
       end subroutine bcu_GPU
 
       subroutine bcv_GPU(v)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
+          ibw,ibe,ibs,ibn,timestats,time_bc,mytime,axisymm
       implicit none
 
       real, dimension(ib:ie,jb:je+1,kb:ke) :: v
@@ -4072,7 +4110,8 @@
       end subroutine bcv_GPU
 
       subroutine bcw_GPU(w,flag)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
+          ibw,ibe,ibs,ibn,timestats,time_bc,mytime
       implicit none
 
       real, dimension(ib:ie,jb:je,kb:ke+1) :: w
@@ -4279,7 +4318,9 @@
 
 
    subroutine bcs2(s)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
+          ibw,ibe,ibs,ibn,timestats,time_bc,mytime,patchsww,patchnww, &
+          patchsee,patchnee,patchsws,patchses,patchnwn,patchnen
       implicit none
 
       real s(ib:ie,jb:je,kb:ke)
@@ -4399,7 +4440,9 @@
       end subroutine bcs2
 
       subroutine bcs2_GPU(s)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
+          ibw,ibe,ibs,ibn,timestats,time_bcs2,mytime,patchsww,patchnww, &
+          patchsee,patchnee,patchsws,patchses,patchnwn,patchnen
       implicit none
 
       real s(ib:ie,jb:je,kb:ke)

--- a/src/comm.F
+++ b/src/comm.F
@@ -72,7 +72,8 @@
 
 #ifdef MPI
       subroutine getcorner(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
  
@@ -245,7 +246,8 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       subroutine getcorner_GPU(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
 
@@ -502,7 +504,8 @@
 
 
       subroutine getcornert(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
 
@@ -677,7 +680,8 @@
 
 
       subroutine getcornert_GPU(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
 
@@ -923,7 +927,8 @@
 
 
       subroutine getcorneru(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
 
@@ -1113,7 +1118,8 @@
 
 
       subroutine getcorneru_GPU(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
 
@@ -1339,7 +1345,8 @@
 
 
       subroutine getcornerv(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
 
@@ -1529,7 +1536,8 @@
 
 
       subroutine getcornerv_GPU(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
 
@@ -1796,7 +1804,8 @@
 
 
       subroutine getcornerw(w,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
 
@@ -1986,7 +1995,8 @@
 
 
       subroutine getcornerw_GPU(w,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
 
@@ -2250,7 +2260,8 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       subroutine getcorner3(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          cmp,nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
  
@@ -2450,7 +2461,8 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       subroutine getcorner3_GPU(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          cmp,nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
       implicit none
 
@@ -2740,7 +2752,8 @@
 
 
       subroutine comm_2we_start_GPU(s,west,newwest,east,neweast,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          cs2we,nf,nkp1,myeast,mywest,ierr,timestats,time_mps3,mytime
       use mpi
       implicit none
 
@@ -2863,7 +2876,8 @@
 
 
       subroutine comm_2we_end_GPU(s,west,newwest,east,neweast,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          cs2we,nf,nkp1,myeast,mywest,ierr,timestats,time_mps4,mytime
       use mpi
       implicit none
 
@@ -2954,7 +2968,8 @@
 
 
       subroutine comm_2sn_start_GPU(s,south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          nf,cs2sn,nkp1,mysouth,mynorth,ierr,timestats,time_mps3,mytime
       use mpi
       implicit none
 
@@ -3078,7 +3093,8 @@
 
 
       subroutine comm_2sn_end_GPU(s,south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
+          nf,cs2sn,nkp1,mysouth,mynorth,ierr,timestats,time_mps4,mytime
       use mpi
       implicit none
 
@@ -3167,7 +3183,9 @@
 
       subroutine comm_3s_start(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
+          myeast,mywest,mysouth,mynorth,nf,cs3we,cs3sn,timestats,time_mps1, &
+          mytime,ierr
       use mpi
       implicit none
  
@@ -3322,7 +3340,9 @@
 
       subroutine comm_3s_start_GPU(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
+          myeast,mywest,mysouth,mynorth,nf,cs3we,cs3sn,timestats,time_mps1, &
+          mytime,ierr
       use mpi
       implicit none
  
@@ -3543,7 +3563,10 @@
  
       subroutine comm_3s_end(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
+          wbc,ebc,nbc,sbc,myeast,mywest,mysouth,mynorth,nf,cs3we,cs3sn,timestats, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen, &
+          time_bc,time_mps2,mytime,ierr
       use mpi
       implicit none
  
@@ -3762,7 +3785,10 @@
  
       subroutine comm_3s_end_GPU(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
+          wbc,ebc,nbc,sbc,myeast,mywest,mysouth,mynorth,nf,cs3we,cs3sn,timestats, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen, &
+          time_bc,time_mps2, mytime,ierr
       use mpi
       implicit none
  
@@ -3996,7 +4022,9 @@
       ! tk1
       subroutine comm_3t_start(t,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
+          nf,ct3we,ct3sn,nkp1,timestats,time_mps1,mytime,ierr, &
+          myeast,mywest,mynorth,mysouth
       use mpi
       implicit none
 
@@ -4150,7 +4178,9 @@
       ! tk1
       subroutine comm_3t_start_GPU(t,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
+          nf,ct3we,ct3sn,nkp1,timestats,time_mps1,mytime,ierr, &
+          myeast,mywest,mynorth,mysouth
       use mpi
       implicit none
 
@@ -4369,7 +4399,9 @@
 
       subroutine comm_3t_end(t,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
+          ierr,nkp1,ebc,wbc,sbc,nbc,timestats,time_mps2,time_bc,mytime, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
 
@@ -4584,7 +4616,9 @@
 
       subroutine comm_3t_end_GPU(t,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
+          ierr,nkp1,ebc,wbc,sbc,nbc,timestats,time_mps2,time_bc,mytime, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
 
@@ -4818,7 +4852,8 @@
  
       subroutine comm_3u_start(u,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
+          timestats,mytime,nu,time_mpu1,cs3we,cu3sn,ierr,mynorth,mysouth,myeast,mywest
       use mpi
       implicit none
  
@@ -4971,7 +5006,8 @@
  
       subroutine comm_3u_start_GPU(u,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
+          timestats,mytime,nu,time_mpu1,cs3we,cu3sn,ierr,mynorth,mysouth,myeast,mywest
       use mpi
       implicit none
  
@@ -5191,7 +5227,9 @@
  
       subroutine comm_3u_end(u,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
+          ebc,wbc,sbc,nbc,ierr,timestats,time_mpu2,mytime,time_bc, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -5409,7 +5447,9 @@
  
       subroutine comm_3u_end_GPU(u,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
+          ebc,wbc,sbc,nbc,ierr,timestats,time_mpu2,mytime,time_bc, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -5641,7 +5681,9 @@
  
       subroutine comm_3v_start(v,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,timestats,mytime,nv,time_mpv1,cv3we,cs3sn,ierr, &
+          myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -5793,7 +5835,9 @@
  
       subroutine comm_3v_start_GPU(v,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,timestats,mytime,nv,time_mpv1,cv3we,cs3sn,ierr, &
+          myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -6010,7 +6054,9 @@
  
       subroutine comm_3v_end(v,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
+          ebc,wbc,sbc,nbc,ierr,timestats,time_mpv2,mytime,time_bc, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -6232,7 +6278,9 @@
  
       subroutine comm_3v_end_GPU(v,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
+          ebc,wbc,sbc,nbc,ierr,timestats,time_mpv2,mytime,time_bc, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -6465,7 +6513,9 @@
  
       subroutine comm_3w_start(w,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
+          ierr,timestats,mytime,nw,time_mpw1,cw3we,cw3sn,mywest,myeast, & 
+          mysouth,mynorth
       use mpi
       implicit none
  
@@ -6618,7 +6668,9 @@
  
       subroutine comm_3w_start_GPU(w,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
+          ierr,timestats,mytime,nw,time_mpw1,cw3we,cw3sn,mywest,myeast, &
+          mysouth,mynorth
       use mpi
       implicit none
  
@@ -6836,7 +6888,9 @@
  
       subroutine comm_3w_end(w,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
+          wbc,ebc,nbc,sbc,ierr,mytime,timestats,time_mpw2,time_bc, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -7054,7 +7108,9 @@
  
       subroutine comm_3w_end_GPU(w,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
+          wbc,ebc,nbc,sbc,ierr,mytime,timestats,time_mpw2,time_bc, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -7289,7 +7345,8 @@
 
       subroutine comm_1s2d_start(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
+          nf,ierr,timestats,time_mps1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -7427,7 +7484,8 @@
 
       subroutine comm_1s2d_start_GPU(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
+          nf,ierr,timestats,time_mps1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
 
@@ -7631,7 +7689,9 @@
  
       subroutine comm_1s2d_end(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn, &
+          wbc,ebc,nbc,sbc,timestats,mytime,time_mps2,time_bc,ierr, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -7798,7 +7858,9 @@
 
       subroutine comm_1s2d_end_GPU(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn, &
+          wbc,ebc,nbc,sbc,timestats,mytime,time_mps2,time_bc,ierr, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
 
@@ -7984,7 +8046,9 @@
 
       subroutine comm_1s_start(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,nf,cs1we,cs1sn,ierr,timestats,time_mps1,mytime, & 
+          myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -8125,7 +8189,9 @@
 
       subroutine comm_1s_start_GPU(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,nf,cs1we,cs1sn,ierr,timestats,time_mps1,mytime, & 
+          myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -8345,7 +8411,9 @@
  
       subroutine comm_1s_end(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          ebc,wbc,sbc,nbc,timestats,mytime,ierr,time_bc,time_mps2, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -8555,7 +8623,9 @@
 
       subroutine comm_1s_end_GPU(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          ebc,wbc,sbc,nbc,timestats,mytime,ierr,time_bc,time_mps2, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -8784,7 +8854,9 @@
 
       subroutine comm_1p_start(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,nf,ierr,timestats,time_mpp1,mytime, &
+          cs1we,cs1sn,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -8929,7 +9001,9 @@
 
       subroutine comm_1p_start_GPU(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,nf,ierr,timestats,time_mpp1,mytime, &
+          cs1we,cs1sn,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
 
@@ -9149,7 +9223,8 @@
 
       subroutine comm_1p_end(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          ebc,wbc,sbc,nbc,timestats,mytime,time_bc,time_mpp2,ierr
       use mpi
       implicit none
  
@@ -9260,7 +9335,8 @@
  
       subroutine comm_1p_end_GPU(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          ebc,wbc,sbc,nbc,timestats,mytime,time_bc,time_mpp2,ierr
       use mpi
       implicit none
  
@@ -9396,7 +9472,9 @@
 
       subroutine comm_1t_start(t,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,ct1we,ct1sn,nf,ierr,timestats,time_mps1,mytime, &
+          myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
 
@@ -9542,7 +9620,9 @@
 
       subroutine comm_1t_start_GPU(t,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,ct1we,ct1sn,nf,ierr,timestats,time_mps1,mytime, &
+          myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
 
@@ -9755,7 +9835,9 @@
 
       subroutine comm_1t_end(t,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,mytime,ierr,timestats,time_mps2,time_bc, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
 
@@ -9965,7 +10047,9 @@
 
       subroutine comm_1t_end_GPU(t,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,mytime,ierr,timestats,time_mps2,time_bc, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
 
@@ -10201,7 +10285,8 @@
 
       subroutine comm_1u_start(u,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
+          nu,cs1we,cu1sn,ierr,timestats,time_mpu1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -10346,7 +10431,9 @@
  
       subroutine comm_1u_end(u,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,ierr,timestats,mytime,time_bc,time_mpu2, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen     
       use mpi
       implicit none
  
@@ -10558,7 +10645,8 @@
 
       subroutine comm_1v_start(v,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
+          cv1we,cs1sn,nv,ierr,timestats,time_mps1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -10703,7 +10791,9 @@
  
       subroutine comm_1v_end(v,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,ierr,timestats,mytime,time_bc,time_mps2, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -10914,7 +11004,9 @@
  
       subroutine comm_1w_start(w,ww1,ww2,we1,we2,   &
                                  ws1,ws2,wn1,wn2,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,cw1we,cw1sn, &
+          nw,ierr,timestats,time_mpw1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -11052,7 +11144,9 @@
  
       subroutine comm_1w_start_GPU(w,ww1,ww2,we1,we2,   &
                                  ws1,ws2,wn1,wn2,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,cw1we,cw1sn, &
+          nw,ierr,timestats,time_mpw1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -11256,7 +11350,9 @@
  
       subroutine comm_1w_end(w,ww1,ww2,we1,we2,   &
                                ws1,ws2,wn1,wn2,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibn,ibs, &
+          wbc,ebc,sbc,nbc,timestats,mytime,ierr,time_bc,time_mpw2, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -11493,7 +11589,9 @@
  
       subroutine comm_1w_end_GPU(w,ww1,ww2,we1,we2,   &
                                ws1,ws2,wn1,wn2,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibn,ibs, &
+          wbc,ebc,sbc,nbc,timestats,mytime,ierr,time_bc,time_mpw2, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -11745,7 +11843,8 @@
 
       subroutine comm_2d_start(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
+          nf,ierr,timestats,time_mpq1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
 
@@ -11888,7 +11987,8 @@
 
       subroutine comm_2d_start_GPU(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
+          nf,ierr,timestats,time_mpq1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
 
@@ -12097,7 +12197,8 @@
 
 
       subroutine comm_2dew_end(s,west,newwest,east,neweast,reqs)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ierr, &
+          timestats,time_mpq2,mytime
       use mpi
       implicit none
 
@@ -12155,7 +12256,8 @@
 
 
       subroutine comm_2dew_end_GPU(s,west,newwest,east,neweast,reqs)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ierr, &
+          timestats,time_mpq2,mytime
       use mpi
       implicit none
 
@@ -12226,7 +12328,8 @@ if(Debug) print *, "comm_2dew_end_GPU: Im called"
 
 
       subroutine comm_2dns_end(s,south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,ierr,timestats,time_mpq2,mytime
       use mpi
       implicit none
 
@@ -12317,7 +12420,8 @@ if(Debug) print *, "comm_2dew_end_GPU: Im called"
 
 
       subroutine comm_2dns_end_GPU(s,south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,ierr,timestats,time_mpq2,mytime
       use mpi
       implicit none
 
@@ -12421,7 +12525,8 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
 
 
       subroutine comm_2d_corner(s)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn, &
+          mynw,mysw,myne,myse,timestats,time_mptk1,mytime,ierr
       use mpi
       implicit none
 
@@ -12541,7 +12646,8 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
 
 
       subroutine comm_2d_corner_GPU(s)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn, &
+          mynw,mysw,myne,myse,timestats,time_mptk1,mytime,ierr
       use mpi
       implicit none
 
@@ -12674,7 +12780,8 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       subroutine getcorner3_2d(s)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn, &
+          mynw,mysw,myne,myse,timestats,time_mptk1,mytime,ierr
       use mpi
       implicit none
  
@@ -12853,7 +12960,8 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
 
       subroutine comm_3r_start(th,pp,west,newwest,east,neweast,   &
                                      south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
+          cs3we,cs3sn,nf,ierr,timestats,time_mps1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
 
@@ -13029,7 +13137,9 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
 
       subroutine comm_3r_end(th,pp,west,newwest,east,neweast,   &
                                    south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
+          ebc,wbc,sbc,nbc,ierr,timestats,time_mps2,time_bc,myid,mytime, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
 
@@ -13281,7 +13391,10 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
 
       subroutine comm_3q_start(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,cmp,ni,nj,nk,numq, &
+          ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc,cs3weq,cs3snq,nf, &
+          ierr,timestats,time_mps1, &
+          mytime,myeast,mywest,mysouth,mynorth
       use mpi
       implicit none
  
@@ -13443,7 +13556,10 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
  
       subroutine comm_3q_end(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,numq,cmp, &
+          ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc,myid,ierr, &
+          timestats,mytime,time_mps2,time_bc, &
+          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
       use mpi
       implicit none
  
@@ -13691,7 +13807,7 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
       subroutine comm_all_s(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
 
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt
       use bc_module, only: bcs2
       implicit none
 
@@ -13715,7 +13831,7 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
       subroutine comm_all_s_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
 
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt
       use bc_module, only: bcs2_GPU
       implicit none
 
@@ -13747,7 +13863,8 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
 
       subroutine prepcorners_GPU(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
                                pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,comm)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt,ni,nj,nk, &
+          tbc,bbc,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
       use bc_module, only: bcs_GPU,bcs2_GPU
       implicit none
 
@@ -13817,7 +13934,8 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
 
       subroutine prepcorners3_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                                 n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,comm)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt,ni,nj,nk, &
+          tbc,bbc,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
       use bc_module, only: bcs_GPU
       implicit none
 
@@ -13878,7 +13996,8 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       subroutine prepcornert_GPU(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,comm)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt,ni,nj,nk, &
+          tbc,bbc,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
       use bc_module, only: bcw_GPU, bct2_GPU
       implicit none
 
@@ -13922,7 +14041,8 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
 
       subroutine getcorneru3(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibn,ibs, &
+          wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
       implicit none
 
@@ -14110,7 +14230,8 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
 
       subroutine getcorneru3_GPU(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibn,ibs, &
+          wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
       implicit none
 
@@ -14381,7 +14502,8 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
 
       subroutine getcornerv3(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibn,ibs, &
+          wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
       implicit none
 
@@ -14569,7 +14691,8 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
 
       subroutine getcornerv3_GPU(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibn,ibs, &
+          wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
       implicit none
 
@@ -14842,7 +14965,8 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
 
       subroutine getcornerw3(w,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,cmp,ibw,ibe,ibn,ibs, &
+          wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
       implicit none
 
@@ -15030,7 +15154,8 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
 
       subroutine getcornerw3_GPU(w,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,cmp,ibw,ibe,ibn,ibs, &
+          wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
       implicit none
 
@@ -15300,7 +15425,9 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
 
       subroutine comm_1s_tend_halo(s)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,nf,ierr,cs1we,cs1sn,timestats,time_mps2,mytime, &
+          mynw,mysw,myne,myse,myeast,mywest,mynorth,mysouth
       use mpi
       implicit none
  
@@ -15713,7 +15840,9 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
 
       subroutine comm_1s_tend_halo_GPU(s)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,nf,ierr,cs1we,cs1sn,timestats,time_mps2,mytime, &
+          mynw,mysw,myne,myse,myeast,mywest,mynorth,mysouth
       use mpi
       implicit none
  

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1550,7 +1550,6 @@
       subroutine find_horizontal_location_index (loc_ind, loc, lb, ub, dsize, end_ind, ind)
       !$acc routine seq
 
-      use input, only :
       use constants
 
       implicit none
@@ -1634,7 +1633,6 @@
       subroutine find_vertical_location_index (loc_ind, loc, lb, ub, dsize, ind, is_ge)
       !$acc routine seq
 
-      use input, only :
       use constants
 
       implicit none

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -28,7 +28,11 @@
                                sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,             &
                                n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,      &
                                uten,vten,wten,thten,qten,pdata_locind)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,numq,ni,nj,nk,imp,jmp,kmp,rmp,cmp, &
+          kmt,npvals,nparcels,npvars,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,bbc,tbc,imove,zt,rzt, &
+          umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
+          prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult,prms,przs, &
+          timestats,time_droplet,mytime,ierr,time_droplet_reduce
       use constants
       use comm_module
       use misclibs
@@ -613,7 +617,9 @@
 
       subroutine rk2_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug)
       !$acc routine seq
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,viscosity, &
+          pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
+          prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz
       use constants
       use comm_module
       use misclibs
@@ -929,7 +935,9 @@
 
       subroutine BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000)
       !$acc routine seq
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,viscosity, &
+          pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
+          prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz
       use constants
       use comm_module
       use misclibs
@@ -1136,7 +1144,10 @@
 
       subroutine interpolate_to_parcel(np,nrkp,pdata_locind,iflag,jflag,kflag,x3d,y3d,z3d,sig3d,uval,vval,wval,tval,qval,rhoval,prsval,xh,xf,yh,yf,zh,zf,zs,znt,sigma,sigmaf,ua,va,wa,ta,qa,rho,prs,sigdot)
       !$acc routine seq
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,viscosity, &
+          pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy,ni,nj,nz, &
+          ngxy,ngz,nip1,nk,nkp1,zt,rzt,imoist,nqv,bbc,imove,umove,vmove, &
+          prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz
       use constants
       use parcel_module
       use cm1libs , only : eslf
@@ -1539,7 +1550,7 @@
       subroutine find_horizontal_location_index (loc_ind, loc, lb, ub, dsize, end_ind, ind)
       !$acc routine seq
 
-      use input
+      use input, only :
       use constants
 
       implicit none
@@ -1623,7 +1634,7 @@
       subroutine find_vertical_location_index (loc_ind, loc, lb, ub, dsize, ind, is_ge)
       !$acc routine seq
 
-      use input
+      use input, only :
       use constants
 
       implicit none
@@ -1972,7 +1983,7 @@
       subroutine ie_vrt_nd(diffnorm,tempr,tempt,rt_output,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
       !$acc routine seq
       use constants
-      use input
+      use input, only : viscosity,pr_num,sc_num
       use cm1libs , only : eslf
       implicit none
 

--- a/src/ib_module.F
+++ b/src/ib_module.F
@@ -232,11 +232,11 @@
         kmaxib = max( kmaxib , kbdy(i,j) )
       enddo
       enddo
-      !$acc update device(kmaxib)
 
 #ifdef MPI
       call MPI_ALLREDUCE(mpi_in_place,kmaxib,1,MPI_INTEGER,MPI_MAX,MPI_COMM_WORLD,ierr)
 #endif
+      !$acc update device(kmaxib)
 
       if(dowr) write(outfile,*)
       if(dowr) write(outfile,*) '    kmaxib    = ',kmaxib

--- a/src/ib_module.F
+++ b/src/ib_module.F
@@ -6,6 +6,7 @@
     logical :: do_ib
     integer :: ibib,ieib,jbib,jeib,kbib,keib
     integer :: kmaxib
+    !$acc declare create(kmaxib,ibib,ieib,jbib,jeib,kbib,keib)
 
   CONTAINS
 
@@ -27,8 +28,9 @@
     subroutine ib_init(xh,yh,xf,yf,sigma,sigmaf,zs,zh,bndy,kbdy,out3d,  &
                        west,newwest,east,neweast,                 &
                        south,newsouth,north,newnorth,reqs_p)
-
-    use input
+    use input, only : ib,ie,jb,je,kb,ke,ib3d,ie3d,jb3d,je3d,kb3d,ke3d,nout3d, &
+        rmp,cmp,jmp,imp,ni,nj,nk,nx,ny,nz,dx,testcase,miny,maxy,minx,maxx,ierr, &
+        myid,dowr,nf,nu,nv,nw,centerx,centery,dowr,outfile
     use constants
     use bc_module, only: bc2d_GPU, bcs2_2d_GPU
     use comm_module
@@ -230,6 +232,7 @@
         kmaxib = max( kmaxib , kbdy(i,j) )
       enddo
       enddo
+      !$acc update device(kmaxib)
 
 #ifdef MPI
       call MPI_ALLREDUCE(mpi_in_place,kmaxib,1,MPI_INTEGER,MPI_MAX,MPI_COMM_WORLD,ierr)
@@ -262,7 +265,7 @@
 
     subroutine zero_out_uv(bndy,kbdy,u3d,v3d)
 
-    use input
+    use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk
     use constants
 
       logical, intent(in), dimension(ibib:ieib,jbib:jeib,kbib:keib) :: bndy
@@ -314,7 +317,7 @@
 
     subroutine zero_out_w(bndy,kbdy,w3d)
 
-    use input
+    use input, only : ib,ie,jb,je,kb,ke,ni,nj
     use constants
 
       logical, intent(in), dimension(ibib:ieib,jbib:jeib,kbib:keib) :: bndy
@@ -325,7 +328,7 @@
       !$acc declare present(bndy,kbdy,w3d) 
 
         ! set gridpoints in/on immersed gridpoints to zero:
-        !$acc parallel loop gang vector private(i,j,k)
+        !$acc parallel loop gang vector default(present)
         do j=1,nj
         do i=1,ni
           do k = 1,kbdy(i,j)
@@ -340,7 +343,7 @@
 
     subroutine drag_obstacles(xh,yh,zh,zf,rho,rf,dum1,dum2,dum3,dum4,dum5,dum6,t11,t12,t13,t22,t23,t33,ua,va,wa,kbdy)
 
-    use input
+    use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk
     use constants
 
     real, intent(in), dimension(ib:ie) :: xh
@@ -711,7 +714,7 @@
                            uw31,uw32,ue31,ue32,us31,us32,un31,un32,    &
                            vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,reqs_u,reqs_v)
 
-    use input
+    use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,hadvordrs
     use constants
     use comm_module
 #ifdef MPI
@@ -786,7 +789,8 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
     subroutine ib_side_flx(stag,ix,jy,kz,c1,c2,rru,rrv,dumx,dumy,a,hadvorder,bndy,hflxw,hflxe,hflxs,hflxn,out3d)
-    use input
+    use input, only : ib,ie,jb,je,kb,ke,ngxy,ngz,ib3d,ie3d,jb3d,je3d,kb3d,ke3d,nout3d, &
+        ni,nj,nk
     implicit none
 
     ! reduce order of horizontal advective fluxes near sides of obstacles:
@@ -1176,7 +1180,9 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
     subroutine ib_side_weno(stag,ix,jy,kz,c1,c2,rru,rrv,dumx,dumy,a,hadvorder,bndy,hflxw,hflxe,hflxs,hflxn,weps,out3d)
-    use input
+    use input, only : ib,ie,jb,je,kb,ke,ngxy,ngz,ib3d,ie3d,jb3d,je3d,kb3d,ke3d,nout3d, &
+        ni,nj,nk
+
     implicit none
 
     ! reduce order of horizontal advective fluxes near sides of obstacles:
@@ -1566,7 +1572,9 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
     subroutine ib_lwr_flx(stag,ix,jy,kz,c1,c2,rrw,dumz,a,kbdy,vadvorder)
-    use input
+    use input, only : ib,ie,jb,je,kb,ke,ngxy,ngz,ib3d,ie3d,jb3d,je3d, &
+        kb3d,ke3d,nout3d,ni,nj,nk,ibw,ibe,ibn,ibs
+
     implicit none
 
     ! reduce order of vertical advective fluxes near top of obstacles:
@@ -1744,7 +1752,8 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
     subroutine ib_lwr_weno(stag,ix,jy,kz,c1,c2,rrw,dumz,a,kbdy,vadvorder,weps)
-    use input
+    use input, only : ib,ie,jb,je,kb,ke,ngxy,ngz,ib3d,ie3d,jb3d,je3d, &
+        kb3d,ke3d,nout3d,ni,nj,nk,ibw,ibe,ibn,ibs
     implicit none
 
     ! reduce order of vertical advective fluxes near top of obstacles (for weno):

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -1508,6 +1508,7 @@
 
         amplitude = 0.10
 
+        !JMD-KLUDGE investigate if zh(1,1,k) is corrupt
         do k=1,nk
         if( zh(1,1,k).le.100.0 )then
           ! cm1r17: loop over entire domain

--- a/src/input.F
+++ b/src/input.F
@@ -173,7 +173,7 @@
 !$acc                prtke,prdbz,prb,prvpg,przv,prrho,prqsl,prqsi, &
 !$acc                prznt,prust,przs,prsig,prvpx,prvpy,prvpz,prrp, &
 !$acc                prms,prtp,prmult,pract,ntwk,imp,jmp,kmp,kmt, &
-!$acc                rmp,cmp,ibw,ibe,ibs,ibn,nodex,nodey, &
+!$acc                rmp,cmp,ibw,ibe,ibs,ibn,nodex,nodey,nnc1,nnc2, &
 !$acc                myi,myj,mdiff,nrain,npt,ibl,iel,jbl,jel, &
 !$acc                ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag, &
 !$acc                ibdq,iedq,jbdq,jedq,kbdq,kedq,nqdiag, &
@@ -241,7 +241,7 @@
 !$acc   cnst_znt,cnst_shflx,cnst_lhflx,cnst_ust,cnstcd,cnstce, &
 !$acc   xc_wnudge,xr_wnudge,zr_wnudge,alpha_wnudge,t1_wnudge,t2_wnudge, &
 !$acc   yc_wnudge,yr_wnudge,zc_wnudge,wmax_wnudge,rxrwnudge,ryrwnudge,rzrwnudge, &
-!$acc   dgs1,dgs2,dgs3,dgt1,dgt2,dgt3)
+!$acc   dgs1,dgs2,dgs3,dgt1,dgt2,dgt3,centerx,centery)
 !-----------------------------------------------------------------------
 
       character(len=maxstring) :: string

--- a/src/maxmin.F
+++ b/src/maxmin.F
@@ -3,7 +3,8 @@
   CONTAINS
 
       subroutine maxmin(izz,jzz,kzz,f,nstat,rstat,kmin,kmax,amax,amin)
-      use input
+      use input, only : ni,nj,nk,ngxy,ngz,stat_out,myid,ierr,myi1,myj1, &
+          timestats,time_stat,mytime
 #ifdef MPI
       use mpi
 #endif
@@ -114,7 +115,8 @@
 
 
       subroutine maxmin2d(izz,jzz,f,nstat,rstat,amax,amin)
-      use input
+      use input, only : ni,nj,nk,ngxy,ngz,stat_out,myid,ierr,myi1,myj1, &
+          timestats,time_stat,mytime
 #ifdef MPI
       use mpi
 #endif
@@ -208,7 +210,8 @@
       end subroutine maxmin2d
 
       subroutine maxmin2dhalo(izz,jzz,f,amax,amin)
-      use input
+      use input, only : ni,nj,nk,ngxy,ngz,stat_out,myid,ierr,myi1,myj1, &
+          timestats,time_stat,mytime
 #ifdef MPI
       use mpi
 #endif

--- a/src/param.F
+++ b/src/param.F
@@ -4292,7 +4292,7 @@
 #endif
         call stopcm1
       endif
-
+      !$acc update device(nnc1,nnc2)
       if(dowr) write(outfile,*)
       if(dowr) write(outfile,*) 'iice      =',iice
       if(dowr) write(outfile,*) 'idm       =',idm
@@ -7097,8 +7097,8 @@
 
       minx = xfref(1)
       maxx = xfref(nx+1)
-      !$acc update device(minx,maxx)
       centerx  =  minx + 0.5*(maxx-minx)
+      !$acc update device(minx,maxx,centerx)
 
       do i = 1-ngxy , nx+ngxy
         xhref(i) = 0.5*(xfref(i)+xfref(i+1))
@@ -7429,8 +7429,8 @@
 
       miny = yfref(1)
       maxy = yfref(ny+1)
-      !$acc update device(miny,maxy)
       centery  =  miny + 0.5*(maxy-miny)
+      !$acc update device(miny,maxy,centery)
 
       do j = 1-ngxy , ny+ngxy
         yhref(j) = 0.5*(yfref(j)+yfref(j+1))

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -26,7 +26,11 @@
 
       subroutine parcel_driver(dt,xh,uh,ruh,xf,yh,vh,rvh,yf,zh,mh,rmh,zf,mf,zs,    &
                                sigma,sigmaf,znt,rho,ua,va,wa,pdata)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,numq,ni,nj,nk,imp,jmp,kmp,rmp,cmp, &
+          kmt,npvals,nparcels,npvars,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,bbc,tbc,imove,zt,rzt, &
+          umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
+          prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult,prms,przs, &
+          dx,dy,njp1,nkp1,maxz,minx,maxx,miny,maxy,timestats,mytime,ierr,time_parcels,myid
       use constants
       use comm_module
 #ifdef MPI
@@ -688,7 +692,16 @@
                                pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,        &
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p, &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ibm,iem,jbm,jem, &
+          kbm,kem,numq,ibc,iec,jbc,jec,kbc,kec,ibt,iet,jbt,jet,kbt,ket,npt,ierr, &
+          ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,ibdq,iedq,jbdq,jedq,kbdq,kedq, &
+          nqdiag,jmp,imp,kmp,rmp,cmp,kmt,ibp,iep,jbp,jep,kbp,kep,nparcels,npvals,npvars, &
+          ni,nj,nk,nqv,nql1,nql2,nqs1,nqs2,nqv,imoist,timestats,mytime,time_phys_d2h, &
+          imoist,iice,time_parceli,bbc,tbc,rdz,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,imove, &
+          qd_dbz,rdx,rdy,nx,ny,myi,myj,nodex,nodey,myid,nip1,njp1,nkp1,axisymm,nnc1, &
+          umove,vmove,prth,prt,prqsl,prqsi,prvpg,prb,prprs,prrho,prpt1,prqv,prq1,prnc1, &
+          prkm,prkh,prtke,prdbz,przv,prx,pry,prz,prtime,prq2,prnc2,prznt,prust,pru,prv, &
+          prw,prsig,time_parceli_reduce,terrain_flag
       use constants
       use cm1libs , only : rslf,rsif
       use bc_module, only: bcu2_GPU, bcv2_GPU, bcw2_GPU
@@ -1763,7 +1776,8 @@
 
 
       subroutine parcel_write(prec,rtime,qname,name_prcl,desc_prcl,unit_prcl,pdata,ploc)
-      use input
+      use input, only : maxq,maxvars,nparcels,npvals,output_format,myid,dowr, &
+          maxstring,string,outfile
 #ifdef NETCDF
       use writeout_nc_module, only : writepdata_nc
 #endif
@@ -1831,7 +1845,7 @@
 
       real function tri_interp(iz,jz,kz,i,j,k,w1,w2,w3,w4,w5,w6,w7,w8,s)
       !$acc routine seq
-      use input
+      use input, only : ngxy,ngz
       implicit none
 
       integer :: iz,jz,kz,i,j,k
@@ -1860,7 +1874,7 @@
 
     real function get2d(i,j,x3d,y3d,xh,xf,yh,yf,xs,ys,is,js,s)
     !$acc routine seq
-    use input
+    use input, only : ib,ie,jb,je
     implicit none
 
     integer, intent(in) :: i,j
@@ -1935,7 +1949,9 @@
 
 
       subroutine getparcelzs(xh,uh,ruh,xf,yh,vh,rvh,yf,zs,pdata)
-      use input
+      use input, only : ib,ie,jb,je,nparcels,npvals,ni,nj,nx,ny, &
+          myi,myj,axisymm,nodex,nodey,ierr, &
+          prx,pry,przs
       use constants
 #ifdef MPI
       use mpi
@@ -2039,7 +2055,9 @@
 
 
       subroutine setup_parcel_vars(name_prcl,desc_prcl,unit_prcl,qname)
-      use input
+      use input, only : maxq,maxvars,npt,nql1,nql2,iice,nqs1,nqs2,nnc1,nnc2, &
+          prcl_out,prcl_droplet,prth,prt,prprs,prpt1,prqv,prq1,prnc1,prkm,prkh, &
+          prtke,prdbz,prb,prvpg,przv,prrho,prqsl,prqsi,prznt,prust,przs,prsig
       implicit none
 
       character(len=40), intent(inout), dimension(maxvars) :: name_prcl,desc_prcl,unit_prcl
@@ -2330,7 +2348,8 @@
 
 
       subroutine write_prclctl(name_prcl,desc_prcl,unit_prcl,prec)
-      use input
+      use input, only : maxvars,myid,string,maxstring,dowr,cm1version, &
+          nparcels,prcl_out,outfile
       use constants , only : grads_undef
       implicit none
 

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -545,7 +545,8 @@
                           xland,psfc,qsfc,u10,v10,hfx,qfx,cda,znt,gz1oz0,  &
                           psim,psih,br,zol,mol,hpbl,dsxy,th2,t2,q2,fm,fh,  &
                           zs,za,pi0s,pi0,th0,ppi,tha,rho,rf,qa)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ibl,iel,jbl,jel,ni,nj,nk, &
+          timestats,time_sfcphys,mytime
       use constants
       use cm1libs , only : rslf
       implicit none
@@ -643,7 +644,8 @@
 
 
       subroutine gethpbl(zh,th0,tha,qa,hpbl)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ibl,iel,jbl,jel,ni,nj,nk, &
+          timestats,mytime,time_sfcphys
       use constants
       implicit none
 
@@ -695,7 +697,8 @@
 
 
       subroutine gethpbl2(psfc,qsfc,thflux,qvflux,ust,tsk,zh,th0,tha,qa,ua,va,thv1,thvsfc,govthv,brilast,hpbl,riout)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ibl,iel,jbl,jel,ni,nj,nk, &
+          timestats,mytime,imoist,time_sfcphys
       use constants
       use cm1libs , only : rslf
       implicit none
@@ -831,7 +834,9 @@
                          u10,v10,s10,xland,znt,rznt,ust,cd,ch,cq,   &
                          avgsfcu,avgsfcv,avgsfcs,avgsfct,rtime,     &
                          tsk,psfc,wspd,th0,tha)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ibl,iel,jbl,jel,ni,nj,nk, &
+          nx,ny,use_avg_sfc,testcase,imoist,smeps,ierr,timestats,nzeta, &
+          mytime,time_sfcphys
       use constants
 #ifdef MPI
       use mpi
@@ -1102,7 +1107,8 @@
 
 
       subroutine getavgsfc(u1,v1,s1,t1,avgsfcu,avgsfcv,avgsfcs,avgsfct)
-      use input
+      use input, only : ib,ie,jb,je,ni,nj,nx,ny,timestats,time_sfcphys, &
+          mytime,ierr
 #ifdef MPI
       use mpi
 #endif

--- a/src/turbnba.F
+++ b/src/turbnba.F
@@ -30,7 +30,9 @@
                          ua ,va ,wa ,tkea ,nm,                     &
                          kw1,kw2,ke1,ke2,ks1,ks2,kn1,kn2,reqs_s,   &
                          nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+      use input, only : ib,ie,jb,je,kb,ke,ibnba,ienba,jbnba,jenba,kbnba,kenba, &
+          ibt,iet,jbt,jet,kbt,ket,imp,jmp,rmp,kmt,cmp,ni,nj,nk,dx,dy,dz,myid, &
+          tconfig,rdx,rdy,rdz,bbc,axisymm
       use constants
       use bc_module, only: bc2d_GPU, bcs2_GPU, bct2_GPU, bcs2_2d_GPU
       use comm_module
@@ -467,7 +469,9 @@
                          ua ,va ,wa ,tkea ,nm,                     &
                          kw1,kw2,ke1,ke2,ks1,ks2,kn1,kn2,reqs_s,   &
                          nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input
+     use input, only : ib,ie,jb,je,kb,ke,ibnba,ienba,jbnba,jenba,kbnba,kenba, &
+          ibt,iet,jbt,jet,kbt,ket,imp,jmp,rmp,kmt,cmp,ni,nj,nk,dx,dy,dz,myid, &
+          tconfig,rdx,rdy,rdz,bbc,axisymm
       use constants
       use bc_module, only: bcs2_GPU
       use comm_module


### PR DESCRIPTION
Yet another update that adds the only clause to the input module.  This has the same correctness statistics to the existing gpu-opt branch:

============================================
CPU Intel compared to GPU OpenACC
============================================
29 stat variables are identical.
48 stat variables show a mean relative difference > 1e-06
6 stat variables show a mean relative difference <= 1e-06



============================================
CPU Intel compared to GPU OpenACC+MPI 
============================================
26 stat variables are identical.
57 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06
