### PR TITLE
remove unnecessary module variables from acc directives

### DIFF
--- a/src/base.F
+++ b/src/base.F
@@ -2820,7 +2820,6 @@
      
 !!!      hurr_rad = 40000.0      ! radius from center of hurricane (m) 
       hurr_rad = var2      ! radius from center of hurricane (m) 
-      !$acc update device(hurr_rad)
 
       wmin  =   -0.01    ! value of w at z = z1
 !!!      wmin  =   var1     ! value of w at z = z1

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -336,7 +336,6 @@
       iusetke = .false.
       ramp_up_turb = .false.
       do_adapt_move = .false.
-      !$acc update device(tsmall,qsmall,smeps)
 
       dorestart = .false.
       dowriteout = .false.
@@ -486,8 +485,7 @@
       read(20,nml=param8)
       close(unit=20)
 
-      !OpenACC data movement directives
-      !$acc update device(nx,ny,nz)
+      !$acc update device(nx,ny)
 
       ! note:  read remainder of namelist sections in param.F !
 
@@ -580,11 +578,6 @@
       njp1 = nj+1
       nkp1 = nk+1
       nkm1 = nk-1
-      !$acc update device(nip1,njp1,nkp1,nkm1,ni,nj,nk, &
-      !$acc               npvals,numq, &
-      !$acc               pr_num,sc_num,prvpx,prvpy,prvpz,prrp, &
-      !$acc               prms,prtp,prx,pry,prsig,prz,pract, &
-      !$acc               nodex,nodey)
 
       nimax = ni
       njmax = nj
@@ -755,8 +748,6 @@
 !-----------------------------------------------
 #endif
 
-      !$acc update device (myi,myj)
-
       call wenocheck
 
       ! number of 'ghost' points in the horizontal directions:
@@ -776,8 +767,6 @@
       ! number of 'ghost' points in the vertical direction:
       ngz   = 1
 
-      !$acc update device (ngxy,ngz)
-
 !---------------------------------------------------------------------
 !      For ZVD:
 !      ngz   = 3
@@ -793,7 +782,8 @@
       je = nj + ngxy
       kb =  1 - ngz
       ke = nk + ngz
-      !$acc update device(ib,ie,jb,je,kb,ke)
+
+      !$acc update device(ib,ie,jb,je,kb,ke,ni,nj,nip1,nk,nkp1,ngxy,ngz)
 
       allocate(    xh(ib:ie) )
       xh = 0.0
@@ -974,7 +964,6 @@
       rmp = 1
       cmp = 1
 #endif
-      !$acc update device (imp,jmp,kmp,kmt,rmp,cmp)
 
       allocate( reqs_u(rmp) )
       reqs_u = 0

--- a/src/constants.F
+++ b/src/constants.F
@@ -9,11 +9,7 @@
             cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi,lv1,lv2,ls1,ls2,  &
             rhow,c_e1,c_e2,c_s,rcs,earth_radius,govtwo,mw,ms,surften,ion,os,ru
 
-!$acc declare create(g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp,cpdcv,rovcp, &
-!$acc                rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1, &
-!$acc                cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi, &
-!$acc                lv1,lv2,ls1,ls2,rhow,c_e1,c_e2,c_s,rcs,govtwo, &
-!$acc                earth_radius,govtwo,surften,mw,ms,ion,os,ru)
+    !$acc declare create (ru,mw,surften,rhow,ion,os,ms,lv1,lv2,cpl,cp,eps)
 
       !----------------
 
@@ -179,11 +175,7 @@
       c_s = ( c_m * c_m * c_m / ( c_e1 + c_e2 ) )**0.25   ! Smagorinsky constant
       rcs = 1.0/c_s
 
-!$acc update device(g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp,cpdcv,rovcp, &
-!$acc               rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1, &
-!$acc               cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi, &
-!$acc               lv1,lv2,ls1,ls2,rhow,c_e1,c_e2,c_s,rcs,govtwo, &
-!$acc               earth_radius,govtwo,surften,ms,mw,ion,os,ru)
+      !$acc update device (ru,mw,surften,rhow,ion,os,ms,lv1,lv2,cpl,cp,eps)
 
       end subroutine set_constants
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1144,10 +1144,9 @@
 
       subroutine interpolate_to_parcel(np,nrkp,pdata_locind,iflag,jflag,kflag,x3d,y3d,z3d,sig3d,uval,vval,wval,tval,qval,rhoval,prsval,xh,xf,yh,yf,zh,zf,zs,znt,sigma,sigmaf,ua,va,wa,ta,qa,rho,prs,sigdot)
       !$acc routine seq
-      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,viscosity, &
-          pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy,ni,nj,nz, &
-          ngxy,ngz,nip1,nk,nkp1,zt,rzt,imoist,nqv,bbc,imove,umove,vmove, &
-          prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz
+      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,nx,ny, &
+                        axisymm,terrain_flag,ni,nj,nip1,nk,nkp1, &
+                        zt,rzt,imoist,nqv,bbc,imove,umove,vmove
       use constants
       use parcel_module
       use cm1libs , only : eslf
@@ -1267,11 +1266,6 @@
         w6 = (1.0-rx)*ry*rz
         w7 = rx*ry*(1.0-rz)
         w8 = rx*ry*rz
-        if(np==TROUBLE) then 
-          print *,'parcel: before uval: ',i,j,k
-          print *,'parcel: ngxy,ngz: ',ngxy,ngz
-          print *,'parcel: ni+1,nj,nk: ',nip1,nj,nk
-        endif
 
         uval = tri_interp(nip1,nj,nk,i,j,k,w1,w2,w3,w4,w5,w6,w7,w8,ua)
         ! uval = ua(i  ,j  ,k  )*w1 &
@@ -1550,7 +1544,7 @@
       subroutine find_horizontal_location_index (loc_ind, loc, lb, ub, dsize, end_ind, ind)
       !$acc routine seq
 
-      use constants
+      use constants, only : undefined_index
 
       implicit none
 
@@ -1561,7 +1555,6 @@
       integer,                      intent(in)    :: end_ind    ! end index of x/y dimension
       integer,                      intent(inout) :: ind        ! return the x/y location index closest to 
                                                                 ! the current parcel location
-
       ! local variable
       integer :: i
 #ifdef _VERIFY_FIND_LOC
@@ -1633,7 +1626,7 @@
       subroutine find_vertical_location_index (loc_ind, loc, lb, ub, dsize, ind, is_ge)
       !$acc routine seq
 
-      use constants
+      use constants, only : undefined_index 
 
       implicit none
 

--- a/src/ib_module.F
+++ b/src/ib_module.F
@@ -6,7 +6,6 @@
     logical :: do_ib
     integer :: ibib,ieib,jbib,jeib,kbib,keib
     integer :: kmaxib
-    !$acc declare create(kmaxib,ibib,ieib,jbib,jeib,kbib,keib)
 
   CONTAINS
 
@@ -236,7 +235,6 @@
 #ifdef MPI
       call MPI_ALLREDUCE(mpi_in_place,kmaxib,1,MPI_INTEGER,MPI_MAX,MPI_COMM_WORLD,ierr)
 #endif
-      !$acc update device(kmaxib)
 
       if(dowr) write(outfile,*)
       if(dowr) write(outfile,*) '    kmaxib    = ',kmaxib

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -1385,7 +1385,6 @@
         alpha_uforce  =    0.1                     ! alpha (m/s/s), max intensity of forcing
         t1_uforce     =  3300.0                    ! time (s) to start ramping down u-forcing
         t2_uforce     =  3600.0                    ! time (s) to turn off u-forcing
-        !$acc update device(xc_uforce,xr_uforce,zr_uforce,alpha_uforce,t1_uforce,t2_uforce)
 
 !------------------------------------------------------------------
 !  iinit = 11
@@ -1437,9 +1436,6 @@
         rxrwnudge = 1.0/max( xr_wnudge , 1.0e-12 )
         ryrwnudge = 1.0/max( yr_wnudge , 1.0e-12 )
         rzrwnudge = 1.0/max( zr_wnudge , 1.0e-12 )
-        !$acc update device(xc_wnudge,xr_wnudge,yc_wnudge,yr_wnudge,zc_wnudge, &
-        !$acc   zr_wnudge,alpha_wnudge,wmax_wnudge,t1_wnudge,t2_wnudge,rxrwnudge, &
-        !$acc   ryrwnudge, rzrwnudge)
 
 !------------------------------------------------------------------
 !  iinit = 13

--- a/src/input.F
+++ b/src/input.F
@@ -40,8 +40,6 @@
               use_pbl,use_avg_sfc,dot2p,iusetke,do_adapt_move,                &
               bl_mynn_tkeadvect
 
-!$acc declare create(p2tchsws,p2tchsww,p2tchses,p2tchsee,p2tchnwn,p2tchnww,p2tchnen,p2tchnee)
-
 !-----------------------------------------------------------------------
 
       integer nx,ny,nz,nodex,nodey,ppnode,timeformat,timestats,               &
@@ -162,42 +160,11 @@
               bl_mynn_cloudmix,bl_mynn_mixqt,initflag,spp_pbl,bl_mynn_output, &
               nutk,nvtk,nwtk
 
+      !$acc declare create (ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,   &
+      !$acc                 axisymm,terrain_flag,ni,nj,nip1,nk,nkp1,imoist, &
+      !$acc                 nqv,bbc,imove,prvpx,prvpy,prvpz,prrp,prms,prtp, &
+      !$acc                 prx,pry,prz,prsig,ngxy,ngz,ptype)
 
-!$acc declare create(nql1,nql2,nqs1,nqs2,nqr,nqi,nqs,nqg,nnci,nncc, &
-!$acc                ptype,ngxy,ngz,nx,ny,nz,axisymm, &
-!$acc                nparcels,npvals,npvars,ni,nj,nk,nip1,njp1, &
-!$acc                nkm1,nkp1,ib,ie,jb,je,kb,ke,terrain_flag, &
-!$acc                numq,imoist,imove,nqv,bbc,nqc,prx,pry,prz, &
-!$acc                pru,prv,prw,prth,prt,prprs,prtime,prpt1, &
-!$acc                prpt2,prqv,prq1,prq2,prnc1,prnc2,prkm,prkh, &
-!$acc                prtke,prdbz,prb,prvpg,przv,prrho,prqsl,prqsi, &
-!$acc                prznt,prust,przs,prsig,prvpx,prvpy,prvpz,prrp, &
-!$acc                prms,prtp,prmult,pract,ntwk,imp,jmp,kmp,kmt, &
-!$acc                rmp,cmp,ibw,ibe,ibs,ibn,nodex,nodey,nnc1,nnc2, &
-!$acc                myi,myj,mdiff,nrain,npt,ibl,iel,jbl,jel, &
-!$acc                ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag, &
-!$acc                ibdq,iedq,jbdq,jedq,kbdq,kedq,nqdiag, &
-!$acc                ibdv,iedv,jbdv,jedv,kbdv,kedv,nudiag,nvdiag,nwdiag, &
-!$acc                ibdk,iedk,jbdk,jedk,kbdk,kedk,nkdiag, &
-!$acc                ibdp,iedp,jbdp,jedp,kbdp,kedp,npdiag, &
-!$acc                ib2d,ie2d,jb2d,je2d,nout2d )
-
-!$acc declare create(qd_dbz,qd_vtc,qd_vtr,qd_vts,qd_vtg,qd_vti, &
-!$acc         td_hadv,td_vadv,td_hturb,td_vturb,td_mp,td_rdamp, &
-!$acc         td_rad,td_div,td_diss,td_pbl,td_lsw,td_efall, &
-!$acc         td_cond,td_evac,td_evar,td_dep,td_subl,td_melt,td_frz,td_nudge, &
-!$acc         qd_hadv,qd_vadv,qd_hturb,qd_vturb,qd_mp,qd_pbl,qd_lsw, &
-!$acc         qd_cond,qd_evac,qd_evar,qd_dep,qd_subl,qd_nudge, &
-!$acc         ud_hadv,ud_vadv,ud_hturb,ud_vturb,ud_pgrad,ud_rdamp, &
-!$acc         ud_pbl,ud_cor,ud_cent,ud_lsw, &
-!$acc         vd_hadv,vd_vadv,vd_hturb,vd_vturb,vd_pgrad,vd_rdamp, &
-!$acc         vd_pbl,vd_cor,vd_cent,vd_lsw,kd_adv,kd_turb, &
-!$acc         wd_hadv,wd_vadv,wd_hturb,wd_vturb,wd_pgrad,wd_rdamp,wd_buoy, &
-!$acc         td_hidiff,td_vidiff,td_hediff,td_vediff, &
-!$acc         qd_hidiff,qd_vidiff,qd_hediff,qd_vediff, &
-!$acc         ud_hidiff,ud_vidiff,ud_hediff,ud_vediff, &
-!$acc         vd_hidiff,vd_vidiff,vd_hediff,vd_vediff, &
-!$acc         wd_hidiff,wd_vidiff,wd_hediff,wd_vediff,nutk,nvtk,nwtk)
 !-----------------------------------------------------------------------
 
       real dx,dy,dz,dtl,timax,run_time,                                       &
@@ -233,15 +200,9 @@
            base_pbot,base_ptop,base_thbot,base_thtop,base_qvbot,base_qvtop,   &
            base_tbot,base_ttop,base_pibot,base_pitop
 
-!$acc declare create(dx,dy,dz,dtl,kdiff2,kdiff6,fcor,rdalpha,alph,kdiv, &
-!$acc   rdx,rdy,rdz,minx,maxx,miny,maxy,zt,rzt,umove,vmove, &
-!$acc   xc_uforce,xr_uforce,zr_uforce,alpha_uforce,t1_uforce,t2_uforce,    &
-!$acc   viscosity,pr_num,sc_num,maxz,cgs1,cgs2,tsmall,qsmall, &
-!$acc   cgs3,cgt1,cgt2,cgt3,csound,hurr_rad,smeps,l_h,ptc_bot,ptc_top, &
-!$acc   cnst_znt,cnst_shflx,cnst_lhflx,cnst_ust,cnstcd,cnstce, &
-!$acc   xc_wnudge,xr_wnudge,zr_wnudge,alpha_wnudge,t1_wnudge,t2_wnudge, &
-!$acc   yc_wnudge,yr_wnudge,zc_wnudge,wmax_wnudge,rxrwnudge,ryrwnudge,rzrwnudge, &
-!$acc   dgs1,dgs2,dgs3,dgt1,dgt2,dgt3,centerx,centery)
+      !$acc declare create (zt,rzt,umove,vmove,viscosity,pr_num,sc_num, &
+      !$acc                 minx,maxx,miny,maxy,maxz)
+
 !-----------------------------------------------------------------------
 
       character(len=maxstring) :: string

--- a/src/param.F
+++ b/src/param.F
@@ -228,10 +228,10 @@
 #endif
 
       call bcast_log(terrain_flag,device=.true.)
-      call bcast_real(dx,device=.true.)
-      call bcast_real(dy,device=.true.)
-      call bcast_real(dz,device=.true.)
-      call bcast_real(dtl,device=.true.)
+      call bcast_real(dx)
+      call bcast_real(dy)
+      call bcast_real(dz)
+      call bcast_real(dtl)
       call bcast_real(timax)
       call bcast_real(run_time)
       call bcast_real(tapfrq)
@@ -254,7 +254,7 @@
       call bcast_int(weno_order)
       call bcast_int(apmasscon)
       call bcast_int(idiff)
-      call bcast_int(mdiff,device=.true.)
+      call bcast_int(mdiff)
       call bcast_int(difforder)
       call bcast_int(imoist,device=.true.)
       call bcast_int(ipbl)
@@ -294,23 +294,23 @@
       call bcast_int(axisymm,device=.true.)
       call bcast_int(imove,device=.true.)
       call bcast_int(iptra)
-      call bcast_int(npt,device=.true.)
+      call bcast_int(npt)
       call bcast_int(pdtra)
       call bcast_int(iprcl)
       call bcast_int(nparcels,device=.true.)
-      call bcast_real(kdiff2,device=.true.)
-      call bcast_real(kdiff6,device=.true.)
-      call bcast_real(fcor,device=.true.)
-      call bcast_real(kdiv,device=.true.)
-      call bcast_real(alph,device=.true.)
-      call bcast_real(rdalpha,device=.true.)
+      call bcast_real(kdiff2)
+      call bcast_real(kdiff6)
+      call bcast_real(fcor)
+      call bcast_real(kdiv)
+      call bcast_real(alph)
+      call bcast_real(rdalpha)
       call bcast_real(zd)
       call bcast_real(xhd)
       call bcast_real(alphobc)
       call bcast_real(umove,device=.true.)
       call bcast_real(vmove,device=.true.)
       call bcast_real(v_t)
-      call bcast_real(l_h,device=.true.)
+      call bcast_real(l_h)
       call bcast_real(lhref1)
       call bcast_real(lhref2)
       call bcast_real(l_inf)
@@ -332,8 +332,8 @@
       call bcast_real(dz_bot)
       call bcast_real(dz_top)
       call bcast_int(bc_temp)
-      call bcast_real(ptc_top,device=.true.)
-      call bcast_real(ptc_bot,device=.true.)
+      call bcast_real(ptc_top)
+      call bcast_real(ptc_bot)
       call bcast_real(viscosity,device=.true.)
       call bcast_real(pr_num,device=.true.)
       call bcast_real(sc_num,device=.true.)
@@ -512,8 +512,8 @@
       call bcast_int(season)
       call bcast_int(cecd)
       call bcast_int(pertflx)
-      call bcast_real(cnstce,device=.true.)
-      call bcast_real(cnstcd,device=.true.)
+      call bcast_real(cnstce)
+      call bcast_real(cnstcd)
       call bcast_int(isftcflx)
       call bcast_int(iz0tlnd)
       call bcast_real(oml_hml0)
@@ -522,10 +522,10 @@
       call bcast_int(set_znt)
       call bcast_int(set_ust)
 
-      call bcast_real(cnst_shflx,device=.true.)
-      call bcast_real(cnst_lhflx,device=.true.)
-      call bcast_real(cnst_znt,device=.true.)
-      call bcast_real(cnst_ust,device=.true.)
+      call bcast_real(cnst_shflx)
+      call bcast_real(cnst_lhflx)
+      call bcast_real(cnst_znt)
+      call bcast_real(cnst_ust)
 
       call bcast_log(dodomaindiag)
       call bcast_real(diagfrq)
@@ -592,14 +592,16 @@
           imove = 0
         endif
       endif
-      !$acc update device(umove,vmove)
+
+      !$acc update device (axisymm,imove,umove,vmove)
+
       irst = max( irst , 0 )
       irst = min( irst , 1 )
       if( cm1setup.eq.2 ) tconfig = 2
       if( psolver.eq.4 .or. psolver.eq.5 ) roflux = 1
 
       if( irdamp.eq.0 .and. hrdamp.eq.0 ) rdalpha = 0.0
-      !$acc update device(rdalpha)
+
       if( irdamp.ge.1 .and. hrdamp.ge.1 ) hrdamp = irdamp
 
       pdcomp = .false.
@@ -1816,7 +1818,7 @@
       ENDIF
       !-----
       IF( icor.eq.0 ) fcor = 0.0
-      !$acc update device(fcor)
+
       !-----
       IF( (axisymm.eq.1) .and. (wbc.ne.3) )THEN
         if(myid.eq.0)then
@@ -2413,7 +2415,6 @@
       else
         npt      = 1
       endif
-      !$acc update device(npt)
 
       ! for parcels:
       nparcels = max(1,nparcels)
@@ -2422,7 +2423,6 @@
 
       if(stretch_z.lt.1) ztop = dz*float(nk)
       IF ( stretch_z == 2 ) dz = ztop/float(nk) ! nk is the number of scalar levels
-      !$acc update device(dz)
 
       IF( advwenos.lt.0 .or. advwenos.gt.2 )THEN
         print *
@@ -4236,7 +4236,8 @@
         ENDIF    ! endif for ptype
 
       ENDIF    ! endif for imoist=1
-      !$acc update device(numq,nql1,nql2,nqs1,nqs2)
+
+      !$acc update device (numq)
 
 !-----------------------------------------------------------------------
 !-------   END:  modify stuff above here -------------------------------
@@ -4276,7 +4277,6 @@
         if( qname(n).eq.'nci' ) nnci = n
         if( qname(n).eq.'ncc' ) nncc = n
       enddo
-      !$acc update device(nqc,nqr,nqi,nqs,nqg,nnci,nncc)
 
       if( ptype.eq.55 ) nqi = 4
 
@@ -4292,7 +4292,7 @@
 #endif
         call stopcm1
       endif
-      !$acc update device(nnc1,nnc2)
+
       if(dowr) write(outfile,*)
       if(dowr) write(outfile,*) 'iice      =',iice
       if(dowr) write(outfile,*) 'idm       =',idm
@@ -4398,7 +4398,6 @@
 
       nrain = 1
       if(imove.eq.1) nrain = 2
-      !$acc update device(nrain)
 
       if(dowr) write(outfile,*) 'nrain     =',nrain
       if(dowr) write(outfile,*)
@@ -4743,7 +4742,6 @@
         jbl=1
         jel=1
       endif
-      !$acc update device(ibl,iel,jbl,jel)
 
       if( cm1setup.eq.1 .or. cm1setup.eq.2 .or. ipbl.ge.1 .or. cm1setup.eq.3 )then
         iusekm = 1
@@ -5049,9 +5047,6 @@
           td_frz = ntdiag
         endif
       ENDIF
-      !$acc update device(td_hadv,td_vadv,td_hturb,td_vturb,td_hidiff,td_vidiff, &
-      !$acc   td_hediff,td_vediff,td_mp,td_rdamp,td_nudge,td_rad,td_div,td_diss, &
-      !$acc   td_pbl,td_lsw,td_efall,td_cond,td_evac,td_dep,td_subl,td_melt,td_frz)
 
       nqdiag   = 0
       qd_dbz   = 0
@@ -5204,9 +5199,6 @@
           qd_subl = nqdiag
         endif
       ENDIF
-      !$acc update device(qd_dbz,qd_vtc,qd_vtr,qd_vts,qd_vtg,qd_vti,qd_hadv,qd_vadv, &
-      !$acc   qd_hturb,qd_vturb,qd_hidiff,qd_vidiff,qd_hediff,qd_vediff,qd_mp,qd_nudge, &
-      !$acc   qd_pbl,qd_lsw,qd_cond,qd_evac,qd_dep,qd_subl)
 
       nudiag     = 0
       ud_hadv    = 0
@@ -5304,8 +5296,6 @@
         endif
 
       ENDIF
-      !$acc update device(ud_hadv,ud_vadv,ud_hturb,ud_vturb,ud_hidiff,ud_vidiff, &
-      !$acc   ud_hediff,ud_vediff,ud_pgrad,ud_rdamp,ud_cor,ud_cent,ud_pbl,ud_lsw,nutk)
 
       nvdiag     = 0
       vd_hadv    = 0
@@ -5403,9 +5393,6 @@
         endif
 
       ENDIF
-      !$acc update device(vd_hadv,vd_vadv,vd_hturb,vd_vturb,vd_hidiff,vd_vidiff,vd_vediff, &
-      !$acc   vd_pgrad,vd_rdamp,vd_cor,vd_cent,vd_pbl,vd_lsw,nvtk)
-
 
       nwdiag     = 0
       wd_hadv    = 0
@@ -5482,8 +5469,6 @@
         endif
 
       ENDIF
-      !$acc update device(wd_hadv,wd_vadv,wd_hturb,wd_vturb,wd_hidiff,wd_vidiff,wd_hediff, &
-      !$acc   wd_vediff,wd_pgrad,wd_rdamp,wd_buoy,nwtk)
 
       !-----
 
@@ -5515,7 +5500,6 @@
         kd_turb = nkdiag
 
       ENDIF
-      !$acc update device(kd_adv,kd_turb)
 
       !-----
 
@@ -5543,11 +5527,6 @@
         if( icor.eq.1 ) npdiag = npdiag+1
 
       ENDIF
-      !$acc update device(ibdt,iedt,jbdt,jedt,kbdt,kedt, &
-      !$acc               ibdq,iedq,jbdq,jedq,kbdq,kedq, &
-      !$acc               ibdv,iedv,jbdv,jedv,kbdv,kedv, &
-      !$acc               ibdk,iedk,jbdk,jedk,kbdk,kedk, &
-      !$acc               ibdp,iedp,jbdp,jedp,kbdp,kedp )
 
       !-----
 
@@ -5558,7 +5537,6 @@
       nwdiag = max( nwdiag , 1 )
       nkdiag = max( nkdiag , 1 )
       npdiag = max( npdiag , 1 )
-      !$acc update device(ntdiag,nqdiag,nudiag,nvdiag,nwdiag,nkdiag,npdiag)
 
       !-------------------------------------------------------------!
 
@@ -5575,7 +5553,6 @@
       ENDIF
 
       nout2d = max( nout2d , 1 )
-      !$acc update device(ib2d,ie2d,jb2d,ie2d,nout2d)
 
       !-------------------------------------------------------------!
 
@@ -5969,7 +5946,6 @@
       rdx=1.0/dx
       rdy=1.0/dy
       rdz=1.0/dz
-      !$acc update device(rdx,rdy,rdz)
       rdx2=1.0/(2.0*dx)
       rdy2=1.0/(2.0*dy)
       rdz2=1.0/(2.0*dz)
@@ -6203,7 +6179,9 @@
         nparcels = 1
 
       endif
-      !$acc update device(nparcels)
+
+      !$acc update device(nparcels,npvals)
+
       if(dowr) write(outfile,*)
       if(dowr) write(outfile,*) '  nparcels = ',nparcels
       if(dowr) write(outfile,*) '  npvals   = ',npvals
@@ -6249,13 +6227,8 @@
       if(dowr) write(outfile,*) '    pract    = ',pract
       if(dowr) write(outfile,*)
 
-      !$acc update device (npvals,npvars,prx,pry,prz,pru, &
-      !$acc                prv,prw,prtime,prth,prt,prprs,prpt1, &
-      !$acc                prpt2,prqv,prq1,prq2,prnc1,prnc2,prkm, &
-      !$acc                prkh,prtke,prdbz,prb,prvpg,przv,prrho, &
-      !$acc                prqsl,prqsi,prznt,prust,przs,prsig, &
-      !$acc                prvpx,prvpy,prvpz,prrp,prms,prtp, &
-      !$acc                prmult,pract)
+      !$acc update device (prvpx,prvpy,prvpz,prrp,prms,prtp,prx, &
+      !$acc                pry,prz,prsig)
 
 !--------------------------------------------------------------
 !  Get identity
@@ -6430,8 +6403,6 @@
       endif
 #endif
 
-      !$acc update device (ibw,ibe,ibs,ibn)
-
 !--------------------------------------------------------------
 
       if(dowr) write(outfile,*)
@@ -6486,7 +6457,6 @@
         if(dowr) write(outfile,*) 'csound=',csound
         if(dowr) write(outfile,*)
       endif
-      !$acc update device(csound)
 
       if(dowr) write(outfile,*)
       if(dowr) write(outfile,*) 'timeformat   =',timeformat
@@ -7098,7 +7068,8 @@
       minx = xfref(1)
       maxx = xfref(nx+1)
       centerx  =  minx + 0.5*(maxx-minx)
-      !$acc update device(minx,maxx,centerx)
+
+      !$acc update device (minx,maxx)
 
       do i = 1-ngxy , nx+ngxy
         xhref(i) = 0.5*(xfref(i)+xfref(i+1))
@@ -7430,7 +7401,8 @@
       miny = yfref(1)
       maxy = yfref(ny+1)
       centery  =  miny + 0.5*(maxy-miny)
-      !$acc update device(miny,maxy,centery)
+
+      !$acc update device (miny,maxy)
 
       do j = 1-ngxy , ny+ngxy
         yhref(j) = 0.5*(yfref(j)+yfref(j+1))
@@ -7874,7 +7846,8 @@
       enddo
 
       maxz = sigmaf(nk+1)
-!$acc update device(maxz)
+
+      !$acc update device(maxz)
 
       do k=kb,ke
       do j=jb,je
@@ -7962,7 +7935,6 @@
       if(dowr) write(outfile,*) '  p2tchnwn =',p2tchnwn
       if(dowr) write(outfile,*) '  p2tchnen =',p2tchnen
       if(dowr) write(outfile,*)
-      !$acc update device(p2tchsws,p2tchsww,p2tchses,p2tchsee,p2tchnwn,p2tchnww,p2tchnen,p2tchnee)
 #endif
 
 !CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
@@ -8554,7 +8526,6 @@
           if(dowr) write(outfile,*)
 
         ENDIF
-!$acc update device(ntwk)
 
 !--------------------------------------------------------------
 !  170803:
@@ -8680,7 +8651,6 @@
       wte3 = delta(2,0,2)
       var = wte1*sigmaf(nk)+wte2*sigmaf(nk-1)+wte3*sigmaf(nk-2)
     ENDIF
-    !$acc update device(dgs1,dgs2,dgs3,dgt1,dgt2,dgt3)
 
       if(dowr) write(outfile,*)
       if(dowr) write(outfile,*) '  ---------------------------------- '
@@ -8723,8 +8693,6 @@
       if(dowr) write(outfile,*) '  ---------------------------------- '
 
   ENDDO
-
-  !$acc update device (cgs1,cgs2,cgs3,cgt1,cgt2,cgt3)
 
 !--------------------------------------------------------------
 !  cm1r18:  Set ghost points for zh
@@ -9109,6 +9077,7 @@
 !--------------------------------------------------------------
 
     !$acc update device(imoist)
+
     IF( myid.eq.0 )THEN
       open(unit=21,file='cm1_config.txt')
       write(21,*)


### PR DESCRIPTION
This PR removes some module variables not called by an ACC routine from the OpenACC directives (`acc declare create` and `acc update device`). Ideally it should not change the results if we update all the variables correctly on the device.

The new verification result indicates that the correctness is unchanged.

CPU (intel) versus OpenACC (nvhpc)
29 stat variables are identical.
48 stat variables show a mean relative difference > 1e-06
6 stat variables show a mean relative difference <= 1e-06
four variables with largest error: KSVMAX, KSHMAX, TMW, TKEMAX

CPU (intel) versus MPI+OpenACC (nvhpc)
26 stat variables are identical.
57 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06
four variables with largest error: STHPMX, THPMAX, TMW, PPMAX
