### PR TITLE
Fix gpu bugs and update Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -43,6 +43,7 @@ DM            =
 OMP           =
 DP            =
 OPTS          =
+OPTS_M        =
 CPP           =
 OUTPUTINC     =
 OUTPUTLIB     =
@@ -75,26 +76,33 @@ endif
 #-----------------------------------------------------------------------------
 ifeq (${FC},nvfortran)
     OPTS         += -Mfree -Ktrap=none -Mautoinline -Minline=reshape -Kieee -Mnofma
+    OPTS_M       += -Mfree -Ktrap=none -Mautoinline -Minline=reshape -Kieee -Mnofma
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${DEBUG_L},true)
          OPTS    += -g -O0
+         OPTS_M  += -g -O0
          DM      += -D_B4B
     else
          OPTS    += -g -O2
+         OPTS_M  += -g -O2
     endif
     ifeq (${USE_DOUBLE_L},true)
          OPTS    += -r8
+         OPTS_M  += -r8
          DP      += -DDP
     endif
     ifeq (${USE_OPENMP_L},true)
          OPTS    += -mp
+         OPTS_M  += -mp
          OMP     += -DOPENMP
     endif
     ifeq (${USE_OPENACC_L},true)
         ifeq (${DEBUG_L},true)
             OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform
+            OPTS_M += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform
         else
             OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
+            OPTS_M += -acc -gpu=cc70,lineinfo,nofma,math_uniform,managed -Mpcast -Minfo=accel
         endif
         DM       += -D_OPENACC
     endif
@@ -185,6 +193,7 @@ $(info $$DEBUG_L is [${DEBUG_L}])
 $(info $$USE_MPI_L is [${USE_MPI_L}])
 $(info $$FC is [${FC}])
 $(info $$OPTS is [${OPTS}])
+$(info $$OPTS_M is [${OPTS_M}])
 $(info $$CPP is [${CPP}])
 $(info $$OMP is [${OMP}])
 $(info $$DM is [${DM}])
@@ -201,7 +210,6 @@ SRC   = constants.F \
 	azimavg.F \
 	base.F \
 	bc.F \
-	cm1.F \
 	cm1libs.F \
 	comm.F \
         bcast.F \
@@ -277,13 +285,17 @@ SRC   = constants.F \
 	module_bl_myjpbl.F \
 	module_sf_myjsfc.F
 
+SRC_M = cm1.F
+
 #SRC_NVTX = nvtx_mod.F
 SRC_NVTX = 
 
 OBJS = $(addsuffix .o, $(basename $(SRC)))
+OBJS_M = $(addsuffix .o, $(basename $(SRC_M)))
 OBJS_OPENACC = $(addsuffix .o, $(basename $(SRC_NVTX)))
 
-FFLAGS  =  $(OPTS)
+FFLAGS  = $(OPTS)
+FFLAGS_M  = $(OPTS_M)
 AR      = ar cru
 
 .SUFFIXES:
@@ -292,14 +304,19 @@ AR      = ar cru
 all : cm1
 
 #			$(FC) $(OBJS) $(FFLAGS) $(OUTPUTINC) $(OUTPUTLIB) $(LINKOPTS) -o ../run/cm1.exe
-cm1:			$(OBJS)
-			$(FC) $(LINKOPTS) $(FFLAGS) $(OBJS) $(OBJS_OPENACC) $(OUTPUTINC) $(OUTPUTLIB) -o ../run/cm1.exe
-			$(AR) onefile.F $(SRC)
+cm1:			$(OBJS) $(OBJS_M)
+			$(FC) $(LINKOPTS) $(FFLAGS) $(FFLAGS_M) $(OBJS) ${OBJS_M} $(OUTPUTINC) $(OUTPUTLIB) -o ../run/cm1.exe
+			$(AR) onefile.F $(SRC) $(SRC_M)
 			mv onefile.F ../run
 
-.F.o:
-			$(CPP) $(DM) $(DP) $(ADV) $(OUTPUTOPT) $*.F > $*.f90
-			$(FC) $(FFLAGS) $(OUTPUTINC) -c $*.f90
+%.f90: %.F
+			$(CPP) $(DM) $(DP) $(ADV) $(OUTPUTOPT) $< > $@
+
+$(OBJS): %.o: %.f90
+			$(FC) $(FFLAGS) $(OUTPUTINC) -c $<
+
+$(OBJS_M): %.o: %.f90
+			$(FC) $(FFLAGS_M) $(OUTPUTINC) -c $<
 
 code:
 			$(AR) onefile.F $(SRC)

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -875,8 +875,8 @@
     ENDDO
 
     IF( nql1.gt.0 )THEN
-    !$acc parallel default(present) private(i,j,k,n)
     DO n=nql1,nql2
+      !$acc parallel default(present)
       !$acc loop gang vector collapse(3)
       do k=1,nk
         do j=1,nj
@@ -885,13 +885,13 @@
         enddo
         enddo
       enddo
+      !$acc end parallel
     ENDDO
-    !$acc end parallel
     ENDIF
 
       IF(iice.eq.1)THEN
-      !$acc parallel default(present) private(i,j,k,n)
       DO n=nqs1,nqs2
+        !$acc parallel default(present)
         !$acc loop gang vector collapse(3)
         do k=1,nk
           do j=1,nj
@@ -900,8 +900,8 @@
           enddo
           enddo
         enddo
+        !$acc end parallel
       ENDDO
-      !$acc end parallel
       ENDIF
 
       if(timestats.ge.1) time_misc02=time_misc02+mytime()
@@ -1014,8 +1014,8 @@
       ENDDO
       IF( nql1.gt.0 )THEN
         !$omp parallel do default(shared) private(i,j,k,n)
-        !$acc parallel default(present) private(i,j,k,n)
         do n=nql1,nql2
+        !$acc parallel default(present)
         !$acc loop gang vector collapse(3)
         DO k=1,nk
           do j=1,nj
@@ -1024,13 +1024,13 @@
           enddo
           enddo
         ENDDO
-        enddo
         !$acc end parallel
+        enddo
       ENDIF
       IF(iice.eq.1)THEN
-        !$acc parallel default(present) private(i,j,k,n)
         !$omp parallel do default(shared) private(i,j,k,n)
         do n=nqs1,nqs2
+        !$acc parallel default(present)
         !$acc loop gang vector collapse(3)
         DO k=1,nk
           do j=1,nj
@@ -1039,8 +1039,8 @@
           enddo
           enddo
         ENDDO
-        enddo
         !$acc end parallel
+        enddo
       ENDIF
 
     ENDIF
@@ -3930,8 +3930,9 @@
       !FIXME
 !$omp parallel do default(shared)  &
 !$omp private(i,k,wspd)
-!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
+!$acc parallel loop gang vector default(present)
       do k=1,nk
+        !$acc loop seq
         do i=1,ni
           wspd = sqrt( (0.5*(ua(i,1,k)+ua(i+1,1,k)))**2 + va(i,1,k)**2 )
           IF( wspd.ge.vmaxt(k) )THEN
@@ -3943,8 +3944,11 @@
           ENDIF
         enddo
       enddo
+!$acc end parallel
 
       vmax = 0.0
+
+!$acc serial default(present)
       do k=1,nk
         IF( vmaxt(k).ge.vmax )THEN
           vmax = vmaxt(k)
@@ -3954,6 +3958,7 @@
           kmax = kmaxt(k)
         ENDIF
       enddo
+!$acc end serial
 
       jmax = 1
 

--- a/src/nvtx_mod.F
+++ b/src/nvtx_mod.F
@@ -1,3 +1,4 @@
+#ifdef _OPENACC
 module nvtx_mod
 
 use iso_c_binding
@@ -74,3 +75,4 @@ subroutine nvtxEndRange
 end subroutine
 
 end module nvtx_mod
+#endif

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -399,7 +399,8 @@
       !$acc present(qa,qten) &
       !$acc present(kmh,kmv,khh,khv,tkea,tketen,nm,dissten,epst) &
       !$acc present(pta,ptten,u2pt,v2pt) &
-      !$acc present(tdiag,qdiag,udiag,vdiag,wdiag,kdiag)
+      !$acc present(tdiag,qdiag,udiag,vdiag,wdiag,kdiag) &
+      !$acc present(uavg,vavg,thavg,qavg,cavg)
 
 !--------------------------------------------------------------------
 
@@ -881,7 +882,7 @@
         IF( nql1.ge.1 )THEN
 
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector default(present) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -893,6 +894,7 @@
           do n=nql1+1,nql2
             !$omp parallel do default(shared)  &
             !$omp private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
             do k=1,nk
             do j=1,nj
             do i=1,ni
@@ -900,12 +902,14 @@
             enddo
             enddo
             enddo
+            !$acc end parallel
           enddo
 
         ELSE
 
           !$omp parallel do default(shared)  &
           !$omp private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -918,9 +922,9 @@
 
         IF(iice.eq.1)THEN
 
-        !JMD missing OpenACC
           !$omp parallel do default(shared)  &
           !$omp private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -930,9 +934,9 @@
           enddo
 
           do n=nqs1+1,nqs2
-        !JMD missing OpenACC
             !$omp parallel do default(shared)  &
             !$omp private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj
             do i=1,ni
@@ -940,13 +944,14 @@
             enddo
             enddo
             enddo
+            !$acc end parallel
           enddo
 
         ELSE
 
-        !JMD missing OpenACC
           !$omp parallel do default(shared)  &
           !$omp private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -957,9 +962,9 @@
 
         ENDIF
 
-        !JMD missing OpenACC
         !$omp parallel do default(shared)  &
         !$omp private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         DO k=1,nk
         do j=1,nj
         do i=1,ni
@@ -1072,7 +1077,8 @@
 #ifndef _B4B03R
         !$acc end parallel
 #endif
-        qbudget(9) = qtmp;
+        qbudget(9) = qtmp
+
         !$acc end data
         if(timestats.ge.1) time_misc09=time_misc09+mytime()
       endif
@@ -1139,7 +1145,7 @@
           if( bbc.eq.3 )then
             k = 1
             !$omp parallel do default(shared) private(i,j,dz1,epsd,dheat)
-            !$acc parallel loop gang vector default(present) private(i,j,dz1,epsd,dheat)
+            !$acc parallel loop gang vector collapse(2) default(present) private(i,j,dz1,epsd,dheat)
             do j=1,nj
             do i=1,ni
               dz1 = zf(i,j,2)-zf(i,j,1)
@@ -1185,7 +1191,7 @@
         !$acc loop gang
         do k=1,nk
           budtmp=0.0d0
-          !$acc loop vector reduction(+:budtmp)
+          !$acc loop vector collapse(2) reduction(+:budtmp)
           do j=1,nj
           do i=1,ni
             ! NOTE:  thrad is a POTENTIAL TEMPERATURE tendency
@@ -1206,11 +1212,14 @@
         !$acc end parallel
         !FIXME
         budtmp=qbudget(10)
+
         !$acc parallel loop gang vector default(present) private(k) reduction(+:budtmp)
         do k=1,nk
           budtmp = budtmp + tem0*bud(k)
         enddo
+
         qbudget(10)=budtmp
+
         if( dotbud .and. td_rad.ge.1 )then
           !$omp parallel do default(shared) private(i,j,k)
           !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -460,7 +460,7 @@
 !    t22 = ppterm
 !    dum8 = buoyancy at s pts
      !KLUDGE this to eliminated PCAST ERRORS
-     !$acc parallel loop gang vector collapse(3) private(i,j,k)
+     !$acc parallel loop gang vector collapse(3) default(present)
      do k=kb,ke
      do j=jb,je
      do i=ib,ie
@@ -475,7 +475,7 @@
         ifql:  &
         if( nql1.le.0 )then
 
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present) 
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -486,7 +486,7 @@
 
         else  ifql
 
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present) 
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -496,7 +496,7 @@
           enddo
 
           do n=nql1+1,nql2
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -511,7 +511,7 @@
 
           IF(iice.eq.1)THEN
 
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present) 
             do k=1,nk
             do j=1,nj
             do i=1,ni
@@ -520,9 +520,9 @@
             enddo
             enddo
 
-            !$acc parallel default(present) 
             do n=nqs1+1,nqs2
-            !$acc loop collapse(3)
+            !$acc parallel default(present)
+            !$acc loop gang vector collapse(3)
             do k=1,nk
             do j=1,nj
             do i=1,ni
@@ -530,12 +530,12 @@
             enddo
             enddo
             enddo
-            enddo
             !$acc end parallel
+            enddo
 
           ELSE
 
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj
             do i=1,ni
@@ -547,7 +547,7 @@
           ENDIF
           IF(eqtset.eq.2)THEN
 
-            !$acc parallel loop gang vector collapse(3) private(i,j,k,qv,qli,cpli,cpm,cvm)
+            !$acc parallel loop gang vector collapse(3) default(present) 
             do k=1,nk
             do j=1,nj
             do i=1,ni
@@ -569,7 +569,7 @@
           ELSEIF(eqtset.eq.1)THEN
 
             !print *,'before eqtset==1 loop'
-            !$acc parallel loop gang vector collapse(3) private(i,j,k,qv,qli)
+            !$acc parallel loop gang vector collapse(3) default(present) 
             do k=1,nk
             do j=1,nj
             do i=1,ni
@@ -586,7 +586,7 @@
 
         ELSE
           ! dry:
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present) 
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -611,7 +611,7 @@
 !  Set RK tendency arrays:
 
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) 
         do k=1,nk
         do j=1,nj+1
         do i=1,ni+1
@@ -646,7 +646,7 @@
       ! without terrain:
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present) 
       DO k=1,nk
         do j=0,nj+1
         do i=0,ni+2
@@ -656,7 +656,7 @@
       ENDDO
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present) 
       DO k=1,nk
         do j=0,nj+2
         do i=0,ni+1
@@ -666,7 +666,7 @@
       ENDDO
 
       !$omp parallel do default(shared) private(i,j)
-      !$acc parallel loop gang vector collapse(2) private(i,j)
+      !$acc parallel loop gang vector collapse(2) default(present)
       do j=0,nj+1
       do i=0,ni+1
         rrw(i,j,   1) = 0.0
@@ -675,7 +675,7 @@
       enddo
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present)
       DO k=2,nk
         do j=0,nj+1
         do i=0,ni+1
@@ -687,7 +687,7 @@
     ELSE
       ! with terrain:
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present)
       DO k=1,nk
         do j=0,nj+1
         do i=0,ni+2
@@ -697,7 +697,7 @@
       ENDDO
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present)
       DO k=1,nk
         do j=0,nj+2
         do i=0,ni+1
@@ -707,7 +707,7 @@
       ENDDO
 
       !$omp parallel do default(shared) private(i,j)
-      !$acc parallel loop gang vector collapse(2) private(i,j)
+      !$acc parallel loop gang vector collapse(2) default(present)
       do j=0,nj+1
       do i=0,ni+1
         rrw(i,j,   1) = 0.0
@@ -716,7 +716,7 @@
       enddo
 
       !$omp parallel do default(shared) private(i,j,k,r1,r2)
-      !$acc parallel loop gang vector private(i,j,k,r1,r2)
+      !$acc parallel loop gang vector default(present)
       DO k=1,nk
           r2 = (sigmaf(k)-sigma(k-1))*rds(k)
           r1 = 1.0-r2
@@ -753,7 +753,7 @@
         IF(axisymm.eq.0)THEN
           ! Cartesian without terrain:
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=0,nj+1
           do i=0,ni+1
@@ -767,7 +767,7 @@
         ELSE
           ! axisymmetric:
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=0,nj+1
           do i=0,ni+1
@@ -781,7 +781,7 @@
       ELSE
           ! Cartesian with terrain:
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=0,nj+1
           do i=0,ni+1
@@ -807,7 +807,7 @@
           if( betaplane.eq.0 )then
             ! f plane:
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj+1
             do i=1,ni+1
@@ -822,7 +822,7 @@
           elseif( betaplane.eq.1 )then
 
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj+1
             do i=1,ni+1
@@ -844,7 +844,7 @@
             ! for axisymmetric grid:
             ! note for axisymmetric grid: since cm1r18, Coriolis term for v is included in advvaxi
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj
             do i=1,ni+1
@@ -859,7 +859,7 @@
           !........ budget (infrequent) ........!
           IF( doubud .and. ud_cor.ge.1 .and. nrk.eq.nrkmax )THEN
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj
             do i=1,ni+1
@@ -870,7 +870,7 @@
           ENDIF
           IF( dovbud .and. vd_cor.ge.1 .and. nrk.eq.nrkmax )THEN
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj+1
             do i=1,ni
@@ -892,7 +892,7 @@
         if( nudgeobc.eq.1 .and. wbc.eq.2 .and. ibw.eq.1 )then
           ! 190315: nudge inflow point back towards base state:
           tem = 1.0/alphobc
-          !$acc parallel loop gang vector collapse(2) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present)
           do k=1,nk
           do j=1,nj
             if( u3d(1,j,k).gt.0.0 )then
@@ -904,7 +904,7 @@
         if( nudgeobc.eq.1 .and. ebc.eq.2 .and. ibe.eq.1 )then
           ! 190315: nudge inflow point back towards base state:
           tem = 1.0/alphobc
-          !$acc parallel loop gang vector collapse(2) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present)
           do k=1,nk
           do j=1,nj
             if( u3d(ni+1,j,k).lt.0.0 )then
@@ -920,7 +920,7 @@
         if(axisymm.eq.1)then
 
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj
           do i=1,ni+1
@@ -931,7 +931,7 @@
 
           if(ebc.eq.3)then
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector private(i,j,k)
+            !$acc parallel loop gang vector collapse(2) default(present)
             do k=1,nk
             do j=1,nj
               dum1(ni+1,j,k) = -dum1(ni,j,k)
@@ -940,7 +940,7 @@
           endif
 
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj
           do i=2,ni+1
@@ -951,7 +951,7 @@
 
           IF( doubud .and. nrk.eq.nrkmax )THEN
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj
             do i=2,ni+1
@@ -972,7 +972,7 @@
         if( nudgeobc.eq.1 .and. sbc.eq.2 .and. ibs.eq.1 )then
           ! 190315: nudge inflow point back towards base state:
           tem = 1.0/alphobc
-          !$acc parallel loop gang vector collapse(2) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present)
           do k=1,nk
           do i=1,ni
             if( v3d(i,1,k).gt.0.0 )then
@@ -984,7 +984,7 @@
         if( nudgeobc.eq.1 .and. nbc.eq.2 .and. ibn.eq.1 )then
           ! 190315: nudge inflow point back towards base state:
           tem = 1.0/alphobc
-          !$acc parallel loop gang vector collapse(2) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present)
           do k=1,nk
           do i=1,ni
             if( v3d(i,nj+1,k).lt.0.0 )then
@@ -1019,7 +1019,7 @@
         IF( axisymm.eq.1 .and. nrk.eq.nrkmax )THEN
           !  Diagnostics for axisymm:
           !$omp parallel do default(shared) private(i,j,k,tem1,tem2)
-          !$acc parallel loop gang vector collapse(3)  private(i,j,k,tem1,tem2)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,1
           do i=1,ni
@@ -1068,7 +1068,7 @@
         ! dum8 stores buoyancy at s pts:
  
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=2,nk
         do j=1,nj
         do i=1,ni
@@ -1079,7 +1079,7 @@
 
         if( dowbud .and. nrk.eq.nrkmax )then
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=2,nk
           do j=1,nj
           do i=1,ni
@@ -1098,7 +1098,7 @@
           ! save velocity tendencies before pgrad calculations:
           if( ud_pgrad.ge.1 )then
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj+1
             do i=1,ni+1
@@ -1109,7 +1109,7 @@
           endif
           if( vd_pgrad.ge.1 )then
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj+1
             do i=1,ni+1
@@ -1120,7 +1120,7 @@
           endif
           if( wd_pgrad.ge.1 )then
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj+1
             do i=1,ni+1
@@ -1150,7 +1150,7 @@
 #endif
   
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=2,nk
          do j=0,nj+1
           do i=0,ni+1
@@ -1160,7 +1160,7 @@
         enddo
 
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) private(i,j)
+        !$acc parallel loop gang vector collapse(2) default(present)
         do j=0,nj+1
           do i=0,ni+1
             dum1(i,j,1) = 0.0
@@ -1169,7 +1169,7 @@
         enddo
 
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=1,nk
           ! x-dir
           do j=1,nj
@@ -1182,7 +1182,7 @@
           enddo
         enddo
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=1,nk
           ! y-dir
           do j=1+ibs,nj+1-ibn
@@ -1212,7 +1212,7 @@
 
         IF(.not.terrain_flag)THEN
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=0,nj+1
           do i=0,ni+1
@@ -1222,7 +1222,7 @@
           enddo
         ELSE
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=0,nj+1
           do i=0,ni+1
@@ -1235,7 +1235,7 @@
 
       if( psolver.eq.1 )then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop vector gang private(i,j,k)
+        !$acc parallel loop vector gang default(present)
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -1363,7 +1363,7 @@
         IF(axisymm.eq.1)THEN
 
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -1382,7 +1382,7 @@
         ! pressure gradient accel:
         rdt = 1.0/dt
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=1,nk
         do j=1,nj
         do i=1,ni+1
@@ -1396,7 +1396,7 @@
         rdt = 1.0/dt
         IF( axisymm.eq.1 )THEN
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,2
           do i=1,ni
@@ -1407,7 +1407,7 @@
           enddo
         ELSE
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj+1
           do i=1,ni
@@ -1423,7 +1423,7 @@
         ! pressure gradient accel:
         rdt = 1.0/dt
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=2,nk
         do j=1,nj
         do i=1,ni
@@ -1475,7 +1475,7 @@
 
       if( iprcl.eq.1 .and. nrk.eq.nrkmax )then
         ! save time-averaged velocities for parcel driver:
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=1,nk+1
         do j=1,nj+1
         do i=1,ni+1
@@ -1509,7 +1509,7 @@
 
         IF( imoist.eq.1 .and. eqtset.eq.2 )THEN
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -1519,7 +1519,7 @@
           enddo
           if( dotbud .and. td_div.ge.1 )then
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector collapse(3) default(present)
             do k=1,nk
             do j=1,nj
             do i=1,ni
@@ -1530,7 +1530,7 @@
           endif
         ELSE
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -1542,7 +1542,7 @@
 
         IF(.not.terrain_flag)THEN
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=jb,je
           do i=ib,ie
@@ -1552,7 +1552,7 @@
           enddo
         ELSE
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=jb,je
           do i=ib,ie
@@ -1576,7 +1576,7 @@
       !print *,'solve2: point #14.1'
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present)
       do k=1,nk
       do j=1,nj
       do i=1,ni
@@ -1601,7 +1601,7 @@
       if(stat_qsrc.eq.1 .and. nrk.eq.nrkmax) bflag=1
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k) 
+      !$acc parallel loop gang vector collapse(3) default(present)
       do k=1,nk
       do j=1,nj
       do i=1,ni
@@ -1656,7 +1656,7 @@
     ENDIF
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present)
       do k=1,nk
       do j=1,nj
       do i=1,ni
@@ -1680,7 +1680,7 @@
     IF(psolver.eq.4.or.psolver.eq.5.or.psolver.eq.6.or.psolver.eq.7)THEN
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present)
       do k=1,nk
       do j=1,nj
       do i=1,ni
@@ -1698,7 +1698,7 @@
 
         IF(nrk.eq.nrkmax.and.eqtset.eq.2)THEN
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -1718,7 +1718,7 @@
         ENDIF
 
         IF( nrk.eq.nrkmax .or. (idiff.ge.1 .and. difforder.eq.6) )THEN
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           !$omp parallel do default(shared) private(i,j,k)
           do k=1,nk
           do j=1,nj
@@ -1735,7 +1735,7 @@
       ELSE
 
         IF( nrk.eq.nrkmax .or. (idiff.ge.1 .and. difforder.eq.6) )THEN
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           !$omp parallel do default(shared) private(i,j,k)
           do k=1,nk
           do j=1,nj
@@ -1758,7 +1758,7 @@
         !          conservation of total dry-air mass
 
         IF( axisymm.eq.0 )THEN
-          !$acc parallel reduction(+:tmp1,tmp2)
+          !$acc parallel default(present) reduction(+:tmp1,tmp2)
           !$acc loop gang
           do k=1,nk
             tmp1=0
@@ -1776,7 +1776,7 @@
           enddo
           !$acc end parallel
         ELSEIF( axisymm.eq.1 )THEN
-          !$acc parallel reduction(+:tmp1,tmp2)
+          !$acc parallel default(present) reduction(+:tmp1,tmp2)
           !$acc loop gang
           do k=1,nk
             tmp1=0
@@ -2006,7 +2006,7 @@
       !print *,'solve2: after advs'
 
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -2021,7 +2021,7 @@
         ! without tke advection:
 
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -2054,7 +2054,7 @@
       if(stat_qsrc.eq.1 .and. nrk.eq.nrkmax) bflag=1
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present)
       do k=1,nk
       do j=1,nj
       do i=1,ni
@@ -2088,7 +2088,7 @@
       print *,'solve2: after advs'
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present)
       do k=1,nk
       do j=1,nj
       do i=1,ni

--- a/src/testcase_simple_phys.F
+++ b/src/testcase_simple_phys.F
@@ -208,7 +208,7 @@
 
       !$acc parallel default(present) reduction(+:tmp1,tmp2,tmp3)
       ! Get domain-averages:
-      !$acc loop gang reduction(+:tmp1,tmp2,tmp3)
+      !$acc loop gang
       do k=1,nk
          tmp1=0.0
          tmp2=0.0
@@ -371,6 +371,7 @@
         kzi(i,j) = 0  ! initilize this to zero 
       enddo
       enddo
+      !$acc end parallel
 
       !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,n)
       do k=1,nk
@@ -384,10 +385,10 @@
         enddo
         !----
       enddo
-      !$acc parallel default(present) private(i,j,k)
-      !print *,'nql{1,2}: ',nql1,nql2
+      !$acc end parallel
 
       do n=nql1,nql2
+      !$acc parallel default(present)
       !$acc loop gang vector collapse(3)
       do k=1,nk
         do j=1,nj
@@ -395,12 +396,14 @@
           ql(i,j,k) = ql(i,j,k)+qa(i,j,k,n)
         enddo
         enddo
-        enddo
       enddo
       !$acc end parallel
+      enddo
+
       !----
-      !$acc parallel default(present) private(i,j,k)
+
       do k=1,nk
+        !$acc parallel default(present)
         !$acc loop gang vector collapse(2)
         do j=1,nj
         do i=1,ni
@@ -409,10 +412,10 @@
           dum2(i,j,k+1) = dum2(i,j,k) + kappa*rho0(i,j,k)*ql(i,j,k)*(zf(i,j,k+1)-zf(i,j,k))
         enddo
         enddo
+        !$acc end parallel
       enddo
-      !$acc end parallel
-      !----
 
+      !----
 
       ! interpolate:
       !$acc parallel loop gang vector collapse(2) default(present) private(i,j,k)
@@ -435,8 +438,8 @@
 !!!        print *
 !!!      endif
 
-      !$acc parallel default(present) private(i,j,k,fr1,fr2,fr3)
       do k=nk+1,1,-1
+      !$acc parallel default(present)
       !$acc loop gang vector collapse(2)
       do j=1,nj
       do i=1,ni
@@ -453,8 +456,9 @@
         frad(i,j,k) = fr1+fr2+fr3
       enddo
       enddo
-      enddo
       !$acc end parallel
+      enddo
+
       stop 'simplerad: at the end of the subroutine'
       end subroutine simplerad
 

--- a/src/turb.F
+++ b/src/turb.F
@@ -5494,7 +5494,6 @@
   !                 needed to determine kmw,ufw,vfw on the current level (k)
   !
 
-      !$acc parallel default(present) private(k,d2pm1,d2pm2,d2pm3,dsdz,tem)
       ! Initial condition: two-part wall fluxes are zero at the surface
       ufw = 0.0
       vfw = 0.0
@@ -5503,7 +5502,7 @@
 !!!  GHB, 220309: commented out open-acc commands. This will be difficult to
 !!!               parallelize, because of the "marching" mentioned above.  But
 !!!               it's a small calculation, so probably not a big deal...?
-      !$acc loop seq
+      !$acc serial default(present)
       kloop2:  &
       DO k=1,(ntwk-1)
 
@@ -5530,7 +5529,7 @@
         t2pm3(k+1) = -d2pm3*tem
 
       ENDDO  kloop2
-      !$acc end parallel
+      !$acc end serial 
 
       !$acc parallel default(present)
       ! diagnostic only:
@@ -5643,11 +5642,11 @@
         uavg(k) = 0.0
         vavg(k) = 0.0
       enddo
+      !$acc end parallel
 
+      !$acc parallel default(present)
       !$acc loop gang
       do k=1,nk
-        cavg(k,1) = 0.0
-        cavg(k,2) = 0.0
         ! GHB, 220302: need to initialize cavg1,cavg2
         cavg1 = 0.0
         cavg2 = 0.0
@@ -5746,9 +5745,9 @@
     !$acc end parallel
 
 
-    !$acc parallel
+    !$acc serial default(present)
     gamk(1) = gamk(2)
-    !$acc end parallel 
+    !$acc end serial 
  
     endif  doinggamk
 


### PR DESCRIPTION
This PR:
- fixes some bugs for CM1 GPU code when working on a 4-D array
- adds some missing OpenACC directives
- updates Makefile with managed memory option for GPU runs and ability to apply different compiler options to different source codes
- improves some GPU coding styles

---

The new verification result indicates that the correctness is **unchanged** for GPU runs without managed memory.

CPU (intel) versus OpenACC (nvhpc)
29 stat variables are identical.
48 stat variables show a mean relative difference > 1e-06
6 stat variables show a mean relative difference <= 1e-06
four variables with largest error: KSVMAX, KSHMAX, TMW, TKEMAX

CPU (intel) versus MPI+OpenACC (nvhpc)
26 stat variables are identical.
57 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06
four variables with largest error: STHPMX, THPMAX, TMW, PPMAX

---

The new verification result indicates that the correctness is **improved** for GPU runs with managed memory.

CPU (intel) versus OpenACC (nvhpc)
29 stat variables are identical.
48 stat variables show a mean relative difference > 1e-06
6 stat variables show a mean relative difference <= 1e-06
four variables with largest error: KSVMAX, KSHMAX, TMW, TKEMAX

CPU (intel) versus MPI+OpenACC (nvhpc)
29 stat variables are identical.
48 stat variables show a mean relative difference > 1e-06
6 stat variables show a mean relative difference <= 1e-06
four variables with largest error: KSVMAX, KSHMAX, TMW, TKEMAX