### PR TITLE
Fix GPU bugs for the partnum calculation

### DIFF
--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1671,7 +1671,7 @@
       end do
       !$acc end parallel
 
-      !$acc parallel loop gang vector default(present)
+      !$acc parallel loop gang vector default(present) reduction(partnum)
       do np=1,nparcels
          if (pdata(np,pract) .gt. 0.0) then
             kflag = 1


### PR DESCRIPTION
This PR adds a missing OpenACC reduction clause for the calculation of `partnum` in the droplet diagnostic subroutine.

With this fix, I am able to obtain consistent 1st-order droplet diagnostic results between CPU and GPU runs.