### PR TITLE
Enable the deterministic random number generator on GPU

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -296,7 +296,11 @@ OBJS_M = $(addsuffix .o, $(basename $(SRC_M)))
 OBJS_OPENACC = $(addsuffix .o, $(basename $(SRC_NVTX)))
 
 FFLAGS  = $(OPTS)
-FFLAGS_M  = $(OPTS_M)
+ifeq (${USE_OPENACC_L},true)
+FFLAGS_M = $(OPTS_M) -L/glade/u/apps/opt/nvhpc/22.2/Linux_x86_64/22.2/cuda/11.6/lib64 -lcudart
+else
+FFLAGS_M = $(OPTS)
+endif
 AR      = ar cru
 
 .SUFFIXES:
@@ -371,7 +375,7 @@ module_mp_jensen_ishmael.o: input.o module_ra_etc.o
 mp_driver.o: constants.o input.o misclibs.o kessler.o goddard.o thompson.o lfoice.o morrison.o module_mp_nssl_2mom.o module_mp_p3.o module_mp_jensen_ishmael.o
 param.o: constants.o input.o init_terrain.o bc.o comm.o bcast.o thompson.o morrison.o module_mp_nssl_2mom.o goddard.o lfoice.o module_mp_p3.o module_mp_jensen_ishmael.o ib_module.o eddy_recycle.o lsnudge.o
 parcel.o: constants.o input.o cm1libs.o misclibs.o bc.o comm.o writeout_nc.o
-droplet.o: constants.o input.o cm1libs.o bc.o comm.o parcel.o
+droplet.o: constants.o input.o cm1libs.o bc.o comm.o parcel.o mersennetwister_mod.o
 pdef.o: input.o bc.o comm.o
 pdcomp.o: constants.o input.o adv.o poiss.o ib_module.o
 poiss.o: input.o singleton.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -297,7 +297,7 @@ OBJS_OPENACC = $(addsuffix .o, $(basename $(SRC_NVTX)))
 
 FFLAGS  = $(OPTS)
 ifeq (${USE_OPENACC_L},true)
-FFLAGS_M = $(OPTS_M) -L/glade/u/apps/opt/nvhpc/22.2/Linux_x86_64/22.2/cuda/11.6/lib64 -lcudart
+FFLAGS_M = $(OPTS_M) # -L/glade/u/apps/opt/nvhpc/22.2/Linux_x86_64/22.2/cuda/11.6/lib64 -lcudart
 else
 FFLAGS_M = $(OPTS)
 endif

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -268,7 +268,7 @@
 #else
     !JMD WARNING: Loop does not yet match CPU version.
     !$acc parallel default(present)
-    !$acc loop gang vector
+    !$acc loop gang vector private(zf_tmp)
 #endif
     nploop:  &
     DO np=1,nparcels

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -104,7 +104,6 @@
 
       logical, parameter :: debug = .false.
       
-      real, dimension(kb:ke+1) :: zf_tmp
       type(randomNumberSequence) :: randomNumbers
 
 #ifdef _VERIFY_FIND_LOC
@@ -120,7 +119,7 @@
 !  [Note:  for u,v the array index (i,j,0) means the surface, ie z=0]
 !     (for the parcel subroutines only!)
 
-      !$acc data create(ta,zf_tmp) &
+      !$acc data create (ta) &
       !$acc      copyin (randomNumbers,randomNumbers%state)
 
     IF(bbc.eq.1)THEN
@@ -268,7 +267,7 @@
 #else
     !JMD WARNING: Loop does not yet match CPU version.
     !$acc parallel default(present)
-    !$acc loop gang vector private(zf_tmp)
+    !$acc loop gang vector
 #endif
     nploop:  &
     DO np=1,nparcels
@@ -322,14 +321,7 @@
 
       kflag = 1
       if( .not. terrain_flag )then
-        !JS-KLUDGE: Somehow I have to use the zf_tmp variable 
-        !           for the find_vertical* subroutine,
-        !           otherwise the GPU code breaks for nparcels > ~2000
-        !$acc loop seq
-        do k = kb, ke+1
-           zf_tmp(k) = zf(iflag,jflag,k)
-        end do
-        call find_vertical_location_index (pdata_locind(np,3), z3d, kb, ke+1, zf_tmp, kflag, .TRUE.)
+        call find_vertical_location_index (pdata_locind(np,3), z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .TRUE.)
       else
         call find_vertical_location_index (pdata_locind(np,3), sig3d, kb, ke+1, sigmaf, kflag, .TRUE.)
       endif

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -35,7 +35,7 @@
           kmt,npvals,nparcels,npvars,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,bbc,tbc,imove,zt,rzt, &
           umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
           prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult,prms,przs,pru,prv,prw,prt,prqv,prprs,prrho, &
-          timestats,time_droplet,mytime,ierr,time_droplet_reduce
+          timestats,time_droplet,mytime,ierr,time_droplet_reduce,maxx,maxy,maxz
       use constants
       use comm_module
       use misclibs
@@ -44,6 +44,8 @@
 #ifdef MPI
       use mpi
 #endif
+      use MersenneTwister_mod
+
       implicit none
 
 !-----------------------------------------------------------------------
@@ -101,6 +103,9 @@
       integer :: idropmethod
 
       logical, parameter :: debug = .false.
+      
+      real, dimension(kb:ke+1) :: zf_tmp
+      type(randomNumberSequence) :: randomNumbers
 
 #ifdef _VERIFY_FIND_LOC
       integer :: tmp_flag
@@ -108,12 +113,15 @@
 
       call reinit_random_seed
 
+      randomNumbers = new_RandomNumberSequence(seed = nparcels)
+
 !----------------------------------------------------------------------
 !  apply bottom/top boundary conditions:
 !  [Note:  for u,v the array index (i,j,0) means the surface, ie z=0]
 !     (for the parcel subroutines only!)
 
-      !$acc data create(ta)
+      !$acc data create(ta,zf_tmp) &
+      !$acc      copyin (randomNumbers,randomNumbers%state)
 
     IF(bbc.eq.1)THEN
       ! free slip ... extrapolate:
@@ -260,7 +268,7 @@
 #else
     !JMD WARNING: Loop does not yet match CPU version.
     !$acc parallel default(present)
-    !$acc loop gang vector 
+    !$acc loop gang vector
 #endif
     nploop:  &
     DO np=1,nparcels
@@ -314,7 +322,14 @@
 
       kflag = 1
       if( .not. terrain_flag )then
-        call find_vertical_location_index (pdata_locind(np,3), z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .TRUE.)
+        !JS-KLUDGE: Somehow I have to use the zf_tmp variable 
+        !           for the find_vertical* subroutine,
+        !           otherwise the GPU code breaks for nparcels > ~2000
+        !$acc loop seq
+        do k = kb, ke+1
+           zf_tmp(k) = zf(iflag,jflag,k)
+        end do
+        call find_vertical_location_index (pdata_locind(np,3), z3d, kb, ke+1, zf_tmp, kflag, .TRUE.)
       else
         call find_vertical_location_index (pdata_locind(np,3), sig3d, kb, ke+1, sigmaf, kflag, .TRUE.)
       endif
@@ -529,15 +544,12 @@
       !have fallen out the bottom:
       if (pdata(np,pract).lt.0.0) then
             !Replace with a new droplet at random location
-#if 0
-              !JMD-KLUDGE 
-              call random_number(rand)
+              rand = getRandomReal(randomNumbers)
               pdata(np,prx) = rand*maxx
-              call random_number(rand)
+              rand = getRandomReal(randomNumbers)
               pdata(np,pry) = rand*maxy
-              call random_number(rand)
+              rand = getRandomReal(randomNumbers)
               pdata(np,prz) = rand*maxz
-#endif
               pdata(np,prvpx) = 0.0
               pdata(np,prvpy) = 0.0
               pdata(np,prvpz) = 0.0

--- a/src/mersennetwister_mod.F
+++ b/src/mersennetwister_mod.F
@@ -113,6 +113,7 @@ contains
   end function mixbits
   ! ---------------------------
   function twist(u, v)
+    !$acc routine seq
     integer, intent( in) :: u, v
     integer              :: twist
 
@@ -124,6 +125,7 @@ contains
   end function twist
   ! ---------------------------
   subroutine nextState(twister)
+    !$acc routine seq
     type(randomNumberSequence), intent(inout) :: twister
 
     ! Local variables
@@ -144,6 +146,7 @@ contains
   end subroutine nextState
   ! ---------------------------
   elemental function temper(y)
+    !$acc routine seq
     integer, intent(in) :: y
     integer             :: temper
 
@@ -233,6 +236,7 @@ contains
   ! Public functions
   ! --------------------
   function getRandomInt(twister)
+    !$acc routine seq
     type(randomNumberSequence), intent(inout) :: twister
     integer                      :: getRandomInt
     ! Generate a random integer on the interval [0,0xffffffff]
@@ -265,7 +269,7 @@ contains
   end function getRandomPositiveInt
   ! --------------------
   function getRandomReal(twister)
-
+    !$acc routine seq
     type(randomNumberSequence), intent(inout) :: twister
     double precision             :: getRandomReal
     ! Generate a random number on [0,1]


### PR DESCRIPTION
This PR enables the deterministic random number on GPU by adding the OpenACC directives.

The GPU-enabled deterministic random number is later used in the droplet subroutine for re-injection of fallout droplets.

The results indicate that:
- the 1st-order droplet diagnostic is consistent between CPU and GPU runs.
- the 0th-order droplet diagnostic differs at a small magnitude of relative error.

**CPU runs: intel vs. openacc**
![image](https://user-images.githubusercontent.com/8117233/182302108-983ee6e0-81d8-448e-ae00-c23392eaabf5.png)

CPU run (intel) vs. MPI+GPU (nvhpc)
![image](https://user-images.githubusercontent.com/8117233/182302288-80184d75-865c-4f51-8ce0-9f374e3a062b.png)