### PR TITLE
Fix a GPU error for find_vertical_location_index subroutine

### DIFF
--- a/src/droplet.F
+++ b/src/droplet.F
@@ -103,7 +103,8 @@
       integer :: idropmethod
 
       logical, parameter :: debug = .false.
-      
+     
+      real, dimension(kb:ke+1) :: zf_tmp 
       type(randomNumberSequence) :: randomNumbers
 
 #ifdef _VERIFY_FIND_LOC
@@ -119,7 +120,7 @@
 !  [Note:  for u,v the array index (i,j,0) means the surface, ie z=0]
 !     (for the parcel subroutines only!)
 
-      !$acc data create (ta) &
+      !$acc data create (ta,zf_tmp) &
       !$acc      copyin (randomNumbers,randomNumbers%state)
 
     IF(bbc.eq.1)THEN
@@ -267,7 +268,7 @@
 #else
     !JMD WARNING: Loop does not yet match CPU version.
     !$acc parallel default(present)
-    !$acc loop gang vector
+    !$acc loop gang vector private(zf_tmp)
 #endif
     nploop:  &
     DO np=1,nparcels
@@ -321,7 +322,14 @@
 
       kflag = 1
       if( .not. terrain_flag )then
-        call find_vertical_location_index (pdata_locind(np,3), z3d, kb, ke+1, zf(iflag,jflag,:), kflag, .TRUE.)
+        !JS-KLUDGE: Somehow I have to use the zf_tmp variable 
+        !           for the find_vertical* subroutine,
+        !           otherwise the GPU code breaks for nparcels > ~2000
+        !$acc loop seq
+        do k = kb, ke+1
+           zf_tmp(k) = zf(iflag,jflag,k)
+        end do
+        call find_vertical_location_index (pdata_locind(np,3), z3d, kb, ke+1, zf_tmp, kflag, .TRUE.)
       else
         call find_vertical_location_index (pdata_locind(np,3), sig3d, kb, ke+1, sigmaf, kflag, .TRUE.)
       endif


### PR DESCRIPTION
We recently realize that when we work on a large domain with smaller grid size (e.g., dx=2.5m) and a large number of droplets (nparcels > 2,000), the GPU run of CM1 will crash by invoking the `find_vertical_location_index` subroutine.

We find a temporary solution by generating a local 1-D array `zf_tmp` for each CUDA thread and copying the information from `zf` array. This fixes the GPU error but also increases the CUDA memory usage.

The verification results using `namelist.baseline.dx=40m.short` indicate that:
- the 1st-order droplet diagnostic is consistent between CPU and GPU runs.
- the 0th-order droplet diagnostic differs at a small magnitude of relative error.

**CPU runs: intel vs. OpenACC**
![image](https://user-images.githubusercontent.com/8117233/182517155-da92ba9f-e9e5-4c60-9d38-483b5945b850.png)

**CPU run (intel) vs. MPI+GPU (nvhpc)**
![image](https://user-images.githubusercontent.com/8117233/182517195-e80d0f9d-1301-4edd-8c81-9b5bda07a425.png)
