### PR TITLE
Eliminate remaining B4B blocks

### DIFF
--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -1,21 +1,3 @@
-#ifdef _B4B
-
-#define _B4B16R
-#define _B4B19R
-#define _B4B21R
-#define _B4B22R
-#define _B4B23R
-#define _B4B24R
-#define _B4B25R
-#define _B4B26R
-#define _B4B27RF
-#define _B4B28R
-#define _B4B29R
-#define _B4B30
-#else
-!Appears to be a bug in the B4B28 loop
-#undef _B4B28R
-#endif
   MODULE domaindiag_module
 
   implicit none

--- a/src/kessler.F
+++ b/src/kessler.F
@@ -1,6 +1,3 @@
-#ifdef _B4B
-#define _B4B01R
-#endif
   MODULE kessler_module
 
   implicit none

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -4144,13 +4144,14 @@
         foo4(k) = foo4t
       enddo
       !$acc end parallel
-      !$acc parallel loop vector default(present) reduction(+:ek,ei,ep,le)
+      !$acc parallel loop gang vector default(present) reduction(+:ek,ei,ep,le)
       do k=1,nk
         ek=ek+foo1(k)
         ei=ei+foo2(k)
         ep=ep+foo3(k)
         le=le+foo4(k)
       enddo
+      !$acc end parallel
       !$acc end data
  
       ek=ek*(dx*dy*dz)
@@ -4372,7 +4373,7 @@
       !$acc end parallel
       tmfu=0.0d0
       tmfd=0.0d0
-      !$acc parallel loop vector default(present) reduction(+:tmfu,tmfd)
+      !$acc parallel loop vector gang default(present) reduction(+:tmfu,tmfd)
       do k=1,nk
         tmfu=tmfu+foo1(k)
         tmfd=tmfd+foo2(k)

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -1,9 +1,7 @@
 #ifdef _B4B
 
-#undef _B4B01R
 
 !JMD-expensive
-#define _B4B02R
 #define _B4B04R
 #define _B4B05R
 #define _B4B06R
@@ -1155,41 +1153,28 @@
       integer i,j,k
       double precision :: t1,t2,t3
       double precision :: a1,a2,tem
-      double precision, dimension(nj) :: budj
-      double precision, dimension(nk) :: budk
       double precision :: budt
       !$acc declare present(ruh,rvh,rmh,rho,q3d)
 
 !----------------------------------------------------------------------
 
       !print *,'pdefq_GPU: pdscheme: ',pdscheme
-#ifndef _B4B01R
-      !$acc data create(budj,budk)
-#endif
+      !!$acc data create(budj,budk)
       !tem = dx*dy*dz
       IF(pdscheme.eq.1)THEN
 
-#ifdef _B4B01R
-        !$acc update host(asq,ruh,rvh,rmh,rho,q3d)
-#else
-        !!$acc parallel loop gang vector default(present) private(i,j,k)
-        !$acc parallel default(present) private(i,j,k) &
-        !$acc reduction(+:a1,t1,t2) reduction(+:a2) reduction(+:budt)
-        !$acc loop gang
-#endif
         !$omp parallel do default(shared) private(i,j,k,t1,t2,t3,a1,a2)
+        !$acc parallel default(present) private(i,j,k) &
+        !$acc reduction(+:a1,t1,t2) reduction(+:a2) reduction(+:budt,asq)
+        !$acc loop gang
         do j=1,nj
           budt = 0.0d0
-#ifndef _B4B01R
           !$acc loop vector reduction(+:budt)
-#endif
           do i=1,ni
             t1=0.0d0
             t2=0.0d0
             a1=0.0d0
-#ifndef _B4B01R
             !$acc loop vector reduction(+:a1,t1,t2)
-#endif
             do k=1,nk
               t1=t1+rho(i,j,k)*q3d(i,j,k)
               a1=a1+rho(i,j,k)*q3d(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)
@@ -1200,33 +1185,22 @@
             t3=(t1+1.0d-20)/(t2+1.0d-20)
             if(t3.lt.0.0) t3=1.0d0
             a2=0.0d0
-#ifndef _B4B01R
             !$acc loop vector reduction(+:a2)
-#endif
             do k=1,nk
               q3d(i,j,k)=t3*q3d(i,j,k)
               a2=a2+rho(i,j,k)*q3d(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)
             enddo
             budt = budt+a2-a1
           enddo
-          budj(j)=budt
+          asq=asq+budt*dx*dy*dz
         enddo
-
-#ifndef _B4B01R
         !$acc end parallel
-        !$acc parallel loop vector reduction(+:asq)
-#endif
-        do j=1,nj
-          asq=asq+budj(j)*dx*dy*dz
-        enddo
 
       ELSE
 
         !$omp parallel do default(shared) private(i,j,k,a1,a2)
-#ifndef _B4B01R
         !$acc parallel default(present) private(i,j,k,a1,a2) reduction(+:budt,asq)
         !$acc loop gang
-#endif
         do k=1,nk
           budt=0.0d0
           !$acc loop vector collapse(2) reduction(+:budt)
@@ -1239,25 +1213,11 @@
             budt=budt+a2-a1
           enddo
           enddo
-         budk(k)=budt 
+          asq=asq+budt*dx*dy*dz
         enddo
-
-#ifndef _B4B01R
-        !$acc loop vector reduction(+:asq)
-#endif
-        do k=1,nk
-          asq=asq+budk(k)*dx*dy*dz
-        enddo
-#ifndef _B4B01R
       !$acc end parallel
-#endif
 
       ENDIF
-#ifdef _B4B01R
-      !$acc update device(asq,q3d)
-#else
-      !$acc end data
-#endif
 
 !----------------------------------------------------------------------
 
@@ -1290,7 +1250,6 @@
 !----------------------------------------------------------------------
 
       !print *,'pdefq2_GPU: pdscheme: ',pdscheme
-!      !$acc data create(budj,budk)
       !tem = dx*dy*dz
       IF(pdscheme.eq.1)THEN
 
@@ -1319,7 +1278,6 @@
               q3d(i,j,k)=t3*q3d(i,j,k)
               a2=a2+rho(i,j,k)*q3d(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)
             enddo
-            !budt = budt+a2-a1
             asq=asq+(a2-a1)*dx*dy*dz
           enddo
         enddo
@@ -1342,18 +1300,11 @@
             budt=budt+a2-a1
           enddo
           enddo
-          !budk(k)=budt 
           asq=asq+budt*dx*dy*dz
         enddo
-
-        !!$acc loop vector reduction(+:asq)
-        !do k=1,nk
-        !  asq=asq+budk(k)*dx*dy*dz
-        !enddo
         !$acc end parallel
 
       ENDIF
-!      !$acc end data
 
 !----------------------------------------------------------------------
 
@@ -1453,19 +1404,12 @@
         enddo
         !$acc end parallel
 
-#ifdef _B4B02R
-        !$acc update host(dum2d5,dum2d2) 
-#else
         !$acc parallel loop vector collapse(2) default(present) private(i,j) reduction(+:asq)
-#endif
         do j=1,nj
         do i=1,ni
           asq=asq+(dum2d5(i,j)-dum2d2(i,j))*tem
         enddo
         enddo
-#ifdef _B4B02R
-        !$acc update device(asq)
-#endif
 
       ELSE
 

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -4109,7 +4109,7 @@
       !$omp parallel do default(shared)  &
       !$omp private(i,j,k,u,v,w,tmp,qtot,tem)
       !$acc parallel default(present) private(i,j,k,u,v,w,tmp,qtot,tem) &
-      !$acc reduction(+:foo1t,foo2t,foo3t,foo4t,ek,ei,ep,le)
+      !$acc reduction(+:foo1t,foo2t,foo3t,foo4t)
       !JMD internal compiler error
       !!$acc loop gang reduction(+:ek,ei,ep,le)
       !$acc loop gang
@@ -4143,14 +4143,14 @@
         foo3(k) = foo3t
         foo4(k) = foo4t
       enddo
-      !$acc loop vector reduction(+:ek,ei,ep,le)
+      !$acc end parallel
+      !$acc parallel loop vector default(present) reduction(+:ek,ei,ep,le)
       do k=1,nk
         ek=ek+foo1(k)
         ei=ei+foo2(k)
         ep=ep+foo3(k)
         le=le+foo4(k)
       enddo
-      !$acc end parallel
       !$acc end data
  
       ek=ek*(dx*dy*dz)
@@ -4351,8 +4351,7 @@
 
       !$acc data create(foo1,foo2)
       !$omp parallel do default(shared) private(i,j,k,mf)
-      !$acc parallel default(present)  private(i,j,k,mf) reduction(+:foo1t,foo2t) &
-      !$acc reduction(+:tmfu,tmfd)
+      !$acc parallel default(present)  private(i,j,k,mf) reduction(+:foo1t,foo2t)
       !JMD internal compiler error
       !!$acc loop gang reduction(+:tmfu,tmfd)
       !$acc loop gang 
@@ -4370,9 +4369,10 @@
         foo1(k) = foo1t
         foo2(k) = foo2t
       enddo
+      !$acc end parallel
       tmfu=0.0d0
       tmfd=0.0d0
-      !$acc loop vector reduction(+:tmfu,tmfd)
+      !$acc parallel loop vector default(present) reduction(+:tmfu,tmfd)
       do k=1,nk
         tmfu=tmfu+foo1(k)
         tmfd=tmfd+foo2(k)

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3,11 +3,9 @@
 
 !JMD-expensive
 #define _B4B04R
-#define _B4B05R
 #define _B4B06R
 #define _B4B07R
 #define _B4B08R
-#define _B4B09R
 #define _B4B10R
 #endif
   MODULE misclibs
@@ -1159,7 +1157,6 @@
 !----------------------------------------------------------------------
 
       !print *,'pdefq_GPU: pdscheme: ',pdscheme
-      !!$acc data create(budj,budk)
       !tem = dx*dy*dz
       IF(pdscheme.eq.1)THEN
 
@@ -1334,13 +1331,10 @@
       integer i,j,k
       double precision :: t1,t2,t3
       double precision :: a1,a2,tem
-      double precision, dimension(nj) :: budj
-      double precision, dimension(nk) :: budk
       double precision :: budt
       !$acc declare &
       !$acc present(ruh,rvh,rmh,rho,q3d) &
       !$acc present( dum2d1,dum2d2,dum2d3,dum2d4,dum2d5)
-      !$acc data create(budk)
 
 !----------------------------------------------------------------------
 
@@ -1413,14 +1407,9 @@
 
       ELSE
 
-        !FIXME
         !$omp parallel do default(shared) private(i,j,k,a1,a2)
-#ifdef _B4B05R
-        !$acc update host(rho,q3d,ruh,rvh,rmh)
-#else
-        !$acc parallel default(present) private(k) reduction(+:budt) 
+        !$acc parallel default(present) private(k) reduction(+:budt,asq) 
         !$acc loop gang 
-#endif
         do k=1,nk
           budt = 0.0d0
           !$acc loop vector collapse(2) private(i,j,a1,a2) reduction(+:budt)
@@ -1434,25 +1423,12 @@
           budt=budt+(a2-a1)
           enddo
           enddo
-          budk(k)=budt
+          asq=asq+budt*tem
         enddo
-#ifdef _B4B05R
-        !$acc update host(budk)
-#else
-        !$acc end parallel
-        !$acc parallel loop vector default(present) private(k) reduction(+:asq)
-#endif
-        do k=1,nk
-          asq=asq+budk(k)*tem
-        enddo
-#ifdef _B4B05R
-        !$acc update device(asq)     
-#endif
-
       ENDIF
 
 !----------------------------------------------------------------------
-      !$acc end data
+      !!$acc end data
       if(timestats.ge.1) time_misc05=time_misc05+mytime()
 
       end subroutine pdefqtest
@@ -4382,15 +4358,9 @@
       qltmp=0.0d0
       vrtmp=0.0d0
 
-#ifdef _B4B09R
-      !$acc update host(qv,ql,qi,ruh,rvh,rmh,ua,va,wa,vr,rho)
-#else
-      !$acc parallel default(present) private(i,j,k,qtot,tem) reduction(+:tmu,tmv,tmw,qltmp,vrtmp)
-#endif
       !$omp parallel do default(shared) private(i,j,k,qtot,tem)
-#ifndef _B4B09R
+      !$acc parallel default(present) private(i,j,k,qtot,tem) reduction(+:tmu,tmv,tmw,qltmp,vrtmp)
       !$acc loop vector collapse(3) reduction(+:tmu,tmv,tmw,qltmp,vrtmp)
-#endif
       do k=1,nk
         do j=1,nj
         do i=1,ni
@@ -4408,11 +4378,7 @@
         enddo
         enddo
       enddo
-#ifdef _B4B09R
-      !!$acc update device(tmu,tmv,tmw)
-#else
       !$acc end parallel
-#endif
 
       tmu=tmu*(dx*dy*dz)
       tmv=tmv*(dx*dy*dz)
@@ -4501,22 +4467,17 @@
       double precision, dimension(nk) :: foo1,foo2
       double precision :: foo1t,foo2t
 
+!JMD-cleanup
      !$acc data create(foo1,foo2)
 
      !$omp parallel do default(shared) private(i,j,k,mf)
-#ifdef _B4B10R
-     !$acc update host(wa,ruh,rvh)
-#else
      !$acc parallel default(present)  private(i,j,k,mf) reduction(+:foo1t,foo2t) &
      !$acc reduction(+:tmfu,tmfd)
      !$acc loop gang 
-#endif
       do k=1,nk
         foo1t = 0.0d0
         foo2t = 0.0d0
-#ifndef _B4B10R
         !$acc loop vector collapse(2) reduction(+:foo1t,foo2t)
-#endif
         do j=1,nj
         do i=1,ni
           mf=rho(i,j,k)*0.5*(wa(i,j,k)+wa(i,j,k+1))*ruh(i)*rvh(j)
@@ -4530,18 +4491,12 @@
 
       tmfu=0.0d0
       tmfd=0.0d0
-#ifndef _B4B10R
       !$acc loop vector reduction(+:tmfu,tmfd)
-#endif
       do k=1,nk
         tmfu=tmfu+foo1(k)
         tmfd=tmfd+foo2(k)
       enddo
-#ifdef _B4B10R
-      !$acc update device(tmfu,tmfd)
-#else
       !$acc end parallel
-#endif
 
 #ifdef MPI
       var=0.0d0

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -1419,7 +1419,6 @@
       ENDIF
 
 !----------------------------------------------------------------------
-      !!$acc end data
       if(timestats.ge.1) time_misc05=time_misc05+mytime()
 
       end subroutine pdefqtest
@@ -3999,7 +3998,6 @@
  
       if(timestats.ge.1) time_stat=time_stat+mytime()
 
-!!$acc end data
  
       end subroutine totmois
 
@@ -4028,7 +4026,6 @@
 
       integer i,j,k
       double precision :: tmass,var
-      !double precision, dimension(nk) :: foo
       double precision :: foot
 
 
@@ -4069,8 +4066,6 @@
 #endif
 
       if(timestats.ge.1) time_stat=time_stat+mytime()
-
-!!$acc end data
 
       end subroutine totq
 
@@ -4223,7 +4218,6 @@
  
       integer i,j,k
       double precision :: tmu,tmv,tmw,qtot,var,tem
-      ! double precision, dimension(nk) :: foo1,foo2,foo3
       double precision :: foot1,foot2,foot3
       double precision :: qltmp,vrtmp
 
@@ -4390,7 +4384,6 @@
 #ifdef MPI
       endif
 #endif
-!      !$acc end data
       if(timestats.ge.1) time_stat=time_stat+mytime()
 
 

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -1153,7 +1153,7 @@
         !$omp parallel do default(shared) private(i,j,k,t1,t2,t3,a1,a2)
         !$acc parallel default(present) private(i,j,k) &
         !$acc reduction(+:a1,t1,t2) reduction(+:a2) reduction(+:budt,asq)
-        !$acc loop gang
+        !$acc loop gang reduction(+:asq)
         do j=1,nj
           budt = 0.0d0
           !$acc loop vector reduction(+:budt)
@@ -1399,7 +1399,7 @@
 
         !$omp parallel do default(shared) private(i,j,k,a1,a2)
         !$acc parallel default(present) private(k) reduction(+:budt,asq) 
-        !$acc loop gang 
+        !$acc loop gang reduction(+:asq)
         do k=1,nk
           budt = 0.0d0
           !$acc loop vector collapse(2) private(i,j,a1,a2) reduction(+:budt)
@@ -3893,7 +3893,7 @@
       tmass=0.0d0 
       !$omp parallel do default(shared) private(i,j,k)
       !$acc parallel default(present) private(i,j,k) reduction(+:foot,tmass)
-      !$acc loop gang
+      !$acc loop gang reduction(+:tmass)
       do k=1,nk
         foot=0.0d0
         !$acc loop vector collapse(2) reduction(+:foot)
@@ -3961,7 +3961,7 @@
       tmass=0.0d0
       !$omp parallel do default(shared) private(i,j,k)
       !$acc parallel default(present) private(i,j,k) reduction(+:foot,tmass)
-      !$acc loop gang
+      !$acc loop gang reduction(+:tmass)
       do k=1,nk
         foot = 0.0d0   
         !$acc loop vector collapse(2) reduction(+:foot)
@@ -4032,7 +4032,7 @@
       tmass=0.0d0
       !$omp parallel do default(shared) private(i,j,k)
       !$acc parallel default(present) private(i,j,k) reduction(+:foot,tmass)
-      !$acc loop gang
+      !$acc loop gang reduction(+:tmass)
       do k=1,nk
         foot=0.0d0
         !$acc loop vector collapse(2) reduction(+:foot)
@@ -4098,17 +4098,21 @@
  
       integer i,j,k
       double precision :: u,v,w,tmp,qtot,ek,ei,ep,et,le,var,tem
+      double precision, dimension(nk) :: foo1,foo2,foo3,foo4
       double precision :: foo1t,foo2t,foo3t,foo4t
 
       ek=0.0d0
       ei=0.0d0
       ep=0.0d0
       le=0.0d0
+      !$acc data create(foo1,foo2,foo3,foo4)
       !$omp parallel do default(shared)  &
       !$omp private(i,j,k,u,v,w,tmp,qtot,tem)
       !$acc parallel default(present) private(i,j,k,u,v,w,tmp,qtot,tem) &
       !$acc reduction(+:foo1t,foo2t,foo3t,foo4t,ek,ei,ep,le)
-      !$acc loop gang 
+      !JMD internal compiler error
+      !!$acc loop gang reduction(+:ek,ei,ep,le)
+      !$acc loop gang
       do k=1,nk
         foo1t=0.0d0      ! = ek
         foo2t=0.0d0      ! = ei
@@ -4134,12 +4138,20 @@
                          +rho(i,j,k)*tem*qi(i,j,k)*(cpi*tmp-ls1)
         enddo
         enddo
-        ek=ek+foo1t
-        ei=ei+foo2t
-        ep=ep+foo3t
-        le=le+foo4t
+        foo1(k) = foo1t
+        foo2(k) = foo2t
+        foo3(k) = foo3t
+        foo4(k) = foo4t
+      enddo
+      !$acc loop vector reduction(+:ek,ei,ep,le)
+      do k=1,nk
+        ek=ek+foo1(k)
+        ei=ei+foo2(k)
+        ep=ep+foo3(k)
+        le=le+foo4(k)
       enddo
       !$acc end parallel
+      !$acc end data
  
       ek=ek*(dx*dy*dz)
       ei=ei*(dx*dy*dz)
@@ -4333,14 +4345,16 @@
 
       integer i,j,k
       double precision :: tmfu,tmfd,mf,var
+      double precision, dimension(nk) :: foo1,foo2
       double precision :: foo1t,foo2t
 
 
-      tmfu=0.0d0
-      tmfd=0.0d0
+      !$acc data create(foo1,foo2)
       !$omp parallel do default(shared) private(i,j,k,mf)
       !$acc parallel default(present)  private(i,j,k,mf) reduction(+:foo1t,foo2t) &
       !$acc reduction(+:tmfu,tmfd)
+      !JMD internal compiler error
+      !!$acc loop gang reduction(+:tmfu,tmfd)
       !$acc loop gang 
       do k=1,nk
         foo1t = 0.0d0
@@ -4353,8 +4367,15 @@
           foo2t=foo2t+min(mf,0.0d0)
         enddo
         enddo
-        tmfu=tmfu+foo1t
-        tmfd=tmfd+foo2t
+        foo1(k) = foo1t
+        foo2(k) = foo2t
+      enddo
+      tmfu=0.0d0
+      tmfd=0.0d0
+      !$acc loop vector reduction(+:tmfu,tmfd)
+      do k=1,nk
+        tmfu=tmfu+foo1(k)
+        tmfd=tmfd+foo2(k)
       enddo
       !$acc end parallel
 
@@ -4384,6 +4405,7 @@
 #ifdef MPI
       endif
 #endif
+      !$acc end data
       if(timestats.ge.1) time_stat=time_stat+mytime()
 
 

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -1,13 +1,3 @@
-#ifdef _B4B
-
-
-!JMD-expensive
-#define _B4B04R
-#define _B4B06R
-#define _B4B07R
-#define _B4B08R
-#define _B4B10R
-#endif
   MODULE misclibs
 
   implicit none
@@ -1425,6 +1415,7 @@
           enddo
           asq=asq+budt*tem
         enddo
+        !$acc end parallel
       ENDIF
 
 !----------------------------------------------------------------------
@@ -3316,20 +3307,12 @@
       if(nx.gt.1.and.ny.gt.1)then
         ! 3d:
         !$omp parallel do default(shared) private(i,j,k,tem1,tem2,tem3)
-#ifdef _B4B04R
-        !$acc update host(uh,vh,kmh,kmv,khh,khv)
-#else
         !$acc parallel default(present) private(i,j,k,tem1,tem2,tem3) reduction(max:kstmp) 
-#endif
         ks(1)=0.0
-#ifndef _B4B04R
         !$acc loop gang 
-#endif
         do k=2,nk
            kstmp = 0.0
-#ifndef _B4B04R
            !$acc loop vector collapse(2) reduction(max:kstmp)
-#endif
            do j=1,nj
            do i=1,ni
              tem1 = sqrt( (kmh(i,j,k)*dtdx*uh(i)*uh(i))**2 &
@@ -3343,28 +3326,16 @@
           enddo
           ks(k) = kstmp
         enddo
-#ifdef _B4B04R
-        !$acc update device(ks)
-#else
         !$acc end parallel
-#endif
       elseif(nx.gt.1)then
         ! 2d (including axisymm):
         !$omp parallel do default(shared) private(i,j,tem1,tem2,tem3)
-#ifdef _B4B04R
-        !$acc update host(uh,vh,kmh,kmv,khh,khv)
-#else
         !$acc parallel default(present) private(i,j,k,tem1,tem2,tem3) reduction(max:kstmp) 
-#endif
         ks(1)=0.0
-#ifndef _B4B04R
         !$acc loop gang
-#endif
         do k=2,nk
           kstmp = 0.0
-#ifndef _B4B04R
           !$acc loop vector collapse(2) reduction(max:kstmp)
-#endif
           do j=1,nj
           do i=1,ni
             tem1 = kmh(i,j,k)*dtdx*uh(i)*uh(i)
@@ -3375,11 +3346,7 @@
           enddo
           ks(k) = kstmp
         enddo
-#ifdef _B4B04R
-        !$acc update device(ks)
-#else
         !$acc end parallel
-#endif
       elseif(axisymm.eq.0.and.ny.gt.1)then
         stop 1112
       endif
@@ -3921,47 +3888,24 @@
  
       integer i,j,k
       double precision :: tmass,var
-      double precision, dimension(nk) :: foo
       double precision :: foot
 
-      !$acc data create(foo)
 
+      tmass=0.0d0 
       !$omp parallel do default(shared) private(i,j,k)
-#ifdef _B4B06R
-      !$acc update host(rho,ruh,rvh,rmh)
-#else
-      !$acc parallel default(present) private(i,j,k) reduction(+:foot)
+      !$acc parallel default(present) private(i,j,k) reduction(+:foot,tmass)
       !$acc loop gang
-#endif
       do k=1,nk
         foot=0.0d0
-#ifndef _B4B06R
         !$acc loop vector collapse(2) reduction(+:foot)
-#endif
         do j=1,nj
         do i=1,ni
           foot=foot+rho(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)
         enddo
         enddo
-        foo(k)=foot
+        tmass=tmass+foot
       enddo
-#ifndef _B4B06R
       !$acc end parallel
-#endif
-
-      tmass=0.0d0 
-#ifndef _B4B06R
-      !$acc parallel default(present) private(k) reduction(+:tmass)
-      !$acc loop gang vector reduction(+:tmass)
-#endif
-      do k=1,nk
-        tmass=tmass+foo(k)
-      enddo
-#ifndef _B4B06R
-      !$acc end parallel
-#endif
-
-      !$acc end data
 
 #ifdef MPI
       var=0.0d0
@@ -4013,46 +3957,24 @@
  
       integer i,j,k
       double precision :: tmass,var
-      double precision, dimension(nk) :: foo
       double precision :: foot
 
-#ifdef _B4B07R
-      !$acc update host(rho,qv,ql,qi,ruh,rvh,rmh)
-#else
-      !$acc data create(foo)
-
+      tmass=0.0d0
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present) private(i,j,k) reduction(+:foot)
+      !$acc parallel default(present) private(i,j,k) reduction(+:foot,tmass)
       !$acc loop gang
-#endif
       do k=1,nk
         foot = 0.0d0   
-#ifndef _B4B07R
         !$acc loop vector collapse(2) reduction(+:foot)
-#endif
         do j=1,nj
         do i=1,ni
           foot=foot + rho(i,j,k)*(qv(i,j,k)+ql(i,j,k)+qi(i,j,k))*ruh(i)*rvh(j)*rmh(i,j,k)
         enddo
         enddo
-        foo(k) = foot
+        tmass=tmass+foot
       enddo
-#ifndef _B4B07R
       !$acc end parallel
-#endif
  
-      tmass=0.0d0
-#ifndef _B4B07R
-      !$acc parallel default(present) reduction(+:tmass)
-      !$acc loop gang vector reduction(+:tmass)
-#endif
-      do k=1,nk
-        tmass=tmass+foo(k)
-      enddo
-#ifndef _B4B07R
-      !$acc end parallel
-#endif
-
 
 #ifdef MPI
       var=0.0d0
@@ -4077,9 +3999,7 @@
  
       if(timestats.ge.1) time_stat=time_stat+mytime()
 
-#ifndef _B4B07R
-!$acc end data
-#endif
+!!$acc end data
  
       end subroutine totmois
 
@@ -4108,45 +4028,25 @@
 
       integer i,j,k
       double precision :: tmass,var
-      double precision, dimension(nk) :: foo
+      !double precision, dimension(nk) :: foo
       double precision :: foot
 
-#ifdef _B4B08R
-      !$acc update host(rho,q,ruh,rvh,rmh)
-#else
-      !$acc data create(foo)
 
+      tmass=0.0d0
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present) private(i,j,k) reduction(+:foot)
+      !$acc parallel default(present) private(i,j,k) reduction(+:foot,tmass)
       !$acc loop gang
-#endif
       do k=1,nk
         foot=0.0d0
-#ifndef _B4B08R
         !$acc loop vector collapse(2) reduction(+:foot)
-#endif
         do j=1,nj
         do i=1,ni
           foot=foot+rho(i,j,k)*q(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)
         enddo
         enddo
-        foo(k)=foot
+        tmass=tmass+foot
       enddo
-#ifndef _B4B08R
       !$acc end parallel
-#endif
-
-      tmass=0.0d0
-#ifndef _B4B08R
-      !$acc parallel default(present) reduction(+:tmass)
-      !$acc loop vector reduction(+:tmass)
-#endif
-      do k=1,nk
-        tmass=tmass+foo(k)
-      enddo
-#ifndef _B4B08R
-      !$acc end parallel
-#endif
 
 #ifdef MPI
       var=0.0d0
@@ -4170,9 +4070,7 @@
 
       if(timestats.ge.1) time_stat=time_stat+mytime()
 
-#ifndef _B4B08R
-!$acc end data
-#endif
+!!$acc end data
 
       end subroutine totq
 
@@ -4205,33 +4103,23 @@
  
       integer i,j,k
       double precision :: u,v,w,tmp,qtot,ek,ei,ep,et,le,var,tem
-      double precision, dimension(nk) :: foo1,foo2,foo3,foo4
       double precision :: foo1t,foo2t,foo3t,foo4t
 
       ek=0.0d0
       ei=0.0d0
       ep=0.0d0
       le=0.0d0
-      !$acc data create(foo1,foo2,foo3,foo4)
-#ifdef _B4B
-      !$acc update host(ruh,rvh,rmh,ua,va,wa,qv,ql,qi,rho,vr,pi0,ppi)
-#else
-      !$acc parallel default(present) private(i,j,k,u,v,w,tmp,qtot,tem) &
-      !$acc reduction(+:foo1t,foo2t,foo3t,foo4t,ek,ei,ep,le)
-#endif
       !$omp parallel do default(shared)  &
       !$omp private(i,j,k,u,v,w,tmp,qtot,tem)
-#ifndef _B4B
+      !$acc parallel default(present) private(i,j,k,u,v,w,tmp,qtot,tem) &
+      !$acc reduction(+:foo1t,foo2t,foo3t,foo4t,ek,ei,ep,le)
       !$acc loop gang 
-#endif
       do k=1,nk
         foo1t=0.0d0      ! = ek
         foo2t=0.0d0      ! = ei
         foo3t=0.0d0      ! = ep
         foo4t=0.0d0      ! = le
-#ifndef _B4B
         !$acc loop vector collapse(2) reduction(+:foo1t,foo2t,foo3t,foo4t)
-#endif
         do j=1,nj
         do i=1,ni
           tem=ruh(i)*rvh(j)*rmh(i,j,k)
@@ -4251,26 +4139,13 @@
                          +rho(i,j,k)*tem*qi(i,j,k)*(cpi*tmp-ls1)
         enddo
         enddo
-        foo1(k) = foo1t
-        foo2(k) = foo2t
-        foo3(k) = foo3t
-        foo4(k) = foo4t
+        ek=ek+foo1t
+        ei=ei+foo2t
+        ep=ep+foo3t
+        le=le+foo4t
       enddo
- 
-#ifndef _B4B
-      !$acc loop vector reduction(+:ek,ei,ep,le)
-#endif
-      do k=1,nk
-        ek=ek+foo1(k)
-        ei=ei+foo2(k)
-        ep=ep+foo3(k)
-        le=le+foo4(k)
-      enddo
-#ifndef _B4B
       !$acc end parallel
-#endif
-      !$acc end data
-
+ 
       ek=ek*(dx*dy*dz)
       ei=ei*(dx*dy*dz)
       ep=ep*(dx*dy*dz)
@@ -4348,7 +4223,7 @@
  
       integer i,j,k
       double precision :: tmu,tmv,tmw,qtot,var,tem
-      double precision, dimension(nk) :: foo1,foo2,foo3
+      ! double precision, dimension(nk) :: foo1,foo2,foo3
       double precision :: foot1,foot2,foot3
       double precision :: qltmp,vrtmp
 
@@ -4464,16 +4339,15 @@
 
       integer i,j,k
       double precision :: tmfu,tmfd,mf,var
-      double precision, dimension(nk) :: foo1,foo2
       double precision :: foo1t,foo2t
 
-!JMD-cleanup
-     !$acc data create(foo1,foo2)
 
-     !$omp parallel do default(shared) private(i,j,k,mf)
-     !$acc parallel default(present)  private(i,j,k,mf) reduction(+:foo1t,foo2t) &
-     !$acc reduction(+:tmfu,tmfd)
-     !$acc loop gang 
+      tmfu=0.0d0
+      tmfd=0.0d0
+      !$omp parallel do default(shared) private(i,j,k,mf)
+      !$acc parallel default(present)  private(i,j,k,mf) reduction(+:foo1t,foo2t) &
+      !$acc reduction(+:tmfu,tmfd)
+      !$acc loop gang 
       do k=1,nk
         foo1t = 0.0d0
         foo2t = 0.0d0
@@ -4485,16 +4359,8 @@
           foo2t=foo2t+min(mf,0.0d0)
         enddo
         enddo
-        foo1(k) = foo1t
-        foo2(k) = foo2t
-      enddo
-
-      tmfu=0.0d0
-      tmfd=0.0d0
-      !$acc loop vector reduction(+:tmfu,tmfd)
-      do k=1,nk
-        tmfu=tmfu+foo1(k)
-        tmfd=tmfd+foo2(k)
+        tmfu=tmfu+foo1t
+        tmfd=tmfd+foo2t
       enddo
       !$acc end parallel
 
@@ -4524,7 +4390,7 @@
 #ifdef MPI
       endif
 #endif
-      !$acc end data
+!      !$acc end data
       if(timestats.ge.1) time_stat=time_stat+mytime()
 
 

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -1,8 +1,3 @@
-#ifdef _B4B
-
-#define _B4B06R
-#define _B4B08R
-#endif
   MODULE sfcphys_module
 
   implicit none
@@ -497,36 +492,24 @@
     IF(imoist.eq.1)THEN
       tem = dt*dx*dy
       ! some budget calculations:
-#ifdef _B4B06R
-      !$acc update host(qvflux,ruh,rvh,rf) 
-#else
-      !$acc data create(bud1)
+      !!$acc data create(bud1)
+      !$omp parallel do default(shared) private(i,j)
       !$acc parallel default(present) private(i,j) reduction(+:budtmp,qbsfc) 
       !$acc loop gang
-#endif
-      !$omp parallel do default(shared) private(i,j)
       do j=1,nj
         budtmp=0.0d0
-#ifndef _B4B06R
         !$acc loop vector reduction(+:budtmp)
-#endif
         do i=1,ni
           budtmp=budtmp+qvflux(i,j)*ruh(i)*rvh(j)*rf(i,j,1)
         enddo
-        bud1(j)=budtmp
+        qbsfc=qbsfc+budtmp*dt*dx*dy
       enddo
-#ifndef _B4B06R
-      !$acc loop vector reduction(+:qbsfc)
-#endif
-      do j=1,nj
-        qbsfc=qbsfc+bud1(j)*dt*dx*dy
-      enddo
-#ifdef _B4B06R
-      !$acc update device(qbsfc)
-#else
+      !!$acc loop vector reduction(+:qbsfc)
+      !do j=1,nj
+      !  qbsfc=qbsfc+bud1(j)*dt*dx*dy
+      !enddo
       !$acc end parallel
-      !$acc end data
-#endif
+      !!$acc end data
     ENDIF
 
 !-----------------------------------------------------------------------

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -493,7 +493,7 @@
       ! some budget calculations:
       !$omp parallel do default(shared) private(i,j)
       !$acc parallel default(present) private(i,j) reduction(+:budtmp,qbsfc) 
-      !$acc loop gang
+      !$acc loop gang reduction(+:qbsfc)
       do j=1,nj
         budtmp=0.0d0
         !$acc loop vector reduction(+:budtmp)

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -331,7 +331,6 @@
 
       integer :: i,j
       real :: pisfc,qvsat,tem,shf
-      !double precision, dimension(nj) :: bud1
       double precision :: budtmp
       real :: thmag,qvmag,trat1,trat2
       real :: thtmp,qvtmp

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -331,7 +331,7 @@
 
       integer :: i,j
       real :: pisfc,qvsat,tem,shf
-      double precision, dimension(nj) :: bud1
+      !double precision, dimension(nj) :: bud1
       double precision :: budtmp
       real :: thmag,qvmag,trat1,trat2
       real :: thtmp,qvtmp
@@ -492,7 +492,6 @@
     IF(imoist.eq.1)THEN
       tem = dt*dx*dy
       ! some budget calculations:
-      !!$acc data create(bud1)
       !$omp parallel do default(shared) private(i,j)
       !$acc parallel default(present) private(i,j) reduction(+:budtmp,qbsfc) 
       !$acc loop gang
@@ -504,12 +503,7 @@
         enddo
         qbsfc=qbsfc+budtmp*dt*dx*dy
       enddo
-      !!$acc loop vector reduction(+:qbsfc)
-      !do j=1,nj
-      !  qbsfc=qbsfc+bud1(j)*dt*dx*dy
-      !enddo
       !$acc end parallel
-      !!$acc end data
     ENDIF
 
 !-----------------------------------------------------------------------

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -1,6 +1,3 @@
-#ifdef _B4B
-#define _B4B03R
-#endif
   MODULE solve1_module
 
         ! solve1: pre-RK terms
@@ -1036,17 +1033,13 @@
                  + g*zh(i,j,1)*delqv   )
 
           if( nql1.ge.1 )then
-#ifndef _B4B03R
             !$acc loop seq
-#endif
             do n=nql1,nql2
               budarray(i,j) = budarray(i,j) + dum2(i,j,1)*ruh(i)*rvh(j)*rmh(i,j,1)*cpl*qa(i,j,1,n)*delt
             enddo
           endif
           if(iice.eq.1)then
-#ifndef _B4B03R
             !$acc loop seq
-#endif
             do n=nqs1,nqs2
               !bud2(j) = bud2(j) + dum2(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)*cpi*qa(i,j,k,n)*delt
               budarray(i,j) = budarray(i,j) + dum2(i,j,1)*ruh(i)*rvh(j)*rmh(i,j,1)*cpi*qa(i,j,1,n)*delt
@@ -1054,29 +1047,19 @@
           endif
         enddo
         enddo
-#ifdef _B4B03R
-        !$acc update host(budarray)
-#else
-        !$acc parallel default(present) reduction(+:budtmp,qtmp)
-#endif
 
-#ifndef _B4B03R
+        !$acc parallel default(present) reduction(+:budtmp,qtmp)
         !$acc loop gang reduction(+:budtmp) reduction(+:qtmp)
-#endif
         do j=1,nj
           budtmp=0.0
-#ifndef _B4B03R
           !$acc loop vector reduction(+:budtmp)
-#endif
           do i=1,ni
             budtmp = budtmp + budarray(i,j) 
           enddo
           bud2(j)=budtmp
           qtmp = qtmp + dt*dx*dy*dz*bud2(j)
         enddo
-#ifndef _B4B03R
         !$acc end parallel
-#endif
         qbudget(9) = qtmp
 
         !$acc end data

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -1,8 +1,3 @@
-#ifdef _B4B
-
-#define _B4B06R
-
-#endif
   MODULE solve2_module
 
         ! solve2: RK loop and pressure solver

--- a/src/testcase_simple_phys.F
+++ b/src/testcase_simple_phys.F
@@ -1,7 +1,3 @@
-#ifdef _B4B
-#define _B4B01R
-#define _B4B05R   
-#endif
   MODULE simple_phys_module
 
   implicit none

--- a/src/turb.F
+++ b/src/turb.F
@@ -1,10 +1,7 @@
 #ifdef _B4B
 
 !JMD-changes answers
-#define _B4B07R
 #define _B4B09R
-#define _B4B10R
-#define _B4B11R
 
 #endif
   MODULE turb_module

--- a/src/turb.F
+++ b/src/turb.F
@@ -1,9 +1,3 @@
-#ifdef _B4B
-
-!JMD-changes answers
-#define _B4B09R
-
-#endif
   MODULE turb_module
 
   implicit none
@@ -5430,14 +5424,10 @@
   !
 
         !print *,'t2pcode: point #4'
-#ifdef _B4B09R
-      !$acc update host(rf,u2pt,v2pt,rr)
-#else
       !$acc parallel default(present) private(i,j) &
       !$acc reduction(+:t13avgt,t23avgt,rfavgt)
 
       !$acc loop gang
-#endif
       kloop1:  &
       DO k=1,(ntwk-1)
 
@@ -5445,10 +5435,8 @@
         t23avgt = 0.0
         rfavgt = 0.0
 
-#ifndef _B4B09R
         !$acc loop vector collapse(2) &
         !$acc     reduction(+:t13avgt,t23avgt,rfavgt)
-#endif
         do j=1,nj
         do i=1,ni
           ! 220308: simplified the two-part code
@@ -5463,12 +5451,7 @@
         rfavg(k)  = rfavgt
 
       ENDDO  kloop1
-
-#ifdef _B4B09R
-      !$acc update device(t13avg,t23avg,rfavg)
-#else
       !$acc end parallel
-#endif
 
         !print *,'t2pcode: point #5'
 #ifdef MPI


### PR DESCRIPTION
This pull request eliminates the remaining B4B blocks that are present in the code.  Using a NVHPC+MPI on CPU as a base, all of the diagnostics match with the exception of the following.

NVHPC+MPI on GPU
================
Original:
--------
46 stat variables are identical.
25 stat variables show a mean relative difference > 1e-06
12 stat variables show a mean relative difference <= 1e-06
Biggest differences:  KSVMAX,KSHMAX,VOR1KM,VOR2KM

modified code run
------------------
43 stat variables are identical.
25 stat variables show a mean relative difference > 1e-06
15 stat variables show a mean relative difference <= 1e-06


  