### PR TITLE
Eliminated some commented out code, added default(present)

### DIFF
--- a/src/bc.F
+++ b/src/bc.F
@@ -1504,7 +1504,7 @@
 
       if(ibw.eq.1.and.wbc.eq.2)then
        !$omp parallel do default(shared) private(j,k,foo,avgw,cbcw)
-       !$acc parallel loop gang vector private(j,k,foo,avgw,cbcw)
+       !$acc parallel loop gang vector default(present) private(j,k,foo,avgw,cbcw)
         do j=1,nj
           avgw=0.
           do k=1,nk
@@ -1523,7 +1523,7 @@
 
       if(ibe.eq.1.and.ebc.eq.2)then
         !$omp parallel do default(shared) private(j,k,foo,avge,cbce)
-        !$acc parallel loop gang vector private(j,k,foo,avge,cbce)
+        !$acc parallel loop gang vector default(present) private(j,k,foo,avge,cbce)
         do j=1,nj
           avge=0.
           do k=1,nk
@@ -1570,7 +1570,7 @@
 
       if(ibs.eq.1.and.sbc.eq.2)then
         !$omp parallel do default(shared) private(i,k,avgs,foo,cbcs)
-        !$acc parallel loop gang vector private(i,k,avgs,foo,cbcs)
+        !$acc parallel loop gang vector default(present) private(i,k,avgs,foo,cbcs)
         do i=1,ni
           avgs=0.
           do k=1,nk
@@ -1590,7 +1590,7 @@
 
       if(ibn.eq.1.and.nbc.eq.2)then
         !$omp parallel do default(shared) private(i,k,avgn,foo,cbcn)
-        !$acc parallel loop gang vector private(i,k,avgn,foo,cbcn)
+        !$acc parallel loop gang vector default(present) private(i,k,avgn,foo,cbcn)
         do i=1,ni
           avgn=0.
           do k=1,nk

--- a/src/ib_module.F
+++ b/src/ib_module.F
@@ -275,7 +275,7 @@
       !$acc declare present(bndy,kbdy,u3d,v3d) 
 
           ! set u to zero on east/west faces of immersed gridpoints:
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,kmaxib
           do j=0,nj+1
           do i=0,ni+1
@@ -290,7 +290,7 @@
           enddo
 
           ! set u to zero on east/west faces of immersed gridpoints:
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,kmaxib
           do j=1,nj
           do i=1,ni+1
@@ -300,7 +300,7 @@
           enddo
 
           ! set v to zero on south/north faces of immersed gridpoints:
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,kmaxib
           do j=1,nj+1
           do i=1,ni
@@ -819,7 +819,7 @@
 
   IF( stag.eq.1 )THEN
 
-    !$acc parallel loop private(i,j,k)
+    !$acc parallel loop default(present) private(i,j,k)
     DO k=1,(kmaxib-1)
       do j=1,nj+1
       !dir$ vector always
@@ -900,7 +900,7 @@
   ELSEIF( stag.eq.2 )THEN
 
     if( doit )then
-    !$acc parallel loop private(i,j,k)
+    !$acc parallel loop default(present)
     DO k=1,(kmaxib-1)
       do j=1,nj+1
       !dir$ vector always
@@ -978,7 +978,7 @@
   ELSEIF( stag.eq.3 )THEN
 
     if( doit )then
-    !$acc parallel loop private(i,j,k)
+    !$acc parallel loop default(present)
     DO k=1,(kmaxib-1)
       do j=0,nj+1
       !dir$ vector always
@@ -1056,7 +1056,7 @@
   ELSEIF( stag.eq.4 )THEN
 
   if( doit )then
-    !$acc parallel loop private(i,j,k)
+    !$acc parallel loop default(present)
     DO k=1,(kmaxib-1)
       do j=1,nj+1
       !dir$ vector always
@@ -1211,7 +1211,7 @@
 
   IF( stag.eq.1 )THEN
 
-    !$acc parallel loop private(i,j,k)
+    !$acc parallel loop default(present)
     DO k=1,(kmaxib-1)
       do j=1,nj+1
       !dir$ vector always
@@ -1292,7 +1292,7 @@
   ELSEIF( stag.eq.2 )THEN
 
     if( doit )then
-    !$acc parallel loop private(i,j,k,ubar,vbar)
+    !$acc parallel loop default(present) private(i,j,k,ubar,vbar)
     DO k=1,(kmaxib-1)
       do j=1,nj+1
       !dir$ vector always
@@ -1370,7 +1370,7 @@
   ELSEIF( stag.eq.3 )THEN
 
     if( doit )then
-    !$acc parallel loop private(i,j,k,ubar,vbar)
+    !$acc parallel loop default(present) private(i,j,k,ubar,vbar)
     DO k=1,(kmaxib-1)
       do j=0,nj+1
       !dir$ vector always
@@ -1448,7 +1448,7 @@
   ELSEIF( stag.eq.4 )THEN
 
   if( doit )then
-    !$acc parallel loop private(i,j,k,ubar,vbar,cc1,cc2)
+    !$acc parallel loop default(present) private(i,j,k,ubar,vbar,cc1,cc2)
     DO k=1,(kmaxib-1)
       do j=1,nj+1
       !dir$ vector always
@@ -1593,7 +1593,7 @@
 
   IF( stag.eq.1 )THEN
 
-    !$acc parallel loop private(i,j,k)
+    !$acc parallel loop default(present)
     do j=1,nj
     !dir$ vector always
     do i=1,ni
@@ -1634,7 +1634,7 @@
         i2=ni+1
       endif
 
-    !$acc parallel loop private(i,j,k,kval,wbar)
+    !$acc parallel loop default(present) private(i,j,k,kval,wbar)
     do j=1,nj
     !dir$ vector always
     do i=i1,i2
@@ -1680,7 +1680,7 @@
         j2=nj+1
       endif
 
-    !$acc parallel loop private(i,j,k,kval,wbar,cc1,cc2)
+    !$acc parallel loop default(present) private(i,j,k,kval,wbar,cc1,cc2)
     do j=j1,j2
     !dir$ vector always
     do i=1,ni
@@ -1713,7 +1713,7 @@
 
   ELSEIF( stag.eq.4 )THEN
 
-    !$acc parallel loop private(i,j,k,kval,wbar)
+    !$acc parallel loop default(present) private(i,j,k,kval,wbar)
     do j=1,nj
     !dir$ vector always
     do i=1,ni
@@ -1773,7 +1773,7 @@
 
   IF( stag.eq.1 )THEN
    
-    !$acc parallel loop private(i,j,k)
+    !$acc parallel loop default(present)
     do j=1,nj
     !dir$ vector always
     do i=1,ni
@@ -1814,7 +1814,7 @@
         i2=ni+1
       endif
 
-    !$acc parallel loop private(i,j,k,kval,wbar,cc1,cc2)
+    !$acc parallel loop default(present) private(kval,wbar,cc1,cc2)
     do j=1,nj
     !dir$ vector always
     do i=i1,i2
@@ -1860,7 +1860,7 @@
         j2=nj+1
       endif
 
-    !$acc parallel loop private(i,j,k,kval,wbar,cc1,cc2)
+    !$acc parallel loop default(present) private(i,j,k,kval,wbar,cc1,cc2)
     do j=j1,j2
     !dir$ vector always
     do i=1,ni
@@ -1893,7 +1893,7 @@
 
   ELSEIF( stag.eq.4 )THEN
 
-    !$acc parallel loop private(i,j,k,kval,wbar)
+    !$acc parallel loop default(present) private(i,j,k,kval,wbar)
     do j=1,nj
     !dir$ vector always
     do i=1,ni

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -39,7 +39,7 @@
         IF(axisymm.eq.0)THEN
           ! Cartesian without terrain:
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -53,7 +53,7 @@
         ELSE
           ! axisymmetric:
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -67,7 +67,7 @@
       ELSE
           ! Cartesian with terrain:
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector private(i,j,k)
+          !$acc parallel loop gang vector default(present) private(i,j,k)
           DO k=1,nk
             do j=1,nj
             do i=1,ni+1
@@ -81,7 +81,7 @@
             enddo
           ENDDO
           !$omp parallel do default(shared) private(i,j,k,r1,r2)
-          !$acc parallel loop gang vector private(i,j,k,r1,r2)
+          !$acc parallel loop gang vector default(present) private(i,j,k,r1,r2)
           DO k=1,nk
             IF(k.eq.1)THEN
               do j=1,nj
@@ -108,7 +108,7 @@
             ENDIF
           ENDDO
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector private(i,j,k)
+          !$acc parallel loop gang vector default(present) private(i,j,k)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -159,7 +159,7 @@
     IF(.not.terrain_flag)THEN
       ! without terrain:
 
-      !$acc parallel loop gang vector collapse(2) private(i,j)
+      !$acc parallel loop gang vector default(present) collapse(2)
       do j=1,nj
       do i=1,ni
         rrw(i,j,   1) = 0.0
@@ -167,7 +167,7 @@
       enddo
       enddo
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector default(present) collapse(3)
       DO k=1,nk
         do j=1,nj
         do i=1,ni+1
@@ -176,7 +176,7 @@
         enddo
       ENDDO
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector default(present) collapse(3)
       DO k=1,nk
         do j=1,nj+1
         do i=1,ni
@@ -185,7 +185,7 @@
         enddo
       ENDDO
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) private(i,j,k)
+      !$acc parallel loop gang vector default(present) collapse(3)
       DO k=1,nk
         do j=1,nj
         do i=1,ni
@@ -198,7 +198,7 @@
       ! with terrain:
 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector private(i,j,k)
+      !$acc parallel loop gang vector default(present)
       DO k=1,nk
         do j=1,nj
         do i=1,ni+1
@@ -213,7 +213,7 @@
       ENDDO
 
       !$omp parallel do default(shared) private(i,j,k,r1,r2)
-      !$acc parallel loop gang vector private(i,j,k,r1,r2)
+      !$acc parallel loop gang vector default(present) private(i,j,k,r1,r2)
       DO k=1,nk
         IF(k.eq.1)THEN
           do j=1,nj
@@ -247,7 +247,7 @@
         IF(axisymm.eq.0)THEN
           ! Cartesian without terrain:
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -261,7 +261,7 @@
         ELSE
           ! axisymmetric:
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -275,7 +275,7 @@
       ELSE
           ! Cartesian with terrain:
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -394,7 +394,7 @@
 
 !!!      if(myid.eq.0) print *,'    convinitu '
       !$omp parallel do default(shared) private(i,j,k,term1,term2,term3,term4,umo)
-      !$acc parallel loop gang vector private(i,j,k,term1,term2,term3,term4,umo)
+      !$acc parallel loop gang vector default(present) private(i,j,k,term1,term2,term3,term4,umo)
       do k=1,nk
       do j=1,nj
       do i=1,ni+1
@@ -436,7 +436,7 @@
 
 !!!      if(myid.eq.0) print *,'    convinitv '
       !$omp parallel do default(shared) private(i,j,k,term1,term2,term3,term4,vmo)
-      !$acc parallel loop gang vector private(i,j,k,term1,term2,term3,term4,vmo)
+      !$acc parallel loop gang vector default(present) private(i,j,k,term1,term2,term3,term4,vmo)
       do k=1,nk
       do j=1,nj+1
       do i=1,ni
@@ -492,7 +492,7 @@
       tem = alpha_wnudge * gamm
 
       !$omp parallel do default(shared) private(i,j,k,beta,wmag)
-      !$acc parallel loop gang vector private(i,j,k,beta,wmag)
+      !$acc parallel loop gang vector default(present) private(i,j,k,beta,wmag)
       do k=2,nk
       do j=1,nj
       do i=1,ni
@@ -3109,7 +3109,7 @@
       RANGE=(ni*nj+1)/2       !! Round up.
       do while ( RANGE > 1 )
 !! Now fold the 2-d array with half the threads each time.
-!$acc parallel loop gang vector private(i)
+!$acc parallel loop gang vector default(present) private(i)
         do i=1,PAIRS
           if ( cfl(i) .le. cfl(RANGE)) then
              cfl(i)=cfl(RANGE+i)
@@ -3205,7 +3205,7 @@
       dtdy=0.5*dt*rdy
       dtdz=0.5*dt*rdz
 
-      !$acc parallel private(i,j,k,wsp) reduction(max:fmax)
+      !$acc parallel default(present) private(i,j,k,wsp) reduction(max:fmax)
       fmax=-99999999.
       if(nx.gt.1.and.ny.gt.1)then
         !print *,'calcflquick: point #1'
@@ -3690,7 +3690,7 @@
       RANGE=(ni*nj+1)/2       !! Round up.
       do while ( RANGE > 1 )
 !! Now fold the 2-d array with half the threads each time.
-!$acc parallel loop gang vector private(i)
+!$acc parallel loop gang vector default(present) private(i)
         do i=1,PAIRS
           if( ksh(i) .le. ksh(RANGE)) then
              ksh(i) = ksh(RANGE+1)

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -1831,7 +1831,7 @@
             ! use diabatic tendencies from last timestep as a good estimate:
             !$omp parallel do default(shared)  &
             !$omp private(i,j,k,tnew,pnew,pinew,thnew,qvnew)
-            !$acc parallel loop gang vector collapse(3) private(i,j,k)
+            !$acc parallel loop gang vector default(present) collapse(3)
             do k=1,nk
             do j=1,nj
             do i=1,ni

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -565,10 +565,6 @@
                            ws31,ws32,wn31,wn32,reqs_w)
 #endif
 
-      !print *,'solve3: point #7'
-      !text1='slv3.6'
-      !text2='slv3.6'
-      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 #ifdef MPI
       if(   sgsmodel.eq.5 .or. sgsmodel.eq.6 )then
         call getcorneru_GPU(u3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
@@ -579,10 +575,6 @@
         call bcw2_GPU(w3d)
       endif
 #endif
-      !print *,'solve3: point #8'
-      !text1='slv3.7'
-      !text2='slv3.7'
-      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
       if(terrain_flag)then
         call bcwsfc(gz,dzdx,dzdy,u3d,v3d,w3d)
@@ -668,9 +660,6 @@
         ENDIF
         if(timestats.ge.1) time_parcels=time_parcels+mytime()
         ! bc/comms:
-      !text1='slv3.8'
-      !text2='slv3.8'
-      !call maxmin2dhalo(ni,nj,rrw(ib,jb,13),text1,text2)
         call bcu_GPU(rru)
 #ifdef MPI
         call comm_3u_start_GPU(rru,uw31,uw32,ue31,ue32,us31,us32,un31,un32,reqs_u)
@@ -684,11 +673,6 @@
         call comm_3w_start_GPU(rrw,ww31,ww32,we31,we32,ws31,ws32,wn31,wn32,reqs_w)
 #endif
       ENDIF
-      !print *,'solve3: point #9'
-      !text1='slv3.9'
-      !text2='slv3.9'
-      !call maxmin2dhalo(ni,nj,rrw(ib,jb,13),text1,text2)
-
 
 !----------
 !  Diagnostics (infrequent):

--- a/src/sound.F
+++ b/src/sound.F
@@ -128,7 +128,7 @@
 !!!      print *,'  nloop,dts,dttmp = ',nloop,dts,nloop*dts
 
       !$omp parallel do default(shared) private(i,j)
-      !$acc parallel loop gang vector private(i,j)
+      !$acc parallel loop gang vector default(present)
       do j=1,nj+1
       do i=1,ni+1
         dtu(i,j) = dts*dtu0(i,j)
@@ -145,7 +145,7 @@
         ! "s" velocities ARE NOT coupled with reference density
         !$omp parallel do default(shared)   &
         !$omp private(i,j,k,tem,tem1,r1,r2,c1a,c1b,c2a,c2b)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k,tem,tem1,r1,r2,c1a,c1b,c2a,c2b)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k,tem,tem1,r1,r2,c1a,c1b,c2a,c2b)
         do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -172,7 +172,7 @@
 
         !$omp parallel do default(shared)   &
         !$omp private(i,j,k,tem,tem1,tem2,r1,r2)
-        !$acc parallel loop gang vector private(i,j,k,tem,tem1,r1,r2)
+        !$acc parallel loop gang vector default(present) private(i,j,k,tem,tem1,r1,r2)
         do k=1,nk
           do j=1,nj
           tem = dts*rdsf(k)
@@ -203,7 +203,7 @@
       ENDIF
 
       !$omp parallel do default(shared) private(i,j)
-      !$acc parallel loop gang vector collapse(2) private(i,j)
+      !$acc parallel loop gang vector default(present) collapse(2) private(i,j)
       do j=1,nj
       do i=1,ni
         pk1(i,j,1) = 0.0
@@ -217,7 +217,7 @@
       if( nrk.eq.1 )then
 
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3)
         do k=1,nk
         do j=0,nj+1
         do i=0,ni+1
@@ -234,7 +234,7 @@
         if( axisymm.eq.0 )then
 
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,nk
           do j=0,nj+1
           do i=0,ni+1
@@ -253,7 +253,7 @@
         else
 
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,nk
           do j=0,nj+1
           do i=0,ni+1
@@ -349,7 +349,7 @@
         tem2 = rdy*cp*0.5
 
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3)
         do k=1,nk
           do j=1,nj+1
           do i=1,ni+1
@@ -373,7 +373,7 @@
         tem1 = rdx*cp*0.5
 
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3)
         do k=1,nk
           do j=1,nj
           do i=2,ni+1
@@ -391,7 +391,7 @@
         ! Cartesian grid with terrain:
 
         !$omp parallel do default(shared) private(i,j,k,r1,r2)
-        !$acc parallel loop gang vector private(i,j,k,r1,r2)
+        !$acc parallel loop gang vector default(present) private(i,j,k,r1,r2)
         do j=0,nj+1
           do k=2,nk
           do i=0,ni+1
@@ -407,7 +407,7 @@
         tem = cp*0.5
 
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector private(i,j,k)
+        !$acc parallel loop gang vector default(present)
         do k=1,nk
           ! x-dir
           do j=1,nj
@@ -473,7 +473,7 @@
       IF(terrain_flag)THEN
         ! Cartesian grid with terrain:
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector private(i,j,k)
+        !$acc parallel loop gang vector default(present)
         DO k=1,nk
           do j=1,nj
           do i=1,ni+1
@@ -487,7 +487,7 @@
           enddo
         ENDDO
         !$omp parallel do default(shared) private(i,j,k,r1,r2)
-        !$acc parallel loop gang vector private(i,j,k,r1,r2)
+        !$acc parallel loop gang vector default(present) private(i,j,k,r1,r2)
         DO k=2,nk
           r2 = (sigmaf(k)-sigma(k-1))*rds(k)
           r1 = 1.0-r2
@@ -517,7 +517,7 @@
         ! Cartesian grid without terrain:
         !$omp parallel do default(shared)   &
         !$omp private(i,j,k,div)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k,div)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k,div)
         DO k=1,nk
         do j=1,nj
         do i=1,ni
@@ -540,7 +540,7 @@
         ! (note: see below for advection)
 
         !$omp parallel do default(shared) private(i,j,k,div,u1,u2,v1,v2,w1,w2)
-        !$acc parallel loop gang vector private(i,j,k,div,u1,u2,v1,v2,w1,w2)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k,div,u1,u2,v1,v2,w1,w2)
         DO k=1,nk
         do j=1,nj
         do i=1,ni
@@ -564,7 +564,7 @@
         ! axisymmetric grid:
 
         !$omp parallel do default(shared) private(i,j,k,div,u1,u2,v1,v2,w1,w2)
-        !$acc parallel loop gang vector private(i,j,k,div,u1,u2,v1,v2,w1,w2)
+        !$acc parallel loop gang vector default(present) private(i,j,k,div,u1,u2,v1,v2,w1,w2)
         DO k=1,nk
         do j=1,nj
         do i=1,ni
@@ -606,7 +606,7 @@
         !  here in sound.F, add to fwk array:
         IF( (mtime+dt).le.t2_wnudge )THEN
           if(n.eq.1)then
-            !$acc parallel loop gang vector private(i,j,k)
+            !$acc parallel loop gang vector default(present) collapse(3)
             do k=2,nk
             do j=1,nj
             do i=1,ni
@@ -616,7 +616,7 @@
             enddo
           endif
           call get_wnudge(mtime,dts,xh,yh,zf,w3d,dum4)
-          !$acc parallel loop gang vector private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=2,nk
           do j=1,nj
           do i=1,ni
@@ -638,7 +638,7 @@
         call bcwsfc(gz,dzdx,dzdy,u3d,v3d,w3d)
         ! Cartesian grid with terrain:
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector private(i,j,k)
+        !$acc parallel loop gang vector default(present)
         DO k=1,nk
           do j=1,nj
           do i=1,ni+1
@@ -670,7 +670,7 @@
         temx = dts*0.5*rdx
         temy = dts*0.5*rdy
         !$omp parallel do default(shared) private(i,j,k,u1,u2,v1,v2,w1,w2)
-        !$acc parallel loop gang vector private(i,j,k,u1,u2,v1,v2,w1,w2)
+        !$acc parallel loop gang vector default(present) private(i,j,k,u1,u2,v1,v2,w1,w2)
         DO k=1,nk
         do j=1,nj
         do i=1,ni
@@ -698,7 +698,7 @@
 
         k=2
         !$omp parallel do default(shared) private(i,j,aa,bb,cc,dd,fwk,r1)
-        !$acc parallel loop gang vector collapse(2) private(i,j,aa,bb,cc,dd,fwk,r1)
+        !$acc parallel loop gang vector collapse(2) default(present) private(i,j,aa,bb,cc,dd,fwk,r1)
         do j=1,nj
         do i=1,ni
           cc =      -asq*( -mm(i,j,k)*( pk2(i,j,k  )-qk(i,j,k  ) ) )
@@ -741,7 +741,7 @@
         k = nk
 
         !$omp parallel do default(shared) private(i,j,aa,bb,cc,dd,fwk,r1)
-        !$acc parallel loop gang vector collapse(2) private(i,j,aa,bb,cc,dd,fwk,r1)
+        !$acc parallel loop gang vector collapse(2) default(present) private(i,j,aa,bb,cc,dd,fwk,r1)
         do j=1,nj
         do i=1,ni
           aa =      -asq*( +mm(i,j,k)*( pk1(i,j,k-1)+qk(i,j,k-1) ) )
@@ -756,7 +756,7 @@
         enddo
         enddo
 
-        !$acc parallel private(i,j,k)
+        !$acc parallel default(present) private(i,j,k)
         do k=(nk-1),2,-1
 
         !$omp parallel do default(shared) private(i,j)
@@ -782,7 +782,7 @@
       IF(.not.terrain_flag)THEN
         ! without terrain:
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3)
         DO k=1,nk
         do j=1,nj
         do i=1,ni
@@ -802,7 +802,7 @@
       ELSE
         ! with terrain:
         !$omp parallel do default(shared) private(i,j,k,w1,w2)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k,w1,w2)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k,w1,w2)
         DO k=1,nk
         do j=1,nj
         do i=1,ni
@@ -844,7 +844,7 @@
 
       if( n.lt.nloop )then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3)
         DO k=1,nk
         do j=1,nj+1
         do i=1,ni+1
@@ -857,7 +857,7 @@
       else
         tavg = 1.0/float(nloop)
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3)
         DO k=1,nk
         do j=1,nj+1
         do i=1,ni+1
@@ -879,7 +879,7 @@
       IF( nrk.eq.nrkmax )THEN
         ! pressure tendency term: save for next timestep:
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3)
         do k=1,nk
         do j=1,nj
         do i=1,ni

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -298,9 +298,6 @@
                                ps1,ps2,pn1,pn2,reqs_p)
         endif
 #endif
-      !text1='snd.1b'
-      !text2='snd.1b'
-      !call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
       !$acc compare(ppd)
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -317,22 +314,6 @@
         tem1 = rdx*cp*0.5
         tem2 = rdy*cp*0.5
 
-        !text1='snd.1j'
-        !text2='snd.1j'
-        !call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
-        !text1='snd.1k'
-        !text2='snd.1k'
-        !call maxmin2dhalo(ni,nj,dtv(ib,jb),text1,text2)
-        !text1='snd.1m'
-        !text2='snd.1m'
-        !call maxmin2dhalo(ni,nj+1,vten(ib,jb,13),text1,text2)
-        !text1='snd.1n'
-        !text2='snd.1n'
-        !call maxmin2dhalo(ni,nj,thv(ib,jb,13),text1,text2)
-        !text1='snd.1x'
-        !text2='snd.1x'
-        !call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
-
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
@@ -347,9 +328,6 @@
           enddo
           enddo
         enddo
-        !text1='snd.1h'
-        !text2='snd.1h'
-        !call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
 
         IF( do_ib )THEN
           call zero_out_uv(bndy,kbdy,u3d,v3d)
@@ -577,18 +555,6 @@
           call get_wnudge(mtime,dts,xh,yh,zf,w3d,dum1)
         ENDIF
       ENDIF
-      !text1='snd.2a'
-      !text2='snd.2a'
-      !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
-      !text1='snd.2b'
-      !text2='snd.2b'
-      !call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
-      !text1='snd.2c'
-      !text2='snd.2c'
-      !call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
-      !text1='snd.2e'
-      !text2='snd.2e'
-      !call maxmin2dhalo(ni,nj,wten(ib,jb,13),text1,text2)
 
   !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
@@ -823,40 +789,6 @@
       IF(.not.terrain_flag)THEN
         ! Cartesian grid, without terrain:
 
-        !text1='snd.5a'
-        !text2='snd.5a'
-        !call maxmin2dhalo(ni,nj,pp3d(ib,jb,13),text1,text2)
-#if 0
-#endif
-        !text1='snd.5c'
-        !text2='snd.5c'
-        !call maxmin2dhalo(ni,nj,ppterm(ib,jb,13),text1,text2)
-        !text1='snd.5d'
-        !text2='snd.5d'
-        !call maxmin2dhalo(ni,nj,piadv(ib,jb,13),text1,text2)
-        !text1='snd.5e'
-        !text2='snd.5e'
-        !call maxmin2dhalo(ni,nj,pk1(ib,jb,13),text1,text2)
-        !text1='snd.5f'
-        !text2='snd.5f'
-        !call maxmin2dhalo(ni,nj,pk2(ib,jb,13),text1,text2)
-        !text1='snd.5g'
-        !text2='snd.5g'
-        !call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
-        !text1='snd.5h'
-        !text2='snd.5h'
-        !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
-        !text1='snd.5i'
-        !text2='snd.5i'
-        !call maxmin2dhalo(ni+1,nj,u3d(ib,jb,13),text1,text2)
-        !text1='snd.5j'
-        !text2='snd.5j'
-        !call maxmin2dhalo(ni,nj+1,v3d(ib,jb,13),text1,text2)
-        !text1='snd.5k'
-        !text2='snd.5k'
-        !call maxmin2dhalo(ni,nj+1,mh(ib,jb,13),text1,text2)
-        !print *,'mh(1,1,13): ',mh(1,1,13)
-
         !$omp parallel do default(shared)   &
         !$omp private(i,j,k,div,delp)
         !$acc parallel loop gang vector collapse(3) default(present) &
@@ -882,15 +814,6 @@
         enddo
         enddo
         enddo
-      !text1='snd.6a'
-      !text2='snd.6a'
-      !call maxmin2dhalo(ni,nj,ppd(ib,jb,13),text1,text2)
-      !text1='snd.6b'
-      !text2='snd.6b'
-      !call maxmin2dhalo(ni,nj,dum1(ib,jb,13),text1,text2)
-      !text1='snd.6c'
-      !text2='snd.6c'
-      !call maxmin2dhalo(ni,nj,pp3d(ib,jb,13),text1,text2)
 
       ELSE
         ! Cartesian grid, with terrain:

--- a/src/turb.F
+++ b/src/turb.F
@@ -279,7 +279,7 @@
       IF( cm1setup.ge.1 .or. ipbl.ge.1 .or. horizturb.eq.1 .or. idiss.eq.1 .or. output_dissten.eq.1 )THEN
         ! cm1r17:  dissten is defined on w (full) levels:
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=1,nk+1
         do j=1,nj
         do i=1,ni
@@ -290,7 +290,7 @@
 
       ENDIF
 
-      !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+      !$acc parallel loop gang vector collapse(2) default(present)
       do j=1,nj
       do i=1,ni
         psfc(i,j) = cgs1*prs(i,j,1)+cgs2*prs(i,j,2)+cgs3*prs(i,j,3)
@@ -299,7 +299,7 @@
 
       IF( imove.eq.1 )THEN
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=1,nk
         do j=jb,je
         do i=ib,ie
@@ -312,7 +312,7 @@
       ELSE
         IF( pertflx.eq.1 )THEN
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=jb,je
           do i=ib,ie
@@ -323,7 +323,7 @@
           enddo
         ELSE
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+          !$acc parallel loop gang vector collapse(3) default(present)
           do k=1,nk
           do j=jb,je
           do i=ib,ie
@@ -348,7 +348,7 @@
         endif
 
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         DO j=1,nj
           do k=1,k2
           do i=1,ni
@@ -365,7 +365,7 @@
           if( sfcmodel.eq.6 )then
           if( imoist.eq.1 )then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do j=1,nj
             do k=1,k2
             do i=1,ni
@@ -375,7 +375,7 @@
         ENDDO
           else
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do j=1,nj
             do k=1,k2
             do i=1,ni
@@ -386,7 +386,7 @@
           endif
           endif
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) private(i,j,k)
+        !$acc parallel loop gang vector default(present)
         do j=1,nj
           do k=1,2
           do i=1,ni
@@ -426,7 +426,7 @@
         ! note:  for RRTMG (radopt=2) gsw and glw arrays are already filled !
         IF( radopt.eq.1 )THEN
           !$omp parallel do default(shared) private(i,j)
-          !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+          !$acc parallel loop gang vector collapse(2) default(present)
           do j=1,nj
           do i=1,ni
             gsw(i,j)=radswnet(i,j)
@@ -435,7 +435,7 @@
           enddo
         ELSEIF( radopt.eq.0 )THEN
           !$omp parallel do default(shared) private(i,j)
-          !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+          !$acc parallel loop gang vector collapse(2) default(present)
           do j=1,nj
           do i=1,ni
             gsw(i,j)=0.0
@@ -454,7 +454,7 @@
       ! GHB, 210521: copied from gpu-opt:
       IF(imoist.eq.1)THEN
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         DO k=1,nk
           do j=1,nj
           do i=1,ni
@@ -495,7 +495,7 @@
         ENDIF
       ELSE
           !$omp parallel do default(shared) private(i,j,k,n)
-          !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,n)
+          !$acc parallel loop gang vector collapse(3) default(present)
           DO k=1,nk
             do j=1,nj
             do i=1,ni
@@ -797,7 +797,7 @@
           !$acc fm,fh,chs2,cpmm,cqs2,flhc,flqc,gz1oz0,hfx,lh,psim,psih, &
           !$acc qfx,qgh,qsfc,ust,znt,mznt,swspd,taux,tauy,u10,v10)
 
-          !$acc parallel loop gang vector collapse(2) private(i,j)
+          !$acc parallel loop gang vector default(present) collapse(2)
           do j=1,nj
           do i=1,ni
             ust(i,j) = max(ust(i,j),1.0e-8)
@@ -1228,7 +1228,7 @@
         ! squared Brunt-Vaisala frequency:
 
 
-        !$acc parallel loop gang vector collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present)
         do k=kb,ke
         do j=jb,je
         do i=ib,ie
@@ -4759,7 +4759,7 @@
             (n.ge.nql1.and.n.le.nql2) .or.                  &
             (n.ge.nqs1.and.n.le.nqs2.and.iice.eq.1) )THEN
           !$omp parallel do default(shared) private(i,j,k)
-          !$acc parallel loop gang vector collapse(3) private(i,j,k)
+          !$acc parallel loop gang vector default(present) collapse(3)
           do k=1,nk
           do j=1,nj
           do i=1,ni
@@ -4773,7 +4773,7 @@
       k = 1
 
       !$omp parallel do default(shared) private(i,j)
-      !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+      !$acc parallel loop gang vector collapse(2) default(present)
       do j=1,nj
       do i=1,ni
         t(i,j,k)=(th0(i,j,k)+th(i,j,k))*(pi0(i,j,k)+pp(i,j,k))
@@ -4785,7 +4785,7 @@
     icecheck:  &
     IF( iice.eq.1 )THEN
 
-      !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+      !$acc parallel loop gang vector collapse(3) default(present)
       do k=2,nk
       do j=1,nj
       do i=1,ni


### PR DESCRIPTION
In this PR I deleted some commented-out code and added the default(present) directive to a number of loops for which it was missing.  The diagnostic from statpack are the following:

NVHPC on CPU versus OpenACC
----------------------------------
43 stat variables are identical.
25 stat variables show a mean relative difference > 1e-06
15 stat variables show a mean relative difference <= 1e-06

NVHPC on CPU versus OpenACC+MPI
---------------------------------------
45 stat variables are identical.
25 stat variables show a mean relative difference > 1e-06
13 stat variables show a mean relative difference <= 1e-06
