### PR TITLE
Add GPU memory usage check interface

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -35,6 +35,7 @@ USE_DOUBLE_L  = $(shell echo $(USE_DOUBLE) | tr A-Z a-z)
 USE_OPENACC_L = $(shell echo $(USE_OPENACC) | tr A-Z a-z)
 USE_NETCDF_L  = $(shell echo $(USE_NETCDF) | tr A-Z a-z)
 DEBUG_L       = $(shell echo $(DEBUG) | tr A-Z a-z)
+USE_CUDAMEM_L = $(shell echo $(USE_CUDAMEM) | tr A-Z a-z)
 
 #-----------------------------------------------------------------------------
 #  initialize some options as empty
@@ -105,6 +106,9 @@ ifeq (${FC},nvfortran)
             OPTS_M += -acc -gpu=cc70,lineinfo,nofma,math_uniform,managed -Mpcast -Minfo=accel
         endif
         DM       += -D_OPENACC
+    endif
+    ifeq (${USE_CUDAMEM_L},true)
+        DM       += -D_CUDAMEM
     endif
 endif
 
@@ -297,7 +301,11 @@ OBJS_OPENACC = $(addsuffix .o, $(basename $(SRC_NVTX)))
 
 FFLAGS  = $(OPTS)
 ifeq (${USE_OPENACC_L},true)
-FFLAGS_M = $(OPTS_M) # -L/glade/u/apps/opt/nvhpc/22.2/Linux_x86_64/22.2/cuda/11.6/lib64 -lcudart
+ifeq (${USE_CUDAMEM_L},true)
+FFLAGS_M = $(OPTS_M) -L/glade/u/apps/opt/nvhpc/22.2/Linux_x86_64/22.2/cuda/11.6/lib64 -lcudart
+else
+FFLAGS_M = $(OPTS_M)
+endif
 else
 FFLAGS_M = $(OPTS)
 endif

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -1,3 +1,21 @@
+#ifdef _OPENACC
+module cuda_rt
+
+  use iso_c_binding
+
+  interface
+     !
+     integer (c_int) function cudaMemGetInfo(fre, tot) bind(C, name="cudaMemGetInfo")
+       use iso_c_binding
+       implicit none
+       type(c_ptr),value :: fre
+       type(c_ptr),value :: tot
+     end function cudaMemGetInfo
+     !
+  end interface
+
+end module cuda_rt
+#endif
 
       program cm1
 
@@ -52,6 +70,8 @@
 #endif
 #ifdef _OPENACC
       use openacc
+      use iso_c_binding
+      use cuda_rt
 #endif
 #ifdef _NVTX
       use nvtx_mod
@@ -268,6 +288,12 @@
 #endif
 
       integer, dimension(:,:), allocatable :: pdata_locind  ! 2-D array to store parcel x/y/z location index
+
+#ifdef _OPENACC
+      type(c_ptr) :: cpfre, cptot
+      integer*8, target :: freemem, totmem
+      integer*4   :: stat
+#endif
 
 !----------------------------------------------------------------------
 
@@ -4585,6 +4611,22 @@
       endif
 #else
       print *,'Program terminated normally'
+#endif
+
+#ifdef _OPENACC
+      cpfre = c_loc(freemem)
+      cptot = c_loc(totmem)
+      stat = cudaMemGetInfo(cpfre, cptot)
+      if (stat .ne. 0 ) then
+         write (*,*)
+         write (*, '(A15, I2)') " CUDA error: ", stat
+         write (*,*)
+         stop
+      end if
+
+      write (*, '(A, F6.2, A)') "  free: ", dble(freemem)/1024.0/1024.0/1024.0, " GB"
+      write (*, '(A, F6.2, A)') " total: ", dble(totmem)/1024.0/1024.0/1024.0, " GB"
+      write (*, '(A, F6.2, A)') "  used: ", dble(totmem)/1024.0/1024.0/1024.0 - dble(freemem)/1024.0/1024.0/1024.0, " GB"
 #endif
 
       stop

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -1,4 +1,4 @@
-#ifdef _OPENACC
+#ifdef _CUDAMEM
 module cuda_rt
 
   use iso_c_binding
@@ -70,6 +70,8 @@ end module cuda_rt
 #endif
 #ifdef _OPENACC
       use openacc
+#endif
+#ifdef _CUDAMEM
       use iso_c_binding
       use cuda_rt
 #endif
@@ -289,7 +291,7 @@ end module cuda_rt
 
       integer, dimension(:,:), allocatable :: pdata_locind  ! 2-D array to store parcel x/y/z location index
 
-#ifdef _OPENACC
+#ifdef _CUDAMEM
       type(c_ptr) :: cpfre, cptot
       integer*8, target :: freemem, totmem
       integer*4   :: stat
@@ -4613,7 +4615,7 @@ end module cuda_rt
       print *,'Program terminated normally'
 #endif
 
-#ifdef _OPENACC
+#ifdef _CUDAMEM
       cpfre = c_loc(freemem)
       cptot = c_loc(totmem)
       stat = cudaMemGetInfo(cpfre, cptot)


### PR DESCRIPTION
This PR introduces an interface to check the GPU memory usage for a CM1 run. The Fortran code will call a CUDA API to check the GPU memory usage at the end of simulation.

Note that on Casper, we need to manually link the `cudart` library in the `Makefile` to compile the codes successfully. See the commented-out line for the `FFLAGS_M` option.

`FFLAGS_M = $(OPTS_M) # -L/glade/u/apps/opt/nvhpc/22.2/Linux_x86_64/22.2/cuda/11.6/lib64 -lcudart`