### PR TITLE
New MPI implementation for droplet in CM1

### DIFF
--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2230,13 +2230,17 @@
       allocate( reqt(d3t) )
       reqt = 0
 
+#ifdef MPI
       nparcels_mpi = ceiling(nparcels*1.0/numprocs+pdata_buffer*nparcels)
+#else
+      nparcels_mpi = nparcels
+#endif
 
       !$acc update device (nparcels_mpi)
 
       allocate(  pdata(nparcels_mpi,npvals) )
       pdata = 0.0
-      allocate(   ploc(nparcels,  3   ) )
+      allocate(   ploc(nparcels_mpi,  3   ) )
       ploc = 0.0
       allocate(  pdata_locind(nparcels_mpi,3) )
       pdata_locind = undefined_index

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -3488,7 +3488,18 @@
 
 !#endif
         !Also compute the droplet diagnostics at the same frequency as statpack
-        if(myid == 0) call droplet_diag(rtime,nrec,zh,zf,pdata,pdata_locind)
+
+        ! JS: with the new MPI implementation, we can:
+        !     1) use MPI_GATHER to collect the droplet information from different
+        !        MPI ranks first and only the root rank calculates the diagnostic
+        !     2) let all the MPI ranks call the diagnostic and use MPI_REDUCE
+        !        to collect the results from different MPI ranks and
+        !        output them from the root rank
+        !
+        !     The second method is expected to avoid the creation of an
+        !     array with size "nparcels*npvals" (saving memory space) 
+        !     and thus implemented below 
+        call droplet_diag(rtime,nrec,zh,zf,pdata,pdata_locind)
 
         nrec = nrec + 1
         nstatout = nstatout + 1

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2230,7 +2230,8 @@
       allocate( reqt(d3t) )
       reqt = 0
 
-      nparcels_mpi = ceiling(nparcels*1.0/numprocs)+pdata_buffer
+      nparcels_mpi = ceiling(nparcels*1.0/numprocs+pdata_buffer*nparcels)
+
       !$acc update device (nparcels_mpi)
 
       allocate(  pdata(nparcels_mpi,npvals) )

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2230,7 +2230,7 @@
       allocate( reqt(d3t) )
       reqt = 0
 
-      nparcels_mpi = ceiling(nparcels/numprocs)+pdata_buffer
+      nparcels_mpi = ceiling(nparcels*1.0/numprocs)+pdata_buffer
       !$acc update device (nparcels_mpi)
 
       allocate(  pdata(nparcels_mpi,npvals) )

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2230,12 +2230,14 @@
       allocate( reqt(d3t) )
       reqt = 0
 
+      nparcels_mpi = ceiling(nparcels/numprocs)+pdata_buffer
+      !$acc update device (nparcels_mpi)
 
-      allocate(  pdata(nparcels,npvals) )
+      allocate(  pdata(nparcels_mpi,npvals) )
       pdata = 0.0
       allocate(   ploc(nparcels,  3   ) )
       ploc = 0.0
-      allocate(  pdata_locind(nparcels,3) )
+      allocate(  pdata_locind(nparcels_mpi,3) )
       pdata_locind = undefined_index
 
       allocate( dpten(ib:ie,jb:je,kb:ke,2) )

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2259,18 +2259,18 @@ end module cuda_rt
       reqt = 0
 
 #ifdef MPI
-      nparcels_mpi = ceiling(nparcels*1.0/numprocs+pdata_buffer*nparcels)
+      nparcelsLocal = ceiling(nparcels*1.0/numprocs+pdata_buffer*nparcels)
 #else
-      nparcels_mpi = nparcels
+      nparcelsLocal = nparcels
 #endif
 
-      !$acc update device (nparcels_mpi)
+      !$acc update device (nparcelsLocal)
 
-      allocate(  pdata(nparcels_mpi,npvals) )
+      allocate(  pdata(nparcelsLocal,npvals) )
       pdata = 0.0
-      allocate(   ploc(nparcels_mpi,  3   ) )
+      allocate(   ploc(nparcelsLocal,  3   ) )
       ploc = 0.0
-      allocate(  pdata_locind(nparcels_mpi,3) )
+      allocate(  pdata_locind(nparcelsLocal,3) )
       pdata_locind = undefined_index
 
       allocate( dpten(ib:ie,jb:je,kb:ke,2) )

--- a/src/comm.F
+++ b/src/comm.F
@@ -74,6 +74,7 @@
   public :: comm_3w_start,comm_3w_end
   public :: comm_1s2d_start,comm_1s2d_end
   public :: getcorneru3,getcornerv3,getcorner3_2d,getcorner
+  public :: comm_droplet_number,comm_droplet_value
 
   CONTAINS
 
@@ -12714,6 +12715,512 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+#endif
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+#ifdef MPI
+
+    subroutine comm_droplet_number(holes_ind,num1,num2,pdata, &
+                                   pdata_locind,pdata_neighbor)
+
+      use input, only : myid,nparcels_mpi,npvals,mynw,mysw,myne, &
+                        myse,myeast,mywest,mynorth,mysouth,ierr
+      use constants, only: undefined_index,num_nn,inorth,isouth, &
+                           iwest,ieast,inw,ine,isw,ise
+      use mpi
+
+      implicit none
+
+      integer, intent(inout), dimension(:) :: holes_ind                    ! location index in "pdata" that can 
+                                                                           ! add a new droplet;
+                                                                           ! not a fixed-size array but we do 
+                                                                           ! not need to know its size
+      integer, intent(out) :: num1(num_nn)                                 ! Number of droplets that will enter each 
+                                                                           ! nearest neighbor at different directions
+      integer, intent(out) :: num2(num_nn)                                 ! Number of droplets that will enter the 
+                                                                           ! current MPI region from each nearest 
+                                                                           ! neighbor at different directions
+      real, intent(in), dimension(nparcels_mpi,npvals) :: pdata            ! droplet information
+      integer, intent(in), dimension(nparcels_mpi,3) :: pdata_locind       ! x/y/z location index of each droplet
+      integer, intent(in), dimension(nparcels_mpi) :: pdata_neighbor       ! array to store the new MPI region 
+                                                                           ! info for all the droplets
+
+      ! Local variables
+
+      integer :: n_recv,n_send
+      integer :: reqs(16)
+      integer :: tag_n,tag_s,tag_w,tag_e,tag_nw,tag_ne,tag_sw,tag_se,indx
+      integer, dimension(mpi_status_size,16) :: status1
+      integer :: i,n
+
+      ! initiate some MPI index and tag values
+
+      tag_n  = 1001
+      tag_s  = 1002
+      tag_w  = 1003
+      tag_e  = 1004
+      tag_nw = 1005
+      tag_sw = 1006
+      tag_ne = 1007
+      tag_se = 1008
+
+      do i = 1, num_nn 
+         num1(i) = 0
+      end do
+
+      ! find out how many droplets will leave the 
+      ! current MPI region and to which neighbor
+
+      i = 1
+      do n = 1, nparcels_mpi
+         if ( pdata_locind(n,1) .eq. undefined_index .and. &
+              pdata_locind(n,2) .eq. undefined_index ) then
+            ! record the location index that can be used to store the new droplet
+            ! information after the old drolpet leaves the current MPI region
+            holes_ind(i) = n
+            i = i + 1
+            if ( pdata_neighbor(n) .eq. mynorth ) then
+               num1(inorth) = num1(inorth) + 1 
+            else if ( pdata_neighbor(n) .eq. mysouth ) then
+               num1(isouth) = num1(isouth) + 1 
+            else if ( pdata_neighbor(n) .eq. mywest ) then
+               num1(iwest) = num1(iwest) + 1
+            else if ( pdata_neighbor(n) .eq. myeast ) then
+               num1(ieast) = num1(ieast) + 1
+            else if ( pdata_neighbor(n) .eq. mynw ) then
+               num1(inw) = num1(inw) + 1
+            else if ( pdata_neighbor(n) .eq. myne ) then
+               num1(ine) = num1(ine) + 1
+            else if ( pdata_neighbor(n) .eq. mysw ) then
+               num1(isw) = num1(isw) + 1
+            else if ( pdata_neighbor(n) .eq. myse ) then
+               num1(ise) = num1(ise) + 1
+            else
+               cycle  ! this is a "hole" of "pdata"
+                      ! no action is needed
+            end if
+         end if
+      end do
+
+      ! initiate the MPI non-blocking receive interface to 
+      ! know how many droplets from the nearest neighbors
+
+      n_recv = 1
+      call mpi_irecv(num2(inorth),1,MPI_INT,mynorth,tag_n,MPI_COMM_WORLD, &
+                     reqs(n_recv),ierr)
+
+      n_recv = n_recv + 1
+      call mpi_irecv(num2(isouth),1,MPI_INT,mysouth,tag_s,MPI_COMM_WORLD, &
+                     reqs(n_recv),ierr)
+
+      n_recv = n_recv + 1
+      call mpi_irecv(num2(iwest),1,MPI_INT,mywest,tag_w,MPI_COMM_WORLD, &
+                     reqs(n_recv),ierr)
+
+      n_recv = n_recv + 1
+      call mpi_irecv(num2(ieast),1,MPI_INT,myeast,tag_e,MPI_COMM_WORLD, &
+                     reqs(n_recv),ierr)
+
+      n_recv = n_recv + 1
+      call mpi_irecv(num2(inw),1,MPI_INT,mynw,tag_nw,MPI_COMM_WORLD, &
+                     reqs(n_recv),ierr)
+
+      n_recv = n_recv + 1
+      call mpi_irecv(num2(ine),1,MPI_INT,myne,tag_ne,MPI_COMM_WORLD, &
+                     reqs(n_recv),ierr)
+
+      n_recv = n_recv + 1
+      call mpi_irecv(num2(isw),1,MPI_INT,mysw,tag_sw,MPI_COMM_WORLD, &
+                     reqs(n_recv),ierr)
+
+      n_recv = n_recv + 1
+      call mpi_irecv(num2(ise),1,MPI_INT,myse,tag_se,MPI_COMM_WORLD, &
+                     reqs(n_recv),ierr)
+
+      ! initiate the MPI non-blocking send interface to 
+      ! send how many droplets entering the nearest neighbor 
+
+      n_send = 9
+      call mpi_isend(num1(inorth),1,MPI_INT,mynorth,tag_s,MPI_COMM_WORLD, &
+                     reqs(n_send),ierr)
+  
+      n_send = n_send + 1
+      call mpi_isend(num1(isouth),1,MPI_INT,mysouth,tag_n,MPI_COMM_WORLD, &
+                     reqs(n_send),ierr)
+  
+      n_send = n_send + 1
+      call mpi_isend(num1(iwest),1,MPI_INT,mywest,tag_e,MPI_COMM_WORLD, &
+                     reqs(n_send),ierr)
+  
+      n_send = n_send + 1
+      call mpi_isend(num1(ieast),1,MPI_INT,myeast,tag_w,MPI_COMM_WORLD, &
+                     reqs(n_send),ierr)
+  
+      n_send = n_send + 1
+      call mpi_isend(num1(inw),1,MPI_INT,mynw,tag_se,MPI_COMM_WORLD, &
+                     reqs(n_send),ierr)
+  
+      n_send = n_send + 1
+      call mpi_isend(num1(ine),1,MPI_INT,myne,tag_sw,MPI_COMM_WORLD, &
+                     reqs(n_send),ierr)
+  
+      n_send = n_send + 1
+      call mpi_isend(num1(isw),1,MPI_INT,mysw,tag_ne,MPI_COMM_WORLD, &
+                     reqs(n_send),ierr)
+
+      n_send = n_send + 1
+      call mpi_isend(num1(ise),1,MPI_INT,myse,tag_nw,MPI_COMM_WORLD, &
+                     reqs(n_send),ierr)
+
+      ! make sure that all the non-blocking MPI operations are complete
+
+      call mpi_waitall(16,reqs,status1,ierr)
+
+      ! sanity check: if too many droplets enter the current MPI region
+      !               and exceed the number of "holes", stop the program
+      !               with an error message
+
+      if ( sum(num2) .gt. size(holes_ind) ) then
+          write(*,*) "Too many new droplets will enter the MPI rank: ", myid
+          stop "Stop the program ..."
+      end if
+
+    end subroutine comm_droplet_number
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+    subroutine comm_droplet_value(holes_ind,num1,num2,pdata,pdata_neighbor)
+
+      use input, only : myid,nparcels_mpi,npvals,mynw,mysw,myne, &
+                        myse,myeast,mywest,mynorth,mysouth,ierr
+      use constants, only: undefined_index,neg_huge,num_nn,inorth, &
+                           isouth,iwest,ieast,inw,ine,isw,ise
+      use mpi
+
+      implicit none
+
+      integer, intent(in), dimension(:) :: holes_ind                       ! location index in "pdata" that can 
+                                                                           ! add a new droplet;
+                                                                           ! not a fixed-size array but we do 
+                                                                           ! not need to know its size
+      integer, intent(in) :: num1(num_nn)                                  ! Number of droplets that will enter each 
+                                                                           ! nearest neighbor at different directions
+      integer, intent(in) :: num2(num_nn)                                  ! Number of droplets that will enter the 
+                                                                           ! current MPI region from each nearest 
+                                                                           ! neighbor at different directions
+      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata         ! droplet information
+      integer, intent(in), dimension(nparcels_mpi) :: pdata_neighbor       ! array to store the new MPI region 
+                                                                           ! info for all the droplets
+
+      ! Local variables
+
+      real, dimension(:,:), allocatable :: droplet_n1, droplet_s1, droplet_w1, &     ! information of droplets that will leave the 
+                                           droplet_e1, droplet_nw1, droplet_ne1, &   ! current MPI region and enter the nearest neighbor;
+                                           droplet_sw1, droplet_se1, &               ! 1 means sending array;
+                                           droplet_n2, droplet_s2, droplet_w2, &     ! 2 means receiving array
+                                           droplet_e2, droplet_nw2, droplet_ne2, &
+                                           droplet_sw2, droplet_se2
+      integer :: n_idx,s_idx,w_idx,e_idx,nw_idx,ne_idx,sw_idx,se_idx
+      integer :: reqs(16)
+      integer :: tag_n,tag_s,tag_w,tag_e,tag_nw,tag_ne,tag_sw,tag_se, &
+                 index_n,index_s,index_w,index_e,index_nw,index_ne, &
+                 index_sw,index_se,n_recv,n_send
+      integer, dimension(mpi_status_size,16) :: status1
+      integer :: i,k,n,indx
+
+      ! initialize some MPI related variables
+
+      index_n  = undefined_index
+      index_s  = undefined_index
+      index_w  = undefined_index
+      index_e  = undefined_index
+      index_nw = undefined_index
+      index_sw = undefined_index
+      index_ne = undefined_index
+      index_se = undefined_index
+
+      tag_n    = undefined_index
+      tag_s    = undefined_index
+      tag_w    = undefined_index
+      tag_e    = undefined_index
+      tag_nw   = undefined_index
+      tag_sw   = undefined_index
+      tag_ne   = undefined_index
+      tag_se   = undefined_index
+
+      ! allocate spaces to store the droplets that will leave the current MPI region
+
+      if ( num1(inorth) .ne. 0 ) allocate(droplet_n1(num1(inorth),npvals))
+      if ( num1(isouth) .ne. 0 ) allocate(droplet_s1(num1(isouth),npvals))
+      if ( num1(iwest) .ne. 0 ) allocate(droplet_w1(num1(iwest),npvals))
+      if ( num1(ieast) .ne. 0 ) allocate(droplet_e1(num1(ieast),npvals))
+      if ( num1(inw) .ne. 0 ) allocate(droplet_nw1(num1(inw),npvals))
+      if ( num1(ine) .ne. 0 ) allocate(droplet_ne1(num1(ine),npvals))
+      if ( num1(isw) .ne. 0 ) allocate(droplet_sw1(num1(isw),npvals))
+      if ( num1(ise) .ne. 0 ) allocate(droplet_se1(num1(ise),npvals))
+
+      ! extract the information of droplets that will leave the current MPI region 
+      ! and reset the corresponding "pdata" record to a large negative value
+
+      n_idx  = 1
+      s_idx  = 1
+      w_idx  = 1
+      e_idx  = 1
+      nw_idx = 1
+      ne_idx = 1
+      sw_idx = 1
+      se_idx = 1
+
+      do n = 1, nparcels_mpi
+         if ( pdata_neighbor(n) .eq. mynorth ) then
+            droplet_n1(n_idx,:) = pdata(n,:)
+            n_idx = n_idx + 1
+            pdata(n,:) = neg_huge
+         else if ( pdata_neighbor(n) .eq. mysouth ) then
+            droplet_s1(s_idx,:) = pdata(n,:)
+            s_idx = s_idx + 1
+            pdata(n,:) = neg_huge
+         else if ( pdata_neighbor(n) .eq. mywest ) then
+            droplet_w1(w_idx,:) = pdata(n,:)
+            w_idx = w_idx + 1
+            pdata(n,:) = neg_huge
+         else if ( pdata_neighbor(n) .eq. myeast ) then
+            droplet_e1(e_idx,:) = pdata(n,:)
+            e_idx = e_idx + 1
+            pdata(n,:) = neg_huge
+         else if ( pdata_neighbor(n) .eq. mynw ) then
+            droplet_nw1(nw_idx,:) = pdata(n,:)
+            nw_idx = nw_idx + 1
+            pdata(n,:) = neg_huge
+         else if ( pdata_neighbor(n) .eq. myne ) then
+            droplet_ne1(ne_idx,:) = pdata(n,:)
+            ne_idx = ne_idx + 1
+            pdata(n,:) = neg_huge
+         else if ( pdata_neighbor(n) .eq. mysw ) then
+            droplet_sw1(sw_idx,:) = pdata(n,:)
+            sw_idx = sw_idx + 1
+            pdata(n,:) = neg_huge
+         else if ( pdata_neighbor(n) .eq. myse ) then
+            droplet_se1(se_idx,:) = pdata(n,:)
+            se_idx = se_idx + 1
+            pdata(n,:) = neg_huge
+         else
+            cycle   ! this droplet stays at the same MPI region;
+                    ! no action is needed
+         end if
+      end do
+
+      ! allocate temporary arrays if there are new droplets from the nearest neighbor
+
+      if ( num2(inorth) .ne. 0 ) allocate(droplet_n2(num2(inorth),npvals))
+      if ( num2(isouth) .ne. 0 ) allocate(droplet_s2(num2(isouth),npvals))
+      if ( num2(iwest) .ne. 0 ) allocate(droplet_w2(num2(iwest),npvals))
+      if ( num2(ieast) .ne. 0 ) allocate(droplet_e2(num2(ieast),npvals))
+      if ( num2(inw) .ne. 0 ) allocate(droplet_nw2(num2(inw),npvals))
+      if ( num2(ine) .ne. 0 ) allocate(droplet_ne2(num2(ine),npvals))
+      if ( num2(isw) .ne. 0 ) allocate(droplet_sw2(num2(isw),npvals))
+      if ( num2(ise) .ne. 0 ) allocate(droplet_ne2(num2(ise),npvals))
+
+      ! initiate the MPI non-blocking receive interface to 
+      ! obtain new droplet information from the nearest neighbors
+
+      n_recv   = 0
+      if ( num2(inorth) .ne. 0 ) then
+         n_recv = n_recv + 1
+         tag_n  = 1000 + num2(inorth)
+         call mpi_irecv(droplet_n2,num2(inorth)*npvals,MPI_REAL, &
+                        mynorth,tag_n,MPI_COMM_WORLD,reqs(n_recv),ierr)
+         index_n = n_recv
+      end if
+      if ( num2(isouth) .ne. 0 ) then
+         n_recv = n_recv + 1
+         tag_s  = 1000 + num2(isouth)
+         call mpi_irecv(droplet_s2,num2(isouth)*npvals,MPI_REAL, &
+                        mysouth,tag_s,MPI_COMM_WORLD,reqs(n_recv),ierr)
+         index_s = n_recv
+      end if
+      if ( num2(iwest) .ne. 0 ) then
+         n_recv = n_recv + 1
+         tag_w  = 1000 + num2(iwest)
+         call mpi_irecv(droplet_w2,num2(iwest)*npvals,MPI_REAL, &
+                        mywest,tag_w,MPI_COMM_WORLD,reqs(n_recv),ierr)
+         index_w = n_recv
+      end if
+      if ( num2(ieast) .ne. 0 ) then
+         n_recv = n_recv + 1
+         tag_e  = 1000 + num2(ieast)
+         call mpi_irecv(droplet_e2,num2(ieast)*npvals,MPI_REAL, &
+                        myeast,tag_e,MPI_COMM_WORLD,reqs(n_recv),ierr)
+         index_e = n_recv
+      end if
+      if ( num2(inw) .ne. 0 ) then
+         n_recv = n_recv + 1
+         tag_nw = 1000 + num2(inw)
+         call mpi_irecv(droplet_nw2,num2(inw)*npvals,MPI_REAL, &
+                        mynw,tag_nw,MPI_COMM_WORLD,reqs(n_recv),ierr)
+         index_nw = n_recv
+      end if
+      if ( num2(ine) .ne. 0 ) then
+         n_recv = n_recv + 1
+         tag_ne = 1000 + num2(ine)
+         call mpi_irecv(droplet_ne2,num2(ine)*npvals,MPI_REAL, &
+                        myne,tag_ne,MPI_COMM_WORLD,reqs(n_recv),ierr)
+         index_ne = n_recv
+      end if
+      if ( num2(isw) .ne. 0 ) then
+         n_recv = n_recv + 1
+         tag_sw = 1000 + num2(isw)
+         call mpi_irecv(droplet_sw2,num2(isw)*npvals,MPI_REAL, &
+                        mysw,tag_sw,MPI_COMM_WORLD,reqs(n_recv),ierr)
+         index_sw = n_recv
+      end if
+      if ( num2(ise) .ne. 0 ) then
+         n_recv = n_recv + 1
+         tag_se = 1000 + num2(ise)
+         call mpi_irecv(droplet_se2,num2(ise)*npvals,MPI_REAL, &
+                        myse,tag_se,MPI_COMM_WORLD,reqs(n_recv),ierr)
+         index_se = n_recv
+      end if
+
+      ! initiate the MPI non-blocking send interface to send the information of
+      ! droplets that leave the current MPI region to the nearest neighbors 
+
+      n_send = 8
+      if ( num1(inorth) .ne. 0 ) then
+         n_send = n_send + 1
+         tag_s = 1000 + num1(inorth)
+         call mpi_isend(droplet_n1,num1(inorth)*npvals,MPI_REAL, &
+                        mynorth,tag_s,MPI_COMM_WORLD,reqs(n_send),ierr)
+      end if
+      if ( num1(isouth) .ne. 0 ) then
+         n_send = n_send + 1
+         tag_n = 1000 + num1(isouth)
+         call mpi_isend(droplet_s1,num1(isouth)*npvals,MPI_REAL, &
+                        mysouth,tag_n,MPI_COMM_WORLD,reqs(n_send),ierr)
+      end if
+      if ( num1(iwest) .ne. 0 ) then
+         n_send = n_send + 1
+         tag_e = 1000 + num1(iwest)
+         call mpi_isend(droplet_w1,num1(iwest)*npvals,MPI_REAL, &
+                        mywest,tag_e,MPI_COMM_WORLD,reqs(n_send),ierr)
+      end if
+      if ( num1(ieast) .ne. 0 ) then
+         n_send = n_send + 1
+         tag_w = 1000 + num1(ieast)
+         call mpi_isend(droplet_e1,num1(ieast)*npvals,MPI_REAL, &
+                        myeast,tag_w,MPI_COMM_WORLD,reqs(n_send),ierr)
+      end if
+      if ( num1(inw) .ne. 0 ) then
+         n_send = n_send + 1
+         tag_se = 1000 + num1(inw)
+         call mpi_isend(droplet_nw1,num1(inw)*npvals,MPI_REAL, &
+                        mynw,tag_se,MPI_COMM_WORLD,reqs(n_send),ierr)
+      end if
+      if ( num1(ine) .ne. 0 ) then
+         n_send = n_send + 1
+         tag_sw = 1000 + num1(ine)
+         call mpi_isend(droplet_ne1,num1(ine)*npvals,MPI_REAL, &
+                        myne,tag_sw,MPI_COMM_WORLD,reqs(n_send),ierr)
+      end if
+      if ( num1(isw) .ne. 0 ) then
+         n_send = n_send + 1
+         tag_ne = 1000 + num1(isw)
+         call mpi_isend(droplet_sw1,num1(isw)*npvals,MPI_REAL, &
+                        mysw,tag_ne,MPI_COMM_WORLD,reqs(n_send),ierr)
+      end if
+      if ( num1(ise) .ne. 0 ) then
+         n_send = n_send + 1
+         tag_nw = 1000 + num1(ise)
+         call mpi_isend(droplet_se1,num1(ise)*npvals,MPI_REAL, &
+                        myse,tag_nw,MPI_COMM_WORLD,reqs(n_send),ierr)
+      end if
+
+      ! update the "holes" in "pdata" with the new droplets that
+      ! enter the current MPI region from the nearest neighbors
+
+      n = 1
+      k = 1
+      do while( n .le. n_recv )
+         call mpi_waitany(n_recv,reqs(1:n_recv),indx,MPI_STATUS_IGNORE,ierr)
+         if ( indx .eq. index_n ) then
+            do i = 1, num2(inorth) 
+               pdata(holes_ind(k),:) = droplet_n2(i,:)
+               k = k + 1
+            end do
+         else if ( indx .eq. index_s ) then
+            do i = 1, num2(isouth)
+               pdata(holes_ind(k),:) = droplet_s2(i,:)
+               k = k + 1
+            end do
+         else if ( indx .eq. index_w ) then
+            do i = 1, num2(iwest)
+               pdata(holes_ind(k),:) = droplet_w2(i,:)
+               k = k + 1
+            end do
+         else if ( indx .eq. index_e ) then
+            do i = 1, num2(ieast)
+               pdata(holes_ind(k),:) = droplet_e2(i,:)
+               k = k + 1
+            end do
+         else if ( indx .eq. index_nw ) then
+            do i = 1, num2(inw)
+               pdata(holes_ind(k),:) = droplet_nw2(i,:)
+               k = k + 1
+            end do
+         else if ( indx .eq. index_ne ) then
+            do i = 1, num2(ine)
+               pdata(holes_ind(k),:) = droplet_ne2(i,:)
+               k = k + 1
+            end do
+         else if ( indx .eq. index_sw ) then
+            do i = 1, num2(isw)
+               pdata(holes_ind(k),:) = droplet_sw2(i,:)
+               k = k + 1
+            end do
+         else if ( indx .eq. index_se ) then
+            do i = 1, num2(ise)
+               pdata(holes_ind(k),:) = droplet_se2(i,:)
+               k = k + 1
+            end do
+         else
+            write(*,*) indx," is not a nearest neighbor for myid = ",myid
+            stop "Stop the program..."
+         end if
+         n = n + 1
+      end do
+
+      ! make sure that all the non-blocking MPI send operations are complete
+
+      n_send = n_send - 8
+      if ( n_send .ge. 1 ) then
+         call mpi_waitall(n_send,reqs(9:9+n_send-1),status1(1:mpi_status_size,9:9+n_send-1),ierr)
+      end if
+
+      ! free up the memory for temporary variables
+      if (allocated(droplet_n1))  deallocate(droplet_n1)
+      if (allocated(droplet_n2))  deallocate(droplet_n2)
+      if (allocated(droplet_s1))  deallocate(droplet_s1)
+      if (allocated(droplet_s2))  deallocate(droplet_s2)
+      if (allocated(droplet_w1))  deallocate(droplet_w1)
+      if (allocated(droplet_w2))  deallocate(droplet_w2)
+      if (allocated(droplet_e1))  deallocate(droplet_e1)
+      if (allocated(droplet_e2))  deallocate(droplet_e2)
+      if (allocated(droplet_ne1)) deallocate(droplet_ne1)
+      if (allocated(droplet_ne2)) deallocate(droplet_ne2)
+      if (allocated(droplet_nw1)) deallocate(droplet_nw1)
+      if (allocated(droplet_nw2)) deallocate(droplet_nw2)
+      if (allocated(droplet_se1)) deallocate(droplet_se1)
+      if (allocated(droplet_se2)) deallocate(droplet_se2)
+      if (allocated(droplet_sw1)) deallocate(droplet_sw1)
+      if (allocated(droplet_sw2)) deallocate(droplet_sw2)
+
+    end subroutine comm_droplet_value
 
 #endif
 

--- a/src/comm.F
+++ b/src/comm.F
@@ -13053,7 +13053,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       if ( num2(inw) .ne. 0 ) allocate(droplet_nw2(num2(inw),npvals))
       if ( num2(ine) .ne. 0 ) allocate(droplet_ne2(num2(ine),npvals))
       if ( num2(isw) .ne. 0 ) allocate(droplet_sw2(num2(isw),npvals))
-      if ( num2(ise) .ne. 0 ) allocate(droplet_ne2(num2(ise),npvals))
+      if ( num2(ise) .ne. 0 ) allocate(droplet_se2(num2(ise),npvals))
 
       ! initiate the MPI non-blocking receive interface to 
       ! obtain new droplet information from the nearest neighbors

--- a/src/comm.F
+++ b/src/comm.F
@@ -12777,8 +12777,8 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       i = 1
       do n = 1, nparcels_mpi
-         if ( pdata_locind(n,1) .eq. undefined_index .and. &
-              pdata_locind(n,2) .eq. undefined_index ) then
+         if ( (pdata_locind(n,1) .eq. undefined_index) .and. &
+              (pdata_locind(n,2) .eq. undefined_index) ) then
             ! record the location index that can be used to store the new droplet
             ! information after the old drolpet leaves the current MPI region
             holes_ind(i) = n
@@ -12800,7 +12800,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
             else if ( pdata_neighbor(n) .eq. myse ) then
                num1(ise) = num1(ise) + 1
             else
-               cycle  ! this is a "hole" of "pdata"
+               cycle  ! this is an existing "hole" of "pdata"
                       ! no action is needed
             end if
          end if
@@ -12889,7 +12889,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
           stop "Stop the program ..."
       end if
 
-#if 1 
+#if 0 
       ! sanity check: if the total number of leaving droplets matches
       !               the total number of entering droploets across 
       !               all the MPI ranks
@@ -12931,7 +12931,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
     subroutine comm_droplet_value(holes_ind,num1,num2,pdata,pdata_neighbor)
 
       use input, only : myid,nparcels_mpi,npvals,mynw,mysw,myne, &
-                        myse,myeast,mywest,mynorth,mysouth,ierr
+                        myse,myeast,mywest,mynorth,mysouth,ierr,pract
       use constants, only: undefined_index,neg_huge,num_nn,inorth, &
                            isouth,iwest,ieast,inw,ine,isw,ise
       use mpi
@@ -12960,9 +12960,8 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
                                            droplet_e2, droplet_nw2, droplet_ne2, &
                                            droplet_sw2, droplet_se2
       integer :: n_idx,s_idx,w_idx,e_idx,nw_idx,ne_idx,sw_idx,se_idx
-      integer :: reqs(16)
-      integer :: tag_n,tag_s,tag_w,tag_e,tag_nw,tag_ne,tag_sw,tag_se, &
-                 index_n,index_s,index_w,index_e,index_nw,index_ne, &
+      integer :: reqs(16),tag(num_nn,2)
+      integer :: index_n,index_s,index_w,index_e,index_nw,index_ne, &
                  index_sw,index_se,n_recv,n_send
       integer, dimension(mpi_status_size,16) :: status1
       integer :: i,k,n,indx
@@ -12978,14 +12977,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       index_ne = undefined_index
       index_se = undefined_index
 
-      tag_n    = undefined_index
-      tag_s    = undefined_index
-      tag_w    = undefined_index
-      tag_e    = undefined_index
-      tag_nw   = undefined_index
-      tag_sw   = undefined_index
-      tag_ne   = undefined_index
-      tag_se   = undefined_index
+      do i = 1, num_nn
+         tag(i,1) = undefined_index
+         tag(i,2) = undefined_index
+      end do 
 
       ! allocate spaces to store the droplets that will leave the current MPI region
 
@@ -13044,7 +13039,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
             se_idx = se_idx + 1
             pdata(n,:) = neg_huge
          else
-            cycle   ! this droplet stays at the same MPI region;
+            cycle   ! this droplet stays at the same MPI region or this is a "hole";
                     ! no action is needed
          end if
       end do
@@ -13066,58 +13061,58 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       n_recv   = 0
       if ( num2(inorth) .ne. 0 ) then
          n_recv = n_recv + 1
-         tag_n  = 1000 + num2(inorth)
+         tag(inorth,2)  = 1000 + num2(inorth)
          call mpi_irecv(droplet_n2,num2(inorth)*npvals,MPI_REAL, &
-                        mynorth,tag_n,MPI_COMM_WORLD,reqs(n_recv),ierr)
+                        mynorth,tag(inorth,2),MPI_COMM_WORLD,reqs(n_recv),ierr)
          index_n = n_recv
       end if
       if ( num2(isouth) .ne. 0 ) then
          n_recv = n_recv + 1
-         tag_s  = 1000 + num2(isouth)
+         tag(isouth,2)  = 1000 + num2(isouth)
          call mpi_irecv(droplet_s2,num2(isouth)*npvals,MPI_REAL, &
-                        mysouth,tag_s,MPI_COMM_WORLD,reqs(n_recv),ierr)
+                        mysouth,tag(isouth,2),MPI_COMM_WORLD,reqs(n_recv),ierr)
          index_s = n_recv
       end if
       if ( num2(iwest) .ne. 0 ) then
          n_recv = n_recv + 1
-         tag_w  = 1000 + num2(iwest)
+         tag(iwest,2)  = 1000 + num2(iwest)
          call mpi_irecv(droplet_w2,num2(iwest)*npvals,MPI_REAL, &
-                        mywest,tag_w,MPI_COMM_WORLD,reqs(n_recv),ierr)
+                        mywest,tag(iwest,2),MPI_COMM_WORLD,reqs(n_recv),ierr)
          index_w = n_recv
       end if
       if ( num2(ieast) .ne. 0 ) then
          n_recv = n_recv + 1
-         tag_e  = 1000 + num2(ieast)
+         tag(ieast,2)  = 1000 + num2(ieast)
          call mpi_irecv(droplet_e2,num2(ieast)*npvals,MPI_REAL, &
-                        myeast,tag_e,MPI_COMM_WORLD,reqs(n_recv),ierr)
+                        myeast,tag(ieast,2),MPI_COMM_WORLD,reqs(n_recv),ierr)
          index_e = n_recv
       end if
       if ( num2(inw) .ne. 0 ) then
          n_recv = n_recv + 1
-         tag_nw = 1000 + num2(inw)
+         tag(inw,2) = 1000 + num2(inw)
          call mpi_irecv(droplet_nw2,num2(inw)*npvals,MPI_REAL, &
-                        mynw,tag_nw,MPI_COMM_WORLD,reqs(n_recv),ierr)
+                        mynw,tag(inw,2),MPI_COMM_WORLD,reqs(n_recv),ierr)
          index_nw = n_recv
       end if
       if ( num2(ine) .ne. 0 ) then
          n_recv = n_recv + 1
-         tag_ne = 1000 + num2(ine)
+         tag(ine,2) = 1000 + num2(ine)
          call mpi_irecv(droplet_ne2,num2(ine)*npvals,MPI_REAL, &
-                        myne,tag_ne,MPI_COMM_WORLD,reqs(n_recv),ierr)
+                        myne,tag(ine,2),MPI_COMM_WORLD,reqs(n_recv),ierr)
          index_ne = n_recv
       end if
       if ( num2(isw) .ne. 0 ) then
          n_recv = n_recv + 1
-         tag_sw = 1000 + num2(isw)
+         tag(isw,2) = 1000 + num2(isw)
          call mpi_irecv(droplet_sw2,num2(isw)*npvals,MPI_REAL, &
-                        mysw,tag_sw,MPI_COMM_WORLD,reqs(n_recv),ierr)
+                        mysw,tag(isw,2),MPI_COMM_WORLD,reqs(n_recv),ierr)
          index_sw = n_recv
       end if
       if ( num2(ise) .ne. 0 ) then
          n_recv = n_recv + 1
-         tag_se = 1000 + num2(ise)
+         tag(ise,2) = 1000 + num2(ise)
          call mpi_irecv(droplet_se2,num2(ise)*npvals,MPI_REAL, &
-                        myse,tag_se,MPI_COMM_WORLD,reqs(n_recv),ierr)
+                        myse,tag(ise,2),MPI_COMM_WORLD,reqs(n_recv),ierr)
          index_se = n_recv
       end if
 
@@ -13127,51 +13122,51 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       n_send = 8
       if ( num1(inorth) .ne. 0 ) then
          n_send = n_send + 1
-         tag_s = 1000 + num1(inorth)
+         tag(isouth,1) = 1000 + num1(inorth)
          call mpi_isend(droplet_n1,num1(inorth)*npvals,MPI_REAL, &
-                        mynorth,tag_s,MPI_COMM_WORLD,reqs(n_send),ierr)
+                        mynorth,tag(isouth,1),MPI_COMM_WORLD,reqs(n_send),ierr)
       end if
       if ( num1(isouth) .ne. 0 ) then
          n_send = n_send + 1
-         tag_n = 1000 + num1(isouth)
+         tag(inorth,1) = 1000 + num1(isouth)
          call mpi_isend(droplet_s1,num1(isouth)*npvals,MPI_REAL, &
-                        mysouth,tag_n,MPI_COMM_WORLD,reqs(n_send),ierr)
+                        mysouth,tag(inorth,1),MPI_COMM_WORLD,reqs(n_send),ierr)
       end if
       if ( num1(iwest) .ne. 0 ) then
          n_send = n_send + 1
-         tag_e = 1000 + num1(iwest)
+         tag(ieast,1) = 1000 + num1(iwest)
          call mpi_isend(droplet_w1,num1(iwest)*npvals,MPI_REAL, &
-                        mywest,tag_e,MPI_COMM_WORLD,reqs(n_send),ierr)
+                        mywest,tag(ieast,1),MPI_COMM_WORLD,reqs(n_send),ierr)
       end if
       if ( num1(ieast) .ne. 0 ) then
          n_send = n_send + 1
-         tag_w = 1000 + num1(ieast)
+         tag(iwest,1) = 1000 + num1(ieast)
          call mpi_isend(droplet_e1,num1(ieast)*npvals,MPI_REAL, &
-                        myeast,tag_w,MPI_COMM_WORLD,reqs(n_send),ierr)
+                        myeast,tag(iwest,1),MPI_COMM_WORLD,reqs(n_send),ierr)
       end if
       if ( num1(inw) .ne. 0 ) then
          n_send = n_send + 1
-         tag_se = 1000 + num1(inw)
+         tag(ise,1) = 1000 + num1(inw)
          call mpi_isend(droplet_nw1,num1(inw)*npvals,MPI_REAL, &
-                        mynw,tag_se,MPI_COMM_WORLD,reqs(n_send),ierr)
+                        mynw,tag(ise,1),MPI_COMM_WORLD,reqs(n_send),ierr)
       end if
       if ( num1(ine) .ne. 0 ) then
          n_send = n_send + 1
-         tag_sw = 1000 + num1(ine)
+         tag(isw,1) = 1000 + num1(ine)
          call mpi_isend(droplet_ne1,num1(ine)*npvals,MPI_REAL, &
-                        myne,tag_sw,MPI_COMM_WORLD,reqs(n_send),ierr)
+                        myne,tag(isw,1),MPI_COMM_WORLD,reqs(n_send),ierr)
       end if
       if ( num1(isw) .ne. 0 ) then
          n_send = n_send + 1
-         tag_ne = 1000 + num1(isw)
+         tag(ine,1) = 1000 + num1(isw)
          call mpi_isend(droplet_sw1,num1(isw)*npvals,MPI_REAL, &
-                        mysw,tag_ne,MPI_COMM_WORLD,reqs(n_send),ierr)
+                        mysw,tag(ine,1),MPI_COMM_WORLD,reqs(n_send),ierr)
       end if
       if ( num1(ise) .ne. 0 ) then
          n_send = n_send + 1
-         tag_nw = 1000 + num1(ise)
+         tag(inw,1) = 1000 + num1(ise)
          call mpi_isend(droplet_se1,num1(ise)*npvals,MPI_REAL, &
-                        myse,tag_nw,MPI_COMM_WORLD,reqs(n_send),ierr)
+                        myse,tag(inw,1),MPI_COMM_WORLD,reqs(n_send),ierr)
       end if
 
       ! update the "holes" in "pdata" with the new droplets that

--- a/src/comm.F
+++ b/src/comm.F
@@ -12727,7 +12727,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
     subroutine comm_droplet_number(holes_ind,num1,num2,pdata, &
                                    pdata_locind,pdata_neighbor)
 
-      use input, only : myid,nparcels_mpi,npvals,mynw,mysw,myne, &
+      use input, only : myid,nparcelsLocal,npvals,mynw,mysw,myne, &
                         myse,myeast,mywest,mynorth,mysouth,ierr
       use constants, only: undefined_index,num_nn,inorth,isouth, &
                            iwest,ieast,inw,ine,isw,ise
@@ -12744,9 +12744,9 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       integer, intent(out) :: num2(num_nn)                                 ! Number of droplets that will enter the 
                                                                            ! current MPI region from each nearest 
                                                                            ! neighbor at different directions
-      real, intent(in), dimension(nparcels_mpi,npvals) :: pdata            ! droplet information
-      integer, intent(in), dimension(nparcels_mpi,3) :: pdata_locind       ! x/y/z location index of each droplet
-      integer, intent(in), dimension(nparcels_mpi) :: pdata_neighbor       ! array to store the new MPI region 
+      real, intent(in), dimension(nparcelsLocal,npvals) :: pdata            ! droplet information
+      integer, intent(in), dimension(nparcelsLocal,3) :: pdata_locind       ! x/y/z location index of each droplet
+      integer, intent(in), dimension(nparcelsLocal) :: pdata_neighbor       ! array to store the new MPI region 
                                                                            ! info for all the droplets
 
       ! Local variables
@@ -12776,7 +12776,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       ! current MPI region and to which neighbor
 
       i = 1
-      do n = 1, nparcels_mpi
+      do n = 1, nparcelsLocal
          if ( (pdata_locind(n,1) .eq. undefined_index) .and. &
               (pdata_locind(n,2) .eq. undefined_index) ) then
             ! record the location index that can be used to store the new droplet
@@ -12930,7 +12930,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
     subroutine comm_droplet_value(holes_ind,num1,num2,pdata,pdata_neighbor)
 
-      use input, only : myid,nparcels_mpi,npvals,mynw,mysw,myne, &
+      use input, only : myid,nparcelsLocal,npvals,mynw,mysw,myne, &
                         myse,myeast,mywest,mynorth,mysouth,ierr,pract
       use constants, only: undefined_index,neg_huge,num_nn,inorth, &
                            isouth,iwest,ieast,inw,ine,isw,ise
@@ -12947,8 +12947,8 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       integer, intent(in) :: num2(num_nn)                                  ! Number of droplets that will enter the 
                                                                            ! current MPI region from each nearest 
                                                                            ! neighbor at different directions
-      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata         ! droplet information
-      integer, intent(in), dimension(nparcels_mpi) :: pdata_neighbor       ! array to store the new MPI region 
+      real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata         ! droplet information
+      integer, intent(in), dimension(nparcelsLocal) :: pdata_neighbor       ! array to store the new MPI region 
                                                                            ! info for all the droplets
 
       ! Local variables
@@ -13005,7 +13005,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       sw_idx = 1
       se_idx = 1
 
-      do n = 1, nparcels_mpi
+      do n = 1, nparcelsLocal
          if ( pdata_neighbor(n) .eq. mynorth ) then
             droplet_n1(n_idx,:) = pdata(n,:)
             n_idx = n_idx + 1

--- a/src/comm.F
+++ b/src/comm.F
@@ -12889,6 +12889,39 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
           stop "Stop the program ..."
       end if
 
+#if 1 
+      ! sanity check: if the total number of leaving droplets matches
+      !               the total number of entering droploets across 
+      !               all the MPI ranks
+
+      n_send = sum(num1)
+      if ( myid == 0 ) then
+         call mpi_reduce(MPI_IN_PLACE,n_send,1,MPI_INT, &
+                         MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      else
+         call mpi_reduce(n_send,n_send,1,MPI_INT, &
+                         MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      end if
+
+      n_recv = sum(num2)
+      if ( myid == 0 ) then
+         call mpi_reduce(MPI_IN_PLACE,n_recv,1,MPI_INT, &
+                         MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      else
+         call mpi_reduce(n_recv,n_recv,1,MPI_INT, &
+                         MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      end if
+
+      if ( myid == 0 ) then
+         if ( n_send .ne. n_recv ) then
+            write(*,*) "Unmatched total leaving droplets vs. total entering droplets..."
+            write(*,*) "Total leaving droplets: ", n_send
+            write(*,*) "Total entering droplets: ", n_recv
+            stop "Stop the program ..."
+         end if
+      end if
+#endif
+
     end subroutine comm_droplet_number
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/constants.F
+++ b/src/constants.F
@@ -63,6 +63,10 @@
 
       integer, parameter :: undefined_index = -100
 
+      integer, parameter :: pdata_buffer = 100    ! additional storage space for pdata from
+                                                  ! each MPI rank to account for the droplet
+                                                  ! communication between MPI ranks
+
   CONTAINS
 
     !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/constants.F
+++ b/src/constants.F
@@ -63,9 +63,10 @@
 
       integer, parameter :: undefined_index = -100
 
-      integer, parameter :: pdata_buffer = 100    ! additional storage space for pdata from
+      real, parameter :: pdata_buffer = 0.01      ! additional storage space for pdata from
                                                   ! each MPI rank to account for the droplet
-                                                  ! communication between MPI ranks
+                                                  ! communication between MPI ranks;
+                                                  ! this is a percent of "nparcels" value
        
       real, parameter :: neg_huge = -1.0e30       ! define a large negative number
 

--- a/src/constants.F
+++ b/src/constants.F
@@ -69,6 +69,16 @@
        
       real, parameter :: neg_huge = -1.0e30       ! define a large negative number
 
+      integer, parameter :: num_nn = 8,  &        ! Number of nearest neighbor
+                            inorth = 1,  &        ! north neighbor index 
+                            isouth = 2,  &        ! south neighbor index 
+                             iwest = 3,  &        ! west neighbor index 
+                             ieast = 4,  &        ! east neighbor index 
+                               inw = 5,  &        ! northwest neighbor index 
+                               ine = 6,  &        ! northeast neighbor index 
+                               isw = 7,  &        ! southwest neighbor index 
+                               ise = 8            ! southeast neighbor index 
+
   CONTAINS
 
     !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/constants.F
+++ b/src/constants.F
@@ -66,6 +66,8 @@
       integer, parameter :: pdata_buffer = 100    ! additional storage space for pdata from
                                                   ! each MPI rank to account for the droplet
                                                   ! communication between MPI ranks
+       
+      real, parameter :: neg_huge = -1.0e30       ! define a large negative number
 
   CONTAINS
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -2095,8 +2095,6 @@
 #ifdef MPI
       real, dimension(11) :: droplet_diag0     ! temporary array for MPI reduce operation
                                                ! for the 0th-order diagnostic except rtime 
-      real, dimension(nk) :: droplet_diag1     ! temporary array for MPI reduce operation
-                                               ! for the 1st-order diagnostic 
 #endif
 
       !Compute the various types of droplet statistics
@@ -2247,6 +2245,22 @@
       !WRITE IT OUT:
 
       !Dump to screen for debugging purposes
+#ifdef MPI
+      if ( myid == 0 ) then
+         write(6,200) 'rtime', rtime
+         write(6,200) 'tnumpart', dble(droplet_diag0(1))
+         write(6,200) 'radavg',droplet_diag0(2)
+         write(6,200) 'radmin',droplet_diag0(3)
+         write(6,200) 'radmax',droplet_diag0(4)
+         write(6,200) 'Tpavg',droplet_diag0(5)
+         write(6,200) 'Tpmin',droplet_diag0(6)
+         write(6,200) 'Tpmax',droplet_diag0(7)
+         write(6,200) 'Tfavg',droplet_diag0(8)
+         write(6,200) 'qfavg',droplet_diag0(9)
+         write(6,200) 'prsavg',droplet_diag0(10)
+         write(6,200) 'rhoavg',droplet_diag0(11)
+      end if
+#else
       write(6,200) 'rtime', rtime
       write(6,200) 'tnumpart', dble(tnumpart)
       write(6,200) 'radavg',radavg
@@ -2259,13 +2273,20 @@
       write(6,200) 'qfavg',qfavg
       write(6,200) 'prsavg',prsavg
       write(6,200) 'rhoavg',rhoavg
+#endif
 
 #ifdef NETCDF
       ! JS: this subroutine is not updated with the new MPI
       !     interface for the droplets yet
+#ifdef MPI
+      if ( myid == 0 ) then
+#endif
       call writedropdiag_nc(nrec, &
            rtime,tnumpart,radavg,radsqr,radmin,radmax,Tpavg,Tpsqr,Tpmin,Tpmax,Tfavg,qfavg,prsavg,rhoavg, &
            dumzh,numconc)
+#ifdef MPI
+      end if
+#endif
 #endif
 
 100     format(2x,'DROPLET_DIAG1:: ',A,I0,A,1x,e13.6,1x)

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -865,7 +865,7 @@
        else if ( indx .eq. index_s ) then
           if ( num_s2 .ne. 0 ) allocate(droplet_s2(num_s2,npvals))
        else if ( indx .eq. index_w ) then
-          if ( num_w2 .ne. 0 ) allocate(droplet_s2(num_w2,npvals))
+          if ( num_w2 .ne. 0 ) allocate(droplet_w2(num_w2,npvals))
        else if ( indx .eq. index_e ) then
           if ( num_e2 .ne. 0 ) allocate(droplet_e2(num_e2,npvals))
        else if ( indx .eq. index_ne ) then
@@ -889,7 +889,7 @@
        stop "Stop the program ..."
     end if
 
-#if 0
+#if 1 
     ! Diagnostic only 
     write(*,*) "JS: myid = ", myid, ", new droplets = ", num_n2 + num_s2 + &
                num_w2 + num_e2 + num_ne2 + num_nw2 + num_se2 + num_sw2

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -36,7 +36,7 @@
           umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
           prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult,prms,przs,pru,prv,prw,prt,prqv,prprs,prrho, &
           timestats,time_droplet,mytime,ierr,time_droplet_reduce,maxx,maxy,maxz, &
-          nparcels_mpi,ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest
+          nparcels_mpi,ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest,myid
       use constants
       use comm_module
       use misclibs
@@ -126,7 +126,7 @@
                  index_se,index_n,index_s,index_w,index_e
       integer :: reqs(16)
       integer :: tag_n,tag_s,tag_w,tag_e,tag_nw,tag_ne,tag_sw,tag_se,indx
-      integer, dimension(mpi_status_size,8) :: status1
+      integer, dimension(mpi_status_size,16) :: status1
 
 #ifdef _VERIFY_FIND_LOC
       integer :: tmp_flag
@@ -633,85 +633,181 @@
 
     !$acc update host(pdata,pdata_loc)
      
-    ! JS: all the calculations below are done on CPU
+    ! JS: send/receive the droplet information through MPI;
+    !     all the calculations below are done on CPU
 
+    ! initiate some MPI index and tag values
+    index_n  = undefined_index
+    index_s  = undefined_index
+    index_w  = undefined_index
+    index_e  = undefined_index
+    index_nw = undefined_index
+    index_sw = undefined_index
+    index_ne = undefined_index
+    index_se = undefined_index
+
+    tag_n  = 1001
+    tag_s  = 1002
+    tag_w  = 1003
+    tag_e  = 1004
+    tag_nw = 1005
+    tag_sw = 1006
+    tag_ne = 1007
+    tag_se = 1008
+
+    ! num_holes: number of "holes" in pdata at the beginning of this time step + 
+    !            number of droplets leaving this MPI region at this time step
     num_holes = 0
     do np = 1, nparcels_mpi
        if ( pdata_loc(np,1) .eq. undefined_index .and. &
             pdata_loc(np,2) .eq. undefined_index ) then
-          num_holes = num_holes + 1   ! number of "holes" in pdata at the beginning 
-                                      ! of this time step + number of droplets
-                                      ! leaving this MPI region at this time step
+          num_holes = num_holes + 1
        end if
     end do
 
+    ! allocate "hole" index array and initialize it with a negative value
     allocate(holes_ind(num_holes))
-    holes_ind = undefined_index    ! initialize the "hole" index array with a negative value
-
-    i = 1
-    num_n = 0
-    num_s = 0 
-    num_w = 0 
-    num_e = 0 
-    num_ne = 0
-    num_nw = 0
-    num_sw = 0 
-    num_se = 0
+    holes_ind = undefined_index
 
     ! find out how many droplets will leave the current MPI region and to which neighbor
+    i = 1
+    num_n1 = 0
+    num_s1 = 0 
+    num_w1 = 0 
+    num_e1 = 0 
+    num_ne1 = 0
+    num_nw1 = 0
+    num_sw1 = 0 
+    num_se1 = 0
     do np = 1, nparcels_mpi
        if ( pdata_loc(np,1) .eq. undefined_index .and. &
             pdata_loc(np,2) .eq. undefined_index ) then
-          holes_ind(i) = np  ! record the location index that can be used to
-                             ! store the new droplet information after the 
-                             ! old drolpet leaves the current MPI region
+          ! record the location index that can be used to store the new droplet
+          ! information after the old drolpet leaves the current MPI region
+          holes_ind(i) = np
           i = i + 1
           if ( pdata_neighbor(np) .eq. mywest ) then
-             num_w = num_w + 1
+             num_w1 = num_w1 + 1
           else if ( pdata_neighbor(np) .eq. mysw ) then 
-             num_sw = num_sw + 1
+             num_sw1 = num_sw1 + 1
           else if ( pdata_neighbor(np) .eq. mynw ) then  
-             num_nw = num_nw + 1
+             num_nw1 = num_nw1 + 1
           else if ( pdata_neighbor(np) .eq. myeast ) then  
-             num_e = num_e + 1
+             num_e1 = num_e1 + 1
           else if ( pdata_neighbor(np) .eq. myne ) then  
-             num_ne = num_ne + 1
+             num_ne1 = num_ne1 + 1
           else if ( pdata_neighbor(np) .eq. myse ) then  
-             num_se = num_se + 1
+             num_se1 = num_se1 + 1
           else if ( pdata_neighbor(np) .eq. mynorth ) then  
-             num_n = num_n + 1
+             num_n1 = num_n1 + 1
           else if ( pdata_neighbor(np) .eq. mysouth ) then  
-             num_s = num_s + 1
+             num_s1 = num_s1 + 1
           end if
        end if
     end do
 
     ! allocate spaces to store the droplets that will leave the current MPI region
-    if ( num_n .ne. 0 ) then
-       allocate(droplet_n1(num_n,npvals))
+    if ( num_n1 .ne. 0 ) then
+       allocate(droplet_n1(num_n1,npvals))
     end if
-    if ( num_s .ne. 0 ) then
-       allocate(droplet_s1(num_s,npvals))
+    if ( num_s1 .ne. 0 ) then
+       allocate(droplet_s1(num_s1,npvals))
     end if
-    if ( num_w .ne. 0 ) then
-       allocate(droplet_w1(num_w,npvals))
+    if ( num_w1 .ne. 0 ) then
+       allocate(droplet_w1(num_w1,npvals))
     end if
-    if ( num_e .ne. 0 ) then
-       allocate(droplet_e1(num_e,npvals))
+    if ( num_e1 .ne. 0 ) then
+       allocate(droplet_e1(num_e1,npvals))
     end if
-    if ( num_ne .ne. 0 ) then
-       allocate(droplet_ne1(num_ne,npvals))
+    if ( num_ne1 .ne. 0 ) then
+       allocate(droplet_ne1(num_ne1,npvals))
     end if
-    if ( num_nw .ne. 0 ) then
-       allocate(droplet_nw1(num_nw,npvals))
+    if ( num_nw1 .ne. 0 ) then
+       allocate(droplet_nw1(num_nw1,npvals))
     end if
-    if ( num_se .ne. 0 ) then
-       allocate(droplet_se1(num_se,npvals))
+    if ( num_se1 .ne. 0 ) then
+       allocate(droplet_se1(num_se1,npvals))
     end if
-    if ( num_sw .ne. 0 ) then
-       allocate(droplet_sw1(num_sw,npvals))
+    if ( num_sw1 .ne. 0 ) then
+       allocate(droplet_sw1(num_sw1,npvals))
     end if
-    
+   
+    ! MPI Step 1: initiate the MPI non-blocking receive interface to 
+    !             know how many droplets from the nearest neighbors
+    n_recv = 1 
+    call mpi_irecv(num_n2,1,MPI_INT,mynorth,tag_n,MPI_COMM_WORLD, &
+                   reqs(n_recv),ierr)
+    index_n = n_recv
+   
+    n_recv = n_recv + 1
+    call mpi_irecv(num_s2,1,MPI_INT,mysouth,tag_s,MPI_COMM_WORLD, &
+                   reqs(n_recv),ierr)
+    index_s = n_recv
+
+    n_recv = n_recv + 1
+    call mpi_irecv(num_w2,1,MPI_INT,mywest,tag_w,MPI_COMM_WORLD, &
+                   reqs(n_recv),ierr)
+    index_w = n_recv
+
+    n_recv = n_recv + 1
+    call mpi_irecv(num_e2,1,MPI_INT,myeast,tag_e,MPI_COMM_WORLD, &
+                   reqs(n_recv),ierr)
+    index_e = n_recv
+
+    n_recv = n_recv + 1
+    call mpi_irecv(num_ne2,1,MPI_INT,myne,tag_ne,MPI_COMM_WORLD, &
+                   reqs(n_recv),ierr)
+    index_ne = n_recv
+
+    n_recv = n_recv + 1
+    call mpi_irecv(num_nw2,1,MPI_INT,mynw,tag_nw,MPI_COMM_WORLD, &
+                   reqs(n_recv),ierr)
+    index_nw = n_recv
+ 
+    n_recv = n_recv + 1
+    call mpi_irecv(num_se2,1,MPI_INT,myse,tag_se,MPI_COMM_WORLD, &
+                   reqs(n_recv),ierr)
+    index_se = n_recv
+
+    n_recv = n_recv + 1
+    call mpi_irecv(num_sw2,1,MPI_INT,mysw,tag_sw,MPI_COMM_WORLD, &
+                   reqs(n_recv),ierr)
+    index_sw = n_recv
+
+    ! MPI Step 2: initiate the MPI non-blocking send interface to 
+    !             send how many droplets entering the nearest neighbor 
+    n_send = 9 
+    call mpi_isend(num_n1,1,MPI_INT,mynorth,tag_s,MPI_COMM_WORLD, &
+                   reqs(n_send),ierr)
+
+    n_send = n_send + 1
+    call mpi_isend(num_s1,1,MPI_INT,mysouth,tag_n,MPI_COMM_WORLD, &
+                   reqs(n_send),ierr)
+
+    n_send = n_send + 1
+    call mpi_isend(num_w1,1,MPI_INT,mywest,tag_e,MPI_COMM_WORLD, &
+                   reqs(n_send),ierr)
+
+    n_send = n_send + 1
+    call mpi_isend(num_e1,1,MPI_INT,myeast,tag_w,MPI_COMM_WORLD, &
+                   reqs(n_send),ierr)
+
+    n_send = n_send + 1
+    call mpi_isend(num_ne1,1,MPI_INT,myne,tag_sw,MPI_COMM_WORLD, &
+                   reqs(n_send),ierr)
+
+    n_send = n_send + 1
+    call mpi_isend(num_nw1,1,MPI_INT,mynw,tag_se,MPI_COMM_WORLD, &
+                   reqs(n_send),ierr)
+
+    n_send = n_send + 1
+    call mpi_isend(num_se1,1,MPI_INT,myse,tag_nw,MPI_COMM_WORLD, &
+                   reqs(n_send),ierr)
+
+    n_send = n_send + 1
+    call mpi_isend(num_sw1,1,MPI_INT,mysw,tag_ne,MPI_COMM_WORLD, &
+                   reqs(n_send),ierr)
+
     ! extract the information of droplets that will leave the current MPI region 
     jn = 1
     js = 1
@@ -757,172 +853,186 @@
        end if
     end do
 
-    ! initiate some MPI index and tag values
-    index_n  = undefined_index 
-    index_s  = undefined_index
-    index_w  = undefined_index
-    index_e  = undefined_index
-    index_nw = undefined_index 
-    index_sw = undefined_index
-    index_ne = undefined_index
-    index_se = undefined_index
+    ! MPI step 3: allocate temporary arrays if there are 
+    !             new droplets from the nearest neighbor
+    n = 1
+    do while( n .le. n_recv )
+       call mpi_waitany(n_recv,reqs(1:n_recv),indx,MPI_STATUS_IGNORE,ierr)
+       if ( indx .eq. index_n ) then
+          if ( num_n2 .ne. 0 ) allocate(droplet_n2(num_n2,npvals))
+       else if ( indx .eq. index_s ) then
+          if ( num_s2 .ne. 0 ) allocate(droplet_s2(num_s2,npvals))
+       else if ( indx .eq. index_w ) then
+          if ( num_w2 .ne. 0 ) allocate(droplet_s2(num_w2,npvals))
+       else if ( indx .eq. index_e ) then
+          if ( num_e2 .ne. 0 ) allocate(droplet_e2(num_e2,npvals))
+       else if ( indx .eq. index_ne ) then
+          if ( num_ne2 .ne. 0 ) allocate(droplet_ne2(num_ne2,npvals))
+       else if ( indx .eq. index_nw ) then
+          if ( num_nw2 .ne. 0 ) allocate(droplet_nw2(num_nw2,npvals))
+       else if ( indx .eq. index_se ) then
+          if ( num_se2 .ne. 0 ) allocate(droplet_se2(num_se2,npvals))
+       else if ( indx .eq. index_sw ) then
+          if ( num_sw2 .ne. 0 ) allocate(droplet_sw2(num_sw2,npvals))
+       end if
+       n = n + 1
+    end do
 
-    tag_n  = 1001
-    tag_s  = 1002
-    tag_w  = 1003
-    tag_e  = 1004
-    tag_nw = 1005
-    tag_sw = 1006
-    tag_ne = 1007
-    tag_se = 1008
+    ! sanity check: if too many droplets enter the current MPI region
+    !               and exceed the number of "holes", stop the program
+    !               with an error message
+    if ( ( num_n2 + num_s2 + num_w2 + num_e2 + num_ne2 + &
+           num_nw2 + num_se2 + num_sw2 ) .gt. num_holes ) then
+       write(*,*) "Too many new droplets will enter the MPI rank: ", myid 
+       stop "Stop the program ..."
+    end if
 
-    ! initiate the MPI non-blocking receive interface to 
-    ! receive information from the nearest neighbor 
-    n_recv   = 0
-    if ( num_n .ne. 0 ) then
+    ! make sure that all the non-blocking MPI send operations are complete
+    n_send = n_send - 8
+    if ( n_send .ge. 1 ) then
+       call mpi_waitall (n_send,reqs(9:9+n_send-1),status1(1:mpi_status_size,9:9+n_send-1),ierr)
+    endif
+
+    ! MPI step 4: initiate the MPI non-blocking receive interface to 
+    !             obtain new droplet information from the nearest neighbors
+    n_recv = 0
+    if ( num_n2 .ne. 0 ) then
        n_recv = n_recv + 1
-       call mpi_irecv(droplet_n2,num_n*npvals,MPI_REAL,mynorth,tag_n,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr) 
+       call mpi_irecv(droplet_n2,num_n2*npvals,MPI_REAL,mynorth,tag_n,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr)
        index_n = n_recv
     end if
-    if ( num_s .ne. 0 ) then
+    if ( num_s2 .ne. 0 ) then
        n_recv = n_recv + 1
-       call mpi_irecv(droplet_s2,num_s*npvals,MPI_REAL,mysouth,tag_s,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr) 
+       call mpi_irecv(droplet_s2,num_s2*npvals,MPI_REAL,mysouth,tag_s,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr)
        index_s = n_recv
     end if
-    if ( num_w .ne. 0 ) then
+    if ( num_w2 .ne. 0 ) then
        n_recv = n_recv + 1
-       call mpi_irecv(droplet_w2,num_w*npvals,MPI_REAL,mywest,tag_w,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr) 
+       call mpi_irecv(droplet_w2,num_w2*npvals,MPI_REAL,mywest,tag_w,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr)
        index_w = n_recv
     end if
-    if ( num_e .ne. 0 ) then
+    if ( num_e2 .ne. 0 ) then
        n_recv = n_recv + 1
-       call mpi_irecv(droplet_e2,num_e*npvals,MPI_REAL,myeast,tag_e,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr) 
+       call mpi_irecv(droplet_e2,num_e2*npvals,MPI_REAL,myeast,tag_e,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr)
        index_e = n_recv
     end if
-    if ( num_ne .ne. 0 ) then
+    if ( num_ne2 .ne. 0 ) then
        n_recv = n_recv + 1
-       call mpi_irecv(droplet_ne2,num_ne*npvals,MPI_REAL,myne,tag_ne,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr) 
+       call mpi_irecv(droplet_ne2,num_ne2*npvals,MPI_REAL,myne,tag_ne,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr)
        index_ne = n_recv
     end if
-    if ( num_nw .ne. 0 ) then
+    if ( num_nw2 .ne. 0 ) then
        n_recv = n_recv + 1
-       call mpi_irecv(droplet_nw2,num_nw*npvals,MPI_REAL,mynw,tag_nw,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr) 
+       call mpi_irecv(droplet_nw2,num_nw2*npvals,MPI_REAL,mynw,tag_nw,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr)
        index_nw = n_recv
     end if
-    if ( num_se .ne. 0 ) then
+    if ( num_se2 .ne. 0 ) then
        n_recv = n_recv + 1
-       call mpi_irecv(droplet_se2,num_se*npvals,MPI_REAL,myse,tag_se,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr) 
+       call mpi_irecv(droplet_se2,num_se2*npvals,MPI_REAL,myse,tag_se,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr)
        index_se = n_recv
     end if
-    if ( num_sw .ne. 0 ) then
+    if ( num_sw2 .ne. 0 ) then
        n_recv = n_recv + 1
-       call mpi_irecv(droplet_sw2,num_sw*npvals,MPI_REAL,mysw,tag_sw,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr) 
+       call mpi_irecv(droplet_sw2,num_sw2*npvals,MPI_REAL,mysw,tag_sw,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr)
        index_sw = n_recv
     end if
 
-    ! initiate the MPI non-blocking send interface to 
-    ! send information to the nearest neighbor 
+    ! MPI step 5: initiate the MPI non-blocking send interface to 
+    !             send the information of droplets that leave the 
+    !             current MPI region to the nearest neighbors 
     n_send = 8
-    if ( num_n .ne. 0 ) then
+    if ( num_n1 .ne. 0 ) then
        n_send = n_send + 1
-       call mpi_isend(droplet_n1,num_n*npvals,MPI_REAL,mynorth,tag_n,MPI_COMM_WORLD, &
+       call mpi_isend(droplet_n1,num_n1*npvals,MPI_REAL,mynorth,tag_s,MPI_COMM_WORLD, &
                       reqs(n_send),ierr)
     end if
-    if ( num_s .ne. 0 ) then
+    if ( num_s1 .ne. 0 ) then
        n_send = n_send + 1
-       call mpi_isend(droplet_s1,num_s*npvals,MPI_REAL,mysouth,tag_s,MPI_COMM_WORLD, &
+       call mpi_isend(droplet_s1,num_s1*npvals,MPI_REAL,mysouth,tag_n,MPI_COMM_WORLD, &
                       reqs(n_send),ierr)
     end if
-    if ( num_w .ne. 0 ) then
+    if ( num_w1 .ne. 0 ) then
        n_send = n_send + 1
-       call mpi_isend(droplet_w1,num_w*npvals,MPI_REAL,mywest,tag_w,MPI_COMM_WORLD, &
+       call mpi_isend(droplet_w1,num_w1*npvals,MPI_REAL,mywest,tag_e,MPI_COMM_WORLD, &
                       reqs(n_send),ierr)
     end if
-    if ( num_e .ne. 0 ) then
+    if ( num_e1 .ne. 0 ) then
        n_send = n_send + 1
-       call mpi_isend(droplet_e1,num_e*npvals,MPI_REAL,myeast,tag_e,MPI_COMM_WORLD, &
+       call mpi_isend(droplet_e1,num_e1*npvals,MPI_REAL,myeast,tag_w,MPI_COMM_WORLD, &
                       reqs(n_send),ierr)
     end if
-    if ( num_ne .ne. 0 ) then
+    if ( num_ne1 .ne. 0 ) then
        n_send = n_send + 1
-       call mpi_isend(droplet_ne1,num_ne*npvals,MPI_REAL,myne,tag_ne,MPI_COMM_WORLD, &
+       call mpi_isend(droplet_ne1,num_ne1*npvals,MPI_REAL,myne,tag_sw,MPI_COMM_WORLD, &
                       reqs(n_send),ierr)
     end if
-    if ( num_nw .ne. 0 ) then
+    if ( num_nw1 .ne. 0 ) then
        n_send = n_send + 1
-       call mpi_isend(droplet_nw1,num_nw*npvals,MPI_REAL,mynw,tag_nw,MPI_COMM_WORLD, &
+       call mpi_isend(droplet_nw1,num_nw1*npvals,MPI_REAL,mynw,tag_se,MPI_COMM_WORLD, &
                       reqs(n_send),ierr)
     end if
-    if ( num_se .ne. 0 ) then
+    if ( num_se1 .ne. 0 ) then
        n_send = n_send + 1
-       call mpi_isend(droplet_se1,num_se*npvals,MPI_REAL,myse,tag_se,MPI_COMM_WORLD, &
+       call mpi_isend(droplet_se1,num_se1*npvals,MPI_REAL,myse,tag_nw,MPI_COMM_WORLD, &
                       reqs(n_send),ierr)
     end if
-    if ( num_sw .ne. 0 ) then
+    if ( num_sw1 .ne. 0 ) then
        n_send = n_send + 1
-       call mpi_isend(droplet_sw1,num_sw*npvals,MPI_REAL,mysw,tag_sw,MPI_COMM_WORLD, &
+       call mpi_isend(droplet_sw1,num_sw1*npvals,MPI_REAL,mysw,tag_ne,MPI_COMM_WORLD, &
                       reqs(n_send),ierr)
     end if
 
-    ! update the "holes" in "pdata" with the new droplets entering 
-    ! the current MPI region from the nearest neighbor
+    ! MPI step 6: update the "holes" in "pdata" with the new droplets entering 
+    !             the current MPI region from the nearest neighbor
     n = 1
     k = 1
     do while( n .le. n_recv )
        call mpi_waitany(n_recv,reqs(1:n_recv),indx,MPI_STATUS_IGNORE,ierr)
        if ( indx .eq. index_n ) then
-          do i = 1, num_n
-             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from mynorth'
+          do i = 1, num_n2
              pdata(holes_ind(k),:) = droplet_n2(i,:)
              k + 1
           end do
        else if ( indx .eq. index_s ) then
-          do i = 1, num_s
-             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from mysouth'
+          do i = 1, num_s2
              pdata(holes_ind(k),:) = droplet_s2(i,:)
              k + 1
           end do
        else if ( indx .eq. index_w ) then
-          do i = 1, num_w
-             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from mywest'
+          do i = 1, num_w2
              pdata(holes_ind(k),:) = droplet_w2(i,:)
              k + 1
           end do
        else if ( indx .eq. index_e ) then
-          do i = 1, num_e
-             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from myeast'
+          do i = 1, num_e2
              pdata(holes_ind(k),:) = droplet_e2(i,:)
              k + 1
           end do
        else if ( indx .eq. index_ne ) then
-          do i = 1, num_ne
-             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from myne'
+          do i = 1, num_ne2
              pdata(holes_ind(k),:) = droplet_ne2(i,:)
              k + 1
           end do
        else if ( indx .eq. index_nw ) then
-          do i = 1, num_nw
-             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from mynw'
+          do i = 1, num_nw2
              pdata(holes_ind(k),:) = droplet_nw2(i,:)
              k + 1
           end do
        else if ( indx .eq. index_se ) then
-          do i = 1, num_se
-             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from myse'
+          do i = 1, num_se2
              pdata(holes_ind(k),:) = droplet_se2(i,:)
              k + 1
           end do
        else if ( indx .eq. index_sw ) then
-          do i = 1, num_sw
-             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from mysw'
+          do i = 1, num_sw2
              pdata(holes_ind(k),:) = droplet_sw2(i,:)
              k + 1
           end do
@@ -933,45 +1043,29 @@
     ! make sure that all the non-blocking MPI send operations are complete
     n_send = n_send - 8
     if ( n_send .ge. 1 ) then
-       call mpi_waitall (n_send,reqs(8:8+n_send-1),status1(1:mpi_status_size,8:8+n_send-1),ierr)
+       call mpi_waitall (n_send,reqs(9:9+n_send-1),status1(1:mpi_status_size,9:9+n_send-1),ierr)
     endif
 
     !$acc update device(pdata)
 
+    ! free up the memory for temporary variables
     deallocate(holes_ind(num_holes))
-   if ( num_n .ne. 0 ) then
-       allocate(droplet_n1(num_n,npvals))
-       allocate(droplet_n2(num_n,npvals))
-    end if
-    if ( num_s .ne. 0 ) then
-       allocate(droplet_s1(num_s,npvals))
-       allocate(droplet_s2(num_s,npvals))
-    end if
-    if ( num_w .ne. 0 ) then
-       allocate(droplet_w1(num_w,npvals))
-       allocate(droplet_w2(num_w,npvals))
-    end if
-    if ( num_e .ne. 0 ) then
-       allocate(droplet_e1(num_e,npvals))
-       allocate(droplet_e2(num_e,npvals))
-    end if
-    if ( num_ne .ne. 0 ) then
-       allocate(droplet_ne1(num_ne,npvals))
-       allocate(droplet_ne2(num_ne,npvals))
-    end if
-    if ( num_nw .ne. 0 ) then
-       allocate(droplet_nw1(num_nw,npvals))
-       allocate(droplet_nw2(num_nw,npvals))
-    end if
-    if ( num_se .ne. 0 ) then
-       allocate(droplet_se1(num_se,npvals))
-       allocate(droplet_se2(num_se,npvals))
-    end if
-    if ( num_sw .ne. 0 ) then
-       allocate(droplet_sw1(num_sw,npvals))
-       allocate(droplet_sw2(num_sw,npvals))
-    end if
-
+    if (allocated(droplet_n1))  deallocate(droplet_n1)
+    if (allocated(droplet_n2))  deallocate(droplet_n2)
+    if (allocated(droplet_s1))  deallocate(droplet_s1)
+    if (allocated(droplet_s2))  deallocate(droplet_s2)
+    if (allocated(droplet_w1))  deallocate(droplet_w1)
+    if (allocated(droplet_w2))  deallocate(droplet_w2)
+    if (allocated(droplet_e1))  deallocate(droplet_e1)
+    if (allocated(droplet_e2))  deallocate(droplet_e2)
+    if (allocated(droplet_ne1)) deallocate(droplet_ne1)
+    if (allocated(droplet_ne2)) deallocate(droplet_ne2)
+    if (allocated(droplet_nw1)) deallocate(droplet_nw1)
+    if (allocated(droplet_nw2)) deallocate(droplet_nw2)
+    if (allocated(droplet_se1)) deallocate(droplet_se1)
+    if (allocated(droplet_se2)) deallocate(droplet_se2)
+    if (allocated(droplet_sw1)) deallocate(droplet_sw1)
+    if (allocated(droplet_sw2)) deallocate(droplet_sw2)
 
     if(timestats.ge.1) time_droplet_reduce=time_droplet_reduce+mytime()
 #endif

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1034,10 +1034,10 @@
 
       subroutine BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000,neighbor)
       !$acc routine seq
-      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,viscosity, &
+      use input, only : ib,ie,jb,je,kb,ke,numq,npvals,nx,ny,viscosity, &
           pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
           prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pru,prv,prw,prt,prqv,prprs,prrho, &
-          ni,nj,mywest,mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcels_mpi,myid
+          ni,nj,mywest,mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcels_mpi,myid,dx,dy
       use constants
       use comm_module
       use misclibs
@@ -1229,25 +1229,45 @@
            y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
            neighbor = undefined_index   ! undefined_index means this droplet
                                         ! stays within the same MPI region
-      else if ( x3d .lt. xf(1) .and.  &
-                y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
+      else if ( x3d .lt. xf(1) .and. y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
+           if ( x3d .lt. xf(1)-dx*ni ) then
+              stop "Jump over the west nearest neighbor"
+           end if
            neighbor = mywest
       else if ( x3d .lt. xf(1) .and. y3d .lt. yf(1) ) then
+           if ( (x3d .lt. xf(1)-dx*ni) .or. (y3d .lt. yf(1)-dy*nj) ) then
+              stop "Jump over the southwest nearest neighbor"
+           end if
            neighbor = mysw
       else if ( x3d .lt. xf(1) .and. y3d .gt. yf(nj+1) ) then
+           if ( (x3d .lt. xf(1)-dx*ni) .or. (y3d .gt. yf(nj+1)+dy*nj) ) then
+              stop "Jump over the northwest nearest neighbor"
+           end if
            neighbor = mynw
-      else if ( x3d .gt. xf(ni+1) .and.  &
-                y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
+      else if ( x3d .gt. xf(ni+1) .and. y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
+           if ( x3d .gt. xf(ni+1)+dx*ni ) then
+              stop "Jump over the east nearest neighbor"
+           end if
            neighbor = myeast
       else if ( x3d .gt. xf(ni+1) .and. y3d .lt. yf(1) ) then
+           if ( (x3d .gt. xf(ni+1)+dx*ni) .or. (y3d .lt. yf(1)-dy*nj) ) then
+              stop "Jump over the southeast nearest neighbor"
+           end if
            neighbor = myse
       else if ( x3d .gt. xf(ni+1) .and. y3d .gt. yf(nj+1) ) then
+           if ( (x3d .gt. xf(ni+1)+dx*ni) .or. (y3d .gt. yf(nj+1)+dy*nj) ) then
+              stop "Jump over the northeast nearest neighbor"
+           end if
            neighbor = myne
-      else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. &
-                y3d .lt. yf(1) ) then
+      else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. y3d .lt. yf(1) ) then
+           if ( y3d .lt. yf(1)-dy*nj ) then
+              stop "Jump over the south nearest neighbor"
+           end if
            neighbor = mysouth
-      else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. &
-                y3d .gt. yf(nj+1) ) then
+      else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. y3d .gt. yf(nj+1) ) then
+           if ( y3d .gt. yf(nj+1)+dy*nj ) then
+              stop "Jump over the north nearest neighbor"
+           end if
            neighbor = mynorth
       else
            stop "This section should be never entered!"

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -119,7 +119,7 @@
                  num_nw1, num_sw1, num_se1                          ! nearest neighbor at different directions
       integer :: num_n2, num_s2, num_w2, num_e2, num_ne2, &         ! number of droplets that will enter the current MPI region
                  num_nw2, num_sw2, num_se2                          ! from each nearest neighbor at different directions
-      integer :: jn,js,jw,je,jne,jnw,jsw,jse
+      integer :: n_idx,s_idx,w_idx,e_idx,ne_idx,nw_idx,sw_idx,se_idx
       integer :: neighbor                                           ! indicate which MPI region a droplet stays after this time step 
       integer, dimension(nparcels_mpi) :: pdata_neighbor            ! array to store the new MPI region info for all the droplets
       integer :: n_recv,n_send,index_nw,index_sw,index_ne, &
@@ -659,8 +659,8 @@
     !            number of droplets leaving this MPI region at this time step
     num_holes = 0
     do np = 1, nparcels_mpi
-       if ( pdata_loc(np,1) .eq. undefined_index .and. &
-            pdata_loc(np,2) .eq. undefined_index ) then
+       if ( pdata_locind(np,1) .eq. undefined_index .and. &
+            pdata_locind(np,2) .eq. undefined_index ) then
           num_holes = num_holes + 1
        end if
     end do
@@ -680,8 +680,8 @@
     num_sw1 = 0 
     num_se1 = 0
     do np = 1, nparcels_mpi
-       if ( pdata_loc(np,1) .eq. undefined_index .and. &
-            pdata_loc(np,2) .eq. undefined_index ) then
+       if ( pdata_locind(np,1) .eq. undefined_index .and. &
+            pdata_locind(np,2) .eq. undefined_index ) then
           ! record the location index that can be used to store the new droplet
           ! information after the old drolpet leaves the current MPI region
           holes_ind(i) = np
@@ -809,46 +809,46 @@
                    reqs(n_send),ierr)
 
     ! extract the information of droplets that will leave the current MPI region 
-    jn = 1
-    js = 1
-    jw = 1
-    je = 1
-    jne = 1
-    jse = 1
-    jnw = 1
-    jsw = 1
+    n_idx = 1
+    s_idx = 1
+    w_idx = 1
+    e_idx = 1
+    ne_idx = 1
+    se_idx = 1
+    nw_idx = 1
+    sw_idx = 1
     do np = 1, nparcels_mpi
        if ( pdata_neighbor(np) .eq. mywest ) then
-          droplet_w1(jw,:) = pdata(np,:)
-          jw = jw + 1
+          droplet_w1(w_idx,:) = pdata(np,:)
+          w_idx = w_idx + 1
           pdata(np,:) = neg_huge
        else if ( pdata_neighbor(np) .eq. mysw ) then
-          droplet_sw1(jsw,:) = pdata(np,:)
-          jsw = jsw + 1
+          droplet_sw1(sw_idx,:) = pdata(np,:)
+          sw_idx = sw_idx + 1
           pdata(np,:) = neg_huge
        else if ( pdata_neighbor(np) .eq. mynw ) then
-          droplet_nw1(jnw,:) = pdata(np,:)
-          jnw = jnw + 1
+          droplet_nw1(nw_idx,:) = pdata(np,:)
+          nw_idx = nw_idx + 1
           pdata(np,:) = neg_huge
        else if ( pdata_neighbor(np) .eq. myeast ) then
-          droplet_e1(je,:) = pdata(np,:)
-          je = je + 1
+          droplet_e1(e_idx,:) = pdata(np,:)
+          e_idx = e_idx + 1
           pdata(np,:) = neg_huge
        else if ( pdata_neighbor(np) .eq. myne ) then
-          droplet_ne1(jne,:) = pdata(np,:)
-          jne = jne + 1
+          droplet_ne1(ne_idx,:) = pdata(np,:)
+          ne_idx = ne_idx + 1
           pdata(np,:) = neg_huge
        else if ( pdata_neighbor(np) .eq. myse ) then
-          droplet_se1(jse,:) = pdata(np,:)
-          jse = jse + 1
+          droplet_se1(se_idx,:) = pdata(np,:)
+          se_idx = se_idx + 1
           pdata(np,:) = neg_huge
        else if ( pdata_neighbor(np) .eq. mynorth ) then
-          droplet_n1(jn,:) = pdata(np,:)
-          jn = jn + 1
+          droplet_n1(n_idx,:) = pdata(np,:)
+          n_idx = n_idx + 1
           pdata(np,:) = neg_huge
        else if ( pdata_neighbor(np) .eq. mysouth ) then
-          droplet_s1(js,:) = pdata(np,:)
-          js = js + 1
+          droplet_s1(s_idx,:) = pdata(np,:)
+          s_idx = s_idx + 1
           pdata(np,:) = neg_huge
        end if
     end do
@@ -999,42 +999,42 @@
        if ( indx .eq. index_n ) then
           do i = 1, num_n2
              pdata(holes_ind(k),:) = droplet_n2(i,:)
-             k + 1
+             k = k + 1
           end do
        else if ( indx .eq. index_s ) then
           do i = 1, num_s2
              pdata(holes_ind(k),:) = droplet_s2(i,:)
-             k + 1
+             k = k + 1
           end do
        else if ( indx .eq. index_w ) then
           do i = 1, num_w2
              pdata(holes_ind(k),:) = droplet_w2(i,:)
-             k + 1
+             k = k + 1
           end do
        else if ( indx .eq. index_e ) then
           do i = 1, num_e2
              pdata(holes_ind(k),:) = droplet_e2(i,:)
-             k + 1
+             k = k + 1
           end do
        else if ( indx .eq. index_ne ) then
           do i = 1, num_ne2
              pdata(holes_ind(k),:) = droplet_ne2(i,:)
-             k + 1
+             k = k + 1
           end do
        else if ( indx .eq. index_nw ) then
           do i = 1, num_nw2
              pdata(holes_ind(k),:) = droplet_nw2(i,:)
-             k + 1
+             k = k + 1
           end do
        else if ( indx .eq. index_se ) then
           do i = 1, num_se2
              pdata(holes_ind(k),:) = droplet_se2(i,:)
-             k + 1
+             k = k + 1
           end do
        else if ( indx .eq. index_sw ) then
           do i = 1, num_sw2
              pdata(holes_ind(k),:) = droplet_sw2(i,:)
-             k + 1
+             k = k + 1
           end do
        end if
        n = n + 1
@@ -1049,7 +1049,7 @@
     !$acc update device(pdata)
 
     ! free up the memory for temporary variables
-    deallocate(holes_ind(num_holes))
+    deallocate(holes_ind)
     if (allocated(droplet_n1))  deallocate(droplet_n1)
     if (allocated(droplet_n2))  deallocate(droplet_n2)
     if (allocated(droplet_s1))  deallocate(droplet_s1)
@@ -1093,7 +1093,7 @@
 
       subroutine rk2_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug)
       !$acc routine seq
-      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,viscosity, &
+      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels_mpi,npvals,nx,ny,viscosity, &
           pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
           prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pru,prv,prw,prt,prqv,prprs,prrho
       use constants
@@ -1423,7 +1423,8 @@
       !$acc routine seq
       use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,viscosity, &
           pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
-          prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pru,prv,prw,prt,prqv,prprs,prrho
+          prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pru,prv,prw,prt,prqv,prprs,prrho, &
+          ni,nj,mywest,mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcels_mpi
       use constants
       use comm_module
       use misclibs
@@ -1669,7 +1670,7 @@
 
       subroutine interpolate_to_parcel(np,nrkp,pdata_locind,iflag,jflag,kflag,x3d,y3d,z3d,sig3d,uval,vval,wval,tval,qval,rhoval,prsval,xh,xf,yh,yf,zh,zf,zs,znt,sigma,sigmaf,ua,va,wa,ta,qa,rho,prs,sigdot)
       !$acc routine seq
-      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,nx,ny, &
+      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels_mpi,nx,ny, &
                         axisymm,terrain_flag,ni,nj,nip1,nk,nkp1, &
                         zt,rzt,imoist,nqv,bbc,imove,umove,vmove
       use constants
@@ -2069,6 +2070,9 @@
 
       use input
       !use input, only : nparcels,npvals,prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult,prms,przs,pru,prv,prw,prt,prqv,prprs,prrho
+#ifdef MPI
+      use mpi
+#endif
 #ifdef NETCDF
       use writeout_nc_module, only : writedropdiag_nc
 #endif
@@ -2222,8 +2226,14 @@
 
 #ifdef MPI
       ! The root rank will collect the diagnostic from different MPI ranks
-      call mpi_reduce(MPI_IN_PLACE,partnum,nk,MPI_REAL, &
-                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      ! Example usage: https://stackoverflow.com/questions/17741574/in-place-mpi-reduce-crashes-with-openmpi
+      if ( myid == 0 ) then
+         call mpi_reduce(MPI_IN_PLACE,partnum,nk,MPI_REAL, &
+                         MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      else
+         call mpi_reduce(partnum,partnum,nk,MPI_REAL, &
+                         MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      end if
       if ( myid == 0 ) then 
 #endif
       do iz=1,nk

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -106,27 +106,18 @@
       logical, parameter :: debug = .false.
 
       type(randomNumberSequence) :: randomNumbers
-      real, dimension(kb:ke+1) :: zf_tmp 
-      integer :: num_holes                                          ! how many new droplets could be added to "pdata"
-      integer, dimension(:), allocatable :: holes_ind               ! location index in "pdata" that can add a new droplet
-      real, dimension(:,:), allocatable :: droplet_n1, droplet_s1, droplet_w1,   &   ! information of droplets that will leave the 
-                                           droplet_e1, droplet_ne1, droplet_nw1, &   ! current MPI region and enter the nearest neighbor 
-                                           droplet_se1, droplet_sw1, &               ! at different directions;
-                                           droplet_n2, droplet_s2, droplet_w2,   &   ! 1 means sending array and
-                                           droplet_e2, droplet_ne2, droplet_nw2, &   ! 2 means receiving array
-                                           droplet_se2, droplet_sw2
-      integer :: num_n1, num_s1, num_w1, num_e1, num_ne1, &         ! number of droplets that will enter each 
-                 num_nw1, num_sw1, num_se1                          ! nearest neighbor at different directions
-      integer :: num_n2, num_s2, num_w2, num_e2, num_ne2, &         ! number of droplets that will enter the current MPI region
-                 num_nw2, num_sw2, num_se2                          ! from each nearest neighbor at different directions
-      integer :: n_idx,s_idx,w_idx,e_idx,ne_idx,nw_idx,sw_idx,se_idx
-      integer :: neighbor                                           ! indicate which MPI region a droplet stays after this time step 
-      integer, dimension(nparcels_mpi) :: pdata_neighbor            ! array to store the new MPI region info for all the droplets
-      integer :: n_recv,n_send,index_nw,index_sw,index_ne, &
-                 index_se,index_n,index_s,index_w,index_e
-      integer :: reqs1(16),reqs2(16)
-      integer :: tag_n,tag_s,tag_w,tag_e,tag_nw,tag_ne,tag_sw,tag_se,indx
-      integer, dimension(mpi_status_size,16) :: status1
+      real, dimension(kb:ke+1) :: zf_tmp
+
+#ifdef MPI 
+      integer :: num_holes                                 ! how many new droplets could be added to "pdata"
+      integer, dimension(:), allocatable :: holes_ind      ! location index in "pdata" that can add a new droplet
+      integer :: num1(num_nn)                              ! Number of droplets that will enter each nearest 
+                                                           ! neighbor at different directions
+      integer :: num2(num_nn)                              ! Number of droplets that will enter the current
+                                                           ! MPI region from each nearest neighbor
+      integer :: neighbor                                  ! indicate which MPI region a droplet stays after this time step 
+      integer, dimension(nparcels_mpi) :: pdata_neighbor   ! array to store the new MPI region info for all the droplets
+#endif
 
 #ifdef _VERIFY_FIND_LOC
       integer :: tmp_flag
@@ -141,11 +132,16 @@
 !  [Note:  for u,v the array index (i,j,0) means the surface, ie z=0]
 !     (for the parcel subroutines only!)
 
+#ifdef MPI
       pdata_neighbor = undefined_index
 
       !$acc data create (ta,zf_tmp) &
       !$acc      copyin (randomNumbers,randomNumbers%state, &
       !$acc              pdata_neighbor)
+#else
+      !$acc data create (ta,zf_tmp) &
+      !$acc      copyin (randomNumbers,randomNumbers%state)
+#endif
 
     IF(bbc.eq.1)THEN
       ! free slip ... extrapolate:
@@ -406,10 +402,13 @@
 
       ELSEIF (idropmethod.eq.1) THEN  !Implicit backward Euler for the droplet integration
 
+#ifdef MPI
       call BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000,neighbor)
 
       pdata_neighbor(np) = neighbor 
-
+#else
+      call BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000)
+#endif
       ENDIF dropmethod
 
 
@@ -633,32 +632,17 @@
 
 #ifdef MPI
 
-    !$acc update host(pdata,pdata_loc,pdata_neighbor)
-     
     ! JS: send/receive the droplet information through MPI;
     !     all the calculations below are done on CPU
 
-    ! initiate some MPI index and tag values
-    index_n  = undefined_index
-    index_s  = undefined_index
-    index_w  = undefined_index
-    index_e  = undefined_index
-    index_nw = undefined_index
-    index_sw = undefined_index
-    index_ne = undefined_index
-    index_se = undefined_index
+    !$acc update host(pdata,pdata_locind,pdata_neighbor)
 
-    tag_n  = 1001
-    tag_s  = 1002
-    tag_w  = 1003
-    tag_e  = 1004
-    tag_nw = 1005
-    tag_sw = 1006
-    tag_ne = 1007
-    tag_se = 1008
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    ! Step 1: Count the "num_holes", which is the number of "holes" in "pdata" !
+    !         at the beginning of this time step + the number of droplets      !
+    !         leaving this MPI region at this time step                        !
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    ! num_holes: number of "holes" in pdata at the beginning of this time step + 
-    !            number of droplets leaving this MPI region at this time step
     num_holes = 0
     do np = 1, nparcels_mpi
        if ( pdata_locind(np,1) .eq. undefined_index .and. &
@@ -667,450 +651,34 @@
        end if
     end do
 
-    ! allocate "hole" index array and initialize it with a negative value
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    ! Step 2: Allocate "hole" index array and initialize it ! 
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
     allocate(holes_ind(num_holes))
-    holes_ind = undefined_index
-
-    ! find out how many droplets will leave the current MPI region and to which neighbor
-    i = 1
-    num_n1 = 0
-    num_s1 = 0 
-    num_w1 = 0 
-    num_e1 = 0 
-    num_ne1 = 0
-    num_nw1 = 0
-    num_sw1 = 0 
-    num_se1 = 0
-    do np = 1, nparcels_mpi
-       if ( pdata_locind(np,1) .eq. undefined_index .and. &
-            pdata_locind(np,2) .eq. undefined_index ) then
-          ! record the location index that can be used to store the new droplet
-          ! information after the old drolpet leaves the current MPI region
-          holes_ind(i) = np
-          i = i + 1
-          if ( pdata_neighbor(np) .eq. mywest ) then
-             num_w1 = num_w1 + 1
-          else if ( pdata_neighbor(np) .eq. mysw ) then 
-             num_sw1 = num_sw1 + 1
-          else if ( pdata_neighbor(np) .eq. mynw ) then  
-             num_nw1 = num_nw1 + 1
-          else if ( pdata_neighbor(np) .eq. myeast ) then  
-             num_e1 = num_e1 + 1
-          else if ( pdata_neighbor(np) .eq. myne ) then  
-             num_ne1 = num_ne1 + 1
-          else if ( pdata_neighbor(np) .eq. myse ) then  
-             num_se1 = num_se1 + 1
-          else if ( pdata_neighbor(np) .eq. mynorth ) then  
-             num_n1 = num_n1 + 1
-          else if ( pdata_neighbor(np) .eq. mysouth ) then  
-             num_s1 = num_s1 + 1
-          end if
-       end if
+    do np = 1, num_holes
+       holes_ind(np) = undefined_index
     end do
 
-    ! allocate spaces to store the droplets that will leave the current MPI region
-    if ( num_n1 .ne. 0 ) then
-       allocate(droplet_n1(num_n1,npvals))
-    end if
-    if ( num_s1 .ne. 0 ) then
-       allocate(droplet_s1(num_s1,npvals))
-    end if
-    if ( num_w1 .ne. 0 ) then
-       allocate(droplet_w1(num_w1,npvals))
-    end if
-    if ( num_e1 .ne. 0 ) then
-       allocate(droplet_e1(num_e1,npvals))
-    end if
-    if ( num_ne1 .ne. 0 ) then
-       allocate(droplet_ne1(num_ne1,npvals))
-    end if
-    if ( num_nw1 .ne. 0 ) then
-       allocate(droplet_nw1(num_nw1,npvals))
-    end if
-    if ( num_se1 .ne. 0 ) then
-       allocate(droplet_se1(num_se1,npvals))
-    end if
-    if ( num_sw1 .ne. 0 ) then
-       allocate(droplet_sw1(num_sw1,npvals))
-    end if
-   
-    ! MPI Step 1: initiate the MPI non-blocking receive interface to 
-    !             know how many droplets from the nearest neighbors
-    n_recv = 1 
-    call mpi_irecv(num_n2,1,MPI_INT,mynorth,tag_n,MPI_COMM_WORLD, &
-                   reqs1(n_recv),ierr)
-    index_n = n_recv
-   
-    n_recv = n_recv + 1
-    call mpi_irecv(num_s2,1,MPI_INT,mysouth,tag_s,MPI_COMM_WORLD, &
-                   reqs1(n_recv),ierr)
-    index_s = n_recv
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    ! Step 3: Exchange the number of droplets that will enter/leave !
+    !         the current MPI region with its nearest neighbor      !
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    n_recv = n_recv + 1
-    call mpi_irecv(num_w2,1,MPI_INT,mywest,tag_w,MPI_COMM_WORLD, &
-                   reqs1(n_recv),ierr)
-    index_w = n_recv
+    call comm_droplet_number(holes_ind,num1,num2,pdata, &
+                             pdata_locind,pdata_neighbor)
 
-    n_recv = n_recv + 1
-    call mpi_irecv(num_e2,1,MPI_INT,myeast,tag_e,MPI_COMM_WORLD, &
-                   reqs1(n_recv),ierr)
-    index_e = n_recv
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    ! Step 4: Exchange the detailed information of the droplets that will  !
+    !         enter/leave the current MPI region with its nearest neighbor !
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    n_recv = n_recv + 1
-    call mpi_irecv(num_ne2,1,MPI_INT,myne,tag_ne,MPI_COMM_WORLD, &
-                   reqs1(n_recv),ierr)
-    index_ne = n_recv
-
-    n_recv = n_recv + 1
-    call mpi_irecv(num_nw2,1,MPI_INT,mynw,tag_nw,MPI_COMM_WORLD, &
-                   reqs1(n_recv),ierr)
-    index_nw = n_recv
- 
-    n_recv = n_recv + 1
-    call mpi_irecv(num_se2,1,MPI_INT,myse,tag_se,MPI_COMM_WORLD, &
-                   reqs1(n_recv),ierr)
-    index_se = n_recv
-
-    n_recv = n_recv + 1
-    call mpi_irecv(num_sw2,1,MPI_INT,mysw,tag_sw,MPI_COMM_WORLD, &
-                   reqs1(n_recv),ierr)
-    index_sw = n_recv
-
-    ! MPI Step 2: initiate the MPI non-blocking send interface to 
-    !             send how many droplets entering the nearest neighbor 
-    n_send = 9 
-    call mpi_isend(num_n1,1,MPI_INT,mynorth,tag_s,MPI_COMM_WORLD, &
-                   reqs1(n_send),ierr)
-
-    n_send = n_send + 1
-    call mpi_isend(num_s1,1,MPI_INT,mysouth,tag_n,MPI_COMM_WORLD, &
-                   reqs1(n_send),ierr)
-
-    n_send = n_send + 1
-    call mpi_isend(num_w1,1,MPI_INT,mywest,tag_e,MPI_COMM_WORLD, &
-                   reqs1(n_send),ierr)
-
-    n_send = n_send + 1
-    call mpi_isend(num_e1,1,MPI_INT,myeast,tag_w,MPI_COMM_WORLD, &
-                   reqs1(n_send),ierr)
-
-    n_send = n_send + 1
-    call mpi_isend(num_ne1,1,MPI_INT,myne,tag_sw,MPI_COMM_WORLD, &
-                   reqs1(n_send),ierr)
-
-    n_send = n_send + 1
-    call mpi_isend(num_nw1,1,MPI_INT,mynw,tag_se,MPI_COMM_WORLD, &
-                   reqs1(n_send),ierr)
-
-    n_send = n_send + 1
-    call mpi_isend(num_se1,1,MPI_INT,myse,tag_nw,MPI_COMM_WORLD, &
-                   reqs1(n_send),ierr)
-
-    n_send = n_send + 1
-    call mpi_isend(num_sw1,1,MPI_INT,mysw,tag_ne,MPI_COMM_WORLD, &
-                   reqs1(n_send),ierr)
-
-    ! extract the information of droplets that will leave the current MPI region 
-    n_idx = 1
-    s_idx = 1
-    w_idx = 1
-    e_idx = 1
-    ne_idx = 1
-    se_idx = 1
-    nw_idx = 1
-    sw_idx = 1
-    do np = 1, nparcels_mpi
-       if ( pdata_neighbor(np) .eq. mywest ) then
-          droplet_w1(w_idx,:) = pdata(np,:)
-          w_idx = w_idx + 1
-          pdata(np,:) = neg_huge
-       else if ( pdata_neighbor(np) .eq. mysw ) then
-          droplet_sw1(sw_idx,:) = pdata(np,:)
-          sw_idx = sw_idx + 1
-          pdata(np,:) = neg_huge
-       else if ( pdata_neighbor(np) .eq. mynw ) then
-          droplet_nw1(nw_idx,:) = pdata(np,:)
-          nw_idx = nw_idx + 1
-          pdata(np,:) = neg_huge
-       else if ( pdata_neighbor(np) .eq. myeast ) then
-          droplet_e1(e_idx,:) = pdata(np,:)
-          e_idx = e_idx + 1
-          pdata(np,:) = neg_huge
-       else if ( pdata_neighbor(np) .eq. myne ) then
-          droplet_ne1(ne_idx,:) = pdata(np,:)
-          ne_idx = ne_idx + 1
-          pdata(np,:) = neg_huge
-       else if ( pdata_neighbor(np) .eq. myse ) then
-          droplet_se1(se_idx,:) = pdata(np,:)
-          se_idx = se_idx + 1
-          pdata(np,:) = neg_huge
-       else if ( pdata_neighbor(np) .eq. mynorth ) then
-          droplet_n1(n_idx,:) = pdata(np,:)
-          n_idx = n_idx + 1
-          pdata(np,:) = neg_huge
-       else if ( pdata_neighbor(np) .eq. mysouth ) then
-          droplet_s1(s_idx,:) = pdata(np,:)
-          s_idx = s_idx + 1
-          pdata(np,:) = neg_huge
-       end if
-    end do
-
-    ! MPI step 3: allocate temporary arrays if there are 
-    !             new droplets from the nearest neighbor
-    n = 1
-    do while( n .le. n_recv )
-       call mpi_waitany(n_recv,reqs1(1:n_recv),indx,MPI_STATUS_IGNORE,ierr)
-       if ( indx .eq. index_n ) then
-          if ( num_n2 .ne. 0 ) allocate(droplet_n2(num_n2,npvals))
-       else if ( indx .eq. index_s ) then
-          if ( num_s2 .ne. 0 ) allocate(droplet_s2(num_s2,npvals))
-       else if ( indx .eq. index_w ) then
-          if ( num_w2 .ne. 0 ) allocate(droplet_w2(num_w2,npvals))
-       else if ( indx .eq. index_e ) then
-          if ( num_e2 .ne. 0 ) allocate(droplet_e2(num_e2,npvals))
-       else if ( indx .eq. index_ne ) then
-          if ( num_ne2 .ne. 0 ) allocate(droplet_ne2(num_ne2,npvals))
-       else if ( indx .eq. index_nw ) then
-          if ( num_nw2 .ne. 0 ) allocate(droplet_nw2(num_nw2,npvals))
-       else if ( indx .eq. index_se ) then
-          if ( num_se2 .ne. 0 ) allocate(droplet_se2(num_se2,npvals))
-       else if ( indx .eq. index_sw ) then
-          if ( num_sw2 .ne. 0 ) allocate(droplet_sw2(num_sw2,npvals))
-       end if
-       n = n + 1
-    end do
-
-    ! sanity check: if too many droplets enter the current MPI region
-    !               and exceed the number of "holes", stop the program
-    !               with an error message
-    if ( ( num_n2 + num_s2 + num_w2 + num_e2 + num_ne2 + &
-           num_nw2 + num_se2 + num_sw2 ) .gt. num_holes ) then
-       write(*,*) "Too many new droplets will enter the MPI rank: ", myid 
-       stop "Stop the program ..."
-    end if
-
-#if 0 
-    ! Diagnostic only 
-    write(*,*) "JS: myid = ", myid, ", new droplets = ", num_n2 + num_s2 + &
-               num_w2 + num_e2 + num_ne2 + num_nw2 + num_se2 + num_sw2
-    write(*,*) "JS: myid = ", myid, ", leaving droplets = ", num_n1 + num_s1 + &
-               num_w1 + num_e1 + num_ne1 + num_nw1 + num_se1 + num_sw1
-#endif
-
-    ! make sure that all the non-blocking MPI send operations are complete
-    n_send = n_send - 8
-    if ( n_send .ge. 1 ) then
-       call mpi_waitall (n_send,reqs1(9:9+n_send-1),status1(1:mpi_status_size,9:9+n_send-1),ierr)
-    endif
-
-    ! MPI step 4: initiate the MPI non-blocking receive interface to 
-    !             obtain new droplet information from the nearest neighbors
-
-    index_n  = undefined_index
-    index_s  = undefined_index
-    index_w  = undefined_index
-    index_e  = undefined_index
-    index_nw = undefined_index
-    index_sw = undefined_index
-    index_ne = undefined_index
-    index_se = undefined_index
-
-    tag_n    = undefined_index 
-    tag_s    = undefined_index 
-    tag_w    = undefined_index 
-    tag_e    = undefined_index 
-    tag_nw   = undefined_index 
-    tag_sw   = undefined_index 
-    tag_ne   = undefined_index 
-    tag_se   = undefined_index 
-
-    n_recv   = 0
-    if ( num_n2 .ne. 0 ) then
-       n_recv = n_recv + 1
-       tag_n  = 1000 + num_n2 
-       call mpi_irecv(droplet_n2,num_n2*npvals,MPI_REAL,mynorth,tag_n,MPI_COMM_WORLD, &
-                      reqs2(n_recv),ierr)
-       index_n = n_recv
-    end if
-    if ( num_s2 .ne. 0 ) then
-       n_recv = n_recv + 1
-       tag_s  = 1000 + num_s2
-       call mpi_irecv(droplet_s2,num_s2*npvals,MPI_REAL,mysouth,tag_s,MPI_COMM_WORLD, &
-                      reqs2(n_recv),ierr)
-       index_s = n_recv
-    end if
-    if ( num_w2 .ne. 0 ) then
-       n_recv = n_recv + 1
-       tag_w  = 1000 + num_w2
-       call mpi_irecv(droplet_w2,num_w2*npvals,MPI_REAL,mywest,tag_w,MPI_COMM_WORLD, &
-                      reqs2(n_recv),ierr)
-       index_w = n_recv
-    end if
-    if ( num_e2 .ne. 0 ) then
-       n_recv = n_recv + 1
-       tag_e  = 1000 + num_e2 
-       call mpi_irecv(droplet_e2,num_e2*npvals,MPI_REAL,myeast,tag_e,MPI_COMM_WORLD, &
-                      reqs2(n_recv),ierr)
-       index_e = n_recv
-    end if
-    if ( num_ne2 .ne. 0 ) then
-       n_recv = n_recv + 1
-       tag_ne = 1000 + num_ne2
-       call mpi_irecv(droplet_ne2,num_ne2*npvals,MPI_REAL,myne,tag_ne,MPI_COMM_WORLD, &
-                      reqs2(n_recv),ierr)
-       index_ne = n_recv
-    end if
-    if ( num_nw2 .ne. 0 ) then
-       n_recv = n_recv + 1
-       tag_nw = 1000 + num_nw2
-       call mpi_irecv(droplet_nw2,num_nw2*npvals,MPI_REAL,mynw,tag_nw,MPI_COMM_WORLD, &
-                      reqs2(n_recv),ierr)
-       index_nw = n_recv
-    end if
-    if ( num_se2 .ne. 0 ) then
-       n_recv = n_recv + 1
-       tag_se = 1000 + num_se2
-       call mpi_irecv(droplet_se2,num_se2*npvals,MPI_REAL,myse,tag_se,MPI_COMM_WORLD, &
-                      reqs2(n_recv),ierr)
-       index_se = n_recv
-    end if
-    if ( num_sw2 .ne. 0 ) then
-       n_recv = n_recv + 1
-       tag_sw = 1000 + num_sw2 
-       call mpi_irecv(droplet_sw2,num_sw2*npvals,MPI_REAL,mysw,tag_sw,MPI_COMM_WORLD, &
-                      reqs2(n_recv),ierr)
-       index_sw = n_recv
-    end if
-
-    ! MPI step 5: initiate the MPI non-blocking send interface to 
-    !             send the information of droplets that leave the 
-    !             current MPI region to the nearest neighbors 
-    n_send = 8
-    if ( num_n1 .ne. 0 ) then
-       n_send = n_send + 1
-       tag_s = 1000 + num_n1
-       call mpi_isend(droplet_n1,num_n1*npvals,MPI_REAL,mynorth,tag_s,MPI_COMM_WORLD, &
-                      reqs2(n_send),ierr)
-    end if
-    if ( num_s1 .ne. 0 ) then
-       n_send = n_send + 1
-       tag_n = 1000 + num_s1
-       call mpi_isend(droplet_s1,num_s1*npvals,MPI_REAL,mysouth,tag_n,MPI_COMM_WORLD, &
-                      reqs2(n_send),ierr)
-    end if
-    if ( num_w1 .ne. 0 ) then
-       n_send = n_send + 1
-       tag_e = 1000 + num_w1
-       call mpi_isend(droplet_w1,num_w1*npvals,MPI_REAL,mywest,tag_e,MPI_COMM_WORLD, &
-                      reqs2(n_send),ierr)
-    end if
-    if ( num_e1 .ne. 0 ) then
-       n_send = n_send + 1
-       tag_w = 1000 + num_e1
-       call mpi_isend(droplet_e1,num_e1*npvals,MPI_REAL,myeast,tag_w,MPI_COMM_WORLD, &
-                      reqs2(n_send),ierr)
-    end if
-    if ( num_ne1 .ne. 0 ) then
-       n_send = n_send + 1
-       tag_sw = 1000 + num_ne1
-       call mpi_isend(droplet_ne1,num_ne1*npvals,MPI_REAL,myne,tag_sw,MPI_COMM_WORLD, &
-                      reqs2(n_send),ierr)
-    end if
-    if ( num_nw1 .ne. 0 ) then
-       n_send = n_send + 1
-       tag_se = 1000 + num_nw1
-       call mpi_isend(droplet_nw1,num_nw1*npvals,MPI_REAL,mynw,tag_se,MPI_COMM_WORLD, &
-                      reqs2(n_send),ierr)
-    end if
-    if ( num_se1 .ne. 0 ) then
-       n_send = n_send + 1
-       tag_nw = 1000 + num_se1
-       call mpi_isend(droplet_se1,num_se1*npvals,MPI_REAL,myse,tag_nw,MPI_COMM_WORLD, &
-                      reqs2(n_send),ierr)
-    end if
-    if ( num_sw1 .ne. 0 ) then
-       n_send = n_send + 1
-       tag_ne = 1000 + num_sw1
-       call mpi_isend(droplet_sw1,num_sw1*npvals,MPI_REAL,mysw,tag_ne,MPI_COMM_WORLD, &
-                      reqs2(n_send),ierr)
-    end if
-
-    ! MPI step 6: update the "holes" in "pdata" with the new droplets entering 
-    !             the current MPI region from the nearest neighbor
-    n = 1
-    k = 1
-    do while( n .le. n_recv )
-       call mpi_waitany(n_recv,reqs2(1:n_recv),indx,MPI_STATUS_IGNORE,ierr)
-       if ( indx .eq. index_n ) then
-          do i = 1, num_n2
-             pdata(holes_ind(k),:) = droplet_n2(i,:)
-             k = k + 1
-          end do
-       else if ( indx .eq. index_s ) then
-          do i = 1, num_s2
-             pdata(holes_ind(k),:) = droplet_s2(i,:)
-             k = k + 1
-          end do
-       else if ( indx .eq. index_w ) then
-          do i = 1, num_w2
-             pdata(holes_ind(k),:) = droplet_w2(i,:)
-             k = k + 1
-          end do
-       else if ( indx .eq. index_e ) then
-          do i = 1, num_e2
-             pdata(holes_ind(k),:) = droplet_e2(i,:)
-             k = k + 1
-          end do
-       else if ( indx .eq. index_ne ) then
-          do i = 1, num_ne2
-             pdata(holes_ind(k),:) = droplet_ne2(i,:)
-             k = k + 1
-          end do
-       else if ( indx .eq. index_nw ) then
-          do i = 1, num_nw2
-             pdata(holes_ind(k),:) = droplet_nw2(i,:)
-             k = k + 1
-          end do
-       else if ( indx .eq. index_se ) then
-          do i = 1, num_se2
-             pdata(holes_ind(k),:) = droplet_se2(i,:)
-             k = k + 1
-          end do
-       else if ( indx .eq. index_sw ) then
-          do i = 1, num_sw2
-             pdata(holes_ind(k),:) = droplet_sw2(i,:)
-             k = k + 1
-          end do
-       end if
-       n = n + 1
-    end do
-
-    ! make sure that all the non-blocking MPI send operations are complete
-    n_send = n_send - 8
-    if ( n_send .ge. 1 ) then
-       call mpi_waitall (n_send,reqs2(9:9+n_send-1),status1(1:mpi_status_size,9:9+n_send-1),ierr)
-    endif
+    call comm_droplet_value(holes_ind,num1,num2,pdata,pdata_neighbor)
 
     !$acc update device(pdata)
 
     ! free up the memory for temporary variables
     deallocate(holes_ind)
-    if (allocated(droplet_n1))  deallocate(droplet_n1)
-    if (allocated(droplet_n2))  deallocate(droplet_n2)
-    if (allocated(droplet_s1))  deallocate(droplet_s1)
-    if (allocated(droplet_s2))  deallocate(droplet_s2)
-    if (allocated(droplet_w1))  deallocate(droplet_w1)
-    if (allocated(droplet_w2))  deallocate(droplet_w2)
-    if (allocated(droplet_e1))  deallocate(droplet_e1)
-    if (allocated(droplet_e2))  deallocate(droplet_e2)
-    if (allocated(droplet_ne1)) deallocate(droplet_ne1)
-    if (allocated(droplet_ne2)) deallocate(droplet_ne2)
-    if (allocated(droplet_nw1)) deallocate(droplet_nw1)
-    if (allocated(droplet_nw2)) deallocate(droplet_nw2)
-    if (allocated(droplet_se1)) deallocate(droplet_se1)
-    if (allocated(droplet_se2)) deallocate(droplet_se2)
-    if (allocated(droplet_sw1)) deallocate(droplet_sw1)
-    if (allocated(droplet_sw2)) deallocate(droplet_sw2)
 
     if(timestats.ge.1) time_droplet_reduce=time_droplet_reduce+mytime()
 #endif
@@ -1501,10 +1069,10 @@
       real, intent(inout) :: x3d,y3d,z3d,sig3d,rhoval,tval
       real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
       integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind
-      integer, intent(out) :: neighbor  ! indicate which MPI region a droplet 
-                                        ! stays after this time step 
       real, intent(out) :: Nup,rhop0,taup0,rp0
       real, intent(in) :: dt,part_grav1,part_grav2,part_grav3
+      integer, intent(out), optional :: neighbor  ! indicate which MPI region a droplet 
+                                                  ! stays after this time step 
 
       integer :: nrkp
 
@@ -1652,8 +1220,11 @@
       ! just assume periodic lateral boundary conditions
       ! (no matter what actual settings are for wbc,ebc,sbc,nbc)
 
-      ! JS: determine which new MPI region this droplet 
-      !     enters or stays for the next time step
+#ifdef MPI
+
+      ! determine which new MPI region this droplet 
+      ! enters or stays for the next time step
+
       if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and.  &
            y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
            neighbor = undefined_index   ! undefined_index means this droplet
@@ -1678,6 +1249,8 @@
       else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. &
                 y3d .gt. yf(nj+1) ) then
            neighbor = mynorth
+      else
+           stop "This section should be never entered!"
       end if
 
       if ( neighbor .ne. undefined_index ) then
@@ -1685,6 +1258,8 @@
          pdata_locind(np,2) = undefined_index
          pdata_locind(np,3) = undefined_index
       end if
+
+#endif
 
       if ( x3d .lt. minx ) then
          x3d = x3d + ( maxx - minx )

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -35,7 +35,8 @@
           kmt,npvals,nparcels,npvars,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,bbc,tbc,imove,zt,rzt, &
           umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
           prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult,prms,przs,pru,prv,prw,prt,prqv,prprs,prrho, &
-          timestats,time_droplet,mytime,ierr,time_droplet_reduce,maxx,maxy,maxz
+          timestats,time_droplet,mytime,ierr,time_droplet_reduce,maxx,maxy,maxz, &
+          nparcels_mpi,ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest
       use constants
       use comm_module
       use misclibs
@@ -71,7 +72,7 @@
       real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: ua,uten
       real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: va,vten
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: wa,wten
-      real, intent(inout), dimension(nparcels,npvals) :: pdata
+      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
 
       real, intent(inout), dimension(jmp,kmp) :: pw1,pw2,pe1,pe2
       real, intent(inout), dimension(imp,kmp) :: ps1,ps2,pn1,pn2
@@ -82,7 +83,7 @@
       real, intent(inout), dimension(imp,cmp,kmp)   :: ss31,ss32,sn31,sn32
       real, intent(inout), dimension(cmp,cmp,kmt+1) :: n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2
       integer, intent(inout), dimension(rmp) :: reqs_s
-      integer, intent(inout), dimension(nparcels,3) :: pdata_locind    ! x/y/z location index of each parcel
+      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind    ! x/y/z location index of each parcel
 
       !Need to compute the true temperature
       real, dimension(ib:ie,jb:je,kb:ke) :: ta
@@ -103,9 +104,29 @@
       integer :: idropmethod
 
       logical, parameter :: debug = .false.
-     
-      real, dimension(kb:ke+1) :: zf_tmp 
+
       type(randomNumberSequence) :: randomNumbers
+      real, dimension(kb:ke+1) :: zf_tmp 
+      integer :: num_holes                                          ! how many new droplets could be added to "pdata"
+      integer, dimension(:), allocatable :: holes_ind               ! location index in "pdata" that can add a new droplet
+      real, dimension(:,:), allocatable :: droplet_n1, droplet_s1, droplet_w1,   &   ! information of droplets that will leave the 
+                                           droplet_e1, droplet_ne1, droplet_nw1, &   ! current MPI region and enter the nearest neighbor 
+                                           droplet_se1, droplet_sw1, &               ! at different directions;
+                                           droplet_n2, droplet_s2, droplet_w2,   &   ! 1 means sending array and
+                                           droplet_e2, droplet_ne2, droplet_nw2, &   ! 2 means receiving array
+                                           droplet_se2, droplet_sw2
+      integer :: num_n1, num_s1, num_w1, num_e1, num_ne1, &         ! number of droplets that will enter each 
+                 num_nw1, num_sw1, num_se1                          ! nearest neighbor at different directions
+      integer :: num_n2, num_s2, num_w2, num_e2, num_ne2, &         ! number of droplets that will enter the current MPI region
+                 num_nw2, num_sw2, num_se2                          ! from each nearest neighbor at different directions
+      integer :: jn,js,jw,je,jne,jnw,jsw,jse
+      integer :: neighbor                                           ! indicate which MPI region a droplet stays after this time step 
+      integer, dimension(nparcels_mpi) :: pdata_neighbor            ! array to store the new MPI region info for all the droplets
+      integer :: n_recv,n_send,index_nw,index_sw,index_ne, &
+                 index_se,index_n,index_s,index_w,index_e
+      integer :: reqs(16)
+      integer :: tag_n,tag_s,tag_w,tag_e,tag_nw,tag_ne,tag_sw,tag_se,indx
+      integer, dimension(mpi_status_size,8) :: status1
 
 #ifdef _VERIFY_FIND_LOC
       integer :: tmp_flag
@@ -260,6 +281,7 @@
 
     num100 = 0
     num1000 = 0
+    pdata_neighbor = undefined_index
 
 #ifdef _B4B01F
     !$acc update &
@@ -271,7 +293,7 @@
     !$acc loop gang vector private(zf_tmp)
 #endif
     nploop:  &
-    DO np=1,nparcels
+    DO np=1,nparcels_mpi
 
       x3d = pdata(np,prx)
       y3d = pdata(np,pry)
@@ -382,7 +404,9 @@
 
       ELSEIF (idropmethod.eq.1) THEN  !Implicit backward Euler for the droplet integration
 
-      call BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000)
+      call BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000,neighbor)
+
+      pdata_neighbor(np) = neighbor 
 
       ENDIF dropmethod
 
@@ -573,23 +597,23 @@
 
       ELSE
 
-        ! set to really small number (so we can use the allreduce command below)
+        ! set to really small number
 
-        pdata(np,prx) = -1.0e30
-        pdata(np,pry) = -1.0e30
+        pdata(np,prx) = neg_huge 
+        pdata(np,pry) = neg_huge
         if( .not. terrain_flag )then
-          pdata(np,prz) = -1.0e30
+          pdata(np,prz) = neg_huge
         else
-          pdata(np,prsig) = -1.0e30
+          pdata(np,prsig) = neg_huge
         endif
-        pdata(np,prvpx) = -1.0e30
-        pdata(np,prvpy) = -1.0e30
-        pdata(np,prvpz) = -1.0e30
-        pdata(np,prrp) = -1.0e30
-        pdata(np,prtp) = -1.0e30
-        pdata(np,prms) = -1.0e30
-        pdata(np,prmult) = -1.0e30
-        pdata(np,pract) = -1.0e30
+        pdata(np,prvpx) = neg_huge
+        pdata(np,prvpy) = neg_huge
+        pdata(np,prvpz) = neg_huge
+        pdata(np,prrp) = neg_huge
+        pdata(np,prtp) = neg_huge
+        pdata(np,prms) = neg_huge
+        pdata(np,prmult) = neg_huge
+        pdata(np,pract) = neg_huge
 
 #endif
 
@@ -606,19 +630,350 @@
 !  communicate data  (for MPI runs)
 
 #ifdef MPI
-      !$acc update host(pdata)
-      !!$acc host_data use_device(pdata)
-      if( .not. terrain_flag )then
-        !call MPI_ALLREDUCE(MPI_IN_PLACE,pdata(1,1),npvars*nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
-        call MPI_ALLREDUCE(MPI_IN_PLACE,pdata,npvars*nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
-      else
-        !JMD not clear why two MPI_ALLREDUCE are being performed here
-        ! call MPI_ALLREDUCE(MPI_IN_PLACE,pdata(1,1),(npvars-1)*nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
-        ! call MPI_ALLREDUCE(MPI_IN_PLACE,pdata(1,prsig),nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
-        call MPI_ALLREDUCE(MPI_IN_PLACE,pdata,npvars*nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
-      endif
-      !$acc update device(pdata)
-      if(timestats.ge.1) time_droplet_reduce=time_droplet_reduce+mytime()
+
+    !$acc update host(pdata,pdata_loc)
+     
+    ! JS: all the calculations below are done on CPU
+
+    num_holes = 0
+    do np = 1, nparcels_mpi
+       if ( pdata_loc(np,1) .eq. undefined_index .and. &
+            pdata_loc(np,2) .eq. undefined_index ) then
+          num_holes = num_holes + 1   ! number of "holes" in pdata at the beginning 
+                                      ! of this time step + number of droplets
+                                      ! leaving this MPI region at this time step
+       end if
+    end do
+
+    allocate(holes_ind(num_holes))
+    holes_ind = undefined_index    ! initialize the "hole" index array with a negative value
+
+    i = 1
+    num_n = 0
+    num_s = 0 
+    num_w = 0 
+    num_e = 0 
+    num_ne = 0
+    num_nw = 0
+    num_sw = 0 
+    num_se = 0
+
+    ! find out how many droplets will leave the current MPI region and to which neighbor
+    do np = 1, nparcels_mpi
+       if ( pdata_loc(np,1) .eq. undefined_index .and. &
+            pdata_loc(np,2) .eq. undefined_index ) then
+          holes_ind(i) = np  ! record the location index that can be used to
+                             ! store the new droplet information after the 
+                             ! old drolpet leaves the current MPI region
+          i = i + 1
+          if ( pdata_neighbor(np) .eq. mywest ) then
+             num_w = num_w + 1
+          else if ( pdata_neighbor(np) .eq. mysw ) then 
+             num_sw = num_sw + 1
+          else if ( pdata_neighbor(np) .eq. mynw ) then  
+             num_nw = num_nw + 1
+          else if ( pdata_neighbor(np) .eq. myeast ) then  
+             num_e = num_e + 1
+          else if ( pdata_neighbor(np) .eq. myne ) then  
+             num_ne = num_ne + 1
+          else if ( pdata_neighbor(np) .eq. myse ) then  
+             num_se = num_se + 1
+          else if ( pdata_neighbor(np) .eq. mynorth ) then  
+             num_n = num_n + 1
+          else if ( pdata_neighbor(np) .eq. mysouth ) then  
+             num_s = num_s + 1
+          end if
+       end if
+    end do
+
+    ! allocate spaces to store the droplets that will leave the current MPI region
+    if ( num_n .ne. 0 ) then
+       allocate(droplet_n1(num_n,npvals))
+    end if
+    if ( num_s .ne. 0 ) then
+       allocate(droplet_s1(num_s,npvals))
+    end if
+    if ( num_w .ne. 0 ) then
+       allocate(droplet_w1(num_w,npvals))
+    end if
+    if ( num_e .ne. 0 ) then
+       allocate(droplet_e1(num_e,npvals))
+    end if
+    if ( num_ne .ne. 0 ) then
+       allocate(droplet_ne1(num_ne,npvals))
+    end if
+    if ( num_nw .ne. 0 ) then
+       allocate(droplet_nw1(num_nw,npvals))
+    end if
+    if ( num_se .ne. 0 ) then
+       allocate(droplet_se1(num_se,npvals))
+    end if
+    if ( num_sw .ne. 0 ) then
+       allocate(droplet_sw1(num_sw,npvals))
+    end if
+    
+    ! extract the information of droplets that will leave the current MPI region 
+    jn = 1
+    js = 1
+    jw = 1
+    je = 1
+    jne = 1
+    jse = 1
+    jnw = 1
+    jsw = 1
+    do np = 1, nparcels_mpi
+       if ( pdata_neighbor(np) .eq. mywest ) then
+          droplet_w1(jw,:) = pdata(np,:)
+          jw = jw + 1
+          pdata(np,:) = neg_huge
+       else if ( pdata_neighbor(np) .eq. mysw ) then
+          droplet_sw1(jsw,:) = pdata(np,:)
+          jsw = jsw + 1
+          pdata(np,:) = neg_huge
+       else if ( pdata_neighbor(np) .eq. mynw ) then
+          droplet_nw1(jnw,:) = pdata(np,:)
+          jnw = jnw + 1
+          pdata(np,:) = neg_huge
+       else if ( pdata_neighbor(np) .eq. myeast ) then
+          droplet_e1(je,:) = pdata(np,:)
+          je = je + 1
+          pdata(np,:) = neg_huge
+       else if ( pdata_neighbor(np) .eq. myne ) then
+          droplet_ne1(jne,:) = pdata(np,:)
+          jne = jne + 1
+          pdata(np,:) = neg_huge
+       else if ( pdata_neighbor(np) .eq. myse ) then
+          droplet_se1(jse,:) = pdata(np,:)
+          jse = jse + 1
+          pdata(np,:) = neg_huge
+       else if ( pdata_neighbor(np) .eq. mynorth ) then
+          droplet_n1(jn,:) = pdata(np,:)
+          jn = jn + 1
+          pdata(np,:) = neg_huge
+       else if ( pdata_neighbor(np) .eq. mysouth ) then
+          droplet_s1(js,:) = pdata(np,:)
+          js = js + 1
+          pdata(np,:) = neg_huge
+       end if
+    end do
+
+    ! initiate some MPI index and tag values
+    index_n  = undefined_index 
+    index_s  = undefined_index
+    index_w  = undefined_index
+    index_e  = undefined_index
+    index_nw = undefined_index 
+    index_sw = undefined_index
+    index_ne = undefined_index
+    index_se = undefined_index
+
+    tag_n  = 1001
+    tag_s  = 1002
+    tag_w  = 1003
+    tag_e  = 1004
+    tag_nw = 1005
+    tag_sw = 1006
+    tag_ne = 1007
+    tag_se = 1008
+
+    ! initiate the MPI non-blocking receive interface to 
+    ! receive information from the nearest neighbor 
+    n_recv   = 0
+    if ( num_n .ne. 0 ) then
+       n_recv = n_recv + 1
+       call mpi_irecv(droplet_n2,num_n*npvals,MPI_REAL,mynorth,tag_n,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr) 
+       index_n = n_recv
+    end if
+    if ( num_s .ne. 0 ) then
+       n_recv = n_recv + 1
+       call mpi_irecv(droplet_s2,num_s*npvals,MPI_REAL,mysouth,tag_s,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr) 
+       index_s = n_recv
+    end if
+    if ( num_w .ne. 0 ) then
+       n_recv = n_recv + 1
+       call mpi_irecv(droplet_w2,num_w*npvals,MPI_REAL,mywest,tag_w,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr) 
+       index_w = n_recv
+    end if
+    if ( num_e .ne. 0 ) then
+       n_recv = n_recv + 1
+       call mpi_irecv(droplet_e2,num_e*npvals,MPI_REAL,myeast,tag_e,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr) 
+       index_e = n_recv
+    end if
+    if ( num_ne .ne. 0 ) then
+       n_recv = n_recv + 1
+       call mpi_irecv(droplet_ne2,num_ne*npvals,MPI_REAL,myne,tag_ne,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr) 
+       index_ne = n_recv
+    end if
+    if ( num_nw .ne. 0 ) then
+       n_recv = n_recv + 1
+       call mpi_irecv(droplet_nw2,num_nw*npvals,MPI_REAL,mynw,tag_nw,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr) 
+       index_nw = n_recv
+    end if
+    if ( num_se .ne. 0 ) then
+       n_recv = n_recv + 1
+       call mpi_irecv(droplet_se2,num_se*npvals,MPI_REAL,myse,tag_se,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr) 
+       index_se = n_recv
+    end if
+    if ( num_sw .ne. 0 ) then
+       n_recv = n_recv + 1
+       call mpi_irecv(droplet_sw2,num_sw*npvals,MPI_REAL,mysw,tag_sw,MPI_COMM_WORLD, &
+                      reqs(n_recv),ierr) 
+       index_sw = n_recv
+    end if
+
+    ! initiate the MPI non-blocking send interface to 
+    ! send information to the nearest neighbor 
+    n_send = 8
+    if ( num_n .ne. 0 ) then
+       n_send = n_send + 1
+       call mpi_isend(droplet_n1,num_n*npvals,MPI_REAL,mynorth,tag_n,MPI_COMM_WORLD, &
+                      reqs(n_send),ierr)
+    end if
+    if ( num_s .ne. 0 ) then
+       n_send = n_send + 1
+       call mpi_isend(droplet_s1,num_s*npvals,MPI_REAL,mysouth,tag_s,MPI_COMM_WORLD, &
+                      reqs(n_send),ierr)
+    end if
+    if ( num_w .ne. 0 ) then
+       n_send = n_send + 1
+       call mpi_isend(droplet_w1,num_w*npvals,MPI_REAL,mywest,tag_w,MPI_COMM_WORLD, &
+                      reqs(n_send),ierr)
+    end if
+    if ( num_e .ne. 0 ) then
+       n_send = n_send + 1
+       call mpi_isend(droplet_e1,num_e*npvals,MPI_REAL,myeast,tag_e,MPI_COMM_WORLD, &
+                      reqs(n_send),ierr)
+    end if
+    if ( num_ne .ne. 0 ) then
+       n_send = n_send + 1
+       call mpi_isend(droplet_ne1,num_ne*npvals,MPI_REAL,myne,tag_ne,MPI_COMM_WORLD, &
+                      reqs(n_send),ierr)
+    end if
+    if ( num_nw .ne. 0 ) then
+       n_send = n_send + 1
+       call mpi_isend(droplet_nw1,num_nw*npvals,MPI_REAL,mynw,tag_nw,MPI_COMM_WORLD, &
+                      reqs(n_send),ierr)
+    end if
+    if ( num_se .ne. 0 ) then
+       n_send = n_send + 1
+       call mpi_isend(droplet_se1,num_se*npvals,MPI_REAL,myse,tag_se,MPI_COMM_WORLD, &
+                      reqs(n_send),ierr)
+    end if
+    if ( num_sw .ne. 0 ) then
+       n_send = n_send + 1
+       call mpi_isend(droplet_sw1,num_sw*npvals,MPI_REAL,mysw,tag_sw,MPI_COMM_WORLD, &
+                      reqs(n_send),ierr)
+    end if
+
+    ! update the "holes" in "pdata" with the new droplets entering 
+    ! the current MPI region from the nearest neighbor
+    n = 1
+    k = 1
+    do while( n .le. n_recv )
+       call mpi_waitany(n_recv,reqs(1:n_recv),indx,MPI_STATUS_IGNORE,ierr)
+       if ( indx .eq. index_n ) then
+          do i = 1, num_n
+             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from mynorth'
+             pdata(holes_ind(k),:) = droplet_n2(i,:)
+             k + 1
+          end do
+       else if ( indx .eq. index_s ) then
+          do i = 1, num_s
+             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from mysouth'
+             pdata(holes_ind(k),:) = droplet_s2(i,:)
+             k + 1
+          end do
+       else if ( indx .eq. index_w ) then
+          do i = 1, num_w
+             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from mywest'
+             pdata(holes_ind(k),:) = droplet_w2(i,:)
+             k + 1
+          end do
+       else if ( indx .eq. index_e ) then
+          do i = 1, num_e
+             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from myeast'
+             pdata(holes_ind(k),:) = droplet_e2(i,:)
+             k + 1
+          end do
+       else if ( indx .eq. index_ne ) then
+          do i = 1, num_ne
+             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from myne'
+             pdata(holes_ind(k),:) = droplet_ne2(i,:)
+             k + 1
+          end do
+       else if ( indx .eq. index_nw ) then
+          do i = 1, num_nw
+             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from mynw'
+             pdata(holes_ind(k),:) = droplet_nw2(i,:)
+             k + 1
+          end do
+       else if ( indx .eq. index_se ) then
+          do i = 1, num_se
+             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from myse'
+             pdata(holes_ind(k),:) = droplet_se2(i,:)
+             k + 1
+          end do
+       else if ( indx .eq. index_sw ) then
+          do i = 1, num_sw
+             if ( k .gt. num_holes ) stop 'no more space to receive new droplets from mysw'
+             pdata(holes_ind(k),:) = droplet_sw2(i,:)
+             k + 1
+          end do
+       end if
+       n = n + 1
+    end do
+
+    ! make sure that all the non-blocking MPI send operations are complete
+    n_send = n_send - 8
+    if ( n_send .ge. 1 ) then
+       call mpi_waitall (n_send,reqs(8:8+n_send-1),status1(1:mpi_status_size,8:8+n_send-1),ierr)
+    endif
+
+    !$acc update device(pdata)
+
+    deallocate(holes_ind(num_holes))
+   if ( num_n .ne. 0 ) then
+       allocate(droplet_n1(num_n,npvals))
+       allocate(droplet_n2(num_n,npvals))
+    end if
+    if ( num_s .ne. 0 ) then
+       allocate(droplet_s1(num_s,npvals))
+       allocate(droplet_s2(num_s,npvals))
+    end if
+    if ( num_w .ne. 0 ) then
+       allocate(droplet_w1(num_w,npvals))
+       allocate(droplet_w2(num_w,npvals))
+    end if
+    if ( num_e .ne. 0 ) then
+       allocate(droplet_e1(num_e,npvals))
+       allocate(droplet_e2(num_e,npvals))
+    end if
+    if ( num_ne .ne. 0 ) then
+       allocate(droplet_ne1(num_ne,npvals))
+       allocate(droplet_ne2(num_ne,npvals))
+    end if
+    if ( num_nw .ne. 0 ) then
+       allocate(droplet_nw1(num_nw,npvals))
+       allocate(droplet_nw2(num_nw,npvals))
+    end if
+    if ( num_se .ne. 0 ) then
+       allocate(droplet_se1(num_se,npvals))
+       allocate(droplet_se2(num_se,npvals))
+    end if
+    if ( num_sw .ne. 0 ) then
+       allocate(droplet_sw1(num_sw,npvals))
+       allocate(droplet_sw2(num_sw,npvals))
+    end if
+
+
+    if(timestats.ge.1) time_droplet_reduce=time_droplet_reduce+mytime()
 #endif
 
 
@@ -627,7 +982,7 @@
 
       if( terrain_flag )then
             call getparcelzs(xh,uh,ruh,xf,yh,vh,rvh,yf,zs,pdata)
-            DO np=1,nparcels
+            DO np=1,nparcels_mpi
               ! get z from sigma:
               ! (see Section 3 of "The governing equations for CM1", 
               !  http://www2.mmm.ucar.edu/people/bryan/cm1/cm1_equations.pdf)
@@ -674,8 +1029,8 @@
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: rho,prs
       real, intent(in), dimension(ib:ie,jb:je) :: znt
       real, intent(inout) :: x3d,y3d,z3d,sig3d,rhoval,tval
-      real, intent(inout), dimension(nparcels,npvals) :: pdata
-      integer, intent(inout), dimension(nparcels,3) :: pdata_locind
+      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
+      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind
 
       real, intent(out) :: Nup,rhop0,taup0,rp0
       real, intent(in) :: dt,part_grav1,part_grav2,part_grav3
@@ -970,7 +1325,7 @@
 
       end subroutine rk2_integration
 
-      subroutine BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000)
+      subroutine BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000,neighbor)
       !$acc routine seq
       use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,viscosity, &
           pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
@@ -1004,8 +1359,10 @@
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: rho,prs
       real, intent(in), dimension(ib:ie,jb:je) :: znt
       real, intent(inout) :: x3d,y3d,z3d,sig3d,rhoval,tval
-      real, intent(inout), dimension(nparcels,npvals) :: pdata
-      integer, intent(inout), dimension(nparcels,3) :: pdata_locind
+      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
+      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind
+      integer, intent(out) :: neighbor  ! indicate which MPI region a droplet 
+                                        ! stays after this time step 
       real, intent(out) :: Nup,rhop0,taup0,rp0
       real, intent(in) :: dt,part_grav1,part_grav2,part_grav3
 
@@ -1155,14 +1512,42 @@
       ! just assume periodic lateral boundary conditions
       ! (no matter what actual settings are for wbc,ebc,sbc,nbc)
 
-      if(x3d.lt.minx)then
-        x3d=x3d+(maxx-minx)
-        pdata_locind(np,1) = undefined_index
-      endif
-      if(x3d.gt.maxx)then
-        x3d=x3d-(maxx-minx)
-        pdata_locind(np,1) = undefined_index
-      endif
+      ! determine which new MPI region this droplet 
+      ! enters or stays for the next time step
+      if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and.  &
+           y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
+           neighbor = undefined_index   ! undefined_index means this droplet
+                                        ! stays within the same MPI region
+      else if ( x3d .lt. xf(1) .and.  &
+                y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
+           neighbor = mywest
+      else if ( x3d .lt. xf(1) .and. y3d .lt. yf(1) ) then
+           neighbor = mysw
+      else if ( x3d .lt. xf(1) .and. y3d .gt. yf(nj+1) ) then
+           neighbor = mynw
+      else if ( x3d .gt. xf(nj+1) .and.  &
+                y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
+           neighbor = myeast
+      else if ( x3d .gt. xf(nj+1) .and. y3d .lt. yf(1) ) then
+           neighbor = myse
+      else if ( x3d .gt. xf(nj+1) .and. y3d .gt. yf(nj+1) ) then
+           neighbor = myne
+      else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. &
+                y3d .lt. yf(1) ) then
+           neighbor = mysouth
+      else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. &
+                y3d .gt. yf(nj+1) ) then
+           neighbor = mynorth
+      end if
+
+      if ( x3d .lt. minx ) then
+         x3d = x3d + ( maxx - minx )
+         pdata_locind(np,1) = undefined_index
+      end if
+      if ( x3d .gt. maxx ) then
+         x3d = x3d - ( maxx - minx )
+         pdata_locind(np,1) = undefined_index
+      end if
 
       if( (y3d.gt.maxy).and.(axisymm.ne.1).and.(ny.ne.1) )then
         y3d=y3d-(maxy-miny)
@@ -1214,7 +1599,7 @@
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: ta
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: rho,prs
       real, intent(in), dimension(ib:ie,jb:je) :: znt
-      integer, intent(inout), dimension(nparcels,3) :: pdata_locind    ! x/y/z location index of each parcel
+      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind    ! x/y/z location index of each parcel
 
       integer, intent(in) :: np,nrkp
       integer, intent(inout) :: iflag,jflag,kflag
@@ -1597,8 +1982,8 @@
 
       integer, intent(inout) :: nrec
       real, intent(in) :: rtime
-      real, intent(in), dimension(nparcels,npvals) :: pdata
-      integer, intent(inout), dimension(nparcels,3) :: pdata_locind    ! x/y/z location index of each parcel
+      real, intent(in), dimension(nparcels_mpi,npvals) :: pdata
+      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind    ! x/y/z location index of each parcel
       real, intent(in), dimension(ib:ie,jb:je,kb:ke) :: zh
       real, intent(in), dimension(ib:ie,jb:je,kb:ke+1) :: zf
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1897,7 +1897,7 @@
       if ( myid == 0 ) then
 #endif
       write(6,200) 'rtime', rtime
-      write(6,200) 'tnumpart', dble(tnumpart)
+      write(6,200) 'tnumpart', real(tnumpart)
       write(6,200) 'radavg',radavg
       write(6,200) 'radmin',radmin
       write(6,200) 'radmax',radmax

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1665,12 +1665,12 @@
            neighbor = mysw
       else if ( x3d .lt. xf(1) .and. y3d .gt. yf(nj+1) ) then
            neighbor = mynw
-      else if ( x3d .gt. xf(nj+1) .and.  &
+      else if ( x3d .gt. xf(ni+1) .and.  &
                 y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
            neighbor = myeast
-      else if ( x3d .gt. xf(nj+1) .and. y3d .lt. yf(1) ) then
+      else if ( x3d .gt. xf(ni+1) .and. y3d .lt. yf(1) ) then
            neighbor = myse
-      else if ( x3d .gt. xf(nj+1) .and. y3d .gt. yf(nj+1) ) then
+      else if ( x3d .gt. xf(ni+1) .and. y3d .gt. yf(nj+1) ) then
            neighbor = myne
       else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. &
                 y3d .lt. yf(1) ) then

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -36,7 +36,7 @@
           umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
           prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult,prms,przs,pru,prv,prw,prt,prqv,prprs,prrho, &
           timestats,time_droplet,mytime,ierr,time_droplet_reduce,maxx,maxy,maxz, &
-          nparcels_mpi,ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest,myid
+          ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest,myid,nparcels_mpi
       use constants
       use comm_module
       use misclibs
@@ -133,7 +133,9 @@
 !     (for the parcel subroutines only!)
 
 #ifdef MPI
-      pdata_neighbor = undefined_index
+      do np = 1, nparcels_mpi
+         pdata_neighbor(np) = undefined_index
+      end do
 
       !$acc data create (ta,zf_tmp) &
       !$acc      copyin (randomNumbers,randomNumbers%state, &
@@ -329,12 +331,15 @@
   ENDIF  haveit1
 
 #ifdef MPI
-      ! check for conflict:
-    IF( (iflag.ge.1.and.iflag.le.ni) .and.   &
-        (jflag.ge.1.and.jflag.le.nj) )THEN
-      IF( iflag.eq.ni .and. pdata(np,prx).eq.xf(iflag+1) .and. nodex.gt.1 .and.  myi.ne.nodex ) iflag = -1
-      IF( jflag.eq.nj .and. pdata(np,pry).eq.yf(jflag+1) .and. nodey.gt.1 .and.  myj.ne.nodey ) jflag = -1
-    ENDIF
+! JS: comment out this conflict check for the new MPI interface;
+!     otherwise there will be a droplet leak
+
+!      ! check for conflict:
+!    IF( (iflag.ge.1.and.iflag.le.ni) .and.   &
+!        (jflag.ge.1.and.jflag.le.nj) )THEN
+!      IF( iflag.eq.ni .and. pdata(np,prx).eq.xf(iflag+1) .and. nodex.gt.1 .and.  myi.ne.nodex ) iflag = -1
+!      IF( jflag.eq.nj .and. pdata(np,pry).eq.yf(jflag+1) .and. nodey.gt.1 .and.  myj.ne.nodey ) jflag = -1
+!    ENDIF
 #endif
 
       myparcel:  IF( (iflag.ge.1.and.iflag.le.ni) .and.   &
@@ -404,11 +409,11 @@
 
 #ifdef MPI
       call BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000,neighbor)
-
       pdata_neighbor(np) = neighbor 
 #else
       call BE_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug,num100,num1000)
 #endif
+
       ENDIF dropmethod
 
 
@@ -645,8 +650,8 @@
 
     num_holes = 0
     do np = 1, nparcels_mpi
-       if ( pdata_locind(np,1) .eq. undefined_index .and. &
-            pdata_locind(np,2) .eq. undefined_index ) then
+       if ( (pdata_locind(np,1) .eq. undefined_index) .and. &
+            (pdata_locind(np,2) .eq. undefined_index) ) then
           num_holes = num_holes + 1
        end if
     end do
@@ -1209,11 +1214,13 @@
       if ( z3d .gt. top ) then
          z3d = top - (z3d - top)
          pdata(np,prvpz) = -pdata(np,prvpz)
+         pdata_locind(np,3) = undefined_index
       elseif ( z3d .lt. bot ) then
          !z3d = 1.0e-6  !Just temporary 
          !pdata(np,pract) = -1.0  !Signal this as no longer alive
          z3d = bot + (bot-z3d)
          pdata(np,prvpz) = -pdata(np,prvpz)
+         pdata_locind(np,3) = undefined_index
       endif
 
       ! New for cm1r17:  if parcel exits domain,
@@ -1225,46 +1232,46 @@
       ! determine which new MPI region this droplet 
       ! enters or stays for the next time step
 
-      if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and.  &
-           y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
+      if ( (x3d .ge. xf(1)) .and. (x3d .le. xf(ni+1)) .and.  &
+           (y3d .ge. yf(1)) .and. (y3d .le. yf(nj+1)) ) then
            neighbor = undefined_index   ! undefined_index means this droplet
                                         ! stays within the same MPI region
-      else if ( x3d .lt. xf(1) .and. y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
+      else if ( (x3d .lt. xf(1)) .and. (y3d .ge. yf(1)) .and. (y3d .le. yf(nj+1)) ) then
            if ( x3d .lt. xf(1)-dx*ni ) then
               stop "Jump over the west nearest neighbor"
            end if
            neighbor = mywest
-      else if ( x3d .lt. xf(1) .and. y3d .lt. yf(1) ) then
+      else if ( (x3d .lt. xf(1)) .and. (y3d .lt. yf(1)) ) then
            if ( (x3d .lt. xf(1)-dx*ni) .or. (y3d .lt. yf(1)-dy*nj) ) then
               stop "Jump over the southwest nearest neighbor"
            end if
            neighbor = mysw
-      else if ( x3d .lt. xf(1) .and. y3d .gt. yf(nj+1) ) then
+      else if ( (x3d .lt. xf(1)) .and. (y3d .gt. yf(nj+1)) ) then
            if ( (x3d .lt. xf(1)-dx*ni) .or. (y3d .gt. yf(nj+1)+dy*nj) ) then
               stop "Jump over the northwest nearest neighbor"
            end if
            neighbor = mynw
-      else if ( x3d .gt. xf(ni+1) .and. y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
+      else if ( (x3d .gt. xf(ni+1)) .and. (y3d .ge. yf(1)) .and. (y3d .le. yf(nj+1)) ) then
            if ( x3d .gt. xf(ni+1)+dx*ni ) then
               stop "Jump over the east nearest neighbor"
            end if
            neighbor = myeast
-      else if ( x3d .gt. xf(ni+1) .and. y3d .lt. yf(1) ) then
+      else if ( (x3d .gt. xf(ni+1)) .and. (y3d .lt. yf(1)) ) then
            if ( (x3d .gt. xf(ni+1)+dx*ni) .or. (y3d .lt. yf(1)-dy*nj) ) then
               stop "Jump over the southeast nearest neighbor"
            end if
            neighbor = myse
-      else if ( x3d .gt. xf(ni+1) .and. y3d .gt. yf(nj+1) ) then
+      else if ( (x3d .gt. xf(ni+1)) .and. (y3d .gt. yf(nj+1)) ) then
            if ( (x3d .gt. xf(ni+1)+dx*ni) .or. (y3d .gt. yf(nj+1)+dy*nj) ) then
               stop "Jump over the northeast nearest neighbor"
            end if
            neighbor = myne
-      else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. y3d .lt. yf(1) ) then
+      else if ( (x3d .ge. xf(1)) .and. (x3d .le. xf(ni+1)) .and. (y3d .lt. yf(1)) ) then
            if ( y3d .lt. yf(1)-dy*nj ) then
               stop "Jump over the south nearest neighbor"
            end if
            neighbor = mysouth
-      else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. y3d .gt. yf(nj+1) ) then
+      else if ( (x3d .ge. xf(1)) .and. (x3d .le. xf(ni+1)) .and. (y3d .gt. yf(nj+1)) ) then
            if ( y3d .gt. yf(nj+1)+dy*nj ) then
               stop "Jump over the north nearest neighbor"
            end if
@@ -1917,7 +1924,7 @@
       if ( myid == 0 ) then
 #endif
       write(6,200) 'rtime', rtime
-      write(6,200) 'tnumpart', real(tnumpart)
+      write(6,200) 'tnumpart',real(tnumpart)
       write(6,200) 'radavg',radavg
       write(6,200) 'radmin',radmin
       write(6,200) 'radmax',radmax

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -124,7 +124,7 @@
       integer, dimension(nparcels_mpi) :: pdata_neighbor            ! array to store the new MPI region info for all the droplets
       integer :: n_recv,n_send,index_nw,index_sw,index_ne, &
                  index_se,index_n,index_s,index_w,index_e
-      integer :: reqs(16)
+      integer :: reqs1(16),reqs2(16)
       integer :: tag_n,tag_s,tag_w,tag_e,tag_nw,tag_ne,tag_sw,tag_se,indx
       integer, dimension(mpi_status_size,16) :: status1
 
@@ -141,8 +141,11 @@
 !  [Note:  for u,v the array index (i,j,0) means the surface, ie z=0]
 !     (for the parcel subroutines only!)
 
+      pdata_neighbor = undefined_index
+
       !$acc data create (ta,zf_tmp) &
-      !$acc      copyin (randomNumbers,randomNumbers%state)
+      !$acc      copyin (randomNumbers,randomNumbers%state, &
+      !$acc              pdata_neighbor)
 
     IF(bbc.eq.1)THEN
       ! free slip ... extrapolate:
@@ -281,7 +284,6 @@
 
     num100 = 0
     num1000 = 0
-    pdata_neighbor = undefined_index
 
 #ifdef _B4B01F
     !$acc update &
@@ -631,7 +633,7 @@
 
 #ifdef MPI
 
-    !$acc update host(pdata,pdata_loc)
+    !$acc update host(pdata,pdata_loc,pdata_neighbor)
      
     ! JS: send/receive the droplet information through MPI;
     !     all the calculations below are done on CPU
@@ -736,77 +738,77 @@
     !             know how many droplets from the nearest neighbors
     n_recv = 1 
     call mpi_irecv(num_n2,1,MPI_INT,mynorth,tag_n,MPI_COMM_WORLD, &
-                   reqs(n_recv),ierr)
+                   reqs1(n_recv),ierr)
     index_n = n_recv
    
     n_recv = n_recv + 1
     call mpi_irecv(num_s2,1,MPI_INT,mysouth,tag_s,MPI_COMM_WORLD, &
-                   reqs(n_recv),ierr)
+                   reqs1(n_recv),ierr)
     index_s = n_recv
 
     n_recv = n_recv + 1
     call mpi_irecv(num_w2,1,MPI_INT,mywest,tag_w,MPI_COMM_WORLD, &
-                   reqs(n_recv),ierr)
+                   reqs1(n_recv),ierr)
     index_w = n_recv
 
     n_recv = n_recv + 1
     call mpi_irecv(num_e2,1,MPI_INT,myeast,tag_e,MPI_COMM_WORLD, &
-                   reqs(n_recv),ierr)
+                   reqs1(n_recv),ierr)
     index_e = n_recv
 
     n_recv = n_recv + 1
     call mpi_irecv(num_ne2,1,MPI_INT,myne,tag_ne,MPI_COMM_WORLD, &
-                   reqs(n_recv),ierr)
+                   reqs1(n_recv),ierr)
     index_ne = n_recv
 
     n_recv = n_recv + 1
     call mpi_irecv(num_nw2,1,MPI_INT,mynw,tag_nw,MPI_COMM_WORLD, &
-                   reqs(n_recv),ierr)
+                   reqs1(n_recv),ierr)
     index_nw = n_recv
  
     n_recv = n_recv + 1
     call mpi_irecv(num_se2,1,MPI_INT,myse,tag_se,MPI_COMM_WORLD, &
-                   reqs(n_recv),ierr)
+                   reqs1(n_recv),ierr)
     index_se = n_recv
 
     n_recv = n_recv + 1
     call mpi_irecv(num_sw2,1,MPI_INT,mysw,tag_sw,MPI_COMM_WORLD, &
-                   reqs(n_recv),ierr)
+                   reqs1(n_recv),ierr)
     index_sw = n_recv
 
     ! MPI Step 2: initiate the MPI non-blocking send interface to 
     !             send how many droplets entering the nearest neighbor 
     n_send = 9 
     call mpi_isend(num_n1,1,MPI_INT,mynorth,tag_s,MPI_COMM_WORLD, &
-                   reqs(n_send),ierr)
+                   reqs1(n_send),ierr)
 
     n_send = n_send + 1
     call mpi_isend(num_s1,1,MPI_INT,mysouth,tag_n,MPI_COMM_WORLD, &
-                   reqs(n_send),ierr)
+                   reqs1(n_send),ierr)
 
     n_send = n_send + 1
     call mpi_isend(num_w1,1,MPI_INT,mywest,tag_e,MPI_COMM_WORLD, &
-                   reqs(n_send),ierr)
+                   reqs1(n_send),ierr)
 
     n_send = n_send + 1
     call mpi_isend(num_e1,1,MPI_INT,myeast,tag_w,MPI_COMM_WORLD, &
-                   reqs(n_send),ierr)
+                   reqs1(n_send),ierr)
 
     n_send = n_send + 1
     call mpi_isend(num_ne1,1,MPI_INT,myne,tag_sw,MPI_COMM_WORLD, &
-                   reqs(n_send),ierr)
+                   reqs1(n_send),ierr)
 
     n_send = n_send + 1
     call mpi_isend(num_nw1,1,MPI_INT,mynw,tag_se,MPI_COMM_WORLD, &
-                   reqs(n_send),ierr)
+                   reqs1(n_send),ierr)
 
     n_send = n_send + 1
     call mpi_isend(num_se1,1,MPI_INT,myse,tag_nw,MPI_COMM_WORLD, &
-                   reqs(n_send),ierr)
+                   reqs1(n_send),ierr)
 
     n_send = n_send + 1
     call mpi_isend(num_sw1,1,MPI_INT,mysw,tag_ne,MPI_COMM_WORLD, &
-                   reqs(n_send),ierr)
+                   reqs1(n_send),ierr)
 
     ! extract the information of droplets that will leave the current MPI region 
     n_idx = 1
@@ -857,7 +859,7 @@
     !             new droplets from the nearest neighbor
     n = 1
     do while( n .le. n_recv )
-       call mpi_waitany(n_recv,reqs(1:n_recv),indx,MPI_STATUS_IGNORE,ierr)
+       call mpi_waitany(n_recv,reqs1(1:n_recv),indx,MPI_STATUS_IGNORE,ierr)
        if ( indx .eq. index_n ) then
           if ( num_n2 .ne. 0 ) allocate(droplet_n2(num_n2,npvals))
        else if ( indx .eq. index_s ) then
@@ -887,61 +889,96 @@
        stop "Stop the program ..."
     end if
 
+#if 0
+    ! Diagnostic only 
+    write(*,*) "JS: myid = ", myid, ", new droplets = ", num_n2 + num_s2 + &
+               num_w2 + num_e2 + num_ne2 + num_nw2 + num_se2 + num_sw2
+    write(*,*) "JS: myid = ", myid, ", leaving droplets = ", num_n1 + num_s1 + &
+               num_w1 + num_e1 + num_ne1 + num_nw1 + num_se1 + num_sw1
+#endif
+
     ! make sure that all the non-blocking MPI send operations are complete
     n_send = n_send - 8
     if ( n_send .ge. 1 ) then
-       call mpi_waitall (n_send,reqs(9:9+n_send-1),status1(1:mpi_status_size,9:9+n_send-1),ierr)
+       call mpi_waitall (n_send,reqs1(9:9+n_send-1),status1(1:mpi_status_size,9:9+n_send-1),ierr)
     endif
 
     ! MPI step 4: initiate the MPI non-blocking receive interface to 
     !             obtain new droplet information from the nearest neighbors
-    n_recv = 0
+
+    index_n  = undefined_index
+    index_s  = undefined_index
+    index_w  = undefined_index
+    index_e  = undefined_index
+    index_nw = undefined_index
+    index_sw = undefined_index
+    index_ne = undefined_index
+    index_se = undefined_index
+
+    tag_n    = undefined_index 
+    tag_s    = undefined_index 
+    tag_w    = undefined_index 
+    tag_e    = undefined_index 
+    tag_nw   = undefined_index 
+    tag_sw   = undefined_index 
+    tag_ne   = undefined_index 
+    tag_se   = undefined_index 
+
+    n_recv   = 0
     if ( num_n2 .ne. 0 ) then
        n_recv = n_recv + 1
+       tag_n  = 1000 + num_n2 
        call mpi_irecv(droplet_n2,num_n2*npvals,MPI_REAL,mynorth,tag_n,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr)
+                      reqs2(n_recv),ierr)
        index_n = n_recv
     end if
     if ( num_s2 .ne. 0 ) then
        n_recv = n_recv + 1
+       tag_s  = 1000 + num_s2
        call mpi_irecv(droplet_s2,num_s2*npvals,MPI_REAL,mysouth,tag_s,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr)
+                      reqs2(n_recv),ierr)
        index_s = n_recv
     end if
     if ( num_w2 .ne. 0 ) then
        n_recv = n_recv + 1
+       tag_w  = 1000 + num_w2
        call mpi_irecv(droplet_w2,num_w2*npvals,MPI_REAL,mywest,tag_w,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr)
+                      reqs2(n_recv),ierr)
        index_w = n_recv
     end if
     if ( num_e2 .ne. 0 ) then
        n_recv = n_recv + 1
+       tag_e  = 1000 + num_e2 
        call mpi_irecv(droplet_e2,num_e2*npvals,MPI_REAL,myeast,tag_e,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr)
+                      reqs2(n_recv),ierr)
        index_e = n_recv
     end if
     if ( num_ne2 .ne. 0 ) then
        n_recv = n_recv + 1
+       tag_ne = 1000 + num_ne2
        call mpi_irecv(droplet_ne2,num_ne2*npvals,MPI_REAL,myne,tag_ne,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr)
+                      reqs2(n_recv),ierr)
        index_ne = n_recv
     end if
     if ( num_nw2 .ne. 0 ) then
        n_recv = n_recv + 1
+       tag_nw = 1000 + num_nw2
        call mpi_irecv(droplet_nw2,num_nw2*npvals,MPI_REAL,mynw,tag_nw,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr)
+                      reqs2(n_recv),ierr)
        index_nw = n_recv
     end if
     if ( num_se2 .ne. 0 ) then
        n_recv = n_recv + 1
+       tag_se = 1000 + num_se2
        call mpi_irecv(droplet_se2,num_se2*npvals,MPI_REAL,myse,tag_se,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr)
+                      reqs2(n_recv),ierr)
        index_se = n_recv
     end if
     if ( num_sw2 .ne. 0 ) then
        n_recv = n_recv + 1
+       tag_sw = 1000 + num_sw2 
        call mpi_irecv(droplet_sw2,num_sw2*npvals,MPI_REAL,mysw,tag_sw,MPI_COMM_WORLD, &
-                      reqs(n_recv),ierr)
+                      reqs2(n_recv),ierr)
        index_sw = n_recv
     end if
 
@@ -951,43 +988,51 @@
     n_send = 8
     if ( num_n1 .ne. 0 ) then
        n_send = n_send + 1
+       tag_s = 1000 + num_n1
        call mpi_isend(droplet_n1,num_n1*npvals,MPI_REAL,mynorth,tag_s,MPI_COMM_WORLD, &
-                      reqs(n_send),ierr)
+                      reqs2(n_send),ierr)
     end if
     if ( num_s1 .ne. 0 ) then
        n_send = n_send + 1
+       tag_n = 1000 + num_s1
        call mpi_isend(droplet_s1,num_s1*npvals,MPI_REAL,mysouth,tag_n,MPI_COMM_WORLD, &
-                      reqs(n_send),ierr)
+                      reqs2(n_send),ierr)
     end if
     if ( num_w1 .ne. 0 ) then
        n_send = n_send + 1
+       tag_e = 1000 + num_w1
        call mpi_isend(droplet_w1,num_w1*npvals,MPI_REAL,mywest,tag_e,MPI_COMM_WORLD, &
-                      reqs(n_send),ierr)
+                      reqs2(n_send),ierr)
     end if
     if ( num_e1 .ne. 0 ) then
        n_send = n_send + 1
+       tag_w = 1000 + num_e1
        call mpi_isend(droplet_e1,num_e1*npvals,MPI_REAL,myeast,tag_w,MPI_COMM_WORLD, &
-                      reqs(n_send),ierr)
+                      reqs2(n_send),ierr)
     end if
     if ( num_ne1 .ne. 0 ) then
        n_send = n_send + 1
+       tag_sw = 1000 + num_ne1
        call mpi_isend(droplet_ne1,num_ne1*npvals,MPI_REAL,myne,tag_sw,MPI_COMM_WORLD, &
-                      reqs(n_send),ierr)
+                      reqs2(n_send),ierr)
     end if
     if ( num_nw1 .ne. 0 ) then
        n_send = n_send + 1
+       tag_se = 1000 + num_nw1
        call mpi_isend(droplet_nw1,num_nw1*npvals,MPI_REAL,mynw,tag_se,MPI_COMM_WORLD, &
-                      reqs(n_send),ierr)
+                      reqs2(n_send),ierr)
     end if
     if ( num_se1 .ne. 0 ) then
        n_send = n_send + 1
+       tag_nw = 1000 + num_se1
        call mpi_isend(droplet_se1,num_se1*npvals,MPI_REAL,myse,tag_nw,MPI_COMM_WORLD, &
-                      reqs(n_send),ierr)
+                      reqs2(n_send),ierr)
     end if
     if ( num_sw1 .ne. 0 ) then
        n_send = n_send + 1
+       tag_ne = 1000 + num_sw1
        call mpi_isend(droplet_sw1,num_sw1*npvals,MPI_REAL,mysw,tag_ne,MPI_COMM_WORLD, &
-                      reqs(n_send),ierr)
+                      reqs2(n_send),ierr)
     end if
 
     ! MPI step 6: update the "holes" in "pdata" with the new droplets entering 
@@ -995,7 +1040,7 @@
     n = 1
     k = 1
     do while( n .le. n_recv )
-       call mpi_waitany(n_recv,reqs(1:n_recv),indx,MPI_STATUS_IGNORE,ierr)
+       call mpi_waitany(n_recv,reqs2(1:n_recv),indx,MPI_STATUS_IGNORE,ierr)
        if ( indx .eq. index_n ) then
           do i = 1, num_n2
              pdata(holes_ind(k),:) = droplet_n2(i,:)
@@ -1043,7 +1088,7 @@
     ! make sure that all the non-blocking MPI send operations are complete
     n_send = n_send - 8
     if ( n_send .ge. 1 ) then
-       call mpi_waitall (n_send,reqs(9:9+n_send-1),status1(1:mpi_status_size,9:9+n_send-1),ierr)
+       call mpi_waitall (n_send,reqs2(9:9+n_send-1),status1(1:mpi_status_size,9:9+n_send-1),ierr)
     endif
 
     !$acc update device(pdata)
@@ -1424,7 +1469,7 @@
       use input, only : ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,viscosity, &
           pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
           prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pru,prv,prw,prt,prqv,prprs,prrho, &
-          ni,nj,mywest,mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcels_mpi
+          ni,nj,mywest,mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcels_mpi,myid
       use constants
       use comm_module
       use misclibs
@@ -1607,8 +1652,8 @@
       ! just assume periodic lateral boundary conditions
       ! (no matter what actual settings are for wbc,ebc,sbc,nbc)
 
-      ! determine which new MPI region this droplet 
-      ! enters or stays for the next time step
+      ! JS: determine which new MPI region this droplet 
+      !     enters or stays for the next time step
       if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and.  &
            y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
            neighbor = undefined_index   ! undefined_index means this droplet
@@ -1633,6 +1678,12 @@
       else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. &
                 y3d .gt. yf(nj+1) ) then
            neighbor = mynorth
+      end if
+
+      if ( neighbor .ne. undefined_index ) then
+         pdata_locind(np,1) = undefined_index
+         pdata_locind(np,2) = undefined_index
+         pdata_locind(np,3) = undefined_index
       end if
 
       if ( x3d .lt. minx ) then
@@ -2094,7 +2145,7 @@
       real :: partnum(nk),numconc(nk)
 #ifdef MPI
       real, dimension(11) :: droplet_diag0     ! temporary array for MPI reduce operation
-                                               ! for the 0th-order diagnostic except rtime 
+                                               ! for the 0th-order diagnostic except rtime
 #endif
 
       !Compute the various types of droplet statistics
@@ -2121,7 +2172,7 @@
       !$acc          reduction(+:tnumpart,radavg,radsqr,Tpavg,Tpsqr,Tfavg,qfavg,prsavg,rhoavg) &
       !$acc          reduction(max:radmax,Tpmax) &
       !$acc          reduction(min:radmin,Tpmin)
-      do np=1,nparcels
+      do np=1,nparcels_mpi
          if (pdata(np,pract) .gt. 0.0) then
             tnumpart = tnumpart + 1
             radavg = radavg + pdata(np,prrp)
@@ -2142,30 +2193,52 @@
       !$acc end parallel
 
 #ifdef MPI
+      droplet_diag0(1) = real(tnumpart)
+      droplet_diag0(2) = radavg
+      droplet_diag0(3) = Tpavg
+      droplet_diag0(4) = Tfavg
+      droplet_diag0(5) = qfavg
+      droplet_diag0(6) = prsavg
+      droplet_diag0(7) = rhoavg
+      droplet_diag0(8) = radmin
+      droplet_diag0(9) = Tpmin
+      droplet_diag0(10) = radmax
+      droplet_diag0(11) = Tpmax
+
       ! The root rank will collect the diagnostic from different MPI ranks
-      call mpi_reduce(tnumpart,droplet_diag0(1),1,MPI_INT, &
-                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
-      call mpi_reduce(radavg,droplet_diag0(2),1,MPI_REAL, &
-                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
-      call mpi_reduce(radmin,droplet_diag0(3),1,MPI_REAL, &
-                      MPI_MIN,0,MPI_COMM_WORLD,ierr)
-      call mpi_reduce(radmax,droplet_diag0(4),1,MPI_REAL, &
-                      MPI_MAX,0,MPI_COMM_WORLD,ierr)
-      call mpi_reduce(Tpavg,droplet_diag0(5),1,MPI_REAL, &
-                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
-      call mpi_reduce(Tpmin,droplet_diag0(6),1,MPI_REAL, &
-                      MPI_MIN,0,MPI_COMM_WORLD,ierr)
-      call mpi_reduce(Tpmax,droplet_diag0(7),1,MPI_REAL, &
-                      MPI_MAX,0,MPI_COMM_WORLD,ierr)
-      call mpi_reduce(Tfavg,droplet_diag0(8),1,MPI_REAL, &
-                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
-      call mpi_reduce(qfavg,droplet_diag0(9),1,MPI_REAL, &
-                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
-      call mpi_reduce(prsavg,droplet_diag0(10),1,MPI_REAL, &
-                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
-      call mpi_reduce(rhoavg,droplet_diag0(11),1,MPI_REAL, &
-                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      if ( myid == 0 ) then
+         call mpi_reduce(MPI_IN_PLACE,droplet_diag0(1),7,MPI_REAL, &
+                         MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      else
+         call mpi_reduce(droplet_diag0(1),droplet_diag0(1),7,MPI_REAL, &
+                         MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      end if
+      if ( myid == 0 ) then
+         call mpi_reduce(MPI_IN_PLACE,droplet_diag0(8),2,MPI_REAL, &
+                         MPI_MIN,0,MPI_COMM_WORLD,ierr)
+      else
+         call mpi_reduce(droplet_diag0(8),droplet_diag0(8),2,MPI_REAL, &
+                         MPI_MIN,0,MPI_COMM_WORLD,ierr)
+      end if
+      if ( myid == 0 ) then
+         call mpi_reduce(MPI_IN_PLACE,droplet_diag0(10),2,MPI_REAL, &
+                         MPI_MAX,0,MPI_COMM_WORLD,ierr)
+      else
+         call mpi_reduce(droplet_diag0(10),droplet_diag0(10),2,MPI_REAL, &
+                         MPI_MAX,0,MPI_COMM_WORLD,ierr)
+      end if
       if ( myid == 0 ) then 
+         tnumpart = droplet_diag0(1)
+         radavg = droplet_diag0(2)
+         Tpavg = droplet_diag0(3)
+         Tfavg = droplet_diag0(4)
+         qfavg = droplet_diag0(5)
+         prsavg = droplet_diag0(6)
+         rhoavg = droplet_diag0(7)
+         radmin = droplet_diag0(8)
+         Tpmin = droplet_diag0(9)
+         radmax = droplet_diag0(10)
+         Tpmax = droplet_diag0(11)
 #endif
       radavg = radavg/tnumpart
       radsqr = radsqr/tnumpart
@@ -2247,20 +2320,7 @@
       !Dump to screen for debugging purposes
 #ifdef MPI
       if ( myid == 0 ) then
-         write(6,200) 'rtime', rtime
-         write(6,200) 'tnumpart', dble(droplet_diag0(1))
-         write(6,200) 'radavg',droplet_diag0(2)
-         write(6,200) 'radmin',droplet_diag0(3)
-         write(6,200) 'radmax',droplet_diag0(4)
-         write(6,200) 'Tpavg',droplet_diag0(5)
-         write(6,200) 'Tpmin',droplet_diag0(6)
-         write(6,200) 'Tpmax',droplet_diag0(7)
-         write(6,200) 'Tfavg',droplet_diag0(8)
-         write(6,200) 'qfavg',droplet_diag0(9)
-         write(6,200) 'prsavg',droplet_diag0(10)
-         write(6,200) 'rhoavg',droplet_diag0(11)
-      end if
-#else
+#endif
       write(6,200) 'rtime', rtime
       write(6,200) 'tnumpart', dble(tnumpart)
       write(6,200) 'radavg',radavg
@@ -2273,6 +2333,8 @@
       write(6,200) 'qfavg',qfavg
       write(6,200) 'prsavg',prsavg
       write(6,200) 'rhoavg',rhoavg
+#ifdef MPI
+      end if
 #endif
 
 #ifdef NETCDF

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -2226,7 +2226,6 @@
 
 #ifdef MPI
       ! The root rank will collect the diagnostic from different MPI ranks
-      ! Example usage: https://stackoverflow.com/questions/17741574/in-place-mpi-reduce-crashes-with-openmpi
       if ( myid == 0 ) then
          call mpi_reduce(MPI_IN_PLACE,partnum,nk,MPI_REAL, &
                          MPI_SUM,0,MPI_COMM_WORLD,ierr)

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -36,7 +36,7 @@
           umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
           prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult,prms,przs,pru,prv,prw,prt,prqv,prprs,prrho, &
           timestats,time_droplet,mytime,ierr,time_droplet_reduce,maxx,maxy,maxz, &
-          ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest,myid,nparcels_mpi
+          ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest,myid,nparcelsLocal
       use constants
       use comm_module
       use misclibs
@@ -72,7 +72,7 @@
       real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: ua,uten
       real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: va,vten
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: wa,wten
-      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
+      real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
 
       real, intent(inout), dimension(jmp,kmp) :: pw1,pw2,pe1,pe2
       real, intent(inout), dimension(imp,kmp) :: ps1,ps2,pn1,pn2
@@ -83,7 +83,7 @@
       real, intent(inout), dimension(imp,cmp,kmp)   :: ss31,ss32,sn31,sn32
       real, intent(inout), dimension(cmp,cmp,kmt+1) :: n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2
       integer, intent(inout), dimension(rmp) :: reqs_s
-      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind    ! x/y/z location index of each parcel
+      integer, intent(inout), dimension(nparcelsLocal,3) :: pdata_locind    ! x/y/z location index of each parcel
 
       !Need to compute the true temperature
       real, dimension(ib:ie,jb:je,kb:ke) :: ta
@@ -106,7 +106,7 @@
       logical, parameter :: debug = .false.
 
       type(randomNumberSequence) :: randomNumbers
-      real, dimension(kb:ke+1) :: zf_tmp
+!      real, dimension(kb:ke+1) :: zf_tmp
 
 #ifdef MPI 
       integer :: num_holes                                 ! how many new droplets could be added to "pdata"
@@ -116,7 +116,7 @@
       integer :: num2(num_nn)                              ! Number of droplets that will enter the current
                                                            ! MPI region from each nearest neighbor
       integer :: neighbor                                  ! indicate which MPI region a droplet stays after this time step 
-      integer, dimension(nparcels_mpi) :: pdata_neighbor   ! array to store the new MPI region info for all the droplets
+      integer, dimension(nparcelsLocal) :: pdata_neighbor   ! array to store the new MPI region info for all the droplets
 #endif
 
 #ifdef _VERIFY_FIND_LOC
@@ -133,11 +133,11 @@
 !     (for the parcel subroutines only!)
 
 #ifdef MPI
-      do np = 1, nparcels_mpi
+      do np = 1, nparcelsLocal
          pdata_neighbor(np) = undefined_index
       end do
 
-      !$acc data create (ta,zf_tmp) &
+      !$acc data create (ta) &
       !$acc      copyin (randomNumbers,randomNumbers%state, &
       !$acc              pdata_neighbor)
 #else
@@ -290,10 +290,10 @@
 #else
     !JMD WARNING: Loop does not yet match CPU version.
     !$acc parallel default(present)
-    !$acc loop gang vector private(zf_tmp)
+    !$acc loop gang vector
 #endif
     nploop:  &
-    DO np=1,nparcels_mpi
+    DO np=1,nparcelsLocal
 
       x3d = pdata(np,prx)
       y3d = pdata(np,pry)
@@ -350,11 +350,16 @@
         !JS-KLUDGE: Somehow I have to use the zf_tmp variable 
         !           for the find_vertical* subroutine,
         !           otherwise the GPU code breaks for nparcels > ~2000
-        !$acc loop seq
-        do k = kb, ke+1
-           zf_tmp(k) = zf(iflag,jflag,k)
+!        !$acc loop seq
+!        do k = kb, ke+1
+!           zf_tmp(k) = zf(iflag,jflag,k)
+!        end do
+        kflag = 1
+        do while ( z3d .ge. zf(iflag,jflag,kflag+1) )
+           kflag = kflag + 1
         end do
-        call find_vertical_location_index (pdata_locind(np,3), z3d, kb, ke+1, zf_tmp, kflag, .TRUE.)
+        pdata_locind(np,3) = kflag
+!        call find_vertical_location_index (pdata_locind(np,3), z3d, kb, ke+1, zf_tmp, kflag, .TRUE.)
       else
         call find_vertical_location_index (pdata_locind(np,3), sig3d, kb, ke+1, sigmaf, kflag, .TRUE.)
       endif
@@ -649,7 +654,7 @@
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
     num_holes = 0
-    do np = 1, nparcels_mpi
+    do np = 1, nparcelsLocal
        if ( (pdata_locind(np,1) .eq. undefined_index) .and. &
             (pdata_locind(np,2) .eq. undefined_index) ) then
           num_holes = num_holes + 1
@@ -694,7 +699,7 @@
 
       if( terrain_flag )then
             call getparcelzs(xh,uh,ruh,xf,yh,vh,rvh,yf,zs,pdata)
-            DO np=1,nparcels_mpi
+            DO np=1,nparcelsLocal
               ! get z from sigma:
               ! (see Section 3 of "The governing equations for CM1", 
               !  http://www2.mmm.ucar.edu/people/bryan/cm1/cm1_equations.pdf)
@@ -711,7 +716,7 @@
 
       subroutine rk2_integration(dt,np,pdata,pdata_locind,iflag,jflag,kflag,xf,xh,uh,ruh,yf,yh,vh,rvh,zf,zh,zs,znt,sigma,sigmaf,ua,va,wa,qa,ta,rho,prs,x3d,y3d,z3d,sig3d,rhoval,tval,Nup,rhop0,taup0,rp0,part_grav1,part_grav2,part_grav3,debug)
       !$acc routine seq
-      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels_mpi,npvals,nx,ny,viscosity, &
+      use input, only : ib,ie,jb,je,kb,ke,numq,nparcelsLocal,npvals,nx,ny,viscosity, &
           pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
           prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pru,prv,prw,prt,prqv,prprs,prrho
       use constants
@@ -741,8 +746,8 @@
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: rho,prs
       real, intent(in), dimension(ib:ie,jb:je) :: znt
       real, intent(inout) :: x3d,y3d,z3d,sig3d,rhoval,tval
-      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
-      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind
+      real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
+      integer, intent(inout), dimension(nparcelsLocal,3) :: pdata_locind
 
       real, intent(out) :: Nup,rhop0,taup0,rp0
       real, intent(in) :: dt,part_grav1,part_grav2,part_grav3
@@ -1042,7 +1047,7 @@
       use input, only : ib,ie,jb,je,kb,ke,numq,npvals,nx,ny,viscosity, &
           pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
           prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pru,prv,prw,prt,prqv,prprs,prrho, &
-          ni,nj,mywest,mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcels_mpi,myid,dx,dy
+          ni,nj,mywest,mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcelsLocal,myid,dx,dy
       use constants
       use comm_module
       use misclibs
@@ -1072,8 +1077,8 @@
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: rho,prs
       real, intent(in), dimension(ib:ie,jb:je) :: znt
       real, intent(inout) :: x3d,y3d,z3d,sig3d,rhoval,tval
-      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
-      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind
+      real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
+      integer, intent(inout), dimension(nparcelsLocal,3) :: pdata_locind
       real, intent(out) :: Nup,rhop0,taup0,rp0
       real, intent(in) :: dt,part_grav1,part_grav2,part_grav3
       integer, intent(out), optional :: neighbor  ! indicate which MPI region a droplet 
@@ -1323,7 +1328,7 @@
 
       subroutine interpolate_to_parcel(np,nrkp,pdata_locind,iflag,jflag,kflag,x3d,y3d,z3d,sig3d,uval,vval,wval,tval,qval,rhoval,prsval,xh,xf,yh,yf,zh,zf,zs,znt,sigma,sigmaf,ua,va,wa,ta,qa,rho,prs,sigdot)
       !$acc routine seq
-      use input, only : ib,ie,jb,je,kb,ke,numq,nparcels_mpi,nx,ny, &
+      use input, only : ib,ie,jb,je,kb,ke,numq,nparcelsLocal,nx,ny, &
                         axisymm,terrain_flag,ni,nj,nip1,nk,nkp1, &
                         zt,rzt,imoist,nqv,bbc,imove,umove,vmove
       use constants
@@ -1347,7 +1352,7 @@
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: ta
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: rho,prs
       real, intent(in), dimension(ib:ie,jb:je) :: znt
-      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind    ! x/y/z location index of each parcel
+      integer, intent(inout), dimension(nparcelsLocal,3) :: pdata_locind    ! x/y/z location index of each parcel
 
       integer, intent(in) :: np,nrkp
       integer, intent(inout) :: iflag,jflag,kflag
@@ -1733,8 +1738,8 @@
 
       integer, intent(inout) :: nrec
       real, intent(in) :: rtime
-      real, intent(in), dimension(nparcels_mpi,npvals) :: pdata
-      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind    ! x/y/z location index of each parcel
+      real, intent(in), dimension(nparcelsLocal,npvals) :: pdata
+      integer, intent(inout), dimension(nparcelsLocal,3) :: pdata_locind    ! x/y/z location index of each parcel
       real, intent(in), dimension(ib:ie,jb:je,kb:ke) :: zh
       real, intent(in), dimension(ib:ie,jb:je,kb:ke+1) :: zf
 
@@ -1774,7 +1779,7 @@
       !$acc          reduction(+:tnumpart,radavg,radsqr,Tpavg,Tpsqr,Tfavg,qfavg,prsavg,rhoavg) &
       !$acc          reduction(max:radmax,Tpmax) &
       !$acc          reduction(min:radmin,Tpmin)
-      do np=1,nparcels_mpi
+      do np=1,nparcelsLocal
          if (pdata(np,pract) .gt. 0.0) then
             tnumpart = tnumpart + 1
             radavg = radavg + pdata(np,prrp)
@@ -1875,7 +1880,7 @@
       !$acc end parallel
 
       !$acc parallel loop gang vector default(present) reduction(partnum)
-      do np=1,nparcels_mpi
+      do np=1,nparcelsLocal
          if (pdata(np,pract) .gt. 0.0) then
             kflag = 1
             call find_vertical_location_index (pdata_locind(np,3),pdata(np,prz),kb,ke+1,dumzf(:),kflag,.TRUE.)

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -889,7 +889,7 @@
        stop "Stop the program ..."
     end if
 
-#if 1 
+#if 0 
     ! Diagnostic only 
     write(*,*) "JS: myid = ", myid, ", new droplets = ", num_n2 + num_s2 + &
                num_w2 + num_e2 + num_ne2 + num_nw2 + num_se2 + num_sw2

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -2088,6 +2088,12 @@
       integer :: tnumpart,tnumdrop,tnumaerosol
       real :: radavg,radsqr,radmin,radmax,Tpavg,Tpmin,Tpmax,Tpsqr,Tfavg,qfavg,prsavg,rhoavg
       real :: partnum(nk),numconc(nk)
+#ifdef MPI
+      real, dimension(11) :: droplet_diag0     ! temporary array for MPI reduce operation
+                                               ! for the 0th-order diagnostic except rtime 
+      real, dimension(nk) :: droplet_diag1     ! temporary array for MPI reduce operation
+                                               ! for the 1st-order diagnostic 
+#endif
 
       !Compute the various types of droplet statistics
 
@@ -2133,6 +2139,32 @@
       end do
       !$acc end parallel
 
+#ifdef MPI
+      ! The root rank will collect the diagnostic from different MPI ranks
+      call mpi_reduce(tnumpart,droplet_diag0(1),1,MPI_INT, &
+                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      call mpi_reduce(radavg,droplet_diag0(2),1,MPI_REAL, &
+                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      call mpi_reduce(radmin,droplet_diag0(3),1,MPI_REAL, &
+                      MPI_MIN,0,MPI_COMM_WORLD,ierr)
+      call mpi_reduce(radmax,droplet_diag0(4),1,MPI_REAL, &
+                      MPI_MAX,0,MPI_COMM_WORLD,ierr)
+      call mpi_reduce(Tpavg,droplet_diag0(5),1,MPI_REAL, &
+                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      call mpi_reduce(Tpmin,droplet_diag0(6),1,MPI_REAL, &
+                      MPI_MIN,0,MPI_COMM_WORLD,ierr)
+      call mpi_reduce(Tpmax,droplet_diag0(7),1,MPI_REAL, &
+                      MPI_MAX,0,MPI_COMM_WORLD,ierr)
+      call mpi_reduce(Tfavg,droplet_diag0(8),1,MPI_REAL, &
+                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      call mpi_reduce(qfavg,droplet_diag0(9),1,MPI_REAL, &
+                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      call mpi_reduce(prsavg,droplet_diag0(10),1,MPI_REAL, &
+                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      call mpi_reduce(rhoavg,droplet_diag0(11),1,MPI_REAL, &
+                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      if ( myid == 0 ) then 
+#endif
       radavg = radavg/tnumpart
       radsqr = radsqr/tnumpart
       Tpavg = Tpavg/tnumpart
@@ -2141,6 +2173,9 @@
       qfavg = qfavg/tnumpart
       prsavg = prsavg/tnumpart
       rhoavg = rhoavg/tnumpart
+#ifdef MPI
+      end if
+#endif
 
       !!!!!!! 1st order  !!!!!!!!
       !$acc parallel loop gang vector default(present)
@@ -2172,27 +2207,35 @@
       end do
       !$acc end parallel
 
-     if (stretch_x .eq. 0) then
-        xl = dx*nx
-     else
-        xl = tot_x_len
-     endif
-     if (stretch_y .eq. 0) then
-        yl = dy*nx
-     else
-        yl = tot_y_len
-     endif
+      if (stretch_x .eq. 0) then
+         xl = dx*nx
+      else
+         xl = tot_x_len
+      endif
+      if (stretch_y .eq. 0) then
+         yl = dy*nx
+      else
+         yl = tot_y_len
+      endif
 
-     !$acc update host (dumzf,dumzh,numconc,partnum)
+      !$acc update host (dumzf,dumzh,numconc,partnum)
 
-     do iz=1,nk
-        dzf = dumzf(iz+1)-dumzf(iz)
-        numconc(iz) = partnum(iz)/dzf/xl/yl
-        write(6,100) 'dumzh(',iz,'):',dumzh(iz)
-        write(6,100) 'numconc(',iz,'):',numconc(iz)
-     end do
-
-     !WRITE IT OUT:
+#ifdef MPI
+      ! The root rank will collect the diagnostic from different MPI ranks
+      call mpi_reduce(MPI_IN_PLACE,partnum,nk,MPI_REAL, &
+                      MPI_SUM,0,MPI_COMM_WORLD,ierr)
+      if ( myid == 0 ) then 
+#endif
+      do iz=1,nk
+         dzf = dumzf(iz+1)-dumzf(iz)
+         numconc(iz) = partnum(iz)/dzf/xl/yl
+         write(6,100) 'dumzh(',iz,'):',dumzh(iz)
+         write(6,100) 'numconc(',iz,'):',numconc(iz)
+      end do
+#ifdef MPI
+      end if
+#endif
+      !WRITE IT OUT:
 
       !Dump to screen for debugging purposes
       write(6,200) 'rtime', rtime
@@ -2209,6 +2252,8 @@
       write(6,200) 'rhoavg',rhoavg
 
 #ifdef NETCDF
+      ! JS: this subroutine is not updated with the new MPI
+      !     interface for the droplets yet
       call writedropdiag_nc(nrec, &
            rtime,tnumpart,radavg,radsqr,radmin,radmax,Tpavg,Tpsqr,Tpmin,Tpmax,Tfavg,qfavg,prsavg,rhoavg, &
            dumzh,numconc)
@@ -2217,7 +2262,7 @@
 100     format(2x,'DROPLET_DIAG1:: ',A,I0,A,1x,e13.6,1x)
 200     format(2x,'DROPLET_DIAG:: ',A10,':',1x,e13.6)
 
-     !$acc end data
+      !$acc end data
 
       end subroutine droplet_diag
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -2200,7 +2200,7 @@
       !$acc end parallel
 
       !$acc parallel loop gang vector default(present) reduction(partnum)
-      do np=1,nparcels
+      do np=1,nparcels_mpi
          if (pdata(np,pract) .gt. 0.0) then
             kflag = 1
             call find_vertical_location_index (pdata_locind(np,3),pdata(np,prz),kb,ke+1,dumzf(:),kflag,.TRUE.)

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -119,7 +119,7 @@
       real, dimension(ibc:iec,jbc:jec,kbc:kec) :: kmh,kmv,khh,khv
       real, dimension(ibt:iet,jbt:jet,kbt:ket) :: tkea,tke3d,tketen
       real, dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d,ptten
-      real, dimension(nparcels,npvals) :: pdata
+      real, dimension(nparcels_mpi,npvals) :: pdata
       real, dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: cfb
       real, dimension(kpb:kpe) :: cfa,cfc,ad1,ad2
       complex, dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: pdt,lgbth,lgbph
@@ -173,6 +173,8 @@
       !        (ie, different sets of random perturbations every time CM1 
       !        is used), then change this varliable to .true.
       logical, parameter :: use_truly_random_pert  =  .false.
+
+      real :: tmpx, tmpy, tmpz
 
 !--------------------------
 
@@ -394,7 +396,7 @@
         !   pdata(*,prz) = z location (m ASL)
 
         ! initialize to really small number (so we can use the allreduce command below)
-        do n=1,nparcels
+        do n=1,nparcels_mpi
           pdata(n,prx) = -1.0e30
           pdata(n,pry) = -1.0e30
           pdata(n,prz) = -1.0e30
@@ -403,7 +405,7 @@
 
         if(dowr) write(outfile,*)
         if(dowr) write(outfile,*) '  Parcels ! '
-        if(dowr) write(outfile,*) '  npvals,nparcels = ',npvals,nparcels
+        if(dowr) write(outfile,*) '  npvals,nparcels_mpi = ',npvals,nparcels_mpi
         if(dowr) write(outfile,*) '  Initial parcel locations (x,y,z):'
 
         ! Use the deterministic random number generator from CESM:
@@ -413,53 +415,67 @@
         randomNumbers = new_RandomNumberSequence(seed = nparcels)
 
         do n=1,nparcels
+
           rand = getRandomReal(randomNumbers)
-          pdata(n,prx) = rand*maxx
+          tmpx = rand*maxx
           rand = getRandomReal(randomNumbers)
-          pdata(n,pry) = rand*maxy
+          tmpy = rand*maxy
           rand = getRandomReal(randomNumbers)
-          pdata(n,prz) = rand*maxz
+          tmpz = rand*maxz
 
-          !if(MODULO(n,100)==0) then 
-          if(dowr) write(outfile,*) n,pdata(n,prx),pdata(n,pry),pdata(n,prz)
-          !endif
+          ! check if this parcel falls into this MPI region
+          if ( tmpx .ge. xfref(myi1) .and. tmpx .le. xfref(myi2) .and. &
+               tmpy .ge. yfref(myj1) .and. tmpy .le. yfref(myj2) ) then
 
-          if (prcl_droplet.eq.1) then
+             do i = 1, nparcels_mpi
+                if ( pdata(i,prx) .eq. -1.0e30 ) then
+                   pdata(i,prx) = tmpx
+                   pdata(i,pry) = tmpy
+                   pdata(i,prz) = tmpz
+                   exit
+                end if
+             end do
 
-            pdata(n,prvpx) = 0.0
-            pdata(n,prvpy) = 0.0
-            pdata(n,prvpz) = 0.0
+             !if(MODULO(n,100)==0) then 
+             if(dowr) write(outfile,*) i,pdata(i,prx),pdata(i,pry),pdata(i,prz)
+             !endif
 
-            !Droplet size (radius)
-            pdata(n,prrp) = 20.0e-6
+             if (prcl_droplet.eq.1) then
+    
+                pdata(i,prvpx) = 0.0
+                pdata(i,prvpy) = 0.0
+                pdata(i,prvpz) = 0.0
+     
+                !Droplet size (radius)
+                pdata(i,prrp) = 20.0e-6
+     
+                !Droplet solute mass
+                salinity = 0.034
+                pdata(i,prms) = salinity*rhow*4.0/3.0*pi*pdata(i,prrp)**3
+     
+                !Droplet temperature
+                pdata(i,prtp) = 302.0
+     
+                !Droplet multiplicity
+                pdata(i,prmult) = 1.0e6
+        
+                !Is droplet alive?
+                pdata(i,pract) = 1.0
+     
+                !Initialize the interpolated quantities to zero
+                pdata(i,pru) = 0.0
+                pdata(i,prv) = 0.0
+                pdata(i,prw) = 0.0
+                pdata(i,prt) = 0.0
+                pdata(i,prqv) = 0.0
+                pdata(i,prprs) = 0.0
+                pdata(i,prrho) = 0.0
+    
+             end if ! end of if statement for prcl_droplet == 1
 
-            !Droplet solute mass
-            salinity = 0.034
-            pdata(n,prms) = salinity*rhow*4.0/3.0*pi*pdata(n,prrp)**3
+          end if    ! end of if statement for xfref/yfref check
 
-            !Droplet temperature
-            pdata(n,prtp) = 302.0
-
-            !Droplet multiplicity
-            pdata(n,prmult) = 1.0e6
-   
-            !Is droplet alive?
-            pdata(n,pract) = 1.0
-
-            !Initialize the interpolated quantities to zero
-            pdata(n,pru) = 0.0
-            pdata(n,prv) = 0.0
-            pdata(n,prw) = 0.0
-            pdata(n,prt) = 0.0
-            pdata(n,prqv) = 0.0
-            pdata(n,prprs) = 0.0
-            pdata(n,prrho) = 0.0
-
-          endif
-
-        end do
-
-
+        end do      ! end of loop for nparcels
 
 ! Original stuff:
 !        n = 0
@@ -484,20 +500,21 @@
 
         if(dowr) write(outfile,*)
 
-#ifdef MPI
-        ! this ensures that every processor has all parcel locations:
-        call MPI_ALLREDUCE(MPI_IN_PLACE,pdata(1,1),3*nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
-#endif
+!JS: comment the section below with the new MPI implementation for droplets
+!#ifdef MPI
+!        ! this ensures that every processor has all parcel locations:
+!        call MPI_ALLREDUCE(MPI_IN_PLACE,pdata(1,1),3*nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
+!#endif
 
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           ! 170719,  for 2d setup (x,z), fix all y values:
-          DO n=1,nparcels
+          DO n=1,nparcels_mpi
             pdata(n,pry) = 0.0
           ENDDO
         ENDIF
         IF(nx.eq.1)THEN
           ! 170719,  for 2d setup (y,z), fix all x values:
-          DO n=1,nparcels
+          DO n=1,nparcels_mpi
             pdata(n,prx) = 0.0
           ENDDO
         ENDIF
@@ -2129,7 +2146,7 @@
       real, dimension(ibm:iem,jbm:jem,kbm:kem,numq) :: qa,q3d
       real, dimension(ibt:iet,jbt:jet,kbt:ket) :: tkea,tke3d
       real, dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d
-      real, intent(inout), dimension(nparcels,npvals) :: pdata
+      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
       logical, intent(in), dimension(ibib:ieib,jbib:jeib,kbib:keib) :: bndy
       integer, intent(in), dimension(ibib:ieib,jbib:jeib) :: kbdy
       integer, dimension(rmp) :: reqs_u,reqs_v,reqs_w,reqs_s,reqs_p,reqs_tk
@@ -2606,7 +2623,7 @@
         endif
         if( .not. restarted )then
           ! 181022:  not a restart ... initialize sigma
-          do n=1,nparcels
+          do n=1,nparcels_mpi
             ! get sigma from z:
             ! (see Section 3 of "The governing equations for CM1", 
             !  http://www2.mmm.ucar.edu/people/bryan/cm1/cm1_equations.pdf)
@@ -2614,7 +2631,7 @@
           enddo
         else
           ! 181022:  this is a restart ... get z
-          do n=1,nparcels
+          do n=1,nparcels_mpi
             ! get z from sigma:
             ! (see Section 3 of "The governing equations for CM1", 
             !  http://www2.mmm.ucar.edu/people/bryan/cm1/cm1_equations.pdf)

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -397,9 +397,9 @@
 
         ! initialize to really small number (so we can use the allreduce command below)
         do n=1,nparcels_mpi
-          pdata(n,prx) = -1.0e30
-          pdata(n,pry) = -1.0e30
-          pdata(n,prz) = -1.0e30
+          pdata(n,prx) = neg_huge
+          pdata(n,pry) = neg_huge
+          pdata(n,prz) = neg_huge
         enddo
 
 
@@ -428,7 +428,7 @@
                tmpy .ge. yfref(myj1) .and. tmpy .le. yfref(myj2) ) then
 
              do i = 1, nparcels_mpi
-                if ( pdata(i,prx) .eq. -1.0e30 ) then
+                if ( pdata(i,prx) .eq. neg_huge ) then
                    pdata(i,prx) = tmpx
                    pdata(i,pry) = tmpy
                    pdata(i,prz) = tmpz

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -471,6 +471,12 @@
              end if ! end of if statement for prcl_droplet == 1
 
              i = i + 1
+   
+             if ( i .gt. nparcels_mpi ) then
+                write(*,*) "Not enough space to initialize the droplets on myid = ", myid 
+                write(*,*) 'Please increase the value of "pdata_buffer" in the constants.F'
+                stop "Stop the program..."
+             end if
 
           end if    ! end of if statement for xfref/yfref check
 

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -119,7 +119,7 @@
       real, dimension(ibc:iec,jbc:jec,kbc:kec) :: kmh,kmv,khh,khv
       real, dimension(ibt:iet,jbt:jet,kbt:ket) :: tkea,tke3d,tketen
       real, dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d,ptten
-      real, dimension(nparcels_mpi,npvals) :: pdata
+      real, dimension(nparcelsLocal,npvals) :: pdata
       real, dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: cfb
       real, dimension(kpb:kpe) :: cfa,cfc,ad1,ad2
       complex, dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: pdt,lgbth,lgbph
@@ -396,7 +396,7 @@
         !   pdata(*,prz) = z location (m ASL)
 
         ! initialize to really small number (so we can use the allreduce command below)
-        do n=1,nparcels_mpi
+        do n=1,nparcelsLocal
           pdata(n,prx) = neg_huge
           pdata(n,pry) = neg_huge
           pdata(n,prz) = neg_huge
@@ -405,7 +405,7 @@
 
         if(dowr) write(outfile,*)
         if(dowr) write(outfile,*) '  Parcels ! '
-        if(dowr) write(outfile,*) '  npvals,nparcels_mpi = ',npvals,nparcels_mpi
+        if(dowr) write(outfile,*) '  npvals,nparcelsLocal = ',npvals,nparcelsLocal
         if(dowr) write(outfile,*) '  Initial parcel locations (x,y,z):'
 
         ! Use the deterministic random number generator from CESM:
@@ -472,7 +472,7 @@
 
              i = i + 1
 #ifdef MPI   
-             if ( i .gt. nparcels_mpi ) then
+             if ( i .gt. nparcelsLocal ) then
                 write(*,*) "Not enough space to initialize the droplets on myid = ", myid 
                 write(*,*) 'Please increase the value of "pdata_buffer" in the constants.F'
                 stop "Stop the program..."
@@ -507,13 +507,13 @@
 
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           ! 170719,  for 2d setup (x,z), fix all y values:
-          DO n=1,nparcels_mpi
+          DO n=1,nparcelsLocal
             pdata(n,pry) = 0.0
           ENDDO
         ENDIF
         IF(nx.eq.1)THEN
           ! 170719,  for 2d setup (y,z), fix all x values:
-          DO n=1,nparcels_mpi
+          DO n=1,nparcelsLocal
             pdata(n,prx) = 0.0
           ENDDO
         ENDIF
@@ -2145,7 +2145,7 @@
       real, dimension(ibm:iem,jbm:jem,kbm:kem,numq) :: qa,q3d
       real, dimension(ibt:iet,jbt:jet,kbt:ket) :: tkea,tke3d
       real, dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d
-      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
+      real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
       logical, intent(in), dimension(ibib:ieib,jbib:jeib,kbib:keib) :: bndy
       integer, intent(in), dimension(ibib:ieib,jbib:jeib) :: kbdy
       integer, dimension(rmp) :: reqs_u,reqs_v,reqs_w,reqs_s,reqs_p,reqs_tk
@@ -2622,7 +2622,7 @@
         endif
         if( .not. restarted )then
           ! 181022:  not a restart ... initialize sigma
-          do n=1,nparcels_mpi
+          do n=1,nparcelsLocal
             ! get sigma from z:
             ! (see Section 3 of "The governing equations for CM1", 
             !  http://www2.mmm.ucar.edu/people/bryan/cm1/cm1_equations.pdf)
@@ -2630,7 +2630,7 @@
           enddo
         else
           ! 181022:  this is a restart ... get z
-          do n=1,nparcels_mpi
+          do n=1,nparcelsLocal
             ! get z from sigma:
             ! (see Section 3 of "The governing equations for CM1", 
             !  http://www2.mmm.ucar.edu/people/bryan/cm1/cm1_equations.pdf)

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -499,12 +499,6 @@
 
         if(dowr) write(outfile,*)
 
-!JS: comment the section below with the new MPI implementation for droplets
-!#ifdef MPI
-!        ! this ensures that every processor has all parcel locations:
-!        call MPI_ALLREDUCE(MPI_IN_PLACE,pdata(1,1),3*nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
-!#endif
-
         IF(axisymm.eq.1.or.ny.eq.1)THEN
           ! 170719,  for 2d setup (x,z), fix all y values:
           DO n=1,nparcels_mpi

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -414,6 +414,8 @@
         ! The generated random number is independent of compilers and MPI ranks
         randomNumbers = new_RandomNumberSequence(seed = nparcels)
 
+        i = 1
+
         do n=1,nparcels
 
           rand = getRandomReal(randomNumbers)
@@ -424,17 +426,12 @@
           tmpz = rand*maxz
 
           ! check if this parcel falls into this MPI region
-          if ( tmpx .ge. xfref(myi1) .and. tmpx .le. xfref(myi2) .and. &
-               tmpy .ge. yfref(myj1) .and. tmpy .le. yfref(myj2) ) then
+          if ( tmpx .ge. xf(1) .and. tmpx .le. xf(ni+1) .and. &
+               tmpy .ge. yf(1) .and. tmpy .le. yf(nj+1) ) then
 
-             do i = 1, nparcels_mpi
-                if ( pdata(i,prx) .eq. neg_huge ) then
-                   pdata(i,prx) = tmpx
-                   pdata(i,pry) = tmpy
-                   pdata(i,prz) = tmpz
-                   exit
-                end if
-             end do
+             pdata(i,prx) = tmpx
+             pdata(i,pry) = tmpy
+             pdata(i,prz) = tmpz
 
              !if(MODULO(n,100)==0) then 
              if(dowr) write(outfile,*) i,pdata(i,prx),pdata(i,pry),pdata(i,prz)
@@ -472,6 +469,8 @@
                 pdata(i,prrho) = 0.0
     
              end if ! end of if statement for prcl_droplet == 1
+
+             i = i + 1
 
           end if    ! end of if statement for xfref/yfref check
 

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -471,13 +471,13 @@
              end if ! end of if statement for prcl_droplet == 1
 
              i = i + 1
-   
+#ifdef MPI   
              if ( i .gt. nparcels_mpi ) then
                 write(*,*) "Not enough space to initialize the droplets on myid = ", myid 
                 write(*,*) 'Please increase the value of "pdata_buffer" in the constants.F'
                 stop "Stop the program..."
              end if
-
+#endif
           end if    ! end of if statement for xf/yf check
 
         end do      ! end of loop for nparcels

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -478,7 +478,7 @@
                 stop "Stop the program..."
              end if
 
-          end if    ! end of if statement for xfref/yfref check
+          end if    ! end of if statement for xf/yf check
 
         end do      ! end of loop for nparcels
 

--- a/src/input.F
+++ b/src/input.F
@@ -158,13 +158,13 @@
               bl_mynn_mixlength,bl_mynn_edmf,                                 &
               bl_mynn_edmf_mom,bl_mynn_edmf_tke,bl_mynn_mixscalars,           &
               bl_mynn_cloudmix,bl_mynn_mixqt,initflag,spp_pbl,bl_mynn_output, &
-              nutk,nvtk,nwtk,nparcels_mpi
+              nutk,nvtk,nwtk,nparcelsLocal
 
       !$acc declare create (ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,   &
       !$acc                 axisymm,terrain_flag,ni,nj,nip1,nk,nkp1,imoist, &
       !$acc                 nqv,bbc,imove,prvpx,prvpy,prvpz,prrp,prms,prtp, &
       !$acc                 prx,pry,prz,prsig,ngxy,ngz,ptype,pru,prv,prw,   &
-      !$acc                 prt,prqv,prprs,prrho,nparcels_mpi)
+      !$acc                 prt,prqv,prprs,prrho,nparcelsLocal)
 
 !-----------------------------------------------------------------------
 

--- a/src/input.F
+++ b/src/input.F
@@ -158,13 +158,13 @@
               bl_mynn_mixlength,bl_mynn_edmf,                                 &
               bl_mynn_edmf_mom,bl_mynn_edmf_tke,bl_mynn_mixscalars,           &
               bl_mynn_cloudmix,bl_mynn_mixqt,initflag,spp_pbl,bl_mynn_output, &
-              nutk,nvtk,nwtk
+              nutk,nvtk,nwtk,nparcels_mpi
 
       !$acc declare create (ib,ie,jb,je,kb,ke,numq,nparcels,npvals,nx,ny,   &
       !$acc                 axisymm,terrain_flag,ni,nj,nip1,nk,nkp1,imoist, &
       !$acc                 nqv,bbc,imove,prvpx,prvpy,prvpz,prrp,prms,prtp, &
       !$acc                 prx,pry,prz,prsig,ngxy,ngz,ptype,pru,prv,prw,   &
-      !$acc                 prt,prqv,prprs,prrho)
+      !$acc                 prt,prqv,prprs,prrho,nparcels_mpi)
 
 !-----------------------------------------------------------------------
 

--- a/src/param.F
+++ b/src/param.F
@@ -5075,7 +5075,7 @@
       qd_subl  = 0
 
       ! dbz (new for cm1r19)
-      IF( output_dbz.eq.1 .or. restart_file_dbz )THEN
+      IF( output_dbz.eq.1 .or. restart_file_dbz .or. prcl_dbz )THEN
         ibdq = ib
         iedq = ie
         jbdq = jb

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1752,6 +1752,8 @@
 
 !----------------------------------------------------------------------
 !  communicate data
+
+! JS: the section below needs to be revised for the new MPI implementation
 #ifdef MPI
   !$acc update host(pdata)
   do n=npvars+1,npvals
@@ -1949,7 +1951,7 @@
 
 
       subroutine getparcelzs(xh,uh,ruh,xf,yh,vh,rvh,yf,zs,pdata)
-      use input, only : ib,ie,jb,je,nparcels,npvals,ni,nj,nx,ny, &
+      use input, only : ib,ie,jb,je,nparcels_mpi,npvals,ni,nj,nx,ny, &
           myi,myj,axisymm,nodex,nodey,ierr, &
           prx,pry,przs
       use constants
@@ -1963,13 +1965,13 @@
       real, intent(in), dimension(jb:je) :: yh,vh,rvh
       real, intent(in), dimension(jb:je+1) :: yf
       real, intent(in), dimension(ib:ie,jb:je) :: zs
-      real, intent(inout), dimension(nparcels,npvals) :: pdata
+      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
 
       integer :: i,j,iflag,jflag,np
       real :: x3d,y3d
 
     zsnploop:  &
-    DO np=1,nparcels
+    DO np=1,nparcels_mpi
 
       x3d = pdata(np,prx)
       y3d = pdata(np,pry)
@@ -2042,9 +2044,10 @@
 
     ENDDO  zsnploop
 
-#ifdef MPI
-    call MPI_ALLREDUCE(MPI_IN_PLACE,pdata(1,przs) ,nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
-#endif
+! JS: comment out the section below with the new MPI implementation for droplets
+!#ifdef MPI
+!    call MPI_ALLREDUCE(MPI_IN_PLACE,pdata(1,przs) ,nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
+!#endif
 
       end subroutine getparcelzs
 

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1787,7 +1787,17 @@
 
 !----------------------------------------------------------------------
 !  write out data
+
     !$acc update host(pdata)
+
+    ! JS: use MPI_GATHER to collect all the droplet information
+    !     from different MPI ranks;
+    !     write out the "holes" with garbage information as well
+    if ( myid .eq. 0 ) allocate(rbuf(nparcels_mpi*numprocs,npvals))
+    call mpi_gather(pdata,npvals*nparcels_mpi,MPI_REAL, &
+                    rbuf,npvals*nparcels_mpi,MPI_REAL, &
+                    0,MPI_COMM_WORLD,ierr)
+
     IF(myid.eq.0)THEN
 
       IF(output_format.eq.1)THEN
@@ -1811,14 +1821,6 @@
 
         if(dowr) write(outfile,*)
         if(dowr) write(outfile,*) '  pdata prec = ',prec
-
-        ! JS: use MPI_GATHER to collect all the droplet information
-        !     from different MPI ranks;
-        !     write out the "holes" with garbage information as well
-        allocate(rbuf(nparcels_mpi*numprocs,npvals))
-        call mpi_gather(pdata,npvals*nparcels_mpi,MPI_REAL, &
-                        rbuf,npvals*nparcels_mpi,MPI_REAL, &
-                        0,MPI_COMM_WORLD,ierr)
 
         write(61,rec=prec) ((rbuf(np,n),np=1,nparcels_mpi*numprocs),n=1,npvals)
         

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -744,7 +744,7 @@
       real, intent(inout), dimension(ibc:iec,jbc:jec,kbc:kec) :: kmh,kmv,khh,khv
       real, intent(inout), dimension(ibt:iet,jbt:jet,kbt:ket) :: tke3d
       real, intent(inout), dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pt3d
-      real, intent(inout), dimension(nparcels,npvals) :: pdata
+      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
       real, intent(inout) , dimension(ibdt:iedt,jbdt:jedt,kbdt:kedt,ntdiag) :: tdiag
       real, intent(inout) , dimension(ibdq:iedq,jbdq:jedq,kbdq:kedq,nqdiag) :: qdiag
       real, intent(inout), dimension(jmp,kmp) :: pw1,pw2,pe1,pe2
@@ -1219,7 +1219,7 @@
     !PORTME
     !$acc parallel loop gang vector default(present)
     nploop2:  &
-    DO np=1,nparcels
+    DO np=1,nparcels_mpi
 
       pdata(np,prtime) = mtime
 
@@ -1750,22 +1750,9 @@
     ENDDO  nploop2
     if(timestats.ge.1) time_parceli=time_parceli+mytime()
 
-!----------------------------------------------------------------------
-!  communicate data
+    ! JS: no need to use MPI_REDUCE since different MPI ranks work on
+    !     different parcels now in the new MPI implementation
 
-! JS: the section below needs to be revised for the new MPI implementation
-#ifdef MPI
-  !$acc update host(pdata)
-  do n=npvars+1,npvals
-    if( myid.eq.0 )then
-      call MPI_REDUCE(MPI_IN_PLACE,pdata(1,n),nparcels,MPI_REAL,MPI_MAX,0,MPI_COMM_WORLD,ierr)
-    else
-      call MPI_REDUCE( pdata(1,n),pdata(1,n),nparcels,MPI_REAL,MPI_MAX,0,MPI_COMM_WORLD,ierr)
-    endif
-  enddo
-  !$acc update device(pdata)
-  if(timestats.ge.1) time_parceli_reduce=time_parceli_reduce+mytime()
-#endif
 !----------------------------------------------------------------------
 
 
@@ -1779,7 +1766,7 @@
 
       subroutine parcel_write(prec,rtime,qname,name_prcl,desc_prcl,unit_prcl,pdata,ploc)
       use input, only : maxq,maxvars,nparcels,npvals,output_format,myid,dowr, &
-          maxstring,string,outfile
+          maxstring,string,outfile,nparcels_mpi,numprocs
 #ifdef NETCDF
       use writeout_nc_module, only : writepdata_nc
 #endif
@@ -1789,10 +1776,11 @@
       real, intent(in) :: rtime
       character(len=3), intent(in), dimension(maxq) :: qname
       character(len=40), intent(in), dimension(maxvars) :: name_prcl,desc_prcl,unit_prcl
-      real, intent(in), dimension(nparcels,npvals) :: pdata
+      real, intent(in), dimension(nparcels_mpi,npvals) :: pdata
       real, intent(inout), dimension(nparcels,3) :: ploc
 
       integer :: i,n,np
+      real, dimension(:,:),allocatable :: rbuf
 
 !----------------------------------------------------------------------
 !  write out data
@@ -1816,14 +1804,24 @@
 
         if(dowr) write(outfile,*) string
         open(unit=61,file=string,form='unformatted',access='direct',   &
-             recl=4*npvals*nparcels,status='unknown')
+             recl=4*npvals*nparcels_mpi*numprocs,status='unknown')
 
         if(dowr) write(outfile,*)
         if(dowr) write(outfile,*) '  pdata prec = ',prec
 
-        write(61,rec=prec) ((pdata(np,n),np=1,nparcels),n=1,npvals)
+        ! JS: use MPI_GATHER to collect all the droplet information
+        !     from different MPI ranks;
+        !     write out the "holes" with garbage information as well
+        allocate(rbuf(nparcels_mpi*numprocs,npvals))
+        call mpi_gather(pdata,npvals*nparcels_mpi,MPI_REAL, &
+                        rbuf,npvals*nparcels_mpi,MPI_REAL, &
+                        0,MPI_COMM_WORLD,ierr)
 
+        write(61,rec=prec) ((rbuf(np,n),np=1,nparcels_mpi*numprocs),n=1,npvals)
+        
         close(unit=61)
+     
+        deallocate(rbuf)
 
 #ifdef NETCDF
       ELSEIF(output_format.eq.2)THEN

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -695,13 +695,13 @@
       use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ibm,iem,jbm,jem, &
           kbm,kem,numq,ibc,iec,jbc,jec,kbc,kec,ibt,iet,jbt,jet,kbt,ket,npt,ierr, &
           ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,ibdq,iedq,jbdq,jedq,kbdq,kedq, &
-          nqdiag,jmp,imp,kmp,rmp,cmp,kmt,ibp,iep,jbp,jep,kbp,kep,nparcels,npvals,npvars, &
+          nqdiag,jmp,imp,kmp,rmp,cmp,kmt,ibp,iep,jbp,jep,kbp,kep,nparcels_mpi,npvals,npvars, &
           ni,nj,nk,nqv,nql1,nql2,nqs1,nqs2,nqv,imoist,timestats,mytime,time_phys_d2h, &
           imoist,iice,time_parceli,bbc,tbc,rdz,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,imove, &
           qd_dbz,rdx,rdy,nx,ny,myi,myj,nodex,nodey,myid,nip1,njp1,nkp1,axisymm,nnc1, &
           umove,vmove,prth,prt,prqsl,prqsi,prvpg,prb,prprs,prrho,prpt1,prqv,prq1,prnc1, &
           prkm,prkh,prtke,prdbz,przv,prx,pry,prz,prtime,prq2,prnc2,prznt,prust,pru,prv, &
-          prw,prsig,time_parceli_reduce,terrain_flag,nparcels_mpi
+          prw,prsig,time_parceli_reduce,terrain_flag
       use constants
       use cm1libs , only : rslf,rsif
       use bc_module, only: bcu2_GPU, bcv2_GPU, bcw2_GPU
@@ -1750,9 +1750,6 @@
     ENDDO  nploop2
     if(timestats.ge.1) time_parceli=time_parceli+mytime()
 
-    ! JS: no need to use MPI_REDUCE since different MPI ranks work on
-    !     different parcels now in the new MPI implementation
-
 !----------------------------------------------------------------------
 
 
@@ -1766,7 +1763,7 @@
 
       subroutine parcel_write(prec,rtime,qname,name_prcl,desc_prcl,unit_prcl,pdata,ploc)
       use input, only : maxq,maxvars,nparcels,npvals,output_format,myid,dowr, &
-          maxstring,string,outfile,nparcels_mpi,numprocs,ierr
+          maxstring,string,outfile,numprocs,ierr,nparcels_mpi
 #ifdef MPI
       use mpi
 #endif
@@ -2046,11 +2043,6 @@
       ENDIF  zsmyparcel
 
     ENDDO  zsnploop
-
-! JS: comment out the section below with the new MPI implementation for droplets
-!#ifdef MPI
-!    call MPI_ALLREDUCE(MPI_IN_PLACE,pdata(1,przs) ,nparcels,MPI_REAL,MPI_MAX,MPI_COMM_WORLD,ierr)
-!#endif
 
       end subroutine getparcelzs
 

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1762,8 +1762,8 @@
 
 
       subroutine parcel_write(prec,rtime,qname,name_prcl,desc_prcl,unit_prcl,pdata,ploc)
-      use input, only : maxq,maxvars,nparcels,npvals,output_format,myid,dowr, &
-          maxstring,string,outfile,numprocs,ierr,nparcels_mpi
+      use input, only : maxq,maxvars,nparcels_mpi,npvals,output_format,myid,dowr, &
+          maxstring,string,outfile,numprocs,ierr
 #ifdef MPI
       use mpi
 #endif
@@ -1777,10 +1777,13 @@
       character(len=3), intent(in), dimension(maxq) :: qname
       character(len=40), intent(in), dimension(maxvars) :: name_prcl,desc_prcl,unit_prcl
       real, intent(in), dimension(nparcels_mpi,npvals) :: pdata
-      real, intent(inout), dimension(nparcels,3) :: ploc
+      real, intent(inout), dimension(nparcels_mpi,3) :: ploc
 
       integer :: i,n,np
+
+#ifdef MPI
       real, dimension(:,:),allocatable :: rbuf
+#endif
 
 !----------------------------------------------------------------------
 !  write out data
@@ -1790,6 +1793,7 @@
     ! JS: use MPI_GATHER to collect all the droplet information
     !     from different MPI ranks;
     !     write out the "holes" with garbage information as well
+
 #ifdef MPI
     if ( myid .eq. 0 ) allocate(rbuf(nparcels_mpi*numprocs,npvals))
     call mpi_gather(pdata,npvals*nparcels_mpi,MPI_REAL, &
@@ -1821,11 +1825,17 @@
         if(dowr) write(outfile,*)
         if(dowr) write(outfile,*) '  pdata prec = ',prec
 
+#ifdef MPI
         write(61,rec=prec) ((rbuf(np,n),np=1,nparcels_mpi*numprocs),n=1,npvals)
-        
+#else
+        write(61,rec=prec) ((pdata(np,n),np=1,nparcels_mpi*numprocs),n=1,npvals)
+#endif
+
         close(unit=61)
-     
+
+#ifdef MPI     
         deallocate(rbuf)
+#endif
 
 #ifdef NETCDF
       ELSEIF(output_format.eq.2)THEN

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -701,7 +701,7 @@
           qd_dbz,rdx,rdy,nx,ny,myi,myj,nodex,nodey,myid,nip1,njp1,nkp1,axisymm,nnc1, &
           umove,vmove,prth,prt,prqsl,prqsi,prvpg,prb,prprs,prrho,prpt1,prqv,prq1,prnc1, &
           prkm,prkh,prtke,prdbz,przv,prx,pry,prz,prtime,prq2,prnc2,prznt,prust,pru,prv, &
-          prw,prsig,time_parceli_reduce,terrain_flag
+          prw,prsig,time_parceli_reduce,terrain_flag,nparcels_mpi
       use constants
       use cm1libs , only : rslf,rsif
       use bc_module, only: bcu2_GPU, bcv2_GPU, bcw2_GPU
@@ -1766,7 +1766,10 @@
 
       subroutine parcel_write(prec,rtime,qname,name_prcl,desc_prcl,unit_prcl,pdata,ploc)
       use input, only : maxq,maxvars,nparcels,npvals,output_format,myid,dowr, &
-          maxstring,string,outfile,nparcels_mpi,numprocs
+          maxstring,string,outfile,nparcels_mpi,numprocs,ierr
+#ifdef MPI
+      use mpi
+#endif
 #ifdef NETCDF
       use writeout_nc_module, only : writepdata_nc
 #endif

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -695,7 +695,7 @@
       use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ibm,iem,jbm,jem, &
           kbm,kem,numq,ibc,iec,jbc,jec,kbc,kec,ibt,iet,jbt,jet,kbt,ket,npt,ierr, &
           ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,ibdq,iedq,jbdq,jedq,kbdq,kedq, &
-          nqdiag,jmp,imp,kmp,rmp,cmp,kmt,ibp,iep,jbp,jep,kbp,kep,nparcels_mpi,npvals,npvars, &
+          nqdiag,jmp,imp,kmp,rmp,cmp,kmt,ibp,iep,jbp,jep,kbp,kep,nparcelsLocal,npvals,npvars, &
           ni,nj,nk,nqv,nql1,nql2,nqs1,nqs2,nqv,imoist,timestats,mytime,time_phys_d2h, &
           imoist,iice,time_parceli,bbc,tbc,rdz,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,imove, &
           qd_dbz,rdx,rdy,nx,ny,myi,myj,nodex,nodey,myid,nip1,njp1,nkp1,axisymm,nnc1, &
@@ -744,7 +744,7 @@
       real, intent(inout), dimension(ibc:iec,jbc:jec,kbc:kec) :: kmh,kmv,khh,khv
       real, intent(inout), dimension(ibt:iet,jbt:jet,kbt:ket) :: tke3d
       real, intent(inout), dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pt3d
-      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
+      real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
       real, intent(inout) , dimension(ibdt:iedt,jbdt:jedt,kbdt:kedt,ntdiag) :: tdiag
       real, intent(inout) , dimension(ibdq:iedq,jbdq:jedq,kbdq:kedq,nqdiag) :: qdiag
       real, intent(inout), dimension(jmp,kmp) :: pw1,pw2,pe1,pe2
@@ -1219,7 +1219,7 @@
     !PORTME
     !$acc parallel loop gang vector default(present)
     nploop2:  &
-    DO np=1,nparcels_mpi
+    DO np=1,nparcelsLocal
 
       pdata(np,prtime) = mtime
 
@@ -1762,7 +1762,7 @@
 
 
       subroutine parcel_write(prec,rtime,qname,name_prcl,desc_prcl,unit_prcl,pdata,ploc)
-      use input, only : maxq,maxvars,nparcels_mpi,npvals,output_format,myid,dowr, &
+      use input, only : maxq,maxvars,nparcelsLocal,npvals,output_format,myid,dowr, &
           maxstring,string,outfile,numprocs,ierr
 #ifdef MPI
       use mpi
@@ -1776,8 +1776,8 @@
       real, intent(in) :: rtime
       character(len=3), intent(in), dimension(maxq) :: qname
       character(len=40), intent(in), dimension(maxvars) :: name_prcl,desc_prcl,unit_prcl
-      real, intent(in), dimension(nparcels_mpi,npvals) :: pdata
-      real, intent(inout), dimension(nparcels_mpi,3) :: ploc
+      real, intent(in), dimension(nparcelsLocal,npvals) :: pdata
+      real, intent(inout), dimension(nparcelsLocal,3) :: ploc
 
       integer :: i,n,np
 
@@ -1794,12 +1794,12 @@
     !     from different MPI ranks;
     !     write out the "holes" with garbage information as well
 
-#ifdef MPI
-    if ( myid .eq. 0 ) allocate(rbuf(nparcels_mpi*numprocs,npvals))
-    call mpi_gather(pdata,npvals*nparcels_mpi,MPI_REAL, &
-                    rbuf,npvals*nparcels_mpi,MPI_REAL, &
-                    0,MPI_COMM_WORLD,ierr)
-#endif
+!#ifdef MPI
+!    if ( myid .eq. 0 ) allocate(rbuf(nparcelsLocal*numprocs,npvals))
+!    call mpi_gather(pdata,npvals*nparcelsLocal,MPI_REAL, &
+!                    rbuf,npvals*nparcelsLocal,MPI_REAL, &
+!                    0,MPI_COMM_WORLD,ierr)
+!#endif
 
     IF(myid.eq.0)THEN
 
@@ -1813,29 +1813,29 @@
           string(i:i) = ' '
         enddo
 
-        string = 'cm1out_pdata.dat'
-
-!!!        write(string(15:20),101) prec
-!!!101     format(i6.6)
-
-        if(dowr) write(outfile,*) string
-        open(unit=61,file=string,form='unformatted',access='direct',   &
-             recl=4*npvals*nparcels_mpi*numprocs,status='unknown')
-
-        if(dowr) write(outfile,*)
-        if(dowr) write(outfile,*) '  pdata prec = ',prec
-
-#ifdef MPI
-        write(61,rec=prec) ((rbuf(np,n),np=1,nparcels_mpi*numprocs),n=1,npvals)
-#else
-        write(61,rec=prec) ((pdata(np,n),np=1,nparcels_mpi*numprocs),n=1,npvals)
-#endif
-
-        close(unit=61)
-
-#ifdef MPI     
-        deallocate(rbuf)
-#endif
+!        string = 'cm1out_pdata.dat'
+!
+!!!!        write(string(15:20),101) prec
+!!!!101     format(i6.6)
+!
+!        if(dowr) write(outfile,*) string
+!        open(unit=61,file=string,form='unformatted',access='direct',   &
+!             recl=4*npvals*nparcelsLocal*numprocs,status='unknown')
+!
+!        if(dowr) write(outfile,*)
+!        if(dowr) write(outfile,*) '  pdata prec = ',prec
+!
+!#ifdef MPI
+!        write(61,rec=prec) ((rbuf(np,n),np=1,nparcelsLocal*numprocs),n=1,npvals)
+!#else
+!        write(61,rec=prec) ((pdata(np,n),np=1,nparcelsLocal*numprocs),n=1,npvals)
+!#endif
+!
+!        close(unit=61)
+!
+!#ifdef MPI     
+!        deallocate(rbuf)
+!#endif
 
 #ifdef NETCDF
       ELSEIF(output_format.eq.2)THEN
@@ -1963,7 +1963,7 @@
 
 
       subroutine getparcelzs(xh,uh,ruh,xf,yh,vh,rvh,yf,zs,pdata)
-      use input, only : ib,ie,jb,je,nparcels_mpi,npvals,ni,nj,nx,ny, &
+      use input, only : ib,ie,jb,je,nparcelsLocal,npvals,ni,nj,nx,ny, &
           myi,myj,axisymm,nodex,nodey,ierr, &
           prx,pry,przs
       use constants
@@ -1977,13 +1977,13 @@
       real, intent(in), dimension(jb:je) :: yh,vh,rvh
       real, intent(in), dimension(jb:je+1) :: yf
       real, intent(in), dimension(ib:ie,jb:je) :: zs
-      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
+      real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
 
       integer :: i,j,iflag,jflag,np
       real :: x3d,y3d
 
     zsnploop:  &
-    DO np=1,nparcels_mpi
+    DO np=1,nparcelsLocal
 
       x3d = pdata(np,prx)
       y3d = pdata(np,pry)

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1790,10 +1790,12 @@
     ! JS: use MPI_GATHER to collect all the droplet information
     !     from different MPI ranks;
     !     write out the "holes" with garbage information as well
+#ifdef MPI
     if ( myid .eq. 0 ) allocate(rbuf(nparcels_mpi*numprocs,npvals))
     call mpi_gather(pdata,npvals*nparcels_mpi,MPI_REAL, &
                     rbuf,npvals*nparcels_mpi,MPI_REAL, &
                     0,MPI_COMM_WORLD,ierr)
+#endif
 
     IF(myid.eq.0)THEN
 

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1741,7 +1741,7 @@
 
         ! set to really small number (so we can use the allreduce command below)
         do n=npvars+1,npvals
-          pdata(np,n) = -1.0e30
+          pdata(np,n) = neg_huge 
         enddo
 #endif
 

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -148,7 +148,7 @@
           kbb2,kbe2,ibph,ieph,jbph,jeph,kbph,keph,ibnba,ienba,jbnba,jenba,kbnba,kenba, &
           nx,ny,nz,ni,nj,nk,ibm,iem,jbm,jem,kbm,kem,ibc,iec,jbc,jec,kbc,kec,ibt,iet,jbt, &
           jet,kbt,ket,ibb,ieb,jbb,jeb,kbb,keb,ibr,ier,jbr,jer,kbr,ker,maxq,nbudget,numq,ngxy, &
-          nrain,npt,nparcels_mpi,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
+          nrain,npt,nparcelsLocal,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
           jb2pt,je2pt,kb2pt,ke2pt,ipb,ipe,jpb,jpe,kpb,kpe,rmp,cmp,kmt,imp,jmp,kmp,d3i,d3j, &
           d3t,d3n,d2i,d2j,ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,ibdq,iedq,jbdq,jedq,kbdq, &
           kedq,nqdiag,ibdv,iedv,jbdv,jedv,kbdv,kedv,nudiag,nvdiag,nwdiag,ibdk,iedk,jbdk, &
@@ -263,7 +263,7 @@
       real, intent(inout), dimension(ibl:iel,jbl:jel,num_soil_layers) :: tslb
       real, intent(inout), dimension(ibl:iel,jbl:jel) :: tmn,tml,t0ml,hml,h0ml,huml,hvml,tmoml
       real, intent(inout), dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d,ptten
-      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
+      real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
       real, intent(in), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: cfb
       real, intent(in), dimension(kpb:kpe) :: cfa,cfc,ad1,ad2
       complex, intent(inout), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: pdt,lgbth,lgbph

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -267,7 +267,7 @@
       real, intent(inout), dimension(ibl:iel,jbl:jel,num_soil_layers) :: tslb
       real, intent(inout), dimension(ibl:iel,jbl:jel) :: tmn,tml,t0ml,hml,h0ml,huml,hvml,tmoml
       real, intent(inout), dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d,ptten
-      real, intent(inout), dimension(nparcels,npvals) :: pdata
+      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
       real, intent(in), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: cfb
       real, intent(in), dimension(kpb:kpe) :: cfa,cfc,ad1,ad2
       complex, intent(inout), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: pdt,lgbth,lgbph

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -148,7 +148,7 @@
           kbb2,kbe2,ibph,ieph,jbph,jeph,kbph,keph,ibnba,ienba,jbnba,jenba,kbnba,kenba, &
           nx,ny,nz,ni,nj,nk,ibm,iem,jbm,jem,kbm,kem,ibc,iec,jbc,jec,kbc,kec,ibt,iet,jbt, &
           jet,kbt,ket,ibb,ieb,jbb,jeb,kbb,keb,ibr,ier,jbr,jer,kbr,ker,maxq,nbudget,numq,ngxy, &
-          nrain,npt,nparcels,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
+          nrain,npt,nparcels_mpi,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
           jb2pt,je2pt,kb2pt,ke2pt,ipb,ipe,jpb,jpe,kpb,kpe,rmp,cmp,kmt,imp,jmp,kmp,d3i,d3j, &
           d3t,d3n,d2i,d2j,ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,ibdq,iedq,jbdq,jedq,kbdq, &
           kedq,nqdiag,ibdv,iedv,jbdv,jedv,kbdv,kedv,nudiag,nvdiag,nwdiag,ibdk,iedk,jbdk, &
@@ -164,7 +164,6 @@
           kd_turb,ud_rdamp,vd_rdamp,wd_rdamp,td_rdamp,td_hediff,td_vediff,qd_hediff,qd_vediff, &
           td_diss,td_rad,td_pbl,td_hturb,td_vturb,qd_hturb,qd_vturb,ud_pbl,vd_pbl,qd_pbl, &
           td_nudge,qd_nudge
-           
 
       use constants
       use bc_module, only: radbcew, radbcns 

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -148,7 +148,7 @@
           kbb2,kbe2,ibph,ieph,jbph,jeph,kbph,keph,ibnba,ienba,jbnba,jenba,kbnba,kenba, &
           nx,ny,nz,ni,nj,nk,ibm,iem,jbm,jem,kbm,kem,ibc,iec,jbc,jec,kbc,kec,ibt,iet,jbt, &
           jet,kbt,ket,ibb,ieb,jbb,jeb,kbb,keb,ibr,ier,jbr,jer,kbr,ker,maxq,nbudget,numq,ngxy, &
-          nrain,npt,nparcels_mpi,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
+          nrain,npt,nparcelsLocal,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
           jb2pt,je2pt,kb2pt,ke2pt,ipb,ipe,jpb,jpe,kpb,kpe,rmp,cmp,kmt,imp,jmp,kmp,d3i,d3j, &
           d3t,d3n,d2i,d2j,ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,ibdq,iedq,jbdq,jedq,kbdq, &
           kedq,nqdiag,ibdv,iedv,jbdv,jedv,kbdv,kedv,nudiag,nvdiag,nwdiag,ibdk,iedk,jbdk, &
@@ -274,7 +274,7 @@
       real, intent(inout), dimension(ibl:iel,jbl:jel,num_soil_layers) :: tslb
       real, intent(inout), dimension(ibl:iel,jbl:jel) :: tmn,tml,t0ml,hml,h0ml,huml,hvml,tmoml
       real, intent(inout), dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d,ptten
-      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
+      real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
       real, intent(in), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: cfb
       real, intent(in), dimension(kpb:kpe) :: cfa,cfc,ad1,ad2
       complex, intent(inout), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: pdt,lgbth,lgbph

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -148,7 +148,7 @@
           kbb2,kbe2,ibph,ieph,jbph,jeph,kbph,keph,ibnba,ienba,jbnba,jenba,kbnba,kenba, &
           nx,ny,nz,ni,nj,nk,ibm,iem,jbm,jem,kbm,kem,ibc,iec,jbc,jec,kbc,kec,ibt,iet,jbt, &
           jet,kbt,ket,ibb,ieb,jbb,jeb,kbb,keb,ibr,ier,jbr,jer,kbr,ker,maxq,nbudget,numq,ngxy, &
-          nrain,npt,nparcels,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
+          nrain,npt,nparcels_mpi,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
           jb2pt,je2pt,kb2pt,ke2pt,ipb,ipe,jpb,jpe,kpb,kpe,rmp,cmp,kmt,imp,jmp,kmp,d3i,d3j, &
           d3t,d3n,d2i,d2j,ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,ibdq,iedq,jbdq,jedq,kbdq, &
           kedq,nqdiag,ibdv,iedv,jbdv,jedv,kbdv,kedv,nudiag,nvdiag,nwdiag,ibdk,iedk,jbdk, &

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -279,7 +279,7 @@
       real, intent(inout), dimension(ibl:iel,jbl:jel,num_soil_layers) :: tslb
       real, intent(inout), dimension(ibl:iel,jbl:jel) :: tmn,tml,t0ml,hml,h0ml,huml,hvml,tmoml
       real, intent(inout), dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d,ptten
-      real, intent(inout), dimension(nparcels,npvals) :: pdata
+      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
       real, intent(in), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: cfb
       real, intent(in), dimension(kpb:kpe) :: cfa,cfc,ad1,ad2
       complex, intent(inout), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: pdt,lgbth,lgbph

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -146,7 +146,7 @@
           kbb2,kbe2,ibph,ieph,jbph,jeph,kbph,keph,ibnba,ienba,jbnba,jenba,kbnba,kenba, &
           nx,ny,nz,ni,nj,nk,ibm,iem,jbm,jem,kbm,kem,ibc,iec,jbc,jec,kbc,kec,ibt,iet,jbt, &
           jet,kbt,ket,ibb,ieb,jbb,jeb,kbb,keb,ibr,ier,jbr,jer,kbr,ker,maxq,nbudget,numq,ngxy, &
-          nrain,npt,nparcels,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
+          nrain,npt,nparcels_mpi,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
           jb2pt,je2pt,kb2pt,ke2pt,ipb,ipe,jpb,jpe,kpb,kpe,rmp,cmp,kmt,imp,jmp,kmp,d3i,d3j, &
           d3t,d3n,d2i,d2j,ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,ibdq,iedq,jbdq,jedq,kbdq, &
           kedq,nqdiag,ibdv,iedv,jbdv,jedv,kbdv,kedv,nudiag,nvdiag,nwdiag,ibdk,iedk,jbdk, &

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -146,7 +146,7 @@
           kbb2,kbe2,ibph,ieph,jbph,jeph,kbph,keph,ibnba,ienba,jbnba,jenba,kbnba,kenba, &
           nx,ny,nz,ni,nj,nk,ibm,iem,jbm,jem,kbm,kem,ibc,iec,jbc,jec,kbc,kec,ibt,iet,jbt, &
           jet,kbt,ket,ibb,ieb,jbb,jeb,kbb,keb,ibr,ier,jbr,jer,kbr,ker,maxq,nbudget,numq,ngxy, &
-          nrain,npt,nparcels_mpi,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
+          nrain,npt,nparcelsLocal,npvals,ibl,iel,jbl,jel,ibp,iep,jbp,jep,kbp,kep,ib2pt,ie2pt, &
           jb2pt,je2pt,kb2pt,ke2pt,ipb,ipe,jpb,jpe,kpb,kpe,rmp,cmp,kmt,imp,jmp,kmp,d3i,d3j, &
           d3t,d3n,d2i,d2j,ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,ibdq,iedq,jbdq,jedq,kbdq, &
           kedq,nqdiag,ibdv,iedv,jbdv,jedv,kbdv,kedv,nudiag,nvdiag,nwdiag,ibdk,iedk,jbdk, &
@@ -261,7 +261,7 @@
       real, intent(inout), dimension(ibl:iel,jbl:jel,num_soil_layers) :: tslb
       real, intent(inout), dimension(ibl:iel,jbl:jel) :: tmn,tml,t0ml,hml,h0ml,huml,hvml,tmoml
       real, intent(inout), dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d,ptten
-      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
+      real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
       double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke,2) :: dpten
       real, intent(in), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: cfb
       real, intent(in), dimension(kpb:kpe) :: cfa,cfc,ad1,ad2
@@ -325,7 +325,7 @@
       integer, intent(in), dimension(ibib:ieib,jbib:jeib,kmaxib) :: hflxw,hflxe,hflxs,hflxn
       logical, intent(in) :: dowriteout,dorad,dotdwrite,doazimwrite,dorestart
       logical, intent(inout) :: getdbz,getvt,dotbud,doqbud,doubud,dovbud,dowbud,donudge
-      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind
+      integer, intent(inout), dimension(nparcelsLocal,3) :: pdata_locind
 
 !-----------------------------------------------------------------------
 ! Arrays and variables defined inside solve

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -261,7 +261,7 @@
       real, intent(inout), dimension(ibl:iel,jbl:jel,num_soil_layers) :: tslb
       real, intent(inout), dimension(ibl:iel,jbl:jel) :: tmn,tml,t0ml,hml,h0ml,huml,hvml,tmoml
       real, intent(inout), dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d,ptten
-      real, intent(inout), dimension(nparcels,npvals) :: pdata
+      real, intent(inout), dimension(nparcels_mpi,npvals) :: pdata
       double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke,2) :: dpten
       real, intent(in), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: cfb
       real, intent(in), dimension(kpb:kpe) :: cfa,cfc,ad1,ad2
@@ -325,7 +325,7 @@
       integer, intent(in), dimension(ibib:ieib,jbib:jeib,kmaxib) :: hflxw,hflxe,hflxs,hflxn
       logical, intent(in) :: dowriteout,dorad,dotdwrite,doazimwrite,dorestart
       logical, intent(inout) :: getdbz,getvt,dotbud,doqbud,doubud,dovbud,dowbud,donudge
-      integer, intent(inout), dimension(nparcels,3) :: pdata_locind
+      integer, intent(inout), dimension(nparcels_mpi,3) :: pdata_locind
 
 !-----------------------------------------------------------------------
 ! Arrays and variables defined inside solve


### PR DESCRIPTION
This PR will introduce a new MPI implementation for the droplet calculations in CM1.

In the **original** MPI implementation, each MPI rank has to keep a full copy of `pdata` with the length of `nparcels` and perform the droplet calculation on each droplet (even if a droplet does not belong to this MPI rank). An `mpi_allreduce` operation is performed at the end of droplet calculations to ensure that each droplet id updated properly.

In the **new** MPI implementation, each MPI rank only keeps a partial copy of `pdata` with the length of `nparcels/numprocs+buffer_space`, where `buffer_space` is a user-defined space to hold additional droplets in each MPI rank due to the transport. Each MPI rank works on different portion of `pdata` and no `mpi_allreduce` is needed anymore. The `mpi_isend` and `mpi_irecv` interfaces are exploited to handle the droplet movement between different MPI ranks. An `mpi_gather` operation is used to write the `pdata` out to a file.

The verification results for droplet diagnostic (1000 droplets) suggests:
- Original MPI implementation vs. new MPI implementation (both on CPU): consistent 1st-order droplet diagnostic; only `rhoavg` has an average difference larger than 1E-6 for 0th-order droplet diagnostic.
- New MPI implementation, CPU (intel) vs. GPU (nvhpc, 2 MPI ranks + 2 GPUs): consistent 1st-order droplet diagnostic; only `radmax` and `radmin` have an average difference larger than 1E-6 for 0th-order droplet diagnostic.

There is a correctness issue when we increase the droplet number to ~1M. The droplet diagnostic does not agree between the original and new MPI implementations either on CPU or GPU. The difference also exists between CPU and GPU when only the original MPI implementation is used. The fix is still working in progress.