### PR TITLE
Eliminate stop

### DIFF
--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2701,9 +2701,6 @@ end module cuda_rt
           ndt  = 0
           adt  = 0.0
           acfl = 0.0
-#ifdef _OPENACC
-          !print *, 'WARNING: getnewdt not supported on OpenACC' 
-#endif
           call   getnewdt(ndt,dt,dtlast,adt,acfl,dbldt,                                 &
                           mtime,stattim,taptim,rsttim,prcltim,diagtim,azimavgtim,       &
                           dorestart,dowriteout,dostat,doprclout,dotdwrite,doazimwrite,  &
@@ -3434,7 +3431,7 @@ end module cuda_rt
       IF( (idiff.ge.1).and.(difforder.eq.2) )THEN
         !  get stress terms for explicit diffusion scheme:
 #ifdef _OPENACC
-        stop 'ERROR: diff2def not supported on OpenACC version' 
+        stop 'ERROR: diff2def not supported on OPENACC version' 
 #endif
         call diff2def(uh,arh1,arh2,uf,arf1,arf2,vh,vf,mh,c1,c2,mf,ust,zntmp,u1,v1,s1,  &
                       divx,rho,rr,rf,t11,t12,t13,t22,t23,t33,u3d,v3d,w3d,dissten)
@@ -3458,9 +3455,6 @@ end module cuda_rt
 
         IF( adapt_dt.eq.1 .and. dosolve )THEN
 
-#ifdef _OPENACC
-          !print *,'WARNING: getnewdt not supported on OpenACC' 
-#endif
           call   getnewdt(ndt,dt,dtlast,adt,acfl,dbldt,                                 &
                           mtime,stattim,taptim,rsttim,prcltim,diagtim,azimavgtim,       &
                           dorestart,dowriteout,dostat,doprclout,dotdwrite,doazimwrite,  &
@@ -3854,7 +3848,7 @@ end module cuda_rt
       if( doazimwrite )then
 
 #ifdef _OPENACC
-        stop 'ERROR: azimavg not supported in OpenACC'
+        stop 'ERROR: azimavg not supported in OPENACC'
 #endif
         call   azimavg(nstep,mtime,nwritea,arecs,arecw,qname,dt,dosfcflx,      &
                    icrs,icenter,jcenter,xcenter,ycenter,                       &
@@ -3908,7 +3902,7 @@ end module cuda_rt
       if( dohifrqwrite )then
 
 #ifdef _OPENACC
-        stop 'ERROR: writeout_hifrq not supported in OpenACC'
+        stop 'ERROR: writeout_hifrq not supported in OPENACC'
 #endif
         call   writeout_hifrq(                                                 &
                    nstep,mtime,nwriteh,qname,dt,dosfcflx,                      &
@@ -3975,7 +3969,7 @@ end module cuda_rt
           enddo
         endif
 #ifdef _OPENACC
-        print *,'ERROR: write_restart not supported in OpenACC'
+        print *,'ERROR: write_restart not supported in OPENACC'
 #endif
         call     write_restart(nstep,srec,sirec,urec,vrec,wrec,nrec,mrec,prec,      &
                                trecs,trecw,arecs,arecw,                             &

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -284,6 +284,7 @@ end module cuda_rt
       real :: mp_total,minval,temx,temy,temni,temnj
       double precision :: tstart,tend
       integer, dimension(:), allocatable :: isum,jsum
+      integer :: padding
 #endif
 #ifdef _OPENACC
       integer :: ndev,idev
@@ -2259,7 +2260,8 @@ end module cuda_rt
       reqt = 0
 
 #ifdef MPI
-      nparcelsLocal = ceiling(nparcels*1.0/numprocs+pdata_buffer*nparcels)
+      padding = max(pdata_buffer*nparcels,100)
+      nparcelsLocal = ceiling((nparcels*1.0/numprocs)+padding)
 #else
       nparcelsLocal = nparcels
 #endif

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -141,7 +141,7 @@
       !$acc      copyin (randomNumbers,randomNumbers%state, &
       !$acc              pdata_neighbor)
 #else
-      !$acc data create (ta,zf_tmp) &
+      !$acc data create (ta) &
       !$acc      copyin (randomNumbers,randomNumbers%state)
 #endif
 

--- a/src/interp_routines.F
+++ b/src/interp_routines.F
@@ -440,14 +440,10 @@
 !  w-staggered variable:
 
   ELSEIF( stag.eq.4 )THEN
-#ifdef _OPENACC
-    stop 'vinterp_weno5:  stag == 4 not supported on OpenACC'
-#endif
 
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k,wbar,cc1,cc2)
+    !$omp parallel do default(shared)  private(i,j,k,wbar)
+    !$acc parallel loop gang vector collapse(3) default(present)
     DO j=1,nj
-
       do k=3,nk-2
       !dir$ vector always
       do i=1,ni
@@ -459,10 +455,14 @@
         endif
       enddo
       enddo
+    ENDDO
 
-      !----
-
-      k = 2
+    !----
+    
+    k = 2
+    !$omp parallel do default(shared)  private(i,j,wbar)
+    !$acc parallel loop gang vector collapse(2) default(present)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         wbar = 0.5*(rrw(i,j,k)+rrw(i,j,k+1))
@@ -472,8 +472,12 @@
           dumz(i,j,k) = weno5(a(i,j,k+3),a(i,j,k+2),a(i,j,k+1),a(i,j,k  ),a(i,j,k-1),weps)
         endif
       enddo
+    ENDDO
 
-      k = nk-1
+    k = nk-1
+    !$omp parallel do default(shared)  private(i,j,wbar)
+    !$acc parallel loop gang vector collapse(2) default(present)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         wbar = 0.5*(rrw(i,j,k)+rrw(i,j,k+1))
@@ -483,10 +487,14 @@
           dumz(i,j,k) = upstrpd(a(i,j,k+2),a(i,j,k+1),a(i,j,k  ),weps)
         endif
       enddo
+    ENDDO
 
-      !----
+    !----
 
-      k = 1
+    k = 1
+    !$omp parallel do default(shared)  private(i,j,wbar)
+    !$acc parallel loop gang vector collapse(2) default(present)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         wbar = 0.5*(rrw(i,j,k)+rrw(i,j,k+1))
@@ -496,8 +504,12 @@
           dumz(i,j,k) = upstrpd(a(i,j,k+2),a(i,j,k+1),a(i,j,k  ),weps)
         endif
       enddo
+    ENDDO
 
-      k = nk
+    k = nk
+    !$omp parallel do default(shared)  private(i,j,wbar)
+    !$acc parallel loop gang vector collapse(2) default(present)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         wbar = 0.5*(rrw(i,j,k)+rrw(i,j,k+1))
@@ -507,7 +519,6 @@
           dumz(i,j,k) = 0.5*(a(i,j,k)+a(i,j,k+1))
         endif
       enddo
-
     ENDDO
 
 !ccccccccccccccccccccccccccccccccccc
@@ -537,11 +548,8 @@
 
   print *,'vinterp_flx5: stag: ',stag
   IF( stag.eq.1 )THEN
-#ifdef _OPENACC
-    print *,'vinterp_flx5: stag is ',stag
-    stop 'vinterp_flx5:  not supported on OpenACC'
-#endif
-    !$omp parallel do default(shared)  private(i,j,k)
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel loop gang vector collapse(3) default(present)
     DO j=1,nj
 
       do k=4,nk-2
@@ -554,10 +562,13 @@
         endif
       enddo
       enddo
+    ENDDO
 
-      !----
+    !----
 
-      k = 3
+    k = 3
+    !$acc parallel loop gang vector collapse(2) default(present)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         if(rrw(i,j,k).ge.0.0)then
@@ -566,8 +577,11 @@
           dumz(i,j,k) = flx5(a(i,j,k+2),a(i,j,k+1),a(i,j,k  ),a(i,j,k-1),a(i,j,k-2))
         endif
       enddo
+    ENDDO
 
-      k = nk-1
+    k = nk-1
+    !$acc parallel loop gang vector collapse(2) default(present)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         if(rrw(i,j,k).ge.0.0)then
@@ -576,10 +590,13 @@
           dumz(i,j,k) = flx3(a(i,j,k+1),a(i,j,k  ),a(i,j,k-1))
         endif
       enddo
+    ENDDO
 
       !----
 
-      k = 2
+    k = 2
+    !$acc parallel loop gang vector collapse(2) default(present)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         if(rrw(i,j,k).ge.0.0)then
@@ -588,8 +605,11 @@
           dumz(i,j,k) = flx3(a(i,j,k+1),a(i,j,k  ),a(i,j,k-1))
         endif
       enddo
+    ENDDO
 
-      k = nk
+    k = nk
+    !$acc parallel loop gang vector collapse(2) default(present)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         if(rrw(i,j,k).ge.0.0)then
@@ -598,8 +618,8 @@
           dumz(i,j,k) = (c1(i,j,k)*a(i,j,k-1)+c2(i,j,k)*a(i,j,k))
         endif
       enddo
-
     ENDDO
+
 
   ELSEIF( stag.eq.2 )THEN
     ! u-staggered:
@@ -786,13 +806,9 @@
 
 
   ELSEIF( stag.eq.4 )THEN
-#ifdef _OPENACC
-    print *,'vinterp_flx5: stag is ',stag
-    stop 'vinterp_flx5:  not supported on OpenACC'
-#endif
 
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k,wbar)
+    !$acc parallel loop gang vector collapse(3) default(present)
+    !$omp parallel do default(shared) private(i,j,k,wbar)
     DO j=1,nj
 
       do k=3,nk-2
@@ -806,10 +822,14 @@
         endif
       enddo
       enddo
+    ENDDO
 
-      !----
+    !----
 
-      k = 2
+    k = 2
+    !$acc parallel loop gang vector collapse(2) default(present)
+    !$omp parallel do default(shared) private(i,j,k,wbar)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         wbar = 0.5*(rrw(i,j,k)+rrw(i,j,k+1))
@@ -819,8 +839,12 @@
           dumz(i,j,k) = flx5(a(i,j,k+3),a(i,j,k+2),a(i,j,k+1),a(i,j,k  ),a(i,j,k-1))
         endif
       enddo
+    ENDDO
 
-      k = nk-1
+    k = nk-1
+    !$acc parallel loop gang vector collapse(2) default(present)
+    !$omp parallel do default(shared) private(i,j,k,wbar)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         wbar = 0.5*(rrw(i,j,k)+rrw(i,j,k+1))
@@ -830,10 +854,14 @@
           dumz(i,j,k) = flx3(a(i,j,k+2),a(i,j,k+1),a(i,j,k  ))
         endif
       enddo
+    ENDDO
 
-      !----
+    !----
 
-      k = 1
+    k = 1
+    !$acc parallel loop gang vector collapse(2) default(present)
+    !$omp parallel do default(shared) private(i,j,k,wbar)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         wbar = 0.5*(rrw(i,j,k)+rrw(i,j,k+1))
@@ -843,8 +871,12 @@
           dumz(i,j,k) = flx3(a(i,j,k+2),a(i,j,k+1),a(i,j,k  ))
         endif
       enddo
+    ENDDO
 
-      k = nk
+    k = nk
+    !$acc parallel loop gang vector collapse(2) default(present)
+    !$omp parallel do default(shared) private(i,j,k,wbar)
+    DO j=1,nj
       !dir$ vector always
       do i=1,ni
         wbar = 0.5*(rrw(i,j,k)+rrw(i,j,k+1))
@@ -854,7 +886,6 @@
           dumz(i,j,k) = 0.5*(a(i,j,k)+a(i,j,k+1))
         endif
       enddo
-
     ENDDO
 
   ENDIF
@@ -1015,35 +1046,38 @@
 
 
   ELSEIF( stag.eq.4 )THEN
-#ifdef _OPENACC
-    stop 'vinterp_flx6: stag==4 not supported on OpenACC'
-#endif
 
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
+    !$acc parallel loop gang vector collapse(3) default(present)
+    !$omp parallel do default(shared) private(i,j,k)
     DO j=1,nj
-
       do k=3,nk-2
       !dir$ vector always
       do i=1,ni
         dumz(i,j,k) = flx6(a(i,j,k-2),a(i,j,k-1),a(i,j,k  ),a(i,j,k+1),a(i,j,k+2),a(i,j,k+3))
       enddo
       enddo
+    ENDDO
 
+    !$acc parallel loop gang vector collapse(3) default(present)
+    !$omp parallel do default(shared) private(i,j,k)
+    DO j=1,nj
       do k=2,(nk-1),(nk-3)
       !dir$ vector always
       do i=1,ni
         dumz(i,j,k) = flx4(a(i,j,k-1),a(i,j,k  ),a(i,j,k+1),a(i,j,k+2))
       enddo
       enddo
+    ENDDO
 
+    !$acc parallel loop gang vector collapse(3) default(present)
+    !$omp parallel do default(shared) private(i,j,k)
+    DO j=1,nj
       do k=1,nk,(nk-1)
       !dir$ vector always
       do i=1,ni
         dumz(i,j,k) = 0.5*(a(i,j,k)+a(i,j,k+1))
       enddo
       enddo
-
     ENDDO
 
   ENDIF

--- a/src/interp_routines.F
+++ b/src/interp_routines.F
@@ -567,6 +567,7 @@
     !----
 
     k = 3
+    !$omp parallel do default(shared) private(i,j)
     !$acc parallel loop gang vector collapse(2) default(present)
     DO j=1,nj
       !dir$ vector always
@@ -580,6 +581,7 @@
     ENDDO
 
     k = nk-1
+    !$omp parallel do default(shared) private(i,j)
     !$acc parallel loop gang vector collapse(2) default(present)
     DO j=1,nj
       !dir$ vector always
@@ -595,6 +597,7 @@
       !----
 
     k = 2
+    !$omp parallel do default(shared) private(i,j)
     !$acc parallel loop gang vector collapse(2) default(present)
     DO j=1,nj
       !dir$ vector always
@@ -608,6 +611,7 @@
     ENDDO
 
     k = nk
+    !$omp parallel do default(shared) private(i,j)
     !$acc parallel loop gang vector collapse(2) default(present)
     DO j=1,nj
       !dir$ vector always
@@ -636,7 +640,7 @@
         i2=ni+1
       endif
 
-    !$omp parallel do default(shared) private(i,j,k,wbar)
+    !$omp parallel do default(shared) private(i,j,k,wbar) private(i,j,k,wbar)
     !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,wbar)
     DO k=4,nk-2
       do j=1,nj
@@ -654,6 +658,7 @@
       !----
     ENDDO
     k = 3
+    !$omp parallel do default(shared) private(i,j,wbar)
     !$acc parallel loop gang vector collapse(2) default(present) private(i,j,wbar)
     DO j=1,nj
       !dir$ vector always
@@ -667,7 +672,8 @@
       enddo
     ENDDO
     k = nk-1
-    !$acc parallel loop gang vector collapse(2) default(present) private(i,j,wbar)
+    !$omp parallel do default(shared) private(i,j,wbar)
+    !$acc parallel loop gang vector collapse(2) default(present)
     DO j=1,nj
       !dir$ vector always
       do i=i1,i2
@@ -680,7 +686,8 @@
       enddo
     ENDDO
     k = 2
-    !$acc parallel loop gang vector collapse(2) default(present) private(i,j,wbar,cc1,cc2)
+    !$omp parallel do default(shared) private(i,j,wbar,cc1,cc2)
+    !$acc parallel loop gang vector collapse(2) default(present)
     DO j=1,nj
       !----
       !dir$ vector always
@@ -696,7 +703,8 @@
       enddo
     ENDDO
     k = nk
-    !$acc parallel loop gang vector collapse(2) default(present) private(i,j,wbar,cc1,cc2)
+    !$omp parallel do default(shared) private(i,j,wbar,cc1,cc2)
+    !$acc parallel loop gang vector collapse(2) default(present)
     DO j=1,nj
       !dir$ vector always
       do i=i1,i2
@@ -727,7 +735,7 @@
         j2=nj+1
       endif
     !$omp parallel do default(shared) private(i,j,k,wbar,cc1,cc2)
-    !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,wbar)
+    !$acc parallel loop gang vector collapse(3) default(present)
     DO j=j1,j2
       do k=4,nk-2
       !dir$ vector always
@@ -743,7 +751,8 @@
     ENDDO
 
     k = 3
-    !$acc parallel loop gang vector collapse(2) default(present) private(i,j,k,wbar)
+    !$omp parallel do default(shared) private(i,j,wbar)
+    !$acc parallel loop gang vector collapse(2) default(present)
     DO j=j1,j2
       !----
       !dir$ vector always
@@ -758,7 +767,8 @@
     ENDDO
 
     k = nk-1
-    !$acc parallel loop gang vector collapse(2) default(present) private(i,j,k,wbar)
+    !$omp parallel do default(shared) private(i,j,wbar)
+    !$acc parallel loop gang vector collapse(2) default(present)
     DO j=j1,j2
       !dir$ vector always
       do i=1,ni
@@ -772,7 +782,8 @@
     ENDDO
 
     k = 2
-    !$acc parallel loop gang vector collapse(2) default(present) private(i,j,wbar,cc1,cc2)
+    !$omp parallel do default(shared) private(i,j,wbar,cc1,cc2)
+    !$acc parallel loop gang vector collapse(2) default(present)
     DO j=j1,j2
       !----
       !dir$ vector always
@@ -788,7 +799,8 @@
       enddo
     ENDDO
     k = nk
-    !$acc parallel loop gang vector collapse(2) default(present) private(i,j,wbar,cc1,cc2)
+    !$omp parallel do default(shared) private(i,j,wbar,cc1,cc2)
+    !$acc parallel loop gang vector collapse(2) default(present)
     DO j=j1,j2
       !dir$ vector always
       do i=1,ni
@@ -914,7 +926,7 @@
   IF( stag.eq.1 )THEN
 
     !$omp parallel do default(shared) private(i,j,k)
-    !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+    !$acc parallel loop gang vector collapse(3) default(present)
     DO k=4,nk-2
       do j=1,nj
       !dir$ vector always
@@ -924,7 +936,8 @@
       enddo
     ENDDO
 
-    !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel loop gang vector collapse(3) default(present)
     DO k=3,(nk-1),(nk-4)
       do j=1,nj
       !dir$ vector always
@@ -934,7 +947,8 @@
       enddo
     ENDDO
 
-    !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+    !$omp parallel do default(shared) private(i,j,k)
+    !$acc parallel loop gang vector collapse(3) default(present)
     DO k=2,nk,(nk-2)
       do j=1,nj
       !dir$ vector always

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -392,7 +392,6 @@
       real :: term1,term2,term3,term4,umo
       !$acc declare present(xf,yh,zh,u0,u3d)
 
-!!!      if(myid.eq.0) print *,'    convinitu '
 #ifdef _OPENACC
       print *,'WARNING: OPENACC version of convinitu never verified'
 #endif
@@ -440,7 +439,6 @@
 #ifdef _OPENACC
       print *,'WARNING: OPENACC version of convinitv never verified'
 #endif
-!!!      if(myid.eq.0) print *,'    convinitv '
       !$omp parallel do default(shared) private(i,j,k,term1,term2,term3,term4,vmo)
       !$acc parallel loop gang vector collapse(3) default(present)
       do k=1,nk

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -393,8 +393,11 @@
       !$acc declare present(xf,yh,zh,u0,u3d)
 
 !!!      if(myid.eq.0) print *,'    convinitu '
+#ifdef _OPENACC
+      print *,'WARNING: OPENACC version of convinitu never verified'
+#endif
       !$omp parallel do default(shared) private(i,j,k,term1,term2,term3,term4,umo)
-      !$acc parallel loop gang vector default(present) private(i,j,k,term1,term2,term3,term4,umo)
+      !$acc parallel loop gang vector collapse(3) default(present)
       do k=1,nk
       do j=1,nj
       do i=1,ni+1
@@ -434,9 +437,12 @@
       real :: term1,term2,term3,term4,vmo
       !$acc declare present(xh,yf,zh,v0,v3d)
 
+#ifdef _OPENACC
+      print *,'WARNING: OPENACC version of convinitv never verified'
+#endif
 !!!      if(myid.eq.0) print *,'    convinitv '
       !$omp parallel do default(shared) private(i,j,k,term1,term2,term3,term4,vmo)
-      !$acc parallel loop gang vector default(present) private(i,j,k,term1,term2,term3,term4,vmo)
+      !$acc parallel loop gang vector collapse(3) default(present)
       do k=1,nk
       do j=1,nj+1
       do i=1,ni
@@ -479,6 +485,9 @@
       real :: beta,wmag,gamm,tem
       !$acc declare present(xh,yh,zf,wa,wndgten)
 
+#ifdef _OPENACC
+      print *,'WARNING: OPENACC version of get_wnudge never verified'
+#endif
       !  updraft nudging scheme (Naylor and Gilmore, 2012, MWR, pgs 3699-3705)
 
       gamm = 1.0
@@ -492,7 +501,7 @@
       tem = alpha_wnudge * gamm
 
       !$omp parallel do default(shared) private(i,j,k,beta,wmag)
-      !$acc parallel loop gang vector default(present) private(i,j,k,beta,wmag)
+      !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,beta,wmag)
       do k=2,nk
       do j=1,nj
       do i=1,ni

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -507,17 +507,10 @@
 
     IF( irdamp.eq.2 .or. hrdamp.eq.2 .or. tqnudge .or. do_lsnudge )THEN
       if( imoist.eq.1 )then
-#ifdef _OPENACC
-        !print *,'WARNING: solve1: get_avg_uvtq not verififed on GPU'
-#endif
         call     get_avg_uvtq(uavg,vavg,thavg,qavg,cavg,th0,ua,va,tha,qa,ruh,ruf,rvh,rvf)
       else
-#ifdef _OPENACC
-        print *,'WARNING: solve1: get_avg_uvt not ported to GPU'
-#endif
         call     get_avg_uvt(uavg,vavg,thavg,cavg,th0,ua,va,tha,ruh,ruf,rvh,rvf)
       endif
-
     ENDIF
 
 !--------------------------------------------------------------------
@@ -670,9 +663,6 @@
 
           if( mtime.gt.1800.0 .and. mod(mtime,300.0).lt.0.01 )then
 
-#ifdef _OPENACC
-        print *,'WARNING: solve1: get_avg_uvt not ported to GPU'
-#endif
             call get_avg_uvt(uavg,vavg,thavg,cavg,th0,ua,va,tha,ruh,ruf,rvh,rvf)
 
             ! 200529: modify lspg to match reference wind
@@ -712,15 +702,21 @@
 #endif
             
 
-            ulspg = newval
+            !$acc parallel loop gang vector default(present)
+            do k=kb,ke
+              ulspg(k) = newval
+            enddo
    
           endif
           ENDIF
 
         if(     lspgrad.eq.1 )then
 
-          ulspg = 0.0
-          vlspg = 0.0
+          !$acc parallel loop gang vector default(present)
+          do k=kb,ke
+            ulspg(k) = 0.0
+            vlspg(k) = 0.0
+          enddo
 
           !---------------------------------------------------------------!
           ! Large-scale pressure gradient based on geostropic balance,
@@ -812,7 +808,7 @@
 
       IF( difforder.eq.2 )THEN
 #ifdef _OPENACC
-        print *,'WARNING: solve1: diffusion operator not ported to GPU'
+        print *,'WARNING: solve1: diffusion operator not support with OPENACC'
 #endif
         idiffge1:  &
         if(idiff.ge.1)then
@@ -1703,7 +1699,7 @@
       doeddyrec:  &
       IF( do_recycle )THEN
 #ifdef _OPENACC
-        print *,'WARNING: solve1: do_eddy_{recyr,recys} code not ported to GPU'
+        print *,'WARNING: solve1: do_eddy_{recyr,recys} code not ported to OPENACC'
 #endif
         if( do_recycle_w )then
           call   do_eddy_recyw(dt,xh,xf,yh,yf,zh,zf,u3d,v3d,w3d,uten1,vten1,wten1,urecyw,vrecyw,wrecyw,trecyw,out3d)

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -1263,7 +1263,7 @@
         IF(psolver.eq.1)THEN
 
 #ifdef _OPENACC
-          stop 'ERROR: soundns not ported to GPU'
+          stop 'ERROR: soundns not ported to OPENACC'
 #endif
           call   soundns(xh,rxh,arh1,arh2,uh,xf,uf,yh,vh,yf,vf,           &
                          zh,mh,c1,c2,mf,zf,pi0,thv0,rr0,rf0,              &
@@ -1316,7 +1316,7 @@
           ! anelastic/incompressible solver:
 
 #ifdef _OPENACC
-          stop 'ERROR: anelp not ported to GPU'
+          stop 'ERROR: anelp not ported to OPENACC'
 #endif
           call   anelp(xh,uh,ruh,xf,uf,yh,vh,rvh,yf,vf,             &
                        zh,mh,rmh,mf,rmf,zf,pi0,thv0,rho0,prs0,rf0,  &

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -1475,7 +1475,7 @@ print *,'Here 28 -- Not being executed'
       if(myid.eq.0) print *,'  Getting pressure diagnostics ... '
 
 #ifdef _OPENACC
-      stop 'WARNING: execution of pidcomp not supported under OpenACC'
+      stop 'WARNING: execution of pidcomp not supported under OPENACC'
 #endif
       call       pidcomp(dt,xh,rxh,arh1,arh2,uh,xf,rxf,arf1,arf2,uf,vh,vf,          &
                          gz,rgz,gzu,gzv,mh,rmh,mf,rmf,rds,rdsf,c1,c2,f2d,wprof,     &

--- a/src/soundcb.F
+++ b/src/soundcb.F
@@ -380,9 +380,6 @@
 
         IF( convinit.eq.1 )THEN
           IF( rtime.le.convtime .and. nx.gt.1 )THEN
-#ifdef _OPENACC
-            stop 'soundcb: convinitu not ported to OpenACC'
-#endif
             call convinitu(myid,ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,   &
                            zdeep,lamx,lamy,xcent,ycent,aconv,    &
                            xf,yh,zh,u0,u3d)
@@ -396,9 +393,6 @@
         ! Cartesian grid:
         IF( convinit.eq.1 )THEN
           IF( rtime.le.convtime .and. ny.gt.1 )THEN
-#ifdef _OPENACC
-            stop 'soundcb: convinitv not ported to OpenACC'
-#endif
             call convinitv(myid,ib,ie,jb,je,kb,ke,ni,nj,nk,ibs,ibn,   &
                            zdeep,lamx,lamy,xcent,ycent,aconv,    &
                            xh,yf,zh,v0,v3d)
@@ -419,9 +413,6 @@
       IF( wnudge.eq.1 )THEN
         !  updraft nudging tendency:
         IF( (mtime+dt).le.t2_wnudge )THEN
-#ifdef _OPENACC
-            stop 'soundcb: get_wnudge not ported to OpenACC'
-#endif
           call get_wnudge(mtime,dts,xh,yh,zf,w3d,dum1)
         ENDIF
       ENDIF

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -575,9 +575,6 @@
         endif
  
       if(stat_tenerg.eq.1)then
-#ifdef _OPENACC
-        !print *,'FIXME: subroutine calcener not ported to OPENACC'
-#endif
         call calcener(nstat,rstat,ruh,rvh,zh,rmh,pi0,th0,rho,ua,va,wa,ppi,tha,    &
                       dum1,dum2,dum3,dum4)
       endif

--- a/src/testcase_simple_phys.F
+++ b/src/testcase_simple_phys.F
@@ -202,6 +202,9 @@
 
       tem = dx*dy
 
+#ifdef _OPENACC
+      print *,'WARNING: OPENACC version of get_avg_uvt has not yet been verified'
+#endif
       !$acc parallel default(present) reduction(+:tmp1,tmp2,tmp3)
       ! Get domain-averages:
       !$acc loop gang

--- a/src/turb.F
+++ b/src/turb.F
@@ -623,7 +623,7 @@
 
           IF( ipbl.eq.2 )THEN
 #ifdef _OPENACC
-            stop 'ERROR: call to gethpbl2 not supported in OpenACC'
+            stop 'ERROR: call to gethpbl2 not supported in OPENACC'
 #endif
             ! (note: for ipbl=1,3,4,5 pbl depth is calculated within the PBL subroutine)
             call gethpbl2(psfc,qsfc,thflux,qvflux,ust,tsk,zh,th0,tha,divx,ugr,vgr,dum8(ib,jb,1),dum8(ib,jb,2),dum8(ib,jb,3),dum8(ib,jb,4),hpbl,thten)
@@ -691,7 +691,7 @@
         IF( sfcmodel.eq.5 )THEN
 
 #ifdef _OPENACC
-          stop 'ERROR: call to cm1most not supported in OpenACC'
+          stop 'ERROR: call to cm1most not supported in OPENACC'
 #endif
           call   cm1most(u1,v1,s1,t1,tst,thflux,zol,mol,rmol,       &
                          phim,phih,psim,psih,ppten(ib,jb,1),        &
@@ -706,7 +706,7 @@
           ! surface layer:
         if( sfcmodel.eq.2 )then
 #ifdef _OPENACC
-          stop 'ERROR: call to SFCLAY not supported in OpenACC'
+          stop 'ERROR: call to SFCLAY not supported in OPENACC'
 #endif
           call SFCLAY(dum1,dum2,dum4,divx,prs,dum5,      &
                        CP,G,ROVCP,RD,XLV,lv1,lv2,PSFC,CHS,CHS2,CQS2,CPMM, &
@@ -724,7 +724,7 @@
                        ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,z0t,z0q   )
         elseif( sfcmodel.eq.3 )then
 #ifdef _OPENACC
-          stop 'ERROR: call to SFCLAYREV not supported in OpenACC'
+          stop 'ERROR: call to SFCLAYREV not supported in OPENACC'
 #endif
           call SFCLAYREV(dum1,dum2,dum4,divx,prs,dum5,   &
                        CP,G,ROVCP,RD,XLV,lv1,lv2,PSFC,CHS,CHS2,CQS2,CPMM, &
@@ -765,9 +765,6 @@
             zkmax(i,j) = zh(i,j,1)
           enddo
           enddo
-!#ifdef _OPENACC
-!          print *,'WARNING: call to SF_GFDL not supported in OpenACC'
-!#endif
           !$acc update &
           !$acc host(tsk,br,zkmax,chs,cd_out,ch_out,mol,zol,z0t,fm,fh,&
           !$acc      chs2,cpmm,cqs2,flhc,flqc,gz1oz0,hfx,lh,psim,psih, &
@@ -807,7 +804,7 @@
           ! stop 'surf_and_turb: after call to SF_GFDL'
         elseif( sfcmodel.eq.6 )then
 #ifdef _OPENACC
-          stop 'ERROR: call to SFCLAY_mynn not supported in OpenACC'
+          stop 'ERROR: call to SFCLAY_mynn not supported in OPENACC'
 #endif
           call SFCLAY_mynn(                                                                                     &
                      U3D=dum1,V3D=dum2,T3D=dum4,QV3D=divx,P3D=prs,dz8w=dum5,                                    &
@@ -876,7 +873,7 @@
           endif
 
 #ifdef _OPENACC
-          stop 'ERROR: call to MYSFC not supported in OpenACC'
+          stop 'ERROR: call to MYSFC not supported in OPENACC'
 #endif
           call   MYJSFC(ITIMESTEP=nstep,  &
                         HT=zs(ib,j),  &
@@ -919,7 +916,7 @@
 
         IF( update_sfc .and. testcase.ne.11 )THEN
 #ifdef _OPENACC
-          print *,'ERROR: call to SLAB not supported in OpenACC'
+          print *,'ERROR: call to SLAB not supported in OPENACC'
 #endif
           ! slab scheme (MM5/WRF):
           call SLAB(dum4,divx,prs,FLHC,FLQC,                        &
@@ -1204,7 +1201,7 @@
     IF( update_sfc )THEN
       if( getsfc )then
 #ifdef _OPENACC
-       stop 'ERROR: call to oceanml not supported in OpenACC'
+       stop 'ERROR: call to oceanml not supported in OPENACC'
 #endif
 
         CALL oceanml(tml,t0ml,hml,h0ml,huml,hvml,ust,dum1,dum2, &
@@ -1259,9 +1256,6 @@
     IF( cm1setup.eq.1 )THEN
 
       IF( dot2p )THEN
-!#ifdef _OPENACC
-!        print *,'ERROR: call to getgamk not supported in OpenACC'
-!#endif
         ! get gamk for two-part model:
         call     getgamk(dt,rtime,xf,rxf,c1,c2,zh,mh,zf,mf,rf0,rr0,rho0,rrf0,u0,v0,            &
                          uavg,vavg,savg,l2p,kmw,gamwall,gamk,s2p,s2b,t2pm1,t2pm2,t2pm3,t2pm4,cavg,  &
@@ -1333,7 +1327,7 @@
           ! Nonlinear Backscatter and Anisotropy (NBA) model:
           ! TKE version:
 #ifdef _OPENACC
-          stop 'ERROR: call to turbnba not supported in OpenACC'
+          stop 'ERROR: call to turbnba not supported in OPENACC'
 #endif
           call   turbnba(nstep,uh,ruh,uf,ruf,vh,rvh,vf,rvf,mh,rmh,mf,rmf,zf,c1,c2,rho,rf,zntmp,ust,  &
                          dum1,dum2,dum3,dum4,dum5,dum6,            &
@@ -1347,7 +1341,7 @@
 
       ELSEIF(sgsmodel.eq.2)THEN
 #ifdef _OPENACC
-        stop 'ERROR: call to turbsmag not supported in OpenACC'
+        stop 'ERROR: call to turbsmag not supported in OPENACC'
 #endif
 
          ! Smagorinsky:
@@ -1364,7 +1358,7 @@
       ELSEIF( sgsmodel.eq.6 )THEN
 
 #ifdef _OPENACC
-        stop 'ERROR: call to turbnba2 not supported in OpenACC'
+        stop 'ERROR: call to turbnba2 not supported in OPENACC'
 #endif
         ! Nonlinear Backscatter and Anisotropy (NBA) model:
         ! Smagorinsky version:
@@ -1434,9 +1428,6 @@
                          u1,v1,s1,u1b,v1b,avgsfcu,avgsfcv,avgsfcs,                             &
                          reqs_s,uw31,uw32,ue31,ue32,us31,us32,un31,un32)
           elseif( sgsmodel.eq.4 )then
-!#ifdef _OPENACC
-!            print *,'ERROR: call to t2pcode not supported in OpenACC'
-!#endif
             call t2pcode(dt,rtime,xf,rxf,c1,c2,zh,mh,zf,mf,rf0,rr0,rho0,rrf0,u0,v0,            &
                          uavg,vavg,savg,l2p,kmw,gamwall,gamk,s2p,s2b,t2pm1,t2pm2,t2pm3,t2pm4,cavg,  &
                          ua,va,wa,t11,t12,t13,t22,t23,t33,dum1,dum2,dum3,dum4,                 &
@@ -1462,7 +1453,7 @@
 
       IF( cm1setup.eq.2 .and. ipbl.eq.2 )THEN
 #ifdef _OPENACC
-        stop 'ERROR: call to turbparam_vert not supported in OpenACC'
+        stop 'ERROR: call to turbparam_vert not supported in OPENACC'
 #endif
         call turbparam_vert(nstep,zf,dt,dosfcflx,ruh,rvh,rmh,mf,rmf,th0,thflux,qvflux,rth0s,rf, &
                       nm,defv,defh,dum4,kmv,khv,dissten,out3d,zs,zntmp,ust,xland, &
@@ -1475,7 +1466,7 @@
 
       IF( cm1setup.eq.2 .and. horizturb.eq.1 )THEN
 #ifdef _OPENACC
-        stop 'ERROR: call to turbparam_horiz not supported in OpenACC'
+        stop 'ERROR: call to turbparam_horiz not supported in OPENACC'
 #endif
         call turbparam_horiz(nstep,zf,dt,dosfcflx,ruh,rvh,rmh,mf,rmf,th0,thflux,qvflux,rth0s,rf, &
                       nm,defv,defh,dum4,kmh,khh,dissten,out3d,zs,zntmp,ust,xland,psfc,tlh, &
@@ -1541,7 +1532,7 @@
 
         if( do_ib )then
 #ifdef _OPENACC
-          stop 'ERROR: call to drag_obstacles not supported in OpenACC'
+          stop 'ERROR: call to drag_obstacles not supported in OPENACC'
 #endif
           call drag_obstacles(xh,yh,zh,zf,rho,rf,dum1,dum2,dum3,dum4,dum5,dum6,t11,t12,t13,t22,t23,t33,ua,va,wa,kbdy)
         endif
@@ -1814,7 +1805,7 @@
           endif
         endif
 #ifdef _OPENACC
-        stop 'ERROR: call to ysu not supported in OpenACC'
+        stop 'ERROR: call to ysu not supported in OPENACC'
 #endif
         call ysu(u3d=dum1,v3d=dum2,th3d=dum3,t3d=dum4,qv3d=divx,                    &
                   qc3d=ppten,qi3d=dum8,p3d=prs,p3di=dum6,pi3d=dum7,                 &
@@ -1893,7 +1884,7 @@
           enddo
         endif
 #ifdef _OPENACC
-        stop 'ERROR: call to BL_GFSEDMF not supported in OpenACC'
+        stop 'ERROR: call to BL_GFSEDMF not supported in OPENACC'
 #endif
 
         call  BL_GFSEDMF(U3D=dum1,V3D=dum2,TH3D=dum3,T3D=dum4,QV3D=divx,            &
@@ -2050,7 +2041,7 @@
         ENDIF
 
 #ifdef _OPENACC
-        stop 'ERROR: call to mynn_bl_driver not supported in OpenACC'
+        stop 'ERROR: call to mynn_bl_driver not supported in OPENACC'
 #endif
         call mynn_bl_driver(                                                         &
         initflag=initflag,grav_settling=grav_settling,                               &
@@ -2187,7 +2178,7 @@
         enddo
         enddo
 #ifdef _OPENACC
-        stop 'ERROR: call to MYJPBL not supported in OpenACC'
+        stop 'ERROR: call to MYJPBL not supported in OPENACC'
 #endif
         call     MYJPBL(dt=DT,STEPBL=1,HT=zs(ib,j),DZ=tmp_myj(ibmyj,kbmyj,6)                     &
                        ,PMID=tmp_myj(ibmyj,kbmyj,7),PINT=tmp_myj(ibmyj,kbmyj,8),TH=tmp_myj(ibmyj,kbmyj,9),T=tmp_myj(ibmyj,kbmyj,10),EXNER=tmp_myj(ibmyj,kbmyj,11),QV=tmp_myj(ibmyj,kbmyj,12),QCW=tmp_myj(ibmyj,kbmyj,13),QCI=tmp_myj(ibmyj,kbmyj,14),QCS=tmp_myj(ibmyj,kbmyj,1),QCR=tmp_myj(ibmyj,kbmyj,2),QCG=tmp_myj(ibmyj,kbmyj,3)    &
@@ -5010,7 +5001,7 @@
       double precision, dimension(kb:ke) :: shravg
 
 #ifdef _OPENACC
-    stop 'Subroutine t2psmm not ported to OpenACC'
+    stop 'Subroutine t2psmm not ported to OPENACC'
 #endif
     !-------------------------------------------
     doingt2p:  &


### PR DESCRIPTION
Currently, the gpu-opt has a number of 'stop' calls that protect code sections that have not been ported to GPU.  This PR addresses a number of these in the following manner:
    (1)  Port several sections of code to OPENACC
    (2)  Reduce the level of severity from a fatal error to a warning to indicate code that has not been formally verified
    (3)  Deleted a number of #ifdef OPENACC that were no longer needed.
This PR also addresses a couple of bugs including:
     (A)The length of the padding for droplets that move between MPI is too short for a small number of particles
     (B) Compiler error zf_tmp when OPENACC is enabled and MPI is disabled.

This PR has the same validation characteristics as the current gpu-opt branch