### PR TITLE
Fix nvhpc build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -36,6 +36,7 @@ USE_OPENACC_L = $(shell echo $(USE_OPENACC) | tr A-Z a-z)
 USE_NETCDF_L  = $(shell echo $(USE_NETCDF) | tr A-Z a-z)
 DEBUG_L       = $(shell echo $(DEBUG) | tr A-Z a-z)
 USE_CUDAMEM_L = $(shell echo $(USE_CUDAMEM) | tr A-Z a-z)
+GPU_TYPE_L    = $(shell echo $(GPU_TYPE) | tr A-Z a-z)
 
 #-----------------------------------------------------------------------------
 #  initialize some options as empty
@@ -99,14 +100,24 @@ ifeq (${FC},nvfortran)
     endif
     ifeq (${USE_OPENACC_L},true)
         ifeq (${DEBUG_L},true)
-            OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform
-            OPTS_M += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform
+            ifeq (${GPU_TYPE_L},a100)
+                OPTS += -acc -gpu=cc80,lineinfo,nofma,autocompare,math_uniform
+                OPTS_M += -acc -gpu=cc80,lineinfo,nofma,autocompare,math_uniform
+            else
+                OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform
+                OPTS_M += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform
+            endif
         else
-	    # Potentially interesting non-default compiler flags:: 
-	    #     -Minfo=accel    Provides verbose output for accelerator compilation phase
-	    #     -Mpcast         Enables the use of PCAST functionality
-            OPTS += -acc -gpu=cc70,cc80,lineinfo,nofma,math_uniform
-            OPTS_M += -acc -gpu=cc70,cc80,lineinfo,nofma,math_uniform,managed
+            # Potentially interesting non-default compiler flags:: 
+            #     -Minfo=accel    Provides verbose output for accelerator compilation phase
+            #     -Mpcast         Enables the use of PCAST functionality
+            ifeq (${GPU_TYPE_L},a100)
+                OPTS += -acc -gpu=cc80,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
+                OPTS_M += -acc -gpu=cc80,lineinfo,nofma,math_uniform,managed -Mpcast -Minfo=accel
+            else
+                OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
+                OPTS_M += -acc -gpu=cc70,lineinfo,nofma,math_uniform,managed -Mpcast -Minfo=accel
+            endif
         endif
         DM       += -D_OPENACC
     endif
@@ -153,7 +164,9 @@ endif
 #  Intel compiler
 #-----------------------------------------------------------------------------
 ifeq (${FC},ifort)
-    OPTS         += -g -O2 -xHost -ip -assume byterecl -fp-model precise -ftz -init=snan,arrays -traceback -no-fma
+    # replace -xHost with -march=core-avx2 to make sure the same code builds on
+    # both Intel and AMD CPUs 
+    OPTS         += -g -O2 -march=core-avx2 -ip -assume byterecl -fp-model precise -ftz -init=snan,arrays -traceback -no-fma
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${USE_OPENMP_L},true)
         OPTS     += -qopenmp

--- a/src/Makefile
+++ b/src/Makefile
@@ -102,8 +102,11 @@ ifeq (${FC},nvfortran)
             OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform
             OPTS_M += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform
         else
-            OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
-            OPTS_M += -acc -gpu=cc70,lineinfo,nofma,math_uniform,managed -Mpcast -Minfo=accel
+	    # Potentially interesting non-default compiler flags:: 
+	    #     -Minfo=accel    Provides verbose output for accelerator compilation phase
+	    #     -Mpcast         Enables the use of PCAST functionality
+            OPTS += -acc -gpu=cc70,cc80,lineinfo,nofma,math_uniform
+            OPTS_M += -acc -gpu=cc70,cc80,lineinfo,nofma,math_uniform,managed
         endif
         DM       += -D_OPENACC
     endif

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -141,7 +141,7 @@
       !$acc      copyin (randomNumbers,randomNumbers%state, &
       !$acc              pdata_neighbor)
 #else
-      !$acc data create (ta,zf_tmp) &
+      !$acc data create (ta) &
       !$acc      copyin (randomNumbers,randomNumbers%state)
 #endif
 
@@ -2201,7 +2201,11 @@
 
         v1(1) = rt_start(1)
         v1(2) = rt_start(2)
-        fv2 = (/1., 1./)
+         
+        fv2(:) = 1.
+        !JMD-FIXME:  The following line appears to generate the following compiler error:
+        !JMD-FIXME     Internal compiler error. Basic LLVM base data type required 
+        !fv2 = (/1., 1./)
         coeff = 0.1
 
         do while ((sqrt(fv2(1)*fv2(1)+fv2(2)*fv2(2)) > error) .AND. (iterations<1000))
@@ -2282,12 +2286,20 @@
 
         error = 1.0e-8
 
-        I = reshape((/1, 0, 0, 1/),(/2,2/))
+        
+        !JMD-FIXME generates an internal compiler eerror
+        ! I = reshape((/1, 0, 0, 1/),(/2,2/))
+        I(1,1)=1.0
+        I(2,1)=0.0
+        I(1,2)=0.0
+        I(2,2)=1.0
         iterations = 0
         flag = 0
         v1(1) = rt_start(1)
         v1(2) = rt_start(2)
-        fv2 = (/1., 1./)
+        !JMD-FIXME generates an internal compiler error
+        ! fv2 = (/1., 1./)
+        fv2(:) = 1.0
 
         lambda = 0.001
         lup = 2.0

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -2202,7 +2202,8 @@
         v1(1) = rt_start(1)
         v1(2) = rt_start(2)
          
-        fv2(:) = 1.
+        fv2(1) = 1.
+        fv2(2) = 1.
         !JMD-FIXME:  The following line appears to generate the following compiler error:
         !JMD-FIXME     Internal compiler error. Basic LLVM base data type required 
         !fv2 = (/1., 1./)
@@ -2299,7 +2300,8 @@
         v1(2) = rt_start(2)
         !JMD-FIXME generates an internal compiler error
         ! fv2 = (/1., 1./)
-        fv2(:) = 1.0
+        fv2(1) = 1.0
+        fv2(2) = 1.0
 
         lambda = 0.001
         lup = 2.0

--- a/src/input.F
+++ b/src/input.F
@@ -164,7 +164,8 @@
       !$acc                 axisymm,terrain_flag,ni,nj,nip1,nk,nkp1,imoist, &
       !$acc                 nqv,bbc,imove,prvpx,prvpy,prvpz,prrp,prms,prtp, &
       !$acc                 prx,pry,prz,prsig,ngxy,ngz,ptype,pru,prv,prw,   &
-      !$acc                 prt,prqv,prprs,prrho,nparcelsLocal)
+      !$acc                 prt,prqv,prprs,prrho,nparcelsLocal,mywest,      &
+      !$acc                 myeast,mynorth,mysouth,myne,myse,mysw,mynw)
 
 !-----------------------------------------------------------------------
 
@@ -201,7 +202,7 @@
            base_pbot,base_ptop,base_thbot,base_thtop,base_qvbot,base_qvtop,   &
            base_tbot,base_ttop,base_pibot,base_pitop
 
-      !$acc declare create (zt,rzt,umove,vmove,viscosity,pr_num,sc_num, &
+      !$acc declare create (dx,dy,zt,rzt,umove,vmove,viscosity,pr_num,sc_num, &
       !$acc                 minx,maxx,miny,maxy,maxz)
 
 !-----------------------------------------------------------------------

--- a/src/param.F
+++ b/src/param.F
@@ -228,8 +228,8 @@
 #endif
 
       call bcast_log(terrain_flag,device=.true.)
-      call bcast_real(dx)
-      call bcast_real(dy)
+      call bcast_real(dx,device=.true.)
+      call bcast_real(dy,device=.true.)
       call bcast_real(dz)
       call bcast_real(dtl)
       call bcast_real(timax)
@@ -6284,6 +6284,7 @@
       mysouth = nabor(myi,   myj-1, nodex, nodey)
       myeast  = nabor(myi+1, myj,   nodex, nodey)
       mywest  = nabor(myi-1, myj,   nodex, nodey)
+      !$acc update device(mynorth,mysouth,myeast,mywest)
 
       if(dowr) write(outfile,*) '  mywest  =',mywest
       if(dowr) write(outfile,*) '  myeast  =',myeast
@@ -6295,6 +6296,7 @@
       mynw = nabor(myi-1, myj+1,   nodex, nodey)
       myne = nabor(myi+1, myj+1,   nodex, nodey)
       myse = nabor(myi+1, myj-1,   nodex, nodey)
+      !$acc update device(mysw,mynw,myne,myse)
 
       if(dowr) write(outfile,*) '  mysw    =',mysw
       if(dowr) write(outfile,*) '  mynw    =',mynw


### PR DESCRIPTION
This PR appears to address two issues, the inability to build CM1 on Gust with the NVHPC 22.7 compiler, and the slow leaking of droplets for very large droplet counts.  Note that for the standard verification namelist 'namelist.baseline.dx=40m.short' where nparcels=1000 the verification statistics are unchanged. When nparcels=1000000, the total number of droplets is unchanged for the entire run.  The changes are as follows:

    (1) Properly set several module variables on the device (dx,dy,mywest,myeast,mysouth,mynorth,myse,mysw,myne,mynw). While a compiler warning message was generated, it was missed due to the verbose output generated by -Minfo=accel compiler flag. Because dx and dy were not set properly, droplets near the boundary between different MPI ranks were being lost.

    (2) Changed the makefile to support both A100 and V100 architectures.  The -Minfo=accel compiler flag was removed to allow warning messages to be easily identified.

   (3)  Use of the array constructor appears to generate an internal compiler error under certain circumstances.  For example: fv2 = (/1.,1./) was generated the internal compiler error.  Replaced use of the array constructor with explicit assignment. 
