### PR TITLE
Fix tmass and tmf calculations

### DIFF
--- a/src/cm1.F
+++ b/src/cm1.F
@@ -284,6 +284,7 @@ end module cuda_rt
       real :: mp_total,minval,temx,temy,temni,temnj
       double precision :: tstart,tend
       integer, dimension(:), allocatable :: isum,jsum
+      integer :: padding
 #endif
 #ifdef _OPENACC
       integer :: ndev,idev
@@ -2259,7 +2260,8 @@ end module cuda_rt
       reqt = 0
 
 #ifdef MPI
-      nparcelsLocal = ceiling(nparcels*1.0/numprocs+pdata_buffer*nparcels)
+      padding = max(pdata_buffer*nparcels,100)
+      nparcelsLocal = ceiling((nparcels*1.0/numprocs)+padding)
 #else
       nparcelsLocal = nparcels
 #endif
@@ -3507,7 +3509,6 @@ end module cuda_rt
           enddo
           enddo
         ENDIF
-!#if 0
         call     statpack(mtime,nrec,ndt,dt,dtlast,rtime,adt,acfl,cloudvar,   &
                           qname,budname,qbudget,asq,bsq,                      &
                           name_stat,desc_stat,unit_stat,                      &
@@ -3519,7 +3520,6 @@ end module cuda_rt
                           tke_myj,xkzh,xkzq,xkzm,                             &
                           pta,u10,v10,hpbl,prate,reset,nstatout)
 
-!#endif
         !Also compute the droplet diagnostics at the same frequency as statpack
 
         ! JS: with the new MPI implementation, we can:

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -10327,7 +10327,6 @@
     IF( advwenov.ge.1 )THEN
 
       if(     weno_order.eq.5 )then
-        print *,'momentum_flux: calling vinterp_{weno5,flx6}'
         call vinterp_weno5(  3 ,ni,nj+1,nk,c1,c2,w3d,dum3, v3d ,  0 ,0,weps)
  
         call vinterp_flx6(   3 ,ni,nj+1,nk,c1,c2,w3d,dum4, v3d )
@@ -10337,11 +10336,9 @@
 
         !buh3
       if(     vadvordrs.eq.5 )then
-        print *,'momentum_flux: calling vinterp_{flx5,flx6}'
         call vinterp_flx5(   3 ,ni,nj+1,nk,c1,c2,w3d,dum3, v3d )
         call vinterp_flx6(   3 ,ni,nj+1,nk,c1,c2,w3d,dum4, v3d )
       elseif( vadvordrs.eq.6 )then
-        print *,'momentum_flux: calling vinterp_flx6'
         call vinterp_flx6(   3 ,ni,nj+1,nk,c1,c2,w3d,dum3, v3d )
         !$acc parallel loop gang vector collapse(3) default(present)
         do k=1,nk

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -141,7 +141,7 @@
       !$acc      copyin (randomNumbers,randomNumbers%state, &
       !$acc              pdata_neighbor)
 #else
-      !$acc data create (ta,zf_tmp) &
+      !$acc data create (ta) &
       !$acc      copyin (randomNumbers,randomNumbers%state)
 #endif
 

--- a/src/interp_routines.F
+++ b/src/interp_routines.F
@@ -535,7 +535,6 @@
     real :: wbar,cc1,cc2
 
 
-  print *,'vinterp_flx5: stag: ',stag
   IF( stag.eq.1 )THEN
 #ifdef _OPENACC
     print *,'vinterp_flx5: stag is ',stag

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3899,13 +3899,10 @@
 
       tmass=0.0d0 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop default(present) collapse(3) reduction(+:tmass)
+      !$acc parallel loop gang vector default(present) collapse(3) reduction(+:tmass)
       do k=1,nk
-        !foot=0.0d0
-        !!$acc loop vector collapse(2) reduction(+:foot)
         do j=1,nj
         do i=1,ni
-          ! foot=foot+rho(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)
           tmass=tmass+rho(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)
         enddo
         enddo

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3899,17 +3899,16 @@
 
       tmass=0.0d0 
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present) private(i,j,k) reduction(+:foot,tmass)
-      !$acc loop gang reduction(+:tmass)
+      !$acc parallel loop default(present) collapse(3) reduction(+:tmass)
       do k=1,nk
-        foot=0.0d0
-        !$acc loop vector collapse(2) reduction(+:foot)
+        !foot=0.0d0
+        !!$acc loop vector collapse(2) reduction(+:foot)
         do j=1,nj
         do i=1,ni
-          foot=foot+rho(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)
+          ! foot=foot+rho(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)
+          tmass=tmass+rho(i,j,k)*ruh(i)*rvh(j)*rmh(i,j,k)
         enddo
         enddo
-        tmass=tmass+foot
       enddo
       !$acc end parallel
 
@@ -4357,35 +4356,19 @@
       double precision :: foo1t,foo2t
 
 
-      !$acc data create(foo1,foo2)
+      tmfu=0.0d0
+      tmfd=0.0d0
       !$omp parallel do default(shared) private(i,j,k,mf)
-      !$acc parallel default(present)  private(i,j,k,mf) reduction(+:foo1t,foo2t)
-      !JMD internal compiler error
-      !!$acc loop gang reduction(+:tmfu,tmfd)
-      !$acc loop gang 
+      !$acc parallel loop gang vector default(present) collapse(3) reduction(+:tmfu,tmfd)
       do k=1,nk
-        foo1t = 0.0d0
-        foo2t = 0.0d0
-        !$acc loop vector collapse(2) reduction(+:foo1t,foo2t)
         do j=1,nj
         do i=1,ni
           mf=rho(i,j,k)*0.5*(wa(i,j,k)+wa(i,j,k+1))*ruh(i)*rvh(j)
-          foo1t=foo1t+max(mf,0.0d0)
-          foo2t=foo2t+min(mf,0.0d0)
+          tmfu=tmfu+max(mf,0.0d0)
+          tmfd=tmfd+min(mf,0.0d0)
         enddo
         enddo
-        foo1(k) = foo1t
-        foo2(k) = foo2t
       enddo
-      !$acc end parallel
-      tmfu=0.0d0
-      tmfd=0.0d0
-      !$acc parallel loop vector gang default(present) reduction(+:tmfu,tmfd)
-      do k=1,nk
-        tmfu=tmfu+foo1(k)
-        tmfd=tmfd+foo2(k)
-      enddo
-      !$acc end parallel
 
 #ifdef MPI
       var=0.0d0
@@ -4413,7 +4396,6 @@
 #ifdef MPI
       endif
 #endif
-      !$acc end data
       if(timestats.ge.1) time_stat=time_stat+mytime()
 
 

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -478,7 +478,7 @@
 
       if(stat_vort.eq.1) call vertvort(nstat,rstat,xh,xf,uf,vf,zh,zs,rgzu,rgzv,rds,sigma,rdsf,sigmaf,dum1,dum2,ua,va)
 
-      !JMD-KLUDGE if(stat_tmass.eq.1) call calcmass(nstat,rstat,ruh,rvh,rmh,rho)
+      if(stat_tmass.eq.1) call calcmass(nstat,rstat,ruh,rvh,rmh,rho)
 
 !$omp parallel do default(shared)  &
 !$omp private(i,j,k)
@@ -583,7 +583,7 @@
         call calcmoe(nstat,rstat,ruh,rvh,rmh,rho,ua,va,wa,dum1,dum2,dum3,dum4)
       endif
 
-      !JMD-KLUDGE if(stat_tmf.eq.1) call tmf(nstat,rstat,ruh,rvh,rho,wa)
+      if(stat_tmf.eq.1) call tmf(nstat,rstat,ruh,rvh,rho,wa)
 
 !----------
 


### PR DESCRIPTION
This PR request reactivates the calculation of the TMFU, TMFD, and TMASS values for the statpack.F90.  The correctness tests are different as it now adds three new fields.  The statistics are as follows.  Note that while the TMFU and TMFD are outside the relative difference of >1e-06 they only slightly fail this threshold tolerance.  Based on the simplicity of this code which is fundamentally a reduction, we view these differences as acceptable.

44 stat variables are identical.
27 stat variables show a mean relative difference > 1e-06
15 stat variables show a mean relative difference <= 1e-06
