### PR TITLE
GPU enabled WRF files provided from NVIDIA

### DIFF
--- a/src/fromNVIDIA/module_bl_gwdo.F
+++ b/src/fromNVIDIA/module_bl_gwdo.F
@@ -1,0 +1,896 @@
+!WRF:model_layer:physics
+!
+!
+!
+!
+#define CHNK 8192
+
+module module_bl_gwdo
+contains
+!-------------------------------------------------------------------------------
+   subroutine gwdo(u3d,v3d,t3d,qv3d,p3d,p3di,pi3d,z,                           &
+                  rublten,rvblten,                                             &
+                  dtaux3d,dtauy3d,dusfcg,dvsfcg,                               &
+                  var2d,oc12d,oa2d1,oa2d2,oa2d3,oa2d4,ol2d1,ol2d2,ol2d3,ol2d4, &
+                  znu,znw,mut,p_top,                                           &
+                  cp,g,rd,rv,ep1,pi,                                           &
+                  dt,dx,kpbl2d,itimestep,                                      &
+                  ids,ide, jds,jde, kds,kde,                                   &
+                  ims,ime, jms,jme, kms,kme,                                   &
+                  its,ite, jts,jte, kts,kte)
+!-------------------------------------------------------------------------------
+   implicit none
+!-------------------------------------------------------------------------------
+!                                                                       
+!-- u3d         3d u-velocity interpolated to theta points (m/s)
+!-- v3d         3d v-velocity interpolated to theta points (m/s)
+!-- t3d         temperature (k)
+!-- qv3d        3d water vapor mixing ratio (kg/kg)
+!-- p3d         3d pressure (pa)
+!-- p3di        3d pressure (pa) at interface level
+!-- pi3d        3d exner function (dimensionless)
+!-- rublten     u tendency due to pbl parameterization (m/s/s) 
+!-- rvblten     v tendency due to pbl parameterization (m/s/s)
+!-- znu         eta values (sigma values)
+!-- cp          heat capacity at constant pressure for dry air (j/kg/k)
+!-- g           acceleration due to gravity (m/s^2)
+!-- rd          gas constant for dry air (j/kg/k)
+!-- z           height above sea level (m)
+!-- rv          gas constant for water vapor (j/kg/k)
+!-- dt          time step (s)
+!-- dx          model grid interval (m)
+!-- ep1         constant for virtual temperature (r_v/r_d - 1) (dimensionless)
+!-- ids         start index for i in domain
+!-- ide         end index for i in domain
+!-- jds         start index for j in domain
+!-- jde         end index for j in domain
+!-- kds         start index for k in domain
+!-- kde         end index for k in domain
+!-- ims         start index for i in memory
+!-- ime         end index for i in memory
+!-- jms         start index for j in memory
+!-- jme         end index for j in memory
+!-- kms         start index for k in memory
+!-- kme         end index for k in memory
+!-- its         start index for i in tile
+!-- ite         end index for i in tile
+!-- jts         start index for j in tile
+!-- jte         end index for j in tile
+!-- kts         start index for k in tile
+!-- kte         end index for k in tile
+!
+!-------------------------------------------------------------------------------
+  integer,  intent(in   )   ::      ids,ide, jds,jde, kds,kde,                 &
+                                     ims,ime, jms,jme, kms,kme,                &
+                                     its,ite, jts,jte, kts,kte
+  integer,  intent(in   )   ::      itimestep
+!
+  real,     intent(in   )   ::      dt,dx,cp,g,rd,rv,ep1,pi
+!
+  real,     dimension( ims:ime, kms:kme, jms:jme )                           , &
+            intent(in   )   ::                                           qv3d, &
+                                                                          p3d, &
+                                                                         pi3d, &
+                                                                          t3d, &
+                                                                             z
+  real,     dimension( ims:ime, kms:kme, jms:jme )                           , &
+            intent(in   )   ::                                           p3di
+!
+  real,     dimension( ims:ime, kms:kme, jms:jme )                           , &
+            intent(inout)   ::                                        rublten, &
+                                                                      rvblten
+  real,     dimension( ims:ime, kms:kme, jms:jme )                           , &
+            intent(inout)   ::                                        dtaux3d, &
+                                                                      dtauy3d
+!
+  real,      dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(in   )   ::                                           u3d, &
+                                                                          v3d
+!
+  integer,   dimension( ims:ime, jms:jme )                                   , &
+             intent(in  )   ::                                         kpbl2d
+  real,   dimension( ims:ime, jms:jme )                                      , &
+             intent(inout  )   ::                                      dusfcg, &
+                                                                       dvsfcg
+!
+  real,   dimension( ims:ime, jms:jme )                                      , &
+             intent(in  )   ::                                          var2d, &
+                                                                        oc12d, &
+                                                      oa2d1,oa2d2,oa2d3,oa2d4, &
+                                                      ol2d1,ol2d2,ol2d3,ol2d4
+  real,     dimension( ims:ime, jms:jme )                                    , &
+            optional                                                         , &
+            intent(in  )   ::                                             mut
+!
+  real,     dimension( kms:kme )                                             , &
+            optional                                                         , &
+            intent(in  )   ::                                             znu, &
+                                                                          znw
+!
+  real,     optional, intent(in  )   ::                                 p_top
+!
+!local
+!
+  real,   dimension( CHNK, kts:kte )  ::                           delprsi, &
+                                                                          pdh
+  real,     dimension( CHNK, kts:kte+1 )   ::                         pdhi
+  real,   dimension( CHNK, 4 )        ::                               oa4, &
+                                                                          ol4
+  integer, dimension(CHNK)  :: kpbl
+  real,    dimension(CHNK)  :: dusfc, dvsfc, var, oc1
+  real,    dimension(CHNK,kts:kte) :: zl,prslk,u1,v1,t1,q1,dudt,dvdt,&
+                                      dtaux2d, dtauy2d
+
+  integer ::  i,j,k,kdt,kpblmax
+  INTEGER:: icol, col, ncol, nlon
+  real :: p_top_
+!
+!$acc data create(delprsi,pdh,pdhi,oa4,ol4,kpbl,dusfc, dvsfc, var, oc1,&
+!$acc             zl,prslk,u1,v1,t1,q1,dudt,dvdt,dtaux2d, dtauy2d) &
+!$acc     pcopy(mut,znu,p3d,p3di,oa2d1,oa2d2,oa2d3,oa2d4,ol2d1,ol2d2,&
+!$acc             ol2d3,ol2d4,kpbl2d,var2d,oc12d,dusfcg,dvsfcg,z,pi3d, &
+!$acc             u3d,v3d,t3d,qv3d,rublten,rvblten,dtaux3d,dtauy3d,znw)
+
+  p_top_ = 0.0
+  if(present(mut)) p_top_ = p_top
+
+!!$acc update host(znu)
+   kpblmax = kts
+!$acc kernels
+!$acc loop reduction(max:kpblmax)
+   do k = kts,kte
+     if(znu(k).gt.0.6) kpblmax = k + 1
+   enddo
+!$acc end kernels   
+!
+
+   ncol = (jte - jts + 1)*(ite - its + 1)
+   nlon = (ite - its + 1)
+
+   do icol = 1,ceiling(real(ncol)/real(CHNK))
+
+   
+   if(present(mut))then
+! For ARW we will replace p and p8w with dry hydrostatic pressure
+!$acc kernels
+      do k = kts,kte+1
+      do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK
+         i = MOD((icol-1)*CHNK + col-1, nlon) + its
+         j = ((icol-1)*CHNK + col-1)/nlon + jts
+         if(k.le.kte)pdh(col,k) = mut(i,j)*znu(k) + p_top_
+         pdhi(col,k) = mut(i,j)*znw(k) + p_top_
+      enddo ! col
+      enddo
+!$acc end kernels      
+   else
+!$acc kernels
+      do k = kts,kte+1
+      do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK
+         i = MOD((icol-1)*CHNK + col-1, nlon) + its
+         j = ((icol-1)*CHNK + col-1)/nlon + jts
+         if(k.le.kte)pdh(col,k) = p3d(i,k,j)
+         pdhi(col,k) = p3di(i,k,j)
+      enddo ! col
+      enddo
+!$acc end kernels      
+   endif
+!
+!$acc kernels
+   do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK
+      i = MOD((icol-1)*CHNK + col-1, nlon) + its
+      j = ((icol-1)*CHNK + col-1)/nlon + jts
+
+      oa4(col,1) = oa2d1(i,j)
+      oa4(col,2) = oa2d2(i,j)
+      oa4(col,3) = oa2d3(i,j)
+      oa4(col,4) = oa2d4(i,j)
+      ol4(col,1) = ol2d1(i,j)
+      ol4(col,2) = ol2d2(i,j)
+      ol4(col,3) = ol2d3(i,j)
+      ol4(col,4) = ol2d4(i,j)
+
+      kpbl(col) = kpbl2d(i,j)
+      var(col) = var2d(i,j)
+      oc1(col) = oc12d(i,j)
+      dusfc(col) = dusfcg(i,j)
+      dvsfc(col) = dvsfcg(i,j)
+   enddo ! col
+
+   do k = kts,kte
+   do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK
+      i = MOD((icol-1)*CHNK + col-1, nlon) + its
+      j = ((icol-1)*CHNK + col-1)/nlon + jts
+         delprsi(col,k) = pdhi(col,k)-pdhi(col,k+1)
+         zl(col,k) = z(i,k,j)
+         prslk(col,k) = pi3d(i,k,j)
+         u1(col,k) = u3d(i,k,j)
+         v1(col,k) = v3d(i,k,j)
+         t1(col,k) = t3d(i,k,j)
+         q1(col,k) = qv3d(i,k,j)
+         dudt(col,k) = rublten(i,k,j)
+         dvdt(col,k) = rvblten(i,k,j)
+         dtaux2d(col,k) = dtaux3d(i,k,j)
+         dtauy2d(col,k) = dtauy3d(i,k,j)
+    enddo ! col
+    enddo
+!$acc end kernels
+      call gwdo2d(dudt=dudt,dvdt=dvdt              &
+              ,dtaux2d=dtaux2d,dtauy2d=dtauy2d           &
+              ,u1=u1,v1=v1                             &
+              ,t1=t1,q1=q1                            &
+              ,del=delprsi                                            &
+              ,prsi=pdhi                                              &
+              ,prsl=pdh,prslk=prslk                         &
+              ,zl=zl,rcl=1.0                                         &
+              ,kpblmax=kpblmax                                                 &
+              ,dusfc=dusfc,dvsfc=dvsfc                         &
+              ,var=var,oc1=oc1                               &
+              ,oa4=oa4,ol4=ol4                                                 &
+              ,g=g,cp=cp,rd=rd,rv=rv,fv=ep1,pi=pi                              &
+              ,dxmeter=dx,deltim=dt                                            &
+              ,kpbl=kpbl,kdt=itimestep,lat=1                          &
+              ,ids=1,ide=CHNK, jds=1,jde=1, kds=kts,kde=kte               &
+              ,ims=1,ime=CHNK, jms=1,jme=1, kms=kts,kme=kte               &
+              ,its=1,ite=CHNK, jts=1,jte=1, kts=kts,kte=kte   )
+
+!$acc kernels   
+!$acc loop independent   
+   do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK
+      i = MOD((icol-1)*CHNK + col-1, nlon) + its
+      j = ((icol-1)*CHNK + col-1)/nlon + jts
+
+      dusfcg(i,j) = dusfc(col)
+      dvsfcg(i,j) = dvsfc(col)
+   enddo !col
+
+!$acc loop independent   
+   do k=kts,kte
+!$acc loop independent   
+   do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK
+      i = MOD((icol-1)*CHNK + col-1, nlon) + its
+      j = ((icol-1)*CHNK + col-1)/nlon + jts
+      rublten(i,k,j) = dudt(col,k)
+      rvblten(i,k,j) = dvdt(col,k)
+      dtaux3d(i,k,j) = dtaux2d(col,k)
+      dtauy3d(i,k,j) = dtauy2d(col,k)
+   enddo !col
+   enddo ! k
+!$acc end kernels
+
+   enddo !icol
+!$acc end data
+!
+   end subroutine gwdo
+!-------------------------------------------------------------------------------
+!
+!-------------------------------------------------------------------------------
+   subroutine gwdo2d(dudt,dvdt,dtaux2d,dtauy2d,                                &
+                    u1,v1,t1,q1,                                               &
+                    del,                                                       &
+                    prsi,prsl,prslk,zl,rcl,kpblmax,                            &
+                    var,oc1,oa4,ol4,dusfc,dvsfc,                               &
+                    g,cp,rd,rv,fv,pi,dxmeter,deltim,kpbl,kdt,lat,              &
+                    ids,ide, jds,jde, kds,kde,                                 &
+                    ims,ime, jms,jme, kms,kme,                                 &
+                    its,ite, jts,jte, kts,kte)
+!-------------------------------------------------------------------------------
+!  
+!  this code handles the time tendencies of u v due to the effect of  mountain 
+!  induced gravity wave drag from sub-grid scale orography. this routine 
+!  not only treats the traditional upper-level wave breaking due to mountain 
+!  variance (alpert 1988), but also the enhanced lower-tropospheric wave 
+!  breaking due to mountain convexity and asymmetry (kim and arakawa 1995). 
+!  thus, in addition to the terrain height data in a model grid gox, 
+!  additional 10-2d topographic statistics files are needed, including 
+!  orographic standard  deviation (var), convexity (oc1), asymmetry (oa4) 
+!  and ol (ol4). these data sets are prepared based on the 30 sec usgs orography
+!  hong (1999). the current scheme was implmented as in hong et al.(2008)
+!
+!  coded by song-you hong and young-joon kim and implemented by song-you hong
+!
+!  program history log:
+!    2014-10-01  Hyun-Joo Choi (from KIAPS)  flow-blocking drag of kim and doyle
+!                              with blocked height by dividing streamline theory
+!
+!  references:
+!        hong et al. (2008), wea. and forecasting
+!        kim and doyle (2005), Q. J. R. Meteor. Soc.
+!        kim and arakawa (1995), j. atmos. sci.
+!        alpet et al. (1988), NWP conference.
+!        hong (1999), NCEP office note 424.
+!
+!  notice : comparible or lower resolution orography files than model resolution
+!           are desirable in preprocess (wps) to prevent weakening of the drag
+!-------------------------------------------------------------------------------
+!
+!  input                                                                
+!        dudt (ims:ime,kms:kme)  non-lin tendency for u wind component
+!        dvdt (ims:ime,kms:kme)  non-lin tendency for v wind component
+!        u1(ims:ime,kms:kme) zonal wind / sqrt(rcl)  m/sec  at t0-dt
+!        v1(ims:ime,kms:kme) meridional wind / sqrt(rcl) m/sec at t0-dt
+!        t1(ims:ime,kms:kme) temperature deg k at t0-dt
+!        q1(ims:ime,kms:kme) specific humidity at t0-dt
+!
+!        rcl     a scaling factor = reciprocal of square of cos(lat)
+!                for gmp.  rcl=1 if u1 and v1 are wind components.
+!        deltim  time step    secs                                       
+!        del(kts:kte)  positive increment of pressure across layer (pa)
+!                                                                       
+!  output
+!        dudt, dvdt    wind tendency due to gwdo
+!
+!-------------------------------------------------------------------------------
+   implicit none
+!-------------------------------------------------------------------------------
+   integer              ::  kdt,lat,latd,lond,kpblmax,                         &
+                            ids,ide, jds,jde, kds,kde,                         &
+                            ims,ime, jms,jme, kms,kme,                         &
+                            its,ite, jts,jte, kts,kte
+!
+   real                 ::  g,rd,rv,fv,cp,pi,dxmeter,deltim,rcl
+   real                 ::  dudt(ims:ime,kms:kme),dvdt(ims:ime,kms:kme),       &
+                            dtaux2d(ims:ime,kms:kme),dtauy2d(ims:ime,kms:kme), &
+                            u1(ims:ime,kms:kme),v1(ims:ime,kms:kme),           & 
+                            t1(ims:ime,kms:kme),q1(ims:ime,kms:kme),           &
+                            zl(ims:ime,kms:kme),prsl(its:ite,kts:kte),         &
+                            prslk(ims:ime,kms:kme)
+   real                 ::  prsi(its:ite,kts:kte+1),del(its:ite,kts:kte)
+   real                 ::  oa4(its:ite,4),ol4(its:ite,4)
+!
+   integer              ::  kpbl(ims:ime)
+   real                 ::  var(ims:ime),oc1(ims:ime),                         &
+                            dusfc(ims:ime),dvsfc(ims:ime)
+!
+! critical richardson number for wave breaking : ! larger drag with larger value
+!
+   real,parameter       ::  ric     = 0.25  
+!
+   real,parameter       ::  dw2min  = 1.
+   real,parameter       ::  rimin   = -100.
+   real,parameter       ::  bnv2min = 1.0e-5
+   real,parameter       ::  efmin   = 0.0
+   real,parameter       ::  efmax   = 10.0
+   real,parameter       ::  xl      = 4.0e4  
+   real,parameter       ::  critac  = 1.0e-5
+   real,parameter       ::  gmax    = 1.    
+   real,parameter       ::  veleps  = 1.0                                                 
+   real,parameter       ::  factop  = 0.5                                                  
+   real,parameter       ::  frc     = 1.0      
+   real,parameter       ::  ce      = 0.8     
+   real,parameter       ::  cg      = 0.5    
+   integer,parameter    ::  kpblmin = 2
+!
+!  local variables
+!
+   integer              ::  i,k,lcap,lcapp1,nwd,idir,                          &
+                            klcap,kp1,ikount,kk
+!
+   real                 ::  rcs,rclcs,csg,fdir,cleff,cs,rcsks,                 &
+                            wdir,ti,rdz,temp,tem2,dw2,shr2,bvf2,rdelks,        &
+                            wtkbj,tem,gfobnv,hd,fro,rim,temc,tem1,efact,       &
+                            temv,dtaux,dtauy
+!
+   logical              ::  ldrag(its:ite),icrilv(its:ite),                    &
+                            flag(its:ite),kloop1(its:ite)
+!                                                                       
+   real                 ::  taub(its:ite),taup(its:ite,kts:kte+1),             &
+                            xn(its:ite),yn(its:ite),                           &
+                            ubar(its:ite),vbar(its:ite),                       &
+                            fr(its:ite),ulow(its:ite),                         &
+                            rulow(its:ite),bnv(its:ite),                       &
+                            oa(its:ite),ol(its:ite),                           &
+                            roll(its:ite),dtfac(its:ite),                      &
+                            brvf(its:ite),xlinv(its:ite),                      &
+                            delks(its:ite),delks1(its:ite),                    &
+                            bnv2(its:ite,kts:kte),usqj(its:ite,kts:kte),       &
+                            taud(its:ite,kts:kte),ro(its:ite,kts:kte),         &
+                            vtk(its:ite,kts:kte),vtj(its:ite,kts:kte),         &
+                            zlowtop(its:ite),velco(its:ite,kts:kte-1),         &
+                            coefm(its:ite)
+!
+   integer              ::  kbl(its:ite),klowtop(its:ite)
+!
+   logical :: iope
+   integer,parameter    ::  mdir=8
+   integer              ::  nwdir(mdir)
+   data nwdir/6,7,5,8,2,3,1,4/
+   integer              ::  nwdir_
+!
+!  variables for flow-blocking drag
+!
+   real,parameter       :: frmax  = 10.
+   real,parameter       :: olmin  = 1.0e-5
+   real,parameter       :: odmin  = 0.1 
+   real,parameter       :: odmax  = 10. 
+   real,parameter       :: erad   = 6371.315e+3
+   integer              :: komax(its:ite)
+   integer              :: kblk
+   real                 :: cd
+   real                 :: zblk,tautem
+   real                 :: pe,ke 
+   real                 :: delx,dely,dxy4(4),dxy4p(4)
+   real                 :: dxy(its:ite),dxyp(its:ite)
+   real                 :: ol4p(4),olp(its:ite),od(its:ite)
+   real                 :: taufb(its:ite,kts:kte+1)
+!
+!---- constants                                                         
+!                                                                       
+   rcs    = sqrt(rcl)                                                   
+   cs     = 1. / sqrt(rcl)                                                     
+   csg    = cs * g                                                      
+   lcap   = kte                                                         
+   lcapp1 = lcap + 1                                                 
+   fdir   = mdir / (2.0*pi)
+   nwdir_ = b'01000001001100101000010101110110' !6,7,5,8,2,3,1,4
+!
+!--- calculate length of grid for flow-blocking drag
+!
+   delx   = dxmeter 
+   dely   = dxmeter
+   dxy4(1)  = delx
+   dxy4(2)  = dely
+   dxy4(3)  = sqrt(delx*delx + dely*dely)
+   dxy4(4)  = dxy4(3)
+   dxy4p(1) = dxy4(2)
+   dxy4p(2) = dxy4(1)
+   dxy4p(3) = dxy4(4)
+   dxy4p(4) = dxy4(3)
+
+!$acc data create(ldrag,icrilv,flag,kloop1,taub,taup,xn,yn,ubar,vbar,fr,ulow,&
+!$acc             rulow,bnv,oa,ol,roll,dtfac,brvf,xlinv,delks,delks1,bnv2, &
+!$acc             usqj,taud,ro,vtk,vtj,zlowtop,velco,coefm,kbl,klowtop,&
+!$acc             komax,delx,dely,dxy4,dxy,dxyp,olp,od,taufb) &
+!$acc        copy(del,prsi,prsl,q1,prslk,zl,var,u1,t1,dusfc,dtauy2d,dvdt,&
+!$acc             oa4,oc1,kpbl,dvsfc,v1,ol4,dudt,dtaux2d)
+
+!$acc update device(dxy4)
+!
+!
+!-----initialize arrays                                                 
+!                                                                       
+   dtaux = 0.0
+   dtauy = 0.0
+!$acc kernels   
+   do i = its,ite                                                       
+     klowtop(i)    = 0
+     kbl(i)        = 0
+   enddo                                                             
+!
+   do i = its,ite                                                       
+     xn(i)         = 0.0
+     yn(i)         = 0.0
+     ubar (i)      = 0.0
+     vbar (i)      = 0.0
+     roll (i)      = 0.0
+     taub (i)      = 0.0
+     taup(i,1)     = 0.0
+     oa(i)         = 0.0
+     ol(i)         = 0.0
+     ulow (i)      = 0.0
+     dtfac(i)      = 1.0
+     ldrag(i)      = .false.
+     icrilv(i)     = .false. 
+     flag(i)       = .true.
+   enddo                                                             
+!
+   do k = kts,kte
+     do i = its,ite
+       usqj(i,k) = 0.0
+       bnv2(i,k) = 0.0
+       vtj(i,k)  = 0.0
+       vtk(i,k)  = 0.0
+       taup(i,k) = 0.0
+       taud(i,k) = 0.0
+       dtaux2d(i,k)= 0.0
+       dtauy2d(i,k)= 0.0
+     enddo
+   enddo
+!
+   do i = its,ite
+     taup(i,kte+1) = 0.0
+     xlinv(i)     = 1.0/xl                                                   
+   enddo
+!
+!  initialize array for flow-blocking drag
+!
+   taufb(:,:) = 0.0
+   komax(:) = 0
+!
+   do k = kts,kte
+     do i = its,ite
+       vtj(i,k)  = t1(i,k)  * (1.+fv*q1(i,k))
+       vtk(i,k)  = vtj(i,k) / prslk(i,k)
+       ro(i,k)   = 1./rd * prsl(i,k) / vtj(i,k) ! density kg/m**3
+     enddo
+   enddo
+!
+!  determine reference level: maximum of 2*var and pbl heights
+!
+   do i = its,ite
+     zlowtop(i) = 2. * var(i)
+   enddo
+!
+   do i = its,ite
+     kloop1(i) = .true.
+   enddo
+!
+!$acc loop seq   
+   do k = kts+1,kte
+     do i = its,ite
+       if(kloop1(i).and.zl(i,k)-zl(i,1).ge.zlowtop(i)) then
+         klowtop(i) = k+1
+         kloop1(i)  = .false.
+       endif
+     enddo
+   enddo
+!
+   do i = its,ite
+     kbl(i)   = max(kpbl(i), klowtop(i))
+     kbl(i)   = max(min(kbl(i),kpblmax),kpblmin)
+   enddo
+!
+!  determine the level of maximum orographic height
+!
+   komax(:) = kbl(:)
+!
+   do i = its,ite
+     delks(i)  = 1.0 / (prsi(i,1) - prsi(i,kbl(i)))
+     delks1(i) = 1.0 / (prsl(i,1) - prsl(i,kbl(i)))
+   enddo
+!
+!  compute low level averages within pbl
+!
+!$acc loop seq   
+   do k = kts,kpblmax
+     do i = its,ite
+       if (k.lt.kbl(i)) then
+         rcsks   = rcs     * del(i,k) * delks(i)
+         rdelks  = del(i,k)  * delks(i)
+         ubar(i) = ubar(i) + rcsks  * u1(i,k)      ! pbl u  mean
+         vbar(i) = vbar(i) + rcsks  * v1(i,k)      ! pbl v  mean
+         roll(i) = roll(i) + rdelks * ro(i,k)      ! ro mean
+       endif
+     enddo
+   enddo
+!
+!     figure out low-level horizontal wind direction 
+!
+!             nwd  1   2   3   4   5   6   7   8
+!              wd  w   s  sw  nw   e   n  ne  se
+!
+   do i = its,ite                                                       
+     wdir   = atan2(ubar(i),vbar(i)) + pi
+     idir   = mod(nint(fdir*wdir),mdir) + 1
+#ifndef _OPENACC     
+     nwd    = nwdir(idir)
+#else
+     nwd = and(ishft(nwdir_,-(idir-1)*4),b'1111')
+#endif     
+     oa(i)  = (1-2*int( (nwd-1)/4 )) * oa4(i,mod(nwd-1,4)+1)
+     ol(i) = ol4(i,mod(nwd-1,4)+1) 
+!
+!----- compute orographic width along (ol) and perpendicular (olp)
+!----- the direction of wind
+!
+#ifndef _OPENACC     
+     ol4p(1) = ol4(i,2)
+     ol4p(2) = ol4(i,1)
+     ol4p(3) = ol4(i,4)
+     ol4p(4) = ol4(i,3)
+     olp(i)  = ol4p(mod(nwd-1,4)+1) 
+#else
+     k = mod(nwd-1,4)+1
+     k = k + AND(k,1)*2 - 1
+     olp(i)  = ol4(i,k)
+#endif     
+!
+!----- compute orographic direction (horizontal orographic aspect ratio)
+!
+     od(i) = olp(i)/max(ol(i),olmin)
+     od(i) = min(od(i),odmax)
+     od(i) = max(od(i),odmin)
+!
+!----- compute length of grid in the along(dxy) and cross(dxyp) wind directions
+!
+     dxy(i)  = dxy4(MOD(nwd-1,4)+1)
+#ifndef _OPENACC     
+     dxyp(i) = dxy4p(MOD(nwd-1,4)+1)
+#else
+     dxyp(i) = dxy4(k)
+#endif
+   enddo
+!                                                                       
+!---  saving richardson number in usqj for migwdi                       
+!
+   do k = kts,kte-1                                                     
+     do i = its,ite                                                     
+       ti        = 2.0 / (t1(i,k)+t1(i,k+1))                                
+       rdz       = 1./(zl(i,k+1) - zl(i,k))
+       tem1      = u1(i,k) - u1(i,k+1)
+       tem2      = v1(i,k) - v1(i,k+1)   
+       dw2       = rcl*(tem1*tem1 + tem2*tem2)
+       shr2      = max(dw2,dw2min) * rdz * rdz
+       bvf2      = g*(g/cp+rdz*(vtj(i,k+1)-vtj(i,k))) * ti                
+       usqj(i,k) = max(bvf2/shr2,rimin)                            
+       bnv2(i,k) = 2.0*g*rdz*(vtk(i,k+1)-vtk(i,k))/(vtk(i,k+1)+vtk(i,k))
+       bnv2(i,k) = max( bnv2(i,k), bnv2min )
+     enddo                                                          
+   enddo                                                             
+!
+!----compute the "low level" or 1/3 wind magnitude (m/s)                
+!                                                                       
+   do i = its,ite                                                       
+     ulow(i) = max(sqrt(ubar(i)*ubar(i) + vbar(i)*vbar(i)), 1.0)
+     rulow(i) = 1./ulow(i)
+   enddo                                                             
+!
+   do k = kts,kte-1                                                    
+     do i = its,ite                                                   
+       velco(i,k)  = (0.5*rcs) * ((u1(i,k)+u1(i,k+1)) * ubar(i)                &
+                                + (v1(i,k)+v1(i,k+1)) * vbar(i))                 
+       velco(i,k)  = velco(i,k) * rulow(i)                               
+       if ((velco(i,k).lt.veleps) .and. (velco(i,k).gt.0.)) then
+         velco(i,k) = veleps                                      
+       endif
+     enddo                                                          
+   enddo                                                             
+!                                                                       
+!  no drag when critical level in the base layer                        
+!                                                                       
+   do i = its,ite                                                       
+     ldrag(i) = velco(i,1).le.0.                                    
+   enddo                                                             
+!
+!  no drag when velco.lt.0                                               
+!                                                                       
+   do k = kpblmin,kpblmax
+     do i = its,ite                                                    
+       if (k .lt. kbl(i)) ldrag(i) = ldrag(i).or. velco(i,k).le.0.
+     enddo                                                          
+   enddo                                                             
+!                                                                       
+!  no drag when bnv2.lt.0                                               
+!                                                                       
+   do k = kts,kpblmax
+     do i = its,ite                                                    
+       if (k .lt. kbl(i)) ldrag(i) = ldrag(i).or. bnv2(i,k).lt.0.
+     enddo                                                          
+   enddo                                                             
+!                                                                       
+!-----the low level weighted average ri is stored in usqj(1,1; im)      
+!-----the low level weighted average n**2 is stored in bnv2(1,1; im)    
+!---- this is called bnvl2 in phys_gwd_alpert_sub not bnv2                           
+!---- rdelks (del(k)/delks) vert ave factor so we can * instead of /    
+!                                                                       
+   do i = its,ite                                                       
+     wtkbj     = (prsl(i,1)-prsl(i,2)) * delks1(i)
+     bnv2(i,1) = wtkbj * bnv2(i,1)                                
+     usqj(i,1) = wtkbj * usqj(i,1)                                
+   enddo                                                             
+!
+   do k = kpblmin,kpblmax                                                
+     do i = its,ite                                                    
+       if (k .lt. kbl(i)) then
+         rdelks    = (prsl(i,k)-prsl(i,k+1)) * delks1(i)
+         bnv2(i,1) = bnv2(i,1) + bnv2(i,k) * rdelks
+         usqj(i,1) = usqj(i,1) + usqj(i,k) * rdelks
+       endif
+     enddo                                                          
+   enddo                                                             
+!                                                                       
+   do i = its,ite                                                       
+     ldrag(i) = ldrag(i) .or. bnv2(i,1).le.0.0                         
+     ldrag(i) = ldrag(i) .or. ulow(i).eq.1.0                           
+     ldrag(i) = ldrag(i) .or. var(i) .le. 0.0
+   enddo                                                             
+!                                                                       
+!  set all ri low level values to the low level value          
+!                                                                       
+   do k = kpblmin,kpblmax
+     do i = its,ite                                                    
+       if (k .lt. kbl(i)) usqj(i,k) = usqj(i,1)
+     enddo                                                          
+   enddo                                                             
+!
+   do i = its,ite 
+     if (.not.ldrag(i))   then   
+       bnv(i) = sqrt( bnv2(i,1) )                                  
+       fr(i) = bnv(i)  * rulow(i) * 2. * var(i) * od(i)
+       fr(i) = min(fr(i),frmax)
+       xn(i)  = ubar(i) * rulow(i)
+       yn(i)  = vbar(i) * rulow(i)
+     endif
+   enddo
+!
+!  compute the base level stress and store it in taub
+!  calculate enhancement factor, number of mountains & aspect        
+!  ratio const. use simplified relationship between standard            
+!  deviation & critical hgt                                          
+!
+   do i = its,ite                                                       
+     if (.not. ldrag(i))   then   
+       efact    = (oa(i) + 2.) ** (ce*fr(i)/frc)                         
+       efact    = min( max(efact,efmin), efmax )                            
+!!!!!!! cleff (effective grid length) is highly tunable parameter
+!!!!!!! the bigger (smaller) value produce weaker (stronger) wave drag
+       cleff    = sqrt(dxy(i)**2. + dxyp(i)**2.)
+       cleff    = 3. * max(dxmeter,cleff)
+       coefm(i) = (1. + ol(i)) ** (oa(i)+1.)                   
+       xlinv(i) = coefm(i) / cleff                                             
+       tem      = fr(i) * fr(i) * oc1(i)
+       gfobnv   = gmax * tem / ((tem + cg)*bnv(i))   
+       taub(i)  = xlinv(i) * roll(i) * ulow(i) * ulow(i)                       &
+                * ulow(i) * gfobnv * efact          
+     else                                                          
+       taub(i) = 0.0                                             
+       xn(i)   = 0.0                                             
+       yn(i)   = 0.0                                             
+     endif                                                         
+   enddo                                                             
+!                                                                       
+!   now compute vertical structure of the stress.
+!
+   do k = kts,kpblmax
+     do i = its,ite
+       if (k .le. kbl(i)) taup(i,k) = taub(i)
+     enddo
+   enddo
+!
+   do k = kpblmin, kte-1                   ! vertical level k loop!
+     kp1 = k + 1
+     do i = its,ite
+!
+!   unstablelayer if ri < ric
+!   unstable layer if upper air vel comp along surf vel <=0 (crit lay)
+!   at (u-c)=0. crit layer exists and bit vector should be set (.le.)
+!
+       if (k .ge. kbl(i)) then
+         icrilv(i) = icrilv(i) .or. ( usqj(i,k) .lt. ric)                      &
+                               .or. (velco(i,k) .le. 0.0)
+         brvf(i)  = max(bnv2(i,k),bnv2min) ! brunt-vaisala frequency squared
+         brvf(i)  = sqrt(brvf(i))          ! brunt-vaisala frequency
+       endif
+     enddo
+!   enddo
+!
+!   do k = kpblmin, kte-1                   ! vertical level k loop!
+     do i = its,ite
+       if (k .ge. kbl(i) .and. (.not. ldrag(i)))   then   
+         if (.not.icrilv(i) .and. taup(i,k) .gt. 0.0 ) then
+           temv = 1.0 / velco(i,k)
+           tem1 = coefm(i)/dxy(i)*(ro(i,kp1)+ro(i,k))*brvf(i)*velco(i,k)*0.5
+           hd   = sqrt(taup(i,k) / tem1)
+           fro  = brvf(i) * hd * temv
+!
+!  rim is the  minimum-richardson number by shutts (1985)
+!
+           tem2   = sqrt(usqj(i,k))
+           tem    = 1. + tem2 * fro
+           rim    = usqj(i,k) * (1.-fro) / (tem * tem)
+!
+!  check stability to employ the 'saturation hypothesis'
+!  of lindzen (1981) except at tropospheric downstream regions
+!
+           if (rim .le. ric) then  ! saturation hypothesis!
+             if ((oa(i) .le. 0.).or.(kp1 .ge. kpblmin )) then
+               temc = 2.0 + 1.0 / tem2
+               hd   = velco(i,k) * (2.*sqrt(temc)-temc) / brvf(i)
+               taup(i,kp1) = tem1 * hd * hd
+             endif
+           else                    ! no wavebreaking!
+             taup(i,kp1) = taup(i,k)
+           endif
+         endif
+       endif
+     enddo      
+   enddo
+!
+   if(lcap.lt.kte) then                                               
+     do klcap = lcapp1,kte                                          
+       do i = its,ite                                                 
+         taup(i,klcap) = prsi(i,klcap) / prsi(i,lcap) * taup(i,lcap)      
+       enddo                                                       
+     enddo                                                          
+   endif                                                             
+!$acc loop private(zblk,kblk)   
+   do i = its,ite
+     if(.not.ldrag(i)) then
+!
+!------- determine the height of flow-blocking layer
+!
+        kblk = 0
+        pe = 0.0
+        do k = kte, kpblmin, -1
+          if(kblk.eq.0 .and. k.le.komax(i)) then
+            pe = pe + bnv2(i,k)*(zl(i,komax(i))-zl(i,k))*del(i,k)/g/ro(i,k)
+            ke = 0.5*((rcs*u1(i,k))**2.+(rcs*v1(i,k))**2.)
+!
+!---------- apply flow-blocking drag when pe >= ke 
+!
+            if(pe.ge.ke) then
+              kblk = k
+              kblk = min(kblk,kbl(i))
+              zblk = zl(i,kblk)-zl(i,kts)
+            endif
+          endif
+        enddo
+        if(kblk.ne.0) then
+!
+!--------- compute flow-blocking stress
+!
+          cd = max(2.0-1.0/od(i),0.0)
+          taufb(i,kts) = 0.5 * roll(i) * coefm(i) / dxy(i)**2 * cd * dxyp(i)   &
+                         * olp(i) * zblk * ulow(i)**2
+          tautem = taufb(i,kts)/float(kblk-kts)
+          do k = kts+1, kblk
+            taufb(i,k) = taufb(i,k-1) - tautem
+          enddo
+!
+!----------sum orographic GW stress and flow-blocking stress
+!
+          taup(i,:) = taup(i,:) + taufb(i,:)
+        endif
+     endif
+   enddo 
+!                                                                       
+!  calculate - (g)*d(tau)/d(pressure) and deceleration terms dtaux, dtauy
+!
+   do k = kts,kte                                                       
+     do i = its,ite                                                       
+       taud(i,k) = 1. * (taup(i,k+1) - taup(i,k)) * csg / del(i,k)
+     enddo                                                             
+   enddo                                                             
+!                                                                       
+!  limit de-acceleration (momentum deposition ) at top to 1/2 value 
+!  the idea is some stuff must go out the 'top'                     
+!                                                                       
+   do klcap = lcap,kte                                               
+     do i = its,ite                                                    
+       taud(i,klcap) = taud(i,klcap) * factop
+     enddo                                                          
+   enddo                                                             
+!                                                                       
+!  if the gravity wave drag would force a critical line             
+!  in the lower ksmm1 layers during the next deltim timestep,     
+!  then only apply drag until that critical line is reached.        
+!                                                                       
+   do k = kts,kpblmax-1                                                    
+     do i = its,ite                                                    
+       if (k .le. kbl(i)) then
+         if(taud(i,k).ne.0.)                                                   &
+         dtfac(i) = min(dtfac(i),abs(velco(i,k)                                &
+                   /(deltim*rcs*taud(i,k))))
+       endif
+     enddo                                                          
+   enddo                                                             
+!
+   do i = its,ite
+     dusfc(i) = 0.
+     dvsfc(i) = 0.
+   enddo
+!
+   do k = kts,kte                                                       
+     do i = its,ite 
+       taud(i,k)  = taud(i,k) * dtfac(i)                              
+       dtaux = taud(i,k) * xn(i)
+       dtauy = taud(i,k) * yn(i)
+       dtaux2d(i,k) = dtaux
+       dtauy2d(i,k) = dtauy
+       dudt(i,k)  = dtaux + dudt(i,k)
+       dvdt(i,k)  = dtauy + dvdt(i,k)
+       dusfc(i)   = dusfc(i) + dtaux * del(i,k)
+       dvsfc(i)   = dvsfc(i) + dtauy * del(i,k)
+     enddo                                                          
+   enddo                                                             
+!
+   do i = its,ite
+     dusfc(i) = (-1./g*rcs) * dusfc(i)
+     dvsfc(i) = (-1./g*rcs) * dvsfc(i)
+   enddo
+!$acc end kernels   
+!$acc end data
+!
+   return                                                            
+   end subroutine gwdo2d
+!-------------------------------------------------------------------
+end module module_bl_gwdo

--- a/src/fromNVIDIA/module_bl_ysu.F
+++ b/src/fromNVIDIA/module_bl_ysu.F
@@ -1,0 +1,1855 @@
+!WRF:model_layer:physics
+!
+!
+!
+!
+!
+!
+!
+module module_bl_ysu
+contains
+!
+!
+!-------------------------------------------------------------------------------
+!
+   subroutine ysu(u3d,v3d,th3d,t3d,qv3d,qc3d,qi3d,p3d,p3di,pi3d,               &
+                  rublten,rvblten,rthblten,                                    &
+                  rqvblten,rqcblten,rqiblten,flag_qi,                          &
+                  cp,g,rovcp,rd,rovg,ep1,ep2,karman,xlv,rv,                    &
+                  dz8w,psfc,                                                   &
+                  znu,znw,mut,p_top,                                           &
+                  znt,ust,hpbl,psim,psih,                                      &
+                  xland,hfx,qfx,wspd,br,                                       &
+                  dt,kpbl2d,                                                   &
+                  exch_h,                                                      &
+                  wstar,delta,                                                 &
+                  u10,v10,                                                     &
+                  uoce,voce,                                                   &        
+                  rthraten,ysu_topdown_pblmix,                                 &
+                  ctopo,ctopo2,                                                &
+                  ids,ide, jds,jde, kds,kde,                                   &
+                  ims,ime, jms,jme, kms,kme,                                   &
+                  its,ite, jts,jte, kts,kte,                                   &
+                !optional
+                  regime                                           )
+!-------------------------------------------------------------------------------
+   implicit none
+!-------------------------------------------------------------------------------
+!-- u3d         3d u-velocity interpolated to theta points (m/s)
+!-- v3d         3d v-velocity interpolated to theta points (m/s)
+!-- th3d        3d potential temperature (k)
+!-- t3d         temperature (k)
+!-- qv3d        3d water vapor mixing ratio (kg/kg)
+!-- qc3d        3d cloud mixing ratio (kg/kg)
+!-- qi3d        3d ice mixing ratio (kg/kg)
+!               (note: if P_QI<PARAM_FIRST_SCALAR this should be zero filled)
+!-- p3d         3d pressure (pa)
+!-- p3di        3d pressure (pa) at interface level
+!-- pi3d        3d exner function (dimensionless)
+!-- rr3d        3d dry air density (kg/m^3)
+!-- rublten     u tendency due to
+!               pbl parameterization (m/s/s)
+!-- rvblten     v tendency due to
+!               pbl parameterization (m/s/s)
+!-- rthblten    theta tendency due to
+!               pbl parameterization (K/s)
+!-- rqvblten    qv tendency due to
+!               pbl parameterization (kg/kg/s)
+!-- rqcblten    qc tendency due to
+!               pbl parameterization (kg/kg/s)
+!-- rqiblten    qi tendency due to
+!               pbl parameterization (kg/kg/s)
+!-- cp          heat capacity at constant pressure for dry air (j/kg/k)
+!-- g           acceleration due to gravity (m/s^2)
+!-- rovcp       r/cp
+!-- rd          gas constant for dry air (j/kg/k)
+!-- rovg        r/g
+!-- dz8w        dz between full levels (m)
+!-- xlv         latent heat of vaporization (j/kg)
+!-- rv          gas constant for water vapor (j/kg/k)
+!-- psfc        pressure at the surface (pa)
+!-- znt         roughness length (m)
+!-- ust         u* in similarity theory (m/s)
+!-- hpbl        pbl height (m)
+!-- psim        similarity stability function for momentum
+!-- psih        similarity stability function for heat
+!-- xland       land mask (1 for land, 2 for water)
+!-- hfx         upward heat flux at the surface (w/m^2)
+!-- qfx         upward moisture flux at the surface (kg/m^2/s)
+!-- wspd        wind speed at lowest model level (m/s)
+!-- u10         u-wind speed at 10 m (m/s)
+!-- v10         v-wind speed at 10 m (m/s)
+!-- uoce        sea surface zonal currents (m s-1)
+!-- voce        sea surface meridional currents (m s-1)
+!-- br          bulk richardson number in surface layer
+!-- dt          time step (s)
+!-- rvovrd      r_v divided by r_d (dimensionless)
+!-- ep1         constant for virtual temperature (r_v/r_d - 1)
+!-- ep2         constant for specific humidity calculation
+!-- karman      von karman constant
+!-- ids         start index for i in domain
+!-- ide         end index for i in domain
+!-- jds         start index for j in domain
+!-- jde         end index for j in domain
+!-- kds         start index for k in domain
+!-- kde         end index for k in domain
+!-- ims         start index for i in memory
+!-- ime         end index for i in memory
+!-- jms         start index for j in memory
+!-- jme         end index for j in memory
+!-- kms         start index for k in memory
+!-- kme         end index for k in memory
+!-- its         start index for i in tile
+!-- ite         end index for i in tile
+!-- jts         start index for j in tile
+!-- jte         end index for j in tile
+!-- kts         start index for k in tile
+!-- kte         end index for k in tile
+!-------------------------------------------------------------------------------
+!
+   integer,parameter ::  ndiff = 3
+   real,parameter    ::  rcl = 1.0
+!
+   integer,  intent(in   )   ::      ids,ide, jds,jde, kds,kde,                &
+                                     ims,ime, jms,jme, kms,kme,                &
+                                     its,ite, jts,jte, kts,kte
+
+   integer,  intent(in)      ::      ysu_topdown_pblmix
+!
+   real,     intent(in   )   ::      dt,cp,g,rovcp,rovg,rd,xlv,rv
+!
+   real,     intent(in )     ::      ep1,ep2,karman
+!
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(in   )   ::                                          qv3d, &
+                                                                         qc3d, &
+                                                                         qi3d, &
+                                                                          p3d, &
+                                                                         pi3d, &
+                                                                         th3d, &
+                                                                          t3d, &
+                                                                         dz8w, &
+                                                                     rthraten
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(in   )   ::                                          p3di
+!
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(inout)   ::                                       rublten, &
+                                                                      rvblten, &
+                                                                     rthblten, &
+                                                                     rqvblten, &
+                                                                     rqcblten
+!
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(inout)   ::                                        exch_h
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             intent(inout)   ::                                         wstar
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             intent(inout)   ::                                         delta
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             intent(inout)   ::                                           u10, &
+                                                                          v10
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             intent(in   )   ::                                          uoce, &
+                                                                         voce
+!
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             intent(in   )   ::                                         xland, &
+                                                                          hfx, &
+                                                                          qfx, &
+                                                                           br, &
+                                                                         psfc
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             intent(in   )   ::                                                &
+                                                                         psim, &
+                                                                         psih
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             intent(inout)   ::                                           znt, &
+                                                                          ust, &
+                                                                         hpbl, &
+                                                                          wspd
+!
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(in   )   ::                                           u3d, &
+                                                                          v3d
+!
+   integer,  dimension( ims:ime, jms:jme )                                   , &
+             intent(out  )   ::                                        kpbl2d
+   logical,  intent(in)      ::                                       flag_qi
+!
+!optional
+!
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             optional                                                        , &
+             intent(inout)   ::                                        regime
+!
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             optional                                                        , &
+             intent(inout)   ::                                       rqiblten
+!
+   real,     dimension( kms:kme )                                            , &
+             optional                                                        , &
+             intent(in   )   ::                                           znu, &
+                                                                          znw
+!
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             optional                                                        , &
+             intent(in   )   ::                                           mut
+!
+   real,     optional, intent(in   )   ::                               p_top
+!
+   real,     dimension( ims:ime, jms:jme )                                   , &
+             optional                                                        , &
+             intent(in   )   ::                                         ctopo, &
+                                                                       ctopo2
+!local
+   integer ::  i,j,k
+   real,     dimension( its:ite, kts:kte*ndiff,jts:jte )  ::         rqvbl2dt, &
+                                                                         qv2d
+   real,     dimension( its:ite, kts:kte,jts:jte )  ::                    pdh
+   real,     dimension( its:ite, kts:kte+1,jts:jte )  ::                 pdhi
+   LOGICAL :: present_rqiblten
+   real    :: p_top_
+! Commented by ARomanenko as unused   
+!   real,     dimension( its:ite,jts:jte )          ::                          &
+!                                                                        dusfc, &
+!                                                                        dvsfc, &
+!                                                                        dtsfc, &
+!                                                                        dqsfc
+!
+   present_rqiblten = present(rqiblten)
+!$acc data pcopy(u10,v10,u3d,v3d,t3d,psih,psim,xland,hfx,qfx,br,psfc) &
+!$acc      pcopy(ctopo,ctopo2,uoce,voce,znt,ust,hpbl,wspd) &
+!$acc      pcopy(rublten,rvblten,rthblten,rthraten,wstar,delta,regime) &
+!$acc      pcopy(kpbl2d,dz8w,p3di,pi3d,mut,znu,znw,p3d,qv3d,qc3d,qi3d) &
+!$acc      pcopy(exch_h,rqvblten,rqcblten,rqiblten) &
+!$acc      create(rqvbl2dt,qv2d,pdh,pdhi) 
+
+!$acc kernels async
+   qv2d(its:ite,:,:) = 0.0
+!$acc end kernels
+   if(present(mut))then
+     p_top_ = p_top
+!$acc kernels async
+     do j = jts,jte
+!
+! For ARW we will replace p and p8w with dry hydrostatic pressure
+!
+        do k = kts,kte+1
+          do i = its,ite
+             if(k.le.kte)pdh(i,k,j) = mut(i,j)*znu(k) + p_top_
+             pdhi(i,k,j) = mut(i,j)*znw(k) + p_top_
+          enddo
+        enddo
+      enddo
+!$acc end kernels
+   else
+!$acc kernels async
+      do j = jts,jte
+        do k = kts,kte+1
+          do i = its,ite
+            if(k.le.kte)pdh(i,k,j) = p3d(i,k,j)
+            pdhi(i,k,j) = p3di(i,k,j)
+          enddo
+        enddo
+     enddo
+!$acc end kernels
+   endif
+!$acc kernels async
+   do j = jts,jte
+      do k = kts,kte
+        do i = its,ite
+          qv2d(i,k,j) = qv3d(i,k,j)
+          qv2d(i,k+kte,j) = qc3d(i,k,j)
+          if(present_rqiblten) qv2d(i,k+kte+kte,j) = qi3d(i,k,j)
+        enddo
+      enddo
+   end do
+!$acc end kernels      
+!$acc wait
+      call ysu2d(ux=u3d,vx=v3d                       &
+              ,tx=t3d                                               &
+              ,qx=qv2d                                                &
+              ,p2d=pdh,p2di=pdhi                             &
+              ,pi2d=pi3d                                           &
+              ,utnp=rublten,vtnp=rvblten                 &
+              ,ttnp=rthblten,qtnp=rqvbl2dt,ndiff=ndiff     &
+              ,cp=cp,g=g,rovcp=rovcp,rd=rd,rovg=rovg                           &    
+              ,xlv=xlv,rv=rv                                                   &
+              ,ep1=ep1,ep2=ep2,karman=karman                                   &
+              ,dz8w2d=dz8w                                          &
+              ,psfcpa=psfc,znt=znt,ust=ust                &
+              ,hpbl=hpbl                                                &
+              ,regime=regime,psim=psim                           &
+              ,psih=psih,xland=xland                             &
+              ,hfx=hfx,qfx=qfx                                   &
+              ,wspd=wspd,br=br                                   &
+!              ,dusfc=dusfc,dvsfc=dvsfc,dtsfc=dtsfc,dqsfc=dqsfc                 &
+              ,dt=dt,rcl=1.0,kpbl=kpbl2d                              &
+              ,exch_hx=exch_h                                       &
+              ,wstar=wstar                                              &
+              ,delta=delta                                              &
+              ,u10=u10,v10=v10                                   &
+              ,uox=uoce,vox=voce                                 &
+              ,rthraten=rthraten,p2diORG=p3di            &
+              ,ysu_topdown_pblmix=ysu_topdown_pblmix                           &
+              ,ctopo=ctopo,ctopo2=ctopo2                         &
+              ,ids=ids,ide=ide, jds=jds,jde=jde, kds=kds,kde=kde               &
+              ,ims=ims,ime=ime, jms=jms,jme=jme, kms=kms,kme=kme               &
+              ,its=its,ite=ite, jts=jts,jte=jte, kts=kts,kte=kte   )
+   
+!$acc kernels
+   do j = jts,jte
+     do k = kts,kte
+       do i = its,ite
+         rthblten(i,k,j) = rthblten(i,k,j)/pi3d(i,k,j)
+         rqvblten(i,k,j) = rqvbl2dt(i,k,j)
+         rqcblten(i,k,j) = rqvbl2dt(i,k+kte,j)
+         if(present_rqiblten) rqiblten(i,k,j) = rqvbl2dt(i,k+kte+kte,j)
+       enddo
+     enddo
+!
+   enddo
+!$acc end kernels   
+!$acc end data   
+!
+   end subroutine ysu
+!
+!-------------------------------------------------------------------------------
+!
+   subroutine ysu2d(ux,vx,tx,qx,p2d,p2di,pi2d,                               &
+                  utnp,vtnp,ttnp,qtnp,ndiff,                                   &
+                  cp,g,rovcp,rd,rovg,ep1,ep2,karman,xlv,rv,                    &
+                  dz8w2d,psfcpa,                                               &
+                  znt,ust,hpbl,psim,psih,                                      &
+                  xland,hfx,qfx,wspd,br,                                       &
+!                  dusfc,dvsfc,dtsfc,dqsfc,                                     &
+                  dt,rcl,kpbl,                                               &
+                  exch_hx,                                                     &
+                  wstar,delta,                                                 &
+                  u10,v10,                                                     &
+                  uox,vox,                                                     &
+                  rthraten,p2diORG,                                            &
+                  ysu_topdown_pblmix,                                          &
+                  ctopo,ctopo2,                                                &
+                  ids,ide, jds,jde, kds,kde,                                   &
+                  ims,ime, jms,jme, kms,kme,                                   &
+                  its,ite, jts,jte, kts,kte,                                   &
+                !optional
+                  regime )
+!-------------------------------------------------------------------------------
+   implicit none
+!-------------------------------------------------------------------------------
+!
+!     this code is a revised vertical diffusion package ("ysupbl")
+!     with a nonlocal turbulent mixing in the pbl after "mrfpbl".
+!     the ysupbl (hong et al. 2006) is based on the study of noh
+!     et al.(2003) and accumulated realism of the behavior of the
+!     troen and mahrt (1986) concept implemented by hong and pan(1996).
+!     the major ingredient of the ysupbl is the inclusion of an explicit
+!     treatment of the entrainment processes at the entrainment layer.
+!     this routine uses an implicit approach for vertical flux
+!     divergence and does not require "miter" timesteps.
+!     it includes vertical diffusion in the stable atmosphere
+!     and moist vertical diffusion in clouds.
+!
+!     mrfpbl:
+!     coded by song-you hong (ncep), implemented by jimy dudhia (ncar)
+!              fall 1996
+!
+!     ysupbl:
+!     coded by song-you hong (yonsei university) and implemented by
+!              song-you hong (yonsei university) and jimy dudhia (ncar)
+!              summer 2002
+!
+!     further modifications :
+!              an enhanced stable layer mixing, april 2008
+!              ==> increase pbl height when sfc is stable (hong 2010)
+!              pressure-level diffusion, april 2009
+!              ==> negligible differences
+!              implicit forcing for momentum with clean up, july 2009
+!              ==> prevents model blowup when sfc layer is too low
+!              incresea of lamda, maximum (30, 0.1 x del z) feb 2010
+!              ==> prevents model blowup when delz is extremely large
+!              revised prandtl number at surface, peggy lemone, feb 2010
+!              ==> increase kh, decrease mixing due to counter-gradient term
+!              revised thermal, shin et al. mon. wea. rev. , songyou hong, aug 2011
+!              ==> reduce the thermal strength when z1 < 0.1 h
+!              revised prandtl number for free convection, dudhia, mar 2012
+!              ==> pr0 = 1 + bke (=0.272) when newtral, kh is reduced
+!              minimum kzo = 0.01, lo = min (30m,delz), hong, mar 2012
+!              ==> weaker mixing when stable, and les resolution in vertical
+!              gz1oz0 is removed, and phim phih are ln(z1/z0)-phim,h, hong, mar 2012
+!              ==> consider thermal z0 when differs from mechanical z0
+!              a bug fix in wscale computation in stable bl, sukanta basu, jun 2012
+!              ==> wscale becomes small with height, and less mixing in stable bl
+!
+!     references:
+!
+!        hong (2010) quart. j. roy. met. soc
+!        hong, noh, and dudhia (2006), mon. wea. rev.
+!        hong and pan (1996), mon. wea. rev.
+!        noh, chun, hong, and raasch (2003), boundary layer met.
+!        troen and mahrt (1986), boundary layer met.
+!
+!-------------------------------------------------------------------------------
+!
+   real,parameter    ::  xkzmin = 0.01,xkzmax = 1000.,rimin = -100.
+   real,parameter    ::  rlam = 30.,prmin = 0.25,prmax = 4.
+   real,parameter    ::  brcr_ub = 0.0,brcr_sb = 0.25,cori = 1.e-4
+   real,parameter    ::  afac = 6.8,bfac = 6.8,pfac = 2.0,pfac_q = 2.0
+   real,parameter    ::  phifac = 8.,sfcfrac = 0.1
+   real,parameter    ::  d1 = 0.02, d2 = 0.05, d3 = 0.001
+   real,parameter    ::  h1 = 0.33333335, h2 = 0.6666667
+   real,parameter    ::  ckz = 0.001,zfmin = 1.e-8,aphi5 = 5.,aphi16 = 16.
+   real,parameter    ::  tmin=1.e-2
+   real,parameter    ::  gamcrt = 3.,gamcrq = 2.e-3
+   real,parameter    ::  xka = 2.4e-5
+   integer,parameter ::  imvdif = 1
+!
+   integer,  intent(in   )   ::     ids,ide, jds,jde, kds,kde,                 &
+                                    ims,ime, jms,jme, kms,kme,                 &
+                                    its,ite, jts,jte, kts,kte,                 &
+                                    ndiff
+
+   integer,  intent(in)      ::     ysu_topdown_pblmix
+!
+   real,     intent(in   )   ::     dt,rcl,cp,g,rovcp,rovg,rd,xlv,rv
+!
+   real,     intent(in )     ::     ep1,ep2,karman
+!
+   real,     dimension( ims:ime, kms:kme, jms:jme ),                           &
+             intent(in)      ::                                        dz8w2d, &
+                                                                         pi2d, &
+                                                                      p2diorg
+!
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(in   )   ::                                            tx
+   real,     dimension( its:ite, kts:kte*ndiff,jts:jte )                             , &
+             intent(in   )   ::                                            qx
+!
+   real,     dimension( ims:ime, kms:kme,jms:jme )                           , &
+             intent(inout)   ::                                          utnp, &
+                                                                         vtnp, &
+                                                                         ttnp
+   real,     dimension( its:ite, kts:kte*ndiff,jts:jte )                     , &
+             intent(inout)   ::                                          qtnp
+!
+   real,     dimension( its:ite, kts:kte+1,jts:jte )                                 , &
+             intent(in   )   ::                                          p2di
+!
+   real,     dimension( its:ite, kts:kte,jts:jte )                                   , &
+             intent(in   )   ::                                           p2d
+!
+!
+   real,     dimension( ims:ime, jms:jme )                                            , &
+             intent(inout)   ::                                           ust, &
+                                                                         hpbl, &
+                                                                          znt
+   real,     dimension( ims:ime ,jms:jme)                                            , &
+             intent(in   )   ::                                         xland, &
+                                                                          hfx, &
+                                                                          qfx
+!
+   real,     dimension( ims:ime,jms:jme ), intent(inout)   ::                    wspd
+   real,     dimension( ims:ime,jms:jme ), intent(in  )    ::                      br
+!
+   real,     dimension( ims:ime,jms:jme ), intent(in   )   ::            psim, &
+                                                                         psih
+!
+   real,     dimension( ims:ime,jms:jme ), intent(in   )   ::                  psfcpa
+   integer,  dimension( ims:ime,jms:jme ), intent(out  )   ::                  kpbl
+!
+   real,     dimension( ims:ime, kms:kme, jms:jme )                          , &
+             intent(in   )   ::                                            ux, &
+                                                                           vx, &
+                                                                     rthraten
+   real,     dimension( ims:ime, jms:jme )                                            , &
+             optional                                                        , &
+             intent(in   )   ::                                         ctopo, &
+                                                                       ctopo2
+   real,     dimension( ims:ime,jms:jme )                                            , &
+             optional                                                        , &
+             intent(inout)   ::                                        regime
+!
+! local vars
+!
+!   real,     dimension( its:ite,jts:jte )            ::                           hol
+   real,     dimension( its:ite, kts:kte+1,jts:jte ) ::                            zq
+!
+   real,     dimension( its:ite, kts:kte,jts:jte )   ::                        &
+                                                               thx,thvx,thlix, &
+                                                                          del, &
+                                                                          dza, &
+!                                                                          dzq, &
+                                                                         xkzo, &
+                                                                           za
+!$acc declare device_resident(zq,thx,thvx,thlix,del,dza,xkzo,za)
+   real,    dimension( its:ite,jts:jte )             ::                                &
+                                                                         rhox, &
+                                                                       govrth, &
+                                                                  zl1,thermal, &
+                                                                       wscale, &
+                                                                  hgamt,hgamq, &
+                                                                    brdn,brup, &
+                                                                    phim,phih, &
+                                                              prpbl,thermalli !, &
+!                                                                        wspd1
+!$acc declare device_resident(rhox,govrth,zl1,thermal,wscale,hgamt,hgamq,&
+!$acc           brdn,brup,phim,phih,prpbl,thermalli)
+!   real,    dimension( its:ite,jts:jte )     ::                                &
+!                                                                  dusfc,dvsfc, &
+!                                                                  dtsfc,dqsfc, &
+!
+   real,    dimension( its:ite, kts:kte, jms:jme )    ::                     xkzm,xkzh!, &
+   real,    dimension( its:ite, kts:kte, jms:jme )    ::                f1,f2, &
+                                                                        r1,r2, &
+                                                                        ad,au, &
+                                                                           cu, &
+                                                                           al!!&
+   real,    dimension( its:ite, kts:kte, jms:jme )    ::    rhox2,xkzq!, &
+   real ::                                                        hgamt2,zfac
+!$acc declare device_resident(xkzm,xkzh,f1,f2,r1,r2,ad,au,cu,al,rhox2,xkzq,hgamt2,zfac)
+!
+!jdf added exch_hx
+!
+   real,    dimension( ims:ime, kms:kme, jms:jme )                           , &
+            intent(inout)   ::                                        exch_hx
+!
+   real,    dimension( ims:ime,jms:jme )                                     , &
+            intent(inout)    ::                                           u10, &
+                                                                          v10
+   real,    dimension( ims:ime,jms:jme )                                     , & 
+            intent(in  )    ::                                            uox, &
+                                                                          vox
+   real,    dimension( its:ite,jts:jte )    ::                                 &
+                                                                         brcr, &
+                                                                        sflux, &
+                                                                         zol1, &
+                                                                    brcr_sbro
+   real,    dimension( its:ite, kts:kte, ndiff,jms:jme)  ::                     r3,f3
+!$acc declare device_resident(brcr,sflux,zol1,brcr_sbro,r3,f3)
+   integer, dimension( its:ite,jts:jte )             ::              kpblold
+!
+   logical, dimension( its:ite,jts:jte )     ::                        pblflg, &
+                                                                       sfcflg, &
+                                                                       stable, &
+                                                                 cloudflg
+!$acc declare device_resident(kpblold,pblflg,sfcflg,stable,cloudflg)   
+   logical                                   ::                     definebrup                                                                 
+!
+   integer ::  n,i,k,l,ic,is,kk
+   integer ::  klpbl, ktrace1, ktrace2, ktrace3
+!
+!
+   real    ::  dt2,rdt,spdk2,fm,fh,hol1,gamfac,vpert,prnum,prnum0
+   real    ::  ss,ri,qmean,tmean,alph,chi,zk,rl2,dk,sri
+   real    ::  brint,dtodsd,dtodsu,rdz,dsdzt,dsdzq,dsdz2,rlamdz
+   real    ::  utend,vtend,ttend,qtend
+   real    ::  dtstep,govrthv,hgamq_
+   real    ::  cont, conq, conw, conwrc
+!
+
+   real    ::                         wscalek,wscalek2
+   real, dimension( ims:ime,jms:jme )              ::                           wstar
+   real, dimension( ims:ime,jms:jme )              ::                           delta
+   real, dimension( its:ite, kts:kte,jts:jte )     ::                     xkzml,xkzhl, &
+                                                               zfacent,entfac
+!$acc declare device_resident(xkzml,xkzhl,zfacent,entfac)                                                               
+   real, dimension( its:ite,jts:jte )      ::                            ust3, &
+                                                                       wstar3, &
+                                                                     wstar3_2, &
+                                                                  hgamu,hgamv, &
+                                                                       we, &
+                                                                       bfxpbl, &
+                                                                hfxpbl,qfxpbl, &
+                                                                ufxpbl,vfxpbl!, &
+                                                                     !   dthvx
+!$acc declare device_resident(ust3,wstar3,wstar3_2,hgamu,hgamv,we, &
+!$acc      bfxpbl,hfxpbl,qfxpbl,ufxpbl,vfxpbl )   
+   real    ::  prnumfac,bfx0,hfx0,qfx0,delb,dux,dvx,                           &
+               dsdzu,dsdzv,wm3,dthx,dqx,wspd1,wspd10,ross,tem1,dsig,tvcon,conpr,     &
+               prfac,prfac2,phim8z,wm2,dthvx,radsum,tmp1,templ,rvls,temps,ent_eff, &
+                              rcldb,bruptmp,radflux
+   integer :: j               
+!
+!-------------------------------------------------------------------------------
+!
+
+
+
+!$acc data present(dz8w2d) present(pi2d) &
+!$acc      present(qx) &
+!$acc      present(utnp,vtnp,ttnp,qtnp,rthraten) &
+!$acc      present(p2di) &
+!$acc      present(p2d)  &
+!$acc      present(ust,hpbl,znt) &
+!$acc      present(xland,hfx,qfx) &
+!$acc      present(wspd,p2diorg) & 
+!$acc      present(br,psim,psih) &
+!$acc      present(psfcpa) &
+!$acc      present(ux,vx,tx) &
+!$acc      present(ctopo,ctopo2) &
+!$acc      present(regime,delta,wstar,kpbl) &
+!$acc      present(exch_hx) &
+!$acc      present(u10,v10) &
+!$acc      present(uox,vox) !&
+!!$acc      create(zq,thx,thvx, del, dza, xkzo, za,thlix ) & 
+!!$acc      create(rhox, govrth, zl1,thermal, wscale, hgamt, brdn,brup) &
+!!$acc      create(phim,phih,cloudflg,kpblold,thermalli,rhox2,prpbl) & 
+!!$acc      create(xkzm,xkzh, f1,f2, r1,r2, ad,au, cu, al, xkzq) & 
+!!$acc      create(brcr, sflux, zol1, brcr_sbro, r3,f3,  pblflg, sfcflg, stable) &
+!!$acc      create(xkzml,xkzhl, zfacent,entfac, ust3) & 
+!!$acc      create(wstar3,wstar3_2, hgamu,hgamv, we, bfxpbl, hfxpbl,qfxpbl, ufxpbl,vfxpbl) 
+!-----------------------------------------------------------------------------------------------
+!present
+
+
+   klpbl = kte
+!
+   cont=cp/g
+   conq=xlv/g
+   conw=1./g
+   conwrc = conw*sqrt(rcl)
+   conpr = bfac*karman*sfcfrac
+!
+!  k-start index for tracer diffusion
+!
+   ktrace1 = 0
+   ktrace2 = 0 + kte
+   ktrace3 = 0 + kte*2
+   
+!
+!$acc kernels
+   do j = jts,jte
+   do k = kts,kte
+     do i = its,ite
+       thx(i,k,j) = tx(i,k,j)/pi2d(i,k,j)
+       thlix(i,k,j) = (tx(i,k,j)-xlv*qx(i,ktrace2+k,j)/cp-2.834E6*qx(i,ktrace3+k,j)/cp)/pi2d(i,k,j)
+#ifndef _OPENACC       
+     enddo
+   enddo
+!
+   do k = kts,kte
+     do i = its,ite
+#endif     
+       tvcon = (1.+ep1*qx(i,k,j))
+       thvx(i,k,j) = thx(i,k,j)*tvcon
+     enddo
+   enddo
+!   
+   do i = its,ite
+     tvcon = (1.+ep1*qx(i,1,j))
+     rhox(i,j) = psfcpa(i,j)/(rd*tx(i,1,j)*tvcon)
+     govrth(i,j) = g/thx(i,1,j)
+#ifndef _OPENACC   
+   enddo
+!
+!-----compute the height of full- and half-sigma levels above ground
+!     level, and the layer thicknesses.
+!
+   do i = its,ite
+#endif   
+     zq(i,1,j) = 0.
+   enddo
+   enddo
+!
+   do j = jts,jte
+   do k = kts,kte
+     do i = its,ite
+       zq(i,k+1,j) = dz8w2d(i,k,j)+zq(i,k,j)
+       tvcon = (1.+ep1*qx(i,k,j))
+       rhox2(i,k,j) = p2d(i,k,j)/(rd*tx(i,k,j)*tvcon)
+     enddo
+   enddo
+   enddo
+!
+   do j = jts,jte
+   do k = kts,kte
+     do i = its,ite
+       za(i,k,j) = 0.5*(zq(i,k,j)+zq(i,k+1,j))
+!       dzq(i,k,j) = zq(i,k+1)-zq(i,k)
+       del(i,k,j) = p2di(i,k,j)-p2di(i,k+1,j)
+     enddo
+   enddo
+!
+   do i = its,ite
+     dza(i,1,j) = za(i,1,j)
+   enddo
+!
+   do k = kts+1,kte
+     do i = its,ite
+       dza(i,k,j) = za(i,k,j)-za(i,k-1,j)
+     enddo
+   enddo
+
+!-----initialize vertical tendencies and
+!
+   utnp(its:ite,kms:kme,j) = 0.
+   vtnp(its:ite,kms:kme,j) = 0.
+   ttnp(its:ite,kms:kme,j) = 0.
+   qtnp(its:ite,kts:kte*ndiff,j) = 0.
+
+   
+!
+!   do i = its,ite
+     ! wspd1(i,j) = sqrt( (ux(i,1,j)-uox(i,j))*(ux(i,1,j)-uox(i,j)) + (vx(i,1,j)-vox(i,j))*(vx(i,1,j)-vox(i,j)) )+1.e-9
+!   enddo
+   enddo
+!$acc end kernels
+!
+!---- compute vertical diffusion
+!
+! - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+!     compute preliminary variables
+!
+   dtstep = dt
+   dt2 = 2.*dtstep
+   rdt = 1./dt2
+!
+!$acc kernels   
+   do j = jts,jte
+   do i = its,ite
+     bfxpbl(i,j) = 0.0
+     hfxpbl(i,j) = 0.0
+     qfxpbl(i,j) = 0.0
+     ufxpbl(i,j) = 0.0
+     vfxpbl(i,j) = 0.0
+     hgamu(i,j)  = 0.0
+     hgamv(i,j)  = 0.0
+     delta(i,j)  = 0.0
+     wstar3_2(i,j) =  0.0
+   enddo
+   enddo
+!$acc end kernels
+!
+!$acc kernels   
+!   do j = jts,jte
+!   do k = kts,klpbl
+!     do i = its,ite
+!       wscalek(i,k,j) = 0.0
+!       wscalek2(i,k,j) = 0.0
+!     enddo
+!   enddo
+!   enddo
+!
+   do j = jts,jte
+!   do k = kts,klpbl
+!     do i = its,ite
+!       zfac(i,k) = 0.0
+!     enddo
+!   enddo
+   do k = kts,klpbl-1
+     do i = its,ite
+       xkzo(i,k,j) = ckz*dza(i,k+1,j)
+     enddo
+   enddo
+   enddo
+!$acc end kernels   
+
+!$acc kernels
+!
+!   do i = its,ite
+!     dusfc(i,j) = 0.
+!     dvsfc(i,j) = 0.
+!     dtsfc(i,j) = 0.
+!     dqsfc(i,j) = 0.
+!   enddo
+!
+   do j = jts,jte
+   do i = its,ite
+     hgamt(i,j)  = 0.
+     wscale(i,j) = 0.
+     kpbl(i,j)   = 1
+     hpbl(i,j)   = zq(i,1,j)
+     zl1(i,j)    = za(i,1,j)
+     thermal(i,j)= thvx(i,1,j)
+     thermalli(i,j) = thlix(i,1,j)
+     pblflg(i,j) = .true.
+     sfcflg(i,j) = .true.
+     sflux(i,j) = hfx(i,j)/rhox(i,j)/cp + qfx(i,j)/rhox(i,j)*ep1*thx(i,1,j)
+     if(br(i,j).gt.0.0) sfcflg(i,j) = .false.
+   enddo
+   enddo
+!
+!     compute the first guess of pbl height
+!
+
+   do j = jts,jte
+   do i = its,ite
+     stable(i,j) = .false.
+     brup(i,j) = br(i,j)
+     brcr(i,j) = brcr_ub
+   enddo
+   enddo
+!$acc end kernels
+
+!$acc kernels
+   do j = jts,jte
+   do k = 2,klpbl
+     do i = its,ite
+       if(.not.stable(i,j))then
+         brdn(i,j) = brup(i,j)
+         spdk2   = max(ux(i,k,j)**2+vx(i,k,j)**2,1.)
+         brup(i,j) = (thvx(i,k,j)-thermal(i,j))*(g*za(i,k,j)/thvx(i,1,j))/spdk2
+         kpbl(i,j) = k
+         stable(i,j) = brup(i,j).gt.brcr(i,j)
+       endif
+     enddo
+   enddo
+!
+   do i = its,ite
+     k = kpbl(i,j)
+     if(brdn(i,j).ge.brcr(i,j))then
+       brint = 0.
+     elseif(brup(i,j).le.brcr(i,j))then
+       brint = 1.
+     else
+       brint = (brcr(i,j)-brdn(i,j))/(brup(i,j)-brdn(i,j))
+     endif
+     hpbl(i,j) = za(i,k-1,j)+brint*(za(i,k,j)-za(i,k-1,j))
+     if(hpbl(i,j).lt.zq(i,2,j)) kpbl(i,j) = 1
+     if(kpbl(i,j).le.1) pblflg(i,j) = .false.
+   enddo
+   enddo
+!$acc end kernels   
+
+!
+!$acc kernels
+   do j = jts,jte
+   do i = its,ite
+     fm = psim(i,j)
+     fh = psih(i,j)
+     zol1(i,j) = max(br(i,j)*fm*fm/fh,rimin)
+     if(sfcflg(i,j))then
+       zol1(i,j) = min(zol1(i,j),-zfmin)
+     else
+       zol1(i,j) = max(zol1(i,j),zfmin)
+     endif
+     hol1 = zol1(i,j)*hpbl(i,j)/zl1(i,j)*sfcfrac
+     if(sfcflg(i,j))then
+       phim(i,j) = (1.-aphi16*hol1)**(-1./4.)
+       phih(i,j) = (1.-aphi16*hol1)**(-1./2.)
+       bfx0 = max(sflux(i,j),0.)
+       hfx0 = max(hfx(i,j)/rhox(i,j)/cp,0.)
+       qfx0 = max(ep1*thx(i,1,j)*qfx(i,j)/rhox(i,j),0.)
+       wstar3(i,j) = (govrth(i,j)*bfx0*hpbl(i,j))
+       wstar(i,j) = (wstar3(i,j))**h1
+     else
+       phim(i,j) = (1.+aphi5*hol1)
+       phih(i,j) = phim(i,j)
+       wstar(i,j)  = 0.
+       wstar3(i,j) = 0.
+     endif
+     ust3(i,j)   = ust(i,j)**3.
+     wscale(i,j) = (ust3(i,j)+phifac*karman*wstar3(i,j)*0.5)**h1
+     wscale(i,j) = min(wscale(i,j),ust(i,j)*aphi16)
+     wscale(i,j) = max(wscale(i,j),ust(i,j)/aphi5)
+   enddo
+   enddo
+
+  
+!
+!     compute the surface variables for pbl height estimation
+!     under unstable conditions
+!
+
+   do j = jts,jte
+   do i = its,ite
+     if(sfcflg(i,j).and.sflux(i,j).gt.0.0)then
+       gamfac   = bfac/rhox(i,j)/wscale(i,j)
+       hgamt(i,j) = min(gamfac*hfx(i,j)/cp,gamcrt)
+       hgamq_ = min(gamfac*qfx(i,j),gamcrq)
+       vpert = (hgamt(i,j)+ep1*thx(i,1,j)*hgamq_)/bfac*afac
+       thermal(i,j) = thermal(i,j)+max(vpert,0.)*min(za(i,1,j)/(sfcfrac*hpbl(i,j)),1.0)
+       thermalli(i,j)= thermalli(i,j)+max(vpert,0.)*min(za(i,1,j)/(sfcfrac*hpbl(i,j)),1.0)
+       hgamt(i,j) = max(hgamt(i,j),0.0)
+!       hgamq(i,j) = max(hgamq(i,j),0.0)
+       brint    = -15.9*ust(i,j)*ust(i,j)/wspd(i,j)*wstar3(i,j)/(wscale(i,j)**4.)
+       hgamu(i,j) = brint*ux(i,1,j)
+       hgamv(i,j) = brint*vx(i,1,j)
+     else
+       pblflg(i,j) = .false.
+     endif
+   enddo
+   enddo
+!$acc end kernels
+
+!
+!     enhance the pbl height by considering the thermal
+!
+
+!$acc kernels
+   do j = jts,jte
+   do i = its,ite
+     if(pblflg(i,j))then
+       kpbl(i,j) = 1
+       hpbl(i,j) = zq(i,1,j)
+       stable(i,j) = .false.
+       brup(i,j) = br(i,j)
+       brcr(i,j) = brcr_ub
+     endif
+   enddo
+   enddo
+!$acc end kernels   
+!
+
+!$acc kernels
+   do j = jts,jte
+   do k = 2,klpbl
+     do i = its,ite
+       if(.not.stable(i,j).and.pblflg(i,j))then
+         brdn(i,j) = brup(i,j)
+         spdk2   = max(ux(i,k,j)**2+vx(i,k,j)**2,1.)
+         brup(i,j) = (thvx(i,k,j)-thermal(i,j))*(g*za(i,k,j)/thvx(i,1,j))/spdk2
+         kpbl(i,j) = k
+         stable(i,j) = brup(i,j).gt.brcr(i,j)
+       endif
+     enddo
+   enddo
+   enddo
+!$acc end kernels
+!
+!     enhance pbl by theta-li
+!
+   if (ysu_topdown_pblmix.eq.1)then
+!$acc kernels
+     do j = jts,jte
+     do i = its,ite
+        kpblold(i,j) = kpbl(i,j)
+        definebrup=.false.
+!$acc loop seq
+        do k = kpblold(i,j), kte-1
+           spdk2   = max(ux(i,k,j)**2+vx(i,k,j)**2,1.)
+           bruptmp = (thlix(i,k,j)-thermalli(i,j))*(g*za(i,k,j)/thlix(i,1,j))/spdk2
+           stable(i,j) = bruptmp.ge.brcr(i,j)
+           if (definebrup) then
+           kpbl(i,j) = k
+           brup(i,j) = bruptmp
+           definebrup=.false.
+           endif
+           if (.not.stable(i,j)) then !overwrite brup brdn values
+           brdn(i,j)=bruptmp
+           definebrup=.true.
+           pblflg(i,j)=.true.
+           endif
+        enddo
+     enddo
+     enddo
+!$acc end kernels
+   endif
+
+
+!$acc kernels
+   do j = jts,jte
+   do i = its,ite
+     if(pblflg(i,j)) then
+       k = kpbl(i,j)
+       if(brdn(i,j).ge.brcr(i,j))then
+         brint = 0.
+       elseif(brup(i,j).le.brcr(i,j))then
+         brint = 1.
+       else
+         brint = (brcr(i,j)-brdn(i,j))/(brup(i,j)-brdn(i,j))
+       endif
+       hpbl(i,j) = za(i,k-1,j)+brint*(za(i,k,j)-za(i,k-1,j))
+       if(hpbl(i,j).lt.zq(i,2,j)) kpbl(i,j) = 1
+       if(kpbl(i,j).le.1) pblflg(i,j) = .false.
+     endif
+   enddo
+   enddo
+!$acc end kernels   
+!
+!     stable boundary layer
+!
+!$acc kernels
+   do j = jts,jte
+   do i = its,ite
+     if((.not.sfcflg(i,j)).and.hpbl(i,j).lt.zq(i,2,j)) then
+       brup(i,j) = br(i,j)
+       stable(i,j) = .false.
+     else
+       stable(i,j) = .true.
+     endif
+   enddo
+   enddo
+!$acc end kernels
+!
+!$acc kernels
+   do j = jts,jte
+   do i = its,ite
+     if((.not.stable(i,j)).and.((xland(i,j)-1.5).ge.0))then
+       wspd10 = u10(i,j)*u10(i,j) + v10(i,j)*v10(i,j)
+       wspd10 = sqrt(wspd10)
+       ross = wspd10 / (cori*znt(i,j))
+       brcr_sbro(i,j) = min(0.16*(1.e-7*ross)**(-0.18),.3)
+     endif
+   enddo
+!
+   do i = its,ite
+     if(.not.stable(i,j))then
+       if((xland(i,j)-1.5).ge.0)then
+         brcr(i,j) = brcr_sbro(i,j)
+       else
+         brcr(i,j) = brcr_sb
+       endif
+     endif
+   enddo
+   enddo
+!$acc end kernels
+!
+!$acc kernels
+   do j = jts,jte
+   do k = 2,klpbl
+     do i = its,ite
+       if(.not.stable(i,j))then
+         brdn(i,j) = brup(i,j)
+         spdk2   = max(ux(i,k,j)**2+vx(i,k,j)**2,1.)
+         brup(i,j) = (thvx(i,k,j)-thermal(i,j))*(g*za(i,k,j)/thvx(i,1,j))/spdk2
+         kpbl(i,j) = k
+         stable(i,j) = brup(i,j).gt.brcr(i,j)
+       endif
+     enddo
+   enddo
+   enddo
+!$acc end kernels
+!
+
+!$acc kernels
+   do j = jts,jte
+   do i = its,ite
+     if((.not.sfcflg(i,j)).and.hpbl(i,j).lt.zq(i,2,j)) then
+       k = kpbl(i,j)
+       if(brdn(i,j).ge.brcr(i,j))then
+         brint = 0.
+       elseif(brup(i,j).le.brcr(i,j))then
+         brint = 1.
+       else
+         brint = (brcr(i,j)-brdn(i,j))/(brup(i,j)-brdn(i,j))
+       endif
+       hpbl(i,j) = za(i,k-1,j)+brint*(za(i,k,j)-za(i,k-1,j))
+       if(hpbl(i,j).lt.zq(i,2,j)) kpbl(i,j) = 1
+       if(kpbl(i,j).le.1) pblflg(i,j) = .false.
+     endif
+   enddo
+   enddo
+!$acc end kernels
+   
+!
+!     estimate the entrainment parameters
+!
+
+!$acc kernels
+   do j = jts,jte
+   do i = its,ite
+     cloudflg(i,j)=.false.
+     if(pblflg(i,j)) then
+       k = kpbl(i,j) - 1
+!       prpbl(i,j) = 1.0
+       wm3       = wstar3(i,j) + 5. * ust3(i,j)
+       wm2    = wm3**h2
+       bfxpbl(i,j) = -0.15*thvx(i,1,j)/g*wm3/hpbl(i,j)
+       dthvx  = max(thvx(i,k+1,j)-thvx(i,k,j),tmin)
+       dthx  = max(thx(i,k+1,j)-thx(i,k,j),tmin)
+!---------------------
+       we(i,j) = max(bfxpbl(i,j)/dthvx,-sqrt(wm2))
+       if((qx(i,ktrace2+k,j)+qx(i,ktrace3+k,j)).gt.0.01e-3.and.ysu_topdown_pblmix.eq.1)then
+           if ( kpbl(i,j) .ge. 2) then
+                cloudflg(i,j)=.true. 
+                templ=thlix(i,k,j)*(p2di(i,k+1,j)/100000)**rovcp
+                !rvls is ws at full level
+                rvls=100.*6.112*EXP(17.67*(templ-273.16)/(templ-29.65))*(ep2/p2di(i,k+1,j))
+                temps=templ + ((qx(i,k,j)+qx(i,ktrace2+k,j))-rvls)/(cp/xlv  + &
+                ep2*xlv*rvls/(rd*templ**2))
+                rvls=100.*6.112*EXP(17.67*(temps-273.15)/(temps-29.65))*(ep2/p2di(i,k+1,j))
+                rcldb=max((qx(i,k,j)+qx(i,ktrace2+k,j))-rvls,0.)
+                !entrainment efficiency
+                dthvx  = (thlix(i,k+2,j)+thx(i,k+2,j)*ep1*(qx(i,k+2,j)+qx(i,ktrace2+k+2,j))) &
+                          - (thlix(i,k,j) + thx(i,k,j)  *ep1*(qx(i,k,j) +qx(i,ktrace2+k,j)))
+                dthvx  = max(dthvx,0.1)
+                tmp1      = xlv/cp * rcldb/(pi2d(i,k,j)*dthvx)
+                ent_eff   = 0.2 * 8. * tmp1 +0.2
+
+                radsum=0.
+                do kk = 1,kpbl(i,j)-1
+                   radflux=rthraten(i,kk,j)*pi2d(i,kk,j) !converts theta/s to temp/s
+                   radflux=radflux*cp/g*(p2diORG(i,kk,j)-p2diORG(i,kk+1,j)) !  converts temp/s to W/m^2
+                   if (radflux < 0.0 ) radsum=abs(radflux)+radsum
+                enddo
+                radsum=max(radsum,0.0)
+
+                !recompute entrainment from sfc thermals
+!                bfx0 = max(max(sflux(i,j),0.0)-radsum/rhox2(i,k,j)/cp,0.)
+                bfx0 = max(sflux(i,j),0.0)
+                wm3 = (govrth(i,j)*bfx0*hpbl(i,j))+5. * ust3(i,j)
+                wm2    = wm3**h2
+                bfxpbl(i,j) = -0.15*thvx(i,1,j)/g*wm3/hpbl(i,j)
+                dthvx  = max(thvx(i,k+1,j)-thvx(i,k,j),tmin)
+                we(i,j) = max(bfxpbl(i,j)/dthvx,-sqrt(wm2))
+
+                !entrainment from PBL top thermals
+!                bfx0 = max(radsum/rhox2(i,k,j)/cp-max(sflux(i,j),0.0),0.)
+                bfx0 = max(radsum/rhox2(i,k,j)/cp,0.)
+                wm3       = (g/thvx(i,k,j)*bfx0*hpbl(i,j)) ! this is wstar3(i)
+                wm2    = wm2+wm3**h2
+                bfxpbl(i,j) = - ent_eff * bfx0
+                dthvx  = max(thvx(i,k+1,j)-thvx(i,k,j),0.1)
+                we(i,j) = we(i,j) + max(bfxpbl(i,j)/dthvx,-sqrt(wm3**h2))
+
+                !wstar3_2
+                bfx0 = max(radsum/rhox2(i,k,j)/cp,0.)
+                wstar3_2(i,j) =  (g/thvx(i,k,j)*bfx0*hpbl(i,j))
+                !recompute hgamt 
+                wscale(i,j) = (ust3(i,j)+phifac*karman*(wstar3(i,j)+wstar3_2(i,j))*0.5)**h1
+                wscale(i,j) = min(wscale(i,j),ust(i,j)*aphi16)
+                wscale(i,j) = max(wscale(i,j),ust(i,j)/aphi5)
+                gamfac   = bfac/rhox(i,j)/wscale(i,j)
+                hgamt(i,j) = min(gamfac*hfx(i,j)/cp,gamcrt)
+!                hgamq(i,j) = min(gamfac*qfx(i,j),gamcrq)
+                gamfac   = bfac/rhox2(i,k,j)/wscale(i,j)
+                hgamt2 = min(gamfac*radsum/cp,gamcrt)
+                hgamt(i,j) = max(hgamt(i,j),0.0) + max(hgamt2,0.0)
+                brint    = -15.9*ust(i,j)*ust(i,j)/wspd(i,j)*(wstar3(i,j)+wstar3_2(i,j))/(wscale(i,j)**4.)
+                hgamu(i,j) = brint*ux(i,1,j)
+                hgamv(i,j) = brint*vx(i,1,j)
+           endif
+       endif
+       prpbl(i,j) = 1.0
+!---------------------
+       dqx   = min(qx(i,k+1,j)-qx(i,k,j),0.0)
+!       we(i,j) = max(bfxpbl(i,j)/dthvx,-sqrt(wm2))
+       hfxpbl(i,j) = we(i,j)*dthx
+       qfxpbl(i,j) = we(i,j)*dqx
+!
+       dux = ux(i,k+1,j)-ux(i,k,j)
+       dvx = vx(i,k+1,j)-vx(i,k,j)
+       if(dux.gt.tmin) then
+         ufxpbl(i,j) = max(prpbl(i,j)*we(i,j)*dux,-ust(i,j)*ust(i,j))
+       elseif(dux.lt.-tmin) then
+         ufxpbl(i,j) = min(prpbl(i,j)*we(i,j)*dux,ust(i,j)*ust(i,j))
+       else
+         ufxpbl(i,j) = 0.0
+       endif
+       if(dvx.gt.tmin) then
+         vfxpbl(i,j) = max(prpbl(i,j)*we(i,j)*dvx,-ust(i,j)*ust(i,j))
+       elseif(dvx.lt.-tmin) then
+         vfxpbl(i,j) = min(prpbl(i,j)*we(i,j)*dvx,ust(i,j)*ust(i,j))
+       else
+         vfxpbl(i,j) = 0.0
+       endif
+       delb  = govrth(i,j)*d3*hpbl(i,j)
+       delta(i,j) = min(d1*hpbl(i,j) + d2*wm2/delb,100.)
+     endif
+   enddo
+   enddo
+!$acc end kernels
+!
+
+!$acc kernels
+   do j = jts,jte
+   do k = kts,klpbl
+     do i = its,ite
+       if(pblflg(i,j).and.k.ge.kpbl(i,j))then
+         entfac(i,k,j) = ((zq(i,k+1,j)-hpbl(i,j))/delta(i,j))**2.
+       else
+         entfac(i,k,j) = 1.e30
+       endif
+     enddo
+   enddo
+   enddo
+!$acc end kernels
+!
+!     compute diffusion coefficients below pbl
+!
+
+!$acc kernels
+   do j = jts,jte
+   do k = kts,klpbl
+     do i = its,ite
+       if(k.lt.kpbl(i,j)) then
+         zfac = min(max((1.-(zq(i,k+1,j)-zl1(i,j))/(hpbl(i,j)-zl1(i,j))),zfmin),1.)
+         zfacent(i,k,j) = (1.-zfac)**3.
+         wscalek = (ust3(i,j)+phifac*karman*wstar3(i,j)*(1.-zfac))**h1
+         wscalek2 = (phifac*karman*wstar3_2(i,j)*(zfac))**h1
+         if(sfcflg(i,j)) then
+           prfac = conpr
+           prfac2 = 15.9*(wstar3(i,j)+wstar3_2(i,j))/ust3(i,j)/(1.+4.*karman*(wstar3(i,j)+wstar3_2(i,j))/ust3(i,j))
+           prnumfac = -3.*(max(zq(i,k+1,j)-sfcfrac*hpbl(i,j),0.))**2./hpbl(i,j)**2.
+         else
+           prfac = 0.
+           prfac2 = 0.
+           prnumfac = 0.
+           phim8z = 1.+aphi5*zol1(i,j)*zq(i,k+1,j)/zl1(i,j)
+           wscalek = ust(i,j)/phim8z
+           wscalek = max(wscalek,0.001)
+         endif
+         prnum0 = (phih(i,j)/phim(i,j)+prfac)
+         prnum0 = max(min(prnum0,prmax),prmin)
+         xkzm(i,k,j) = wscalek*karman*zq(i,k+1,j)*zfac**pfac+ &
+                       wscalek2*karman*(hpbl(i,j)-zq(i,k+1,j))*(1-zfac)**pfac
+         !Do not include xkzm at kpbl-1 since it changes entrainment
+         if (k.eq.kpbl(i,j)-1.and.cloudflg(i,j).and.we(i,j).lt.0.0) then
+           xkzm(i,k,j) = 0.0
+         endif
+         prnum =  1. + (prnum0-1.)*exp(prnumfac)
+         xkzq(i,k,j) = xkzm(i,k,j)/prnum*zfac**(pfac_q-pfac)
+         prnum0 = prnum0/(1.+prfac2*karman*sfcfrac)
+         prnum =  1. + (prnum0-1.)*exp(prnumfac)
+         xkzh(i,k,j) = xkzm(i,k,j)/prnum
+         xkzm(i,k,j) = min(xkzm(i,k,j),xkzmax)
+         xkzm(i,k,j) = max(xkzm(i,k,j),xkzo(i,k,j))
+         xkzh(i,k,j) = min(xkzh(i,k,j),xkzmax)
+         xkzh(i,k,j) = max(xkzh(i,k,j),xkzo(i,k,j))
+         xkzq(i,k,j) = min(xkzq(i,k,j),xkzmax)
+         xkzq(i,k,j) = max(xkzq(i,k,j),xkzo(i,k,j))
+       endif
+     enddo
+   enddo
+   enddo
+   
+!$acc end kernels
+!
+!     compute diffusion coefficients over pbl (free atmosphere)
+!
+
+
+!$acc kernels   
+
+   do j = jts,jte
+   do k = kts,kte-1
+     do i = its,ite
+       if(k.ge.kpbl(i,j)) then
+         ss = ((ux(i,k+1,j)-ux(i,k,j))*(ux(i,k+1,j)-ux(i,k,j))                         &
+              +(vx(i,k+1,j)-vx(i,k,j))*(vx(i,k+1,j)-vx(i,k,j)))                        &
+              /(dza(i,k+1,j)*dza(i,k+1,j))+1.e-9
+         govrthv = g/(0.5*(thvx(i,k+1,j)+thvx(i,k,j)))
+         ri = govrthv*(thvx(i,k+1,j)-thvx(i,k,j))/(ss*dza(i,k+1,j))
+         if(imvdif.eq.1.and.ndiff.ge.3)then
+           if((qx(i,ktrace2+k,j)+qx(i,ktrace3+k,j)).gt.0.01e-3.and.(qx(i           &
+             ,ktrace2+k+1,j)+qx(i,ktrace3+k+1,j)).gt.0.01e-3)then
+!      in cloud
+             qmean = 0.5*(qx(i,k,j)+qx(i,k+1,j))
+             tmean = 0.5*(tx(i,k,j)+tx(i,k+1,j))
+             alph  = xlv*qmean/rd/tmean
+             chi   = xlv*xlv*qmean/cp/rv/tmean/tmean
+             ri    = (1.+alph)*(ri-g*g/ss/tmean/cp*((chi-alph)/(1.+chi)))
+           endif
+         endif
+         zk = karman*zq(i,k+1,j)
+         rlamdz = min(max(0.1*dza(i,k+1,j),rlam),300.)
+         rlamdz = min(dza(i,k+1,j),rlamdz)
+         rl2 = (zk*rlamdz/(rlamdz+zk))**2
+         dk = rl2*sqrt(ss)
+         if(ri.lt.0.)then
+! unstable regime
+           ri = max(ri, rimin)
+           sri = sqrt(-ri)
+           xkzm(i,k,j) = dk*(1+8.*(-ri)/(1+1.746*sri))
+           xkzh(i,k,j) = dk*(1+8.*(-ri)/(1+1.286*sri))
+         else
+! stable regime
+           xkzh(i,k,j) = dk/(1+5.*ri)**2
+           prnum = 1.0+2.1*ri
+           prnum = min(prnum,prmax)
+           xkzm(i,k,j) = xkzh(i,k,j)*prnum
+         endif
+!
+         xkzm(i,k,j) = min(xkzm(i,k,j),xkzmax)
+         xkzm(i,k,j) = max(xkzm(i,k,j),xkzo(i,k,j))
+         xkzh(i,k,j) = min(xkzh(i,k,j),xkzmax)
+         xkzh(i,k,j) = max(xkzh(i,k,j),xkzo(i,k,j))
+         xkzml(i,k,j) = xkzm(i,k,j)
+         xkzhl(i,k,j) = xkzh(i,k,j)
+       endif
+     enddo
+   enddo
+   enddo
+!$acc end kernels
+
+!
+!     compute tridiagonal matrix elements for heat
+!
+!$acc kernels   
+   do j = jts,jte
+   do k = kts,kte
+     do i = its,ite
+       au(i,k,j) = 0.
+       al(i,k,j) = 0.
+       ad(i,k,j) = 0.
+       f1(i,k,j) = 0.
+     enddo
+   enddo
+!
+   do i = its,ite
+     ad(i,1,j) = 1.
+     f1(i,1,j) = thx(i,1,j)-300.+hfx(i,j)/cont/del(i,1,j)*dt2
+   enddo
+!
+   do k = kts,kte-1
+     do i = its,ite
+       dtodsd = dt2/del(i,k,j)
+       dtodsu = dt2/del(i,k+1,j)
+       dsig   = p2d(i,k,j)-p2d(i,k+1,j)
+       rdz    = 1./dza(i,k+1,j)
+       tem1   = dsig*xkzh(i,k,j)*rdz
+       if(pblflg(i,j).and.k.lt.kpbl(i,j)) then
+         dsdzt = tem1*(-hgamt(i,j)/hpbl(i,j)-hfxpbl(i,j)*zfacent(i,k,j)/xkzh(i,k,j))
+         f1(i,k,j)   = f1(i,k,j)+dtodsd*dsdzt
+         f1(i,k+1,j) = thx(i,k+1,j)-300.-dtodsu*dsdzt
+       elseif(pblflg(i,j).and.k.ge.kpbl(i,j).and.entfac(i,k,j).lt.4.6) then
+         xkzh(i,k,j) = -we(i,j)*dza(i,kpbl(i,j),j)*exp(-entfac(i,k,j))
+         xkzh(i,k,j) = sqrt(xkzh(i,k,j)*xkzhl(i,k,j))
+         xkzh(i,k,j) = min(xkzh(i,k,j),xkzmax)
+         xkzh(i,k,j) = max(xkzh(i,k,j),xkzo(i,k,j))
+         f1(i,k+1,j) = thx(i,k+1,j)-300.
+       else
+         f1(i,k+1,j) = thx(i,k+1,j)-300.
+       endif
+       tem1   = dsig*xkzh(i,k,j)*rdz
+       dsdz2     = tem1*rdz
+       au(i,k,j)   = -dtodsd*dsdz2
+       al(i,k,j)   = -dtodsu*dsdz2
+       ad(i,k,j)   = ad(i,k,j)-au(i,k,j)
+       ad(i,k+1,j) = 1.-al(i,k,j)
+       exch_hx(i,k+1,j) = xkzh(i,k,j)
+     enddo
+   enddo
+   
+!
+! copies here to avoid duplicate input args for tridin
+!
+   do k = kts,kte
+     do i = its,ite
+       cu(i,k,j) = au(i,k,j)
+       r1(i,k,j) = f1(i,k,j)
+     enddo
+   enddo
+   enddo
+!$acc end kernels
+   
+!
+!   do j = jts,jte
+!   call tridin_ysu(al(its,kts,j),ad(its,kts,j),cu(its,kts,j),r1(its,kts,j),au(its,kts,j),f1(its,kts,j),its,ite,kts,kte,1)
+   call tridin_ysu(al,ad,cu,r1,au,f1,its,ite,kts,kte,1,jts,jte,jms,jme)
+!   enddo
+   
+!$acc kernels   
+   do j = jts,jte
+   
+!
+!     recover tendencies of heat
+!
+   do k = kte,kts,-1
+     do i = its,ite
+       ttend = (f1(i,k,j)-thx(i,k,j)+300.)*rdt*pi2d(i,k,j)
+       ttnp(i,k,j) = ttnp(i,k,j)+ttend
+!       dtsfc(i,j) = dtsfc(i,j)+ttend*cont*del(i,k)/pi2d(i,k)
+     enddo
+   enddo
+!
+!     compute tridiagonal matrix elements for moisture, clouds, and gases
+!
+   do k = kts,kte
+     do i = its,ite
+       au(i,k,j) = 0.
+       al(i,k,j) = 0.
+       ad(i,k,j) = 0.
+     enddo
+   enddo
+!
+   do ic = 1,ndiff
+     do k = kts,kte
+       do i = its,ite
+         f3(i,k,ic,j) = 0.
+       enddo
+     enddo
+   enddo
+!
+   do i = its,ite
+     ad(i,1,j) = 1.
+     f3(i,1,1,j) = qx(i,1,j)+qfx(i,j)*g/del(i,1,j)*dt2
+   enddo
+!
+   if(ndiff.ge.2) then
+     do ic = 2,ndiff
+       is = (ic-1) * kte
+       do i = its,ite
+         f3(i,1,ic,j) = qx(i,1+is,j)
+       enddo
+     enddo
+   endif
+!
+   do k = kts,kte-1
+     do i = its,ite
+       if(k.ge.kpbl(i,j)) then
+         xkzq(i,k,j) = xkzh(i,k,j)
+       endif
+     enddo
+   enddo
+!
+   do k = kts,kte-1
+     do i = its,ite
+       dtodsd = dt2/del(i,k,j)
+       dtodsu = dt2/del(i,k+1,j)
+       dsig   = p2d(i,k,j)-p2d(i,k+1,j)
+       rdz    = 1./dza(i,k+1,j)
+       tem1   = dsig*xkzq(i,k,j)*rdz
+       if(pblflg(i,j).and.k.lt.kpbl(i,j)) then
+         dsdzq = tem1*(-qfxpbl(i,j)*zfacent(i,k,j)/xkzq(i,k,j))
+         f3(i,k,1,j) = f3(i,k,1,j)+dtodsd*dsdzq
+         f3(i,k+1,1,j) = qx(i,k+1,j)-dtodsu*dsdzq
+       elseif(pblflg(i,j).and.k.ge.kpbl(i,j).and.entfac(i,k,j).lt.4.6) then
+         xkzq(i,k,j) = -we(i,j)*dza(i,kpbl(i,j),j)*exp(-entfac(i,k,j))
+         xkzq(i,k,j) = sqrt(xkzq(i,k,j)*xkzhl(i,k,j))
+         xkzq(i,k,j) = min(xkzq(i,k,j),xkzmax)
+         xkzq(i,k,j) = max(xkzq(i,k,j),xkzo(i,k,j))
+         f3(i,k+1,1,j) = qx(i,k+1,j)
+       else
+         f3(i,k+1,1,j) = qx(i,k+1,j)
+       endif
+       tem1   = dsig*xkzq(i,k,j)*rdz
+       dsdz2     = tem1*rdz
+       au(i,k,j)   = -dtodsd*dsdz2
+       al(i,k,j)   = -dtodsu*dsdz2
+       ad(i,k,j)   = ad(i,k,j)-au(i,k,j)
+       ad(i,k+1,j) = 1.-al(i,k,j)
+!      exch_hx(i,k+1) = xkzh(i,k)
+     enddo
+   enddo
+
+
+!
+   if(ndiff.ge.2) then
+     do ic = 2,ndiff
+       is = (ic-1) * kte
+       do k = kts,kte-1
+         do i = its,ite
+           f3(i,k+1,ic,j) = qx(i,k+1+is,j)
+         enddo
+       enddo
+     enddo
+   endif
+!
+! copies here to avoid duplicate input args for tridin
+!
+   do k = kts,kte
+     do i = its,ite
+       cu(i,k,j) = au(i,k,j)
+     enddo
+   enddo
+!
+   do ic = 1,ndiff
+     do k = kts,kte
+       do i = its,ite
+         r3(i,k,ic,j) = f3(i,k,ic,j)
+       enddo
+     enddo
+   enddo
+   enddo
+!$acc end kernels
+!
+!     solve tridiagonal problem for moisture, clouds, and gases
+!
+!   do j = jts,jte
+   call tridin_ysu(al,ad,cu,r3,au,f3,its,ite,kts,kte,ndiff,jts,jte,jms,jme)
+!   call tridin_ysu(al(its,kts,j),ad(its,kts,j),cu(its,kts,j),r3(its,kts,1,j),au(its,kts,j),f3(its,kts,1,j),its,ite,kts,kte,ndiff)
+!   enddo
+!$acc kernels   
+   
+   do j = jts,jte
+!
+!     recover tendencies of heat and moisture
+!
+   do k = kte,kts,-1
+     do i = its,ite
+       qtend = (f3(i,k,1,j)-qx(i,k,j))*rdt
+       qtnp(i,k,j) = qtnp(i,k,j)+qtend
+!       dqsfc(i,j) = dqsfc(i,j)+qtend*conq*del(i,k)
+     enddo
+   enddo
+!
+   if(ndiff.ge.2) then
+     do ic = 2,ndiff
+       is = (ic-1) * kte
+       do k = kte,kts,-1
+         do i = its,ite
+           qtend = (f3(i,k,ic,j)-qx(i,k+is,j))*rdt
+           qtnp(i,k+is,j) = qtnp(i,k+is,j)+qtend
+         enddo
+       enddo
+     enddo
+   endif
+!
+!     compute tridiagonal matrix elements for momentum
+!
+   do i = its,ite
+     do k = kts,kte
+       au(i,k,j) = 0.
+       al(i,k,j) = 0.
+       ad(i,k,j) = 0.
+       f1(i,k,j) = 0.
+       f2(i,k,j) = 0.
+     enddo
+   enddo
+!
+   do i = its,ite
+! paj: ctopo=1 if topo_wind=0 (default)
+! mchen add this line to make sure NMM can still work with YSU PBL
+     wspd1 = sqrt( (ux(i,1,j)-uox(i,j))*(ux(i,1,j)-uox(i,j)) + (vx(i,1,j)-vox(i,j))*(vx(i,1,j)-vox(i,j)) )+1.e-9
+     if(present(ctopo)) then
+       ad(i,1,j) = 1.+ctopo(i,j)*ust(i,j)**2/wspd1*rhox(i,j)*g/del(i,1,j)*dt2         &
+        *(wspd1/wspd(i,j))**2
+     else
+       ad(i,1,j) = 1.+ust(i,j)**2/wspd1*rhox(i,j)*g/del(i,1,j)*dt2                  &
+        *(wspd1/wspd(i,j))**2
+     endif
+     f1(i,1,j) = ux(i,1,j)+uox(i,j)*ust(i,j)**2*g/del(i,1,j)*dt2/wspd1
+     f2(i,1,j) = vx(i,1,j)+vox(i,j)*ust(i,j)**2*g/del(i,1,j)*dt2/wspd1
+   enddo
+!
+
+   do k = kts,kte-1
+     do i = its,ite
+       dtodsd = dt2/del(i,k,j)
+       dtodsu = dt2/del(i,k+1,j)
+       dsig   = p2d(i,k,j)-p2d(i,k+1,j)
+       rdz    = 1./dza(i,k+1,j)
+       tem1   = dsig*xkzm(i,k,j)*rdz
+       !print*,'flags ',pblflg(i),k,kpbl(i),(pblflg(i).and.k.lt.kpbl(i))
+       if(pblflg(i,j).and.k.lt.kpbl(i,j))then
+         !print*,'tem1,hgamu(i),hpbl(i),ufxpbl(i),zfacent(i,k),xkzm(i,k) ',&
+         !         tem1,hgamu(i),hpbl(i),ufxpbl(i),zfacent(i,k),xkzm(i,k)
+         dsdzu     = tem1*(-hgamu(i,j)/hpbl(i,j)-ufxpbl(i,j)*zfacent(i,k,j)/xkzm(i,k,j))
+         dsdzv     = tem1*(-hgamv(i,j)/hpbl(i,j)-vfxpbl(i,j)*zfacent(i,k,j)/xkzm(i,k,j))
+         f1(i,k,j)   = f1(i,k,j)+dtodsd*dsdzu
+         !print*,i,k+1,'f1(i,k+1),dtodsd,dsdzu ',f1(i,k+1),dtodsd,dsdzu
+         f1(i,k+1,j) = ux(i,k+1,j)-dtodsu*dsdzu
+         f2(i,k,j)   = f2(i,k,j)+dtodsd*dsdzv
+         f2(i,k+1,j) = vx(i,k+1,j)-dtodsu*dsdzv
+       elseif(pblflg(i,j).and.k.ge.kpbl(i,j).and.entfac(i,k,j).lt.4.6) then
+         xkzm(i,k,j) = prpbl(i,j)*xkzh(i,k,j)
+         xkzm(i,k,j) = sqrt(xkzm(i,k,j)*xkzml(i,k,j))
+         xkzm(i,k,j) = min(xkzm(i,k,j),xkzmax)
+         xkzm(i,k,j) = max(xkzm(i,k,j),xkzo(i,k,j))
+         f1(i,k+1,j) = ux(i,k+1,j)
+         f2(i,k+1,j) = vx(i,k+1,j)
+         !print*,'elseif ',i,k+1,f1(i,k+1),f2(i,k+1)
+       else
+         f1(i,k+1,j) = ux(i,k+1,j)
+         f2(i,k+1,j) = vx(i,k+1,j)
+         !print*,'else ',i,k+1,f1(i,k+1),f2(i,k+1)
+       endif
+       tem1   = dsig*xkzm(i,k,j)*rdz
+       dsdz2     = tem1*rdz
+       au(i,k,j)   = -dtodsd*dsdz2
+       al(i,k,j)   = -dtodsu*dsdz2
+       ad(i,k,j)   = ad(i,k,j)-au(i,k,j)
+       ad(i,k+1,j) = 1.-al(i,k,j)
+       !print*,i,k,f1(i,k+1),f2(i,k+1)
+     enddo
+   enddo
+   
+   
+!
+! copies here to avoid duplicate input args for tridin
+!
+   do k = kts,kte
+     do i = its,ite
+       cu(i,k,j) = au(i,k,j)
+       r1(i,k,j) = f1(i,k,j)
+       r2(i,k,j) = f2(i,k,j)
+     enddo
+   enddo
+   enddo
+!$acc end kernels
+   
+!
+!     solve tridiagonal problem for momentum
+!
+!   do j = jts,jte
+!   call tridi1n(al(its,kts,j),ad(its,kts,j),cu(its,kts,j),r1(its,kts,j),r2(its,kts,j), &
+!      au(its,kts,j),f1(its,kts,j),f2(its,kts,j),its,ite,kts,kte,1)
+   call tridi1n(al,ad,cu,r1,r2,au,f1,f2,its,ite,kts,kte,1,jts,jte,jms,jme)
+!   enddo
+!
+!     recover tendencies of momentum
+!
+!
+!$acc kernels
+
+
+   do j = jts,jte
+   do k = kte,kts,-1
+     do i = its,ite
+       utend = (f1(i,k,j)-ux(i,k,j))*rdt
+       vtend = (f2(i,k,j)-vx(i,k,j))*rdt
+       utnp(i,k,j) = utnp(i,k,j)+utend
+       vtnp(i,k,j) = vtnp(i,k,j)+vtend
+!       dusfc(i,j) = dusfc(i,j) + utend*conwrc*del(i,k)
+!       dvsfc(i,j) = dvsfc(i,j) + vtend*conwrc*del(i,k)
+     enddo
+   enddo
+   end do ! j loop
+!$acc end kernels
+
+!
+! paj: ctopo2=1 if topo_wind=0 (default)
+!
+   if(present(ctopo).and.present(ctopo2)) then ! mchen for NMM
+
+!$acc kernels 
+   do j = jts,jte
+   do i = its,ite
+       u10(i,j) = ctopo2(i,j)*u10(i,j)+(1-ctopo2(i,j))*ux(i,1,j)
+       v10(i,j) = ctopo2(i,j)*v10(i,j)+(1-ctopo2(i,j))*vx(i,1,j)
+   enddo
+   enddo
+!$acc end kernels
+   endif !mchen
+!
+!---- end of vertical diffusion
+!
+!!$acc kernels
+!   do i = its,ite
+!     kpbl1d(i,j) = kpbl(i,j)
+!   enddo
+!!$acc end kernels
+!$acc end data   
+   
+!
+!
+   end subroutine ysu2d
+!-------------------------------------------------------------------------------
+!
+!-------------------------------------------------------------------------------
+   subroutine tridi1n(cl,cm,cu,r1,r2,au,f1,f2,its,ite,kts,kte,nt,jts,jte,jms,jme)
+!-------------------------------------------------------------------------------
+   implicit none
+!-------------------------------------------------------------------------------
+!
+   integer, intent(in )      ::     its,ite, kts,kte, nt, jts,jte,jms,jme
+!
+   real, dimension( its:ite, kts+1:kte+1, jms:jme )                                   , &
+         intent(in   )  ::                                                 cl
+!
+   real, dimension( its:ite, kts:kte, jms:jme )                                       , &
+         intent(in   )  ::                                                 cm, &
+                                                                           r1
+   real, dimension( its:ite, kts:kte,nt,jms:jme )                                    , &
+         intent(in   )  ::                                                 r2
+!
+   real, dimension( its:ite, kts:kte, jms:jme )                                       , &
+         intent(inout)  ::                                                 au, &
+                                                                           cu, &
+                                                                           f1
+   real, dimension( its:ite, kts:kte,nt, jms:jme )                                    , &
+         intent(inout)  ::                                                 f2
+!
+   real    :: fk
+   integer :: i,k,l,n,it,j
+!
+!-------------------------------------------------------------------------------
+!
+!$acc data present(cl,cm,r1,r2) &
+!$acc      present(au,cu,f1,f2)
+
+!$acc kernels
+
+   l = ite
+   n = kte
+!
+   do j = jts,jte
+   do i = its,l
+     fk = 1./cm(i,1,j)
+     au(i,1,j) = fk*cu(i,1,j)
+     f1(i,1,j) = fk*r1(i,1,j)
+   enddo
+!
+   do it = 1,nt
+     do i = its,l
+       fk = 1./cm(i,1,j)
+       f2(i,1,it,j) = fk*r2(i,1,it,j)
+     enddo
+   enddo
+!
+   do k = kts+1,n-1
+     do i = its,l
+       fk = 1./(cm(i,k,j)-cl(i,k,j)*au(i,k-1,j))
+       au(i,k,j) = fk*cu(i,k,j)
+       f1(i,k,j) = fk*(r1(i,k,j)-cl(i,k,j)*f1(i,k-1,j))
+     enddo
+   enddo
+!
+   do it = 1,nt
+     do k = kts+1,n-1
+       do i = its,l
+         fk = 1./(cm(i,k,j)-cl(i,k,j)*au(i,k-1,j))
+         f2(i,k,it,j) = fk*(r2(i,k,it,j)-cl(i,k,j)*f2(i,k-1,it,j))
+       enddo
+     enddo
+   enddo
+!
+   do i = its,l
+     fk = 1./(cm(i,n,j)-cl(i,n,j)*au(i,n-1,j))
+     f1(i,n,j) = fk*(r1(i,n,j)-cl(i,n,j)*f1(i,n-1,j))
+   enddo
+!
+   do it = 1,nt
+     do i = its,l
+       fk = 1./(cm(i,n,j)-cl(i,n,j)*au(i,n-1,j))
+       f2(i,n,it,j) = fk*(r2(i,n,it,j)-cl(i,n,j)*f2(i,n-1,it,j))
+     enddo
+   enddo
+!
+   do k = n-1,kts,-1
+     do i = its,l
+       f1(i,k,j) = f1(i,k,j)-au(i,k,j)*f1(i,k+1,j)
+     enddo
+   enddo
+!
+   do it = 1,nt
+     do k = n-1,kts,-1
+       do i = its,l
+         f2(i,k,it,j) = f2(i,k,it,j)-au(i,k,j)*f2(i,k+1,it,j)
+       enddo
+     enddo
+   enddo
+   enddo
+!$acc end kernels
+!$acc end data   
+!
+   end subroutine tridi1n
+!-------------------------------------------------------------------------------
+!
+!-------------------------------------------------------------------------------
+   subroutine tridin_ysu(cl,cm,cu,r2,au,f2,its,ite,kts,kte,nt,jts,jte,jms,jme)
+!-------------------------------------------------------------------------------
+   implicit none
+!-------------------------------------------------------------------------------
+!
+   integer, intent(in )      ::     its,ite, kts,kte, nt,jts,jte,jms,jme
+!
+   real, dimension( its:ite, kts+1:kte+1, jms:jme )                                   , &
+         intent(in   )  ::                                                 cl
+!
+   real, dimension( its:ite, kts:kte, jms:jme )                                       , &
+         intent(in   )  ::                                                 cm
+   real, dimension( its:ite, kts:kte,nt, jms:jme )                                    , &
+         intent(in   )  ::                                                 r2
+!
+   real, dimension( its:ite, kts:kte, jms:jme )                                       , &
+         intent(inout)  ::                                                 au, &
+                                                                           cu
+   real, dimension( its:ite, kts:kte,nt, jms:jme )                                    , &
+         intent(inout)  ::                                                 f2
+!
+   real    :: fk
+   integer :: i,k,l,n,it,j
+!
+!-------------------------------------------------------------------------------
+
+
+!$acc data present(au,cu,f2, cl,cm,r2) 
+
+!$acc kernels
+!
+   l = ite
+   n = kte
+!
+   do j = jts,jte
+   do it = 1,nt
+     do i = its,l
+       fk = 1./cm(i,1,j)
+       au(i,1,j) = fk*cu(i,1,j)
+       f2(i,1,it,j) = fk*r2(i,1,it,j)
+     enddo
+   enddo
+!
+   do it = 1,nt
+     do k = kts+1,n-1
+       do i = its,l
+         fk = 1./(cm(i,k,j)-cl(i,k,j)*au(i,k-1,j))
+         au(i,k,j) = fk*cu(i,k,j)
+         f2(i,k,it,j) = fk*(r2(i,k,it,j)-cl(i,k,j)*f2(i,k-1,it,j))
+       enddo
+     enddo
+   enddo
+!
+   do it = 1,nt
+     do i = its,l
+       fk = 1./(cm(i,n,j)-cl(i,n,j)*au(i,n-1,j))
+       f2(i,n,it,j) = fk*(r2(i,n,it,j)-cl(i,n,j)*f2(i,n-1,it,j))
+     enddo
+   enddo
+!
+   do it = 1,nt
+     do k = n-1,kts,-1
+       do i = its,l
+         f2(i,k,it,j) = f2(i,k,it,j)-au(i,k,j)*f2(i,k+1,it,j)
+       enddo
+     enddo
+   enddo
+   enddo 
+!$acc end kernels
+!$acc end data   
+!
+   end subroutine tridin_ysu
+!-------------------------------------------------------------------------------
+!
+!-------------------------------------------------------------------------------
+   subroutine ysuinit(rublten,rvblten,rthblten,rqvblten,                       &
+                      rqcblten,rqiblten,p_qi,p_first_scalar,                   &
+                      restart, allowed_to_read,                                &
+                      ids, ide, jds, jde, kds, kde,                            &
+                      ims, ime, jms, jme, kms, kme,                            &
+                      its, ite, jts, jte, kts, kte                 )
+!-------------------------------------------------------------------------------
+   implicit none
+!-------------------------------------------------------------------------------
+!
+   logical , intent(in)          :: restart, allowed_to_read
+   integer , intent(in)          ::  ids, ide, jds, jde, kds, kde,             &
+                                     ims, ime, jms, jme, kms, kme,             &
+                                     its, ite, jts, jte, kts, kte
+   integer , intent(in)          ::  p_qi,p_first_scalar
+   real , dimension( ims:ime , kms:kme , jms:jme ), intent(out) ::             &
+                                                                      rublten, &
+                                                                      rvblten, &
+                                                                     rthblten, &
+                                                                     rqvblten, &
+                                                                     rqcblten, &
+                                                                     rqiblten
+   integer :: i, j, k, itf, jtf, ktf
+!
+   jtf = min0(jte,jde-1)
+   ktf = min0(kte,kde-1)
+   itf = min0(ite,ide-1)
+!
+   if(.not.restart)then
+     do j = jts,jtf
+       do k = kts,ktf
+         do i = its,itf
+            rublten(i,k,j) = 0.
+            rvblten(i,k,j) = 0.
+            rthblten(i,k,j) = 0.
+            rqvblten(i,k,j) = 0.
+            rqcblten(i,k,j) = 0.
+         enddo
+       enddo
+     enddo
+   endif
+!
+   if (p_qi .ge. p_first_scalar .and. .not.restart) then
+     do j = jts,jtf
+       do k = kts,ktf
+         do i = its,itf
+           rqiblten(i,k,j) = 0.
+         enddo
+       enddo
+     enddo
+   endif
+!
+   end subroutine ysuinit
+!-------------------------------------------------------------------------------
+end module module_bl_ysu
+!-------------------------------------------------------------------------------

--- a/src/fromNVIDIA/module_mp_thompson.F
+++ b/src/fromNVIDIA/module_mp_thompson.F
@@ -1,0 +1,5572 @@
+!+---+-----------------------------------------------------------------+
+!.. This subroutine computes the moisture tendencies of water vapor,
+!.. cloud droplets, rain, cloud ice (pristine), snow, and graupel.
+!.. Prior to WRFv2.2 this code was based on Reisner et al (1998), but
+!.. few of those pieces remain.  A complete description is now found in
+!.. Thompson, G., P. R. Field, R. M. Rasmussen, and W. D. Hall, 2008:
+!.. Explicit Forecasts of winter precipitation using an improved bulk
+!.. microphysics scheme. Part II: Implementation of a new snow
+!.. parameterization.  Mon. Wea. Rev., 136, 5095-5115.
+!.. Prior to WRFv3.1, this code was single-moment rain prediction as
+!.. described in the reference above, but in v3.1 and higher, the
+!.. scheme is two-moment rain (predicted rain number concentration).
+!..
+!.. Beginning with WRFv3.6, this is also the "aerosol-aware" scheme as
+!.. described in Thompson, G. and T. Eidhammer, 2014:  A study of
+!.. aerosol impacts on clouds and precipitation development in a large
+!.. winter cyclone.  J. Atmos. Sci., 71, 3636-3658.  Setting WRF
+!.. namelist option mp_physics=8 utilizes the older one-moment cloud
+!.. water with constant droplet concentration set as Nt_c (found below)
+!.. while mp_physics=28 uses double-moment cloud droplet number
+!.. concentration, which is not permitted to exceed Nt_c_max below.
+!..
+!.. Most importantly, users may wish to modify the prescribed number of
+!.. cloud droplets (Nt_c; see guidelines mentioned below).  Otherwise,
+!.. users may alter the rain and graupel size distribution parameters
+!.. to use exponential (Marshal-Palmer) or generalized gamma shape.
+!.. The snow field assumes a combination of two gamma functions (from
+!.. Field et al. 2005) and would require significant modifications
+!.. throughout the entire code to alter its shape as well as accretion
+!.. rates.  Users may also alter the constants used for density of rain,
+!.. graupel, ice, and snow, but the latter is not constant when using
+!.. Paul Field's snow distribution and moments methods.  Other values
+!.. users can modify include the constants for mass and/or velocity
+!.. power law relations and assumed capacitances used in deposition/
+!.. sublimation/evaporation/melting.
+!.. Remaining values should probably be left alone.
+!..
+!..Author: Greg Thompson, NCAR-RAL, gthompsn@ucar.edu, 303-497-2805
+!..Last modified: 11 Feb 2015   Aerosol additions to v3.5.1 code 9/2013
+!..                 Cloud fraction additions 11/2014 part of pre-v3.7
+!+---+-----------------------------------------------------------------+
+!wrft:model_layer:physics
+!+---+-----------------------------------------------------------------+
+!
+
+#define CHNK 4096
+
+      MODULE module_mp_thompson
+
+      USE module_wrf_error
+      USE module_mp_radar
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
+      USE module_dm, ONLY : wrf_dm_max_real
+#endif
+
+      IMPLICIT NONE
+
+      LOGICAL, PARAMETER, PRIVATE:: iiwarm = .false.
+      LOGICAL, PRIVATE:: is_aerosol_aware = .false.
+      LOGICAL, PARAMETER, PRIVATE:: dustyIce = .true.
+      LOGICAL, PARAMETER, PRIVATE:: homogIce = .true.
+
+      INTEGER, PARAMETER, PRIVATE:: IFDRY = 0
+      REAL, PARAMETER, PRIVATE:: T_0 = 273.15
+      REAL, PARAMETER, PRIVATE:: PI = 3.1415926536
+
+!..Densities of rain, snow, graupel, and cloud ice.
+      REAL, PARAMETER, PRIVATE:: rho_w = 1000.0
+      REAL, PARAMETER, PRIVATE:: rho_s = 100.0
+      REAL, PARAMETER, PRIVATE:: rho_g = 500.0
+      REAL, PARAMETER, PRIVATE:: rho_i = 890.0
+
+!..Prescribed number of cloud droplets.  Set according to known data or
+!.. roughly 100 per cc (100.E6 m^-3) for Maritime cases and
+!.. 300 per cc (300.E6 m^-3) for Continental.  Gamma shape parameter,
+!.. mu_c, calculated based on Nt_c is important in autoconversion
+!.. scheme.  In 2-moment cloud water, Nt_c represents a maximum of
+!.. droplet concentration and nu_c is also variable depending on local
+!.. droplet number concentration.
+      REAL, PARAMETER, PRIVATE:: Nt_c = 100.E6
+      REAL, PARAMETER, PRIVATE:: Nt_c_max = 1999.E6
+
+!..Declaration of constants for assumed CCN/IN aerosols when none in
+!.. the input data.  Look inside the init routine for modifications
+!.. due to surface land-sea points or vegetation characteristics.
+      REAL, PARAMETER, PRIVATE:: naIN0 = 1.5E6
+      REAL, PARAMETER, PRIVATE:: naIN1 = 0.5E6
+      REAL, PARAMETER, PRIVATE:: naCCN0 = 300.0E6
+      REAL, PARAMETER, PRIVATE:: naCCN1 = 50.0E6
+
+!..Generalized gamma distributions for rain, graupel and cloud ice.
+!.. N(D) = N_0 * D**mu * exp(-lamda*D);  mu=0 is exponential.
+      REAL, PARAMETER, PRIVATE:: mu_r = 0.0
+      REAL, PARAMETER, PRIVATE:: mu_g = 0.0
+      REAL, PARAMETER, PRIVATE:: mu_i = 0.0
+      REAL, PRIVATE:: mu_c
+
+!..Sum of two gamma distrib for snow (Field et al. 2005).
+!.. N(D) = M2**4/M3**3 * [Kap0*exp(-M2*Lam0*D/M3)
+!..    + Kap1*(M2/M3)**mu_s * D**mu_s * exp(-M2*Lam1*D/M3)]
+!.. M2 and M3 are the (bm_s)th and (bm_s+1)th moments respectively
+!.. calculated as function of ice water content and temperature.
+      REAL, PARAMETER, PRIVATE:: mu_s = 0.6357
+      REAL, PARAMETER, PRIVATE:: Kap0 = 490.6
+      REAL, PARAMETER, PRIVATE:: Kap1 = 17.46
+      REAL, PARAMETER, PRIVATE:: Lam0 = 20.78
+      REAL, PARAMETER, PRIVATE:: Lam1 = 3.29
+
+!..Y-intercept parameter for graupel is not constant and depends on
+!.. mixing ratio.  Also, when mu_g is non-zero, these become equiv
+!.. y-intercept for an exponential distrib and proper values are
+!.. computed based on same mixing ratio and total number concentration.
+      REAL, PARAMETER, PRIVATE:: gonv_min = 1.E4
+      REAL, PARAMETER, PRIVATE:: gonv_max = 3.E6
+
+!..Mass power law relations:  mass = am*D**bm
+!.. Snow from Field et al. (2005), others assume spherical form.
+      REAL, PARAMETER, PRIVATE:: am_r = PI*rho_w/6.0
+      REAL, PARAMETER, PRIVATE:: bm_r = 3.0
+      REAL, PARAMETER, PRIVATE:: am_s = 0.069
+      REAL, PARAMETER, PRIVATE:: bm_s = 2.0
+      REAL, PARAMETER, PRIVATE:: am_g = PI*rho_g/6.0
+      REAL, PARAMETER, PRIVATE:: bm_g = 3.0
+      REAL, PARAMETER, PRIVATE:: am_i = PI*rho_i/6.0
+      REAL, PARAMETER, PRIVATE:: bm_i = 3.0
+
+!..Fallspeed power laws relations:  v = (av*D**bv)*exp(-fv*D)
+!.. Rain from Ferrier (1994), ice, snow, and graupel from
+!.. Thompson et al (2008). Coefficient fv is zero for graupel/ice.
+      REAL, PARAMETER, PRIVATE:: av_r = 4854.0
+      REAL, PARAMETER, PRIVATE:: bv_r = 1.0
+      REAL, PARAMETER, PRIVATE:: fv_r = 195.0
+      REAL, PARAMETER, PRIVATE:: av_s = 40.0
+      REAL, PARAMETER, PRIVATE:: bv_s = 0.55
+      REAL, PARAMETER, PRIVATE:: fv_s = 100.0
+      REAL, PARAMETER, PRIVATE:: av_g = 442.0
+      REAL, PARAMETER, PRIVATE:: bv_g = 0.89
+      REAL, PARAMETER, PRIVATE:: av_i = 1847.5
+      REAL, PARAMETER, PRIVATE:: bv_i = 1.0
+      REAL, PARAMETER, PRIVATE:: av_c = 0.316946E8
+      REAL, PARAMETER, PRIVATE:: bv_c = 2.0
+
+!..Capacitance of sphere and plates/aggregates: D**3, D**2
+      REAL, PARAMETER, PRIVATE:: C_cube = 0.5
+      REAL, PARAMETER, PRIVATE:: C_sqrd = 0.3
+
+!..Collection efficiencies.  Rain/snow/graupel collection of cloud
+!.. droplets use variables (Ef_rw, Ef_sw, Ef_gw respectively) and
+!.. get computed elsewhere because they are dependent on stokes
+!.. number.
+      REAL, PARAMETER, PRIVATE:: Ef_si = 0.05
+      REAL, PARAMETER, PRIVATE:: Ef_rs = 0.95
+      REAL, PARAMETER, PRIVATE:: Ef_rg = 0.75
+      REAL, PARAMETER, PRIVATE:: Ef_ri = 0.95
+
+!..Minimum microphys values
+!.. R1 value, 1.E-12, cannot be set lower because of numerical
+!.. problems with Paul Field's moments and should not be set larger
+!.. because of truncation problems in snow/ice growth.
+      REAL, PARAMETER, PRIVATE:: R1 = 1.E-12
+      REAL, PARAMETER, PRIVATE:: R2 = 1.E-6
+      REAL, PARAMETER, PRIVATE:: eps = 1.E-15
+
+!..Constants in Cooper curve relation for cloud ice number.
+      REAL, PARAMETER, PRIVATE:: TNO = 5.0
+      REAL, PARAMETER, PRIVATE:: ATO = 0.304
+
+!..Rho_not used in fallspeed relations (rho_not/rho)**.5 adjustment.
+      REAL, PARAMETER, PRIVATE:: rho_not = 101325.0/(287.05*298.0)
+
+!..Schmidt number
+      REAL, PARAMETER, PRIVATE:: Sc = 0.632
+      REAL, PRIVATE:: Sc3
+
+!..Homogeneous freezing temperature
+      REAL, PARAMETER, PRIVATE:: HGFR = 235.16
+
+!..Water vapor and air gas constants at constant pressure
+      REAL, PARAMETER, PRIVATE:: Rv = 461.5
+      REAL, PARAMETER, PRIVATE:: oRv = 1./Rv
+      REAL, PARAMETER, PRIVATE:: R = 287.04
+      REAL, PARAMETER, PRIVATE:: Cp = 1004.0
+      REAL, PARAMETER, PRIVATE:: R_uni = 8.314                           ! J (mol K)-1
+
+      DOUBLE PRECISION, PARAMETER, PRIVATE:: k_b = 1.38065E-23           ! Boltzmann constant [J/K]
+      DOUBLE PRECISION, PARAMETER, PRIVATE:: M_w = 18.01528E-3           ! molecular mass of water [kg/mol]
+      DOUBLE PRECISION, PARAMETER, PRIVATE:: M_a = 28.96E-3              ! molecular mass of air [kg/mol]
+      DOUBLE PRECISION, PARAMETER, PRIVATE:: N_avo = 6.022E23            ! Avogadro number [1/mol]
+      DOUBLE PRECISION, PARAMETER, PRIVATE:: ma_w = M_w / N_avo          ! mass of water molecule [kg]
+      REAL, PARAMETER, PRIVATE:: ar_volume = 4./3.*PI*(2.5e-6)**3        ! assume radius of 0.025 micrometer, 2.5e-6 cm
+
+!..Enthalpy of sublimation, vaporization, and fusion at 0C.
+      REAL, PARAMETER, PRIVATE:: lsub = 2.834E6
+      REAL, PARAMETER, PRIVATE:: lvap0 = 2.5E6
+      REAL, PARAMETER, PRIVATE:: lfus = lsub - lvap0
+      REAL, PARAMETER, PRIVATE:: olfus = 1./lfus
+
+!..Ice initiates with this mass (kg), corresponding diameter calc.
+!..Min diameters and mass of cloud, rain, snow, and graupel (m, kg).
+      REAL, PARAMETER, PRIVATE:: xm0i = 1.E-12
+      REAL, PARAMETER, PRIVATE:: D0c = 1.E-6
+      REAL, PARAMETER, PRIVATE:: D0r = 50.E-6
+      REAL, PARAMETER, PRIVATE:: D0s = 200.E-6
+      REAL, PARAMETER, PRIVATE:: D0g = 250.E-6
+      REAL, PRIVATE:: D0i, xm0s, xm0g
+
+!..Lookup table dimensions
+      INTEGER, PARAMETER, PRIVATE:: nbins = 100
+      INTEGER, PARAMETER, PRIVATE:: nbc = nbins
+      INTEGER, PARAMETER, PRIVATE:: nbi = nbins
+      INTEGER, PARAMETER, PRIVATE:: nbr = nbins
+      INTEGER, PARAMETER, PRIVATE:: nbs = nbins
+      INTEGER, PARAMETER, PRIVATE:: nbg = nbins
+      INTEGER, PARAMETER, PRIVATE:: ntb_c = 37
+      INTEGER, PARAMETER, PRIVATE:: ntb_i = 64
+      INTEGER, PARAMETER, PRIVATE:: ntb_r = 37
+      INTEGER, PARAMETER, PRIVATE:: ntb_s = 28
+      INTEGER, PARAMETER, PRIVATE:: ntb_g = 28
+      INTEGER, PARAMETER, PRIVATE:: ntb_g1 = 28
+      INTEGER, PARAMETER, PRIVATE:: ntb_r1 = 37
+      INTEGER, PARAMETER, PRIVATE:: ntb_i1 = 55
+      INTEGER, PARAMETER, PRIVATE:: ntb_t = 9
+      INTEGER, PRIVATE:: nic1, nic2, nii2, nii3, nir2, nir3, nis2, nig2, nig3
+      INTEGER, PARAMETER, PRIVATE:: ntb_arc = 7
+      INTEGER, PARAMETER, PRIVATE:: ntb_arw = 9
+      INTEGER, PARAMETER, PRIVATE:: ntb_art = 7
+      INTEGER, PARAMETER, PRIVATE:: ntb_arr = 5
+      INTEGER, PARAMETER, PRIVATE:: ntb_ark = 4
+      INTEGER, PARAMETER, PRIVATE:: ntb_IN = 55
+      INTEGER, PRIVATE:: niIN2
+
+      DOUBLE PRECISION, DIMENSION(nbins+1):: xDx
+      DOUBLE PRECISION, DIMENSION(nbc):: Dc, dtc
+      DOUBLE PRECISION, DIMENSION(nbi):: Di, dti
+      DOUBLE PRECISION, DIMENSION(nbr):: Dr, dtr
+      DOUBLE PRECISION, DIMENSION(nbs):: Ds, dts
+      DOUBLE PRECISION, DIMENSION(nbg):: Dg, dtg
+      DOUBLE PRECISION, DIMENSION(nbc):: t_Nc
+
+!..Lookup tables for cloud water content (kg/m**3).
+      REAL, DIMENSION(ntb_c), PARAMETER, PRIVATE:: &
+      r_c = (/1.e-6,2.e-6,3.e-6,4.e-6,5.e-6,6.e-6,7.e-6,8.e-6,9.e-6, &
+              1.e-5,2.e-5,3.e-5,4.e-5,5.e-5,6.e-5,7.e-5,8.e-5,9.e-5, &
+              1.e-4,2.e-4,3.e-4,4.e-4,5.e-4,6.e-4,7.e-4,8.e-4,9.e-4, &
+              1.e-3,2.e-3,3.e-3,4.e-3,5.e-3,6.e-3,7.e-3,8.e-3,9.e-3, &
+              1.e-2/)
+
+!..Lookup tables for cloud ice content (kg/m**3).
+      REAL, DIMENSION(ntb_i), PARAMETER, PRIVATE:: &
+      r_i = (/1.e-10,2.e-10,3.e-10,4.e-10, &
+              5.e-10,6.e-10,7.e-10,8.e-10,9.e-10, &
+              1.e-9,2.e-9,3.e-9,4.e-9,5.e-9,6.e-9,7.e-9,8.e-9,9.e-9, &
+              1.e-8,2.e-8,3.e-8,4.e-8,5.e-8,6.e-8,7.e-8,8.e-8,9.e-8, &
+              1.e-7,2.e-7,3.e-7,4.e-7,5.e-7,6.e-7,7.e-7,8.e-7,9.e-7, &
+              1.e-6,2.e-6,3.e-6,4.e-6,5.e-6,6.e-6,7.e-6,8.e-6,9.e-6, &
+              1.e-5,2.e-5,3.e-5,4.e-5,5.e-5,6.e-5,7.e-5,8.e-5,9.e-5, &
+              1.e-4,2.e-4,3.e-4,4.e-4,5.e-4,6.e-4,7.e-4,8.e-4,9.e-4, &
+              1.e-3/)
+
+!..Lookup tables for rain content (kg/m**3).
+      REAL, DIMENSION(ntb_r), PARAMETER, PRIVATE:: &
+      r_r = (/1.e-6,2.e-6,3.e-6,4.e-6,5.e-6,6.e-6,7.e-6,8.e-6,9.e-6, &
+              1.e-5,2.e-5,3.e-5,4.e-5,5.e-5,6.e-5,7.e-5,8.e-5,9.e-5, &
+              1.e-4,2.e-4,3.e-4,4.e-4,5.e-4,6.e-4,7.e-4,8.e-4,9.e-4, &
+              1.e-3,2.e-3,3.e-3,4.e-3,5.e-3,6.e-3,7.e-3,8.e-3,9.e-3, &
+              1.e-2/)
+
+!..Lookup tables for graupel content (kg/m**3).
+      REAL, DIMENSION(ntb_g), PARAMETER, PRIVATE:: &
+      r_g = (/1.e-5,2.e-5,3.e-5,4.e-5,5.e-5,6.e-5,7.e-5,8.e-5,9.e-5, &
+              1.e-4,2.e-4,3.e-4,4.e-4,5.e-4,6.e-4,7.e-4,8.e-4,9.e-4, &
+              1.e-3,2.e-3,3.e-3,4.e-3,5.e-3,6.e-3,7.e-3,8.e-3,9.e-3, &
+              1.e-2/)
+
+!..Lookup tables for snow content (kg/m**3).
+      REAL, DIMENSION(ntb_s), PARAMETER, PRIVATE:: &
+      r_s = (/1.e-5,2.e-5,3.e-5,4.e-5,5.e-5,6.e-5,7.e-5,8.e-5,9.e-5, &
+              1.e-4,2.e-4,3.e-4,4.e-4,5.e-4,6.e-4,7.e-4,8.e-4,9.e-4, &
+              1.e-3,2.e-3,3.e-3,4.e-3,5.e-3,6.e-3,7.e-3,8.e-3,9.e-3, &
+              1.e-2/)
+
+!..Lookup tables for rain y-intercept parameter (/m**4).
+      REAL, DIMENSION(ntb_r1), PARAMETER, PRIVATE:: &
+      N0r_exp = (/1.e6,2.e6,3.e6,4.e6,5.e6,6.e6,7.e6,8.e6,9.e6, &
+                  1.e7,2.e7,3.e7,4.e7,5.e7,6.e7,7.e7,8.e7,9.e7, &
+                  1.e8,2.e8,3.e8,4.e8,5.e8,6.e8,7.e8,8.e8,9.e8, &
+                  1.e9,2.e9,3.e9,4.e9,5.e9,6.e9,7.e9,8.e9,9.e9, &
+                  1.e10/)
+
+!..Lookup tables for graupel y-intercept parameter (/m**4).
+      REAL, DIMENSION(ntb_g1), PARAMETER, PRIVATE:: &
+      N0g_exp = (/1.e4,2.e4,3.e4,4.e4,5.e4,6.e4,7.e4,8.e4,9.e4, &
+                  1.e5,2.e5,3.e5,4.e5,5.e5,6.e5,7.e5,8.e5,9.e5, &
+                  1.e6,2.e6,3.e6,4.e6,5.e6,6.e6,7.e6,8.e6,9.e6, &
+                  1.e7/)
+
+!..Lookup tables for ice number concentration (/m**3).
+      REAL, DIMENSION(ntb_i1), PARAMETER, PRIVATE:: &
+      Nt_i = (/1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0, &
+               1.e1,2.e1,3.e1,4.e1,5.e1,6.e1,7.e1,8.e1,9.e1, &
+               1.e2,2.e2,3.e2,4.e2,5.e2,6.e2,7.e2,8.e2,9.e2, &
+               1.e3,2.e3,3.e3,4.e3,5.e3,6.e3,7.e3,8.e3,9.e3, &
+               1.e4,2.e4,3.e4,4.e4,5.e4,6.e4,7.e4,8.e4,9.e4, &
+               1.e5,2.e5,3.e5,4.e5,5.e5,6.e5,7.e5,8.e5,9.e5, &
+               1.e6/)
+
+!..Aerosol table parameter: Number of available aerosols, vertical
+!.. velocity, temperature, aerosol mean radius, and hygroscopicity.
+      REAL, DIMENSION(ntb_arc), PARAMETER, PRIVATE:: &
+      ta_Na = (/10.0, 31.6, 100.0, 316.0, 1000.0, 3160.0, 10000.0/)
+      REAL, DIMENSION(ntb_arw), PARAMETER, PRIVATE:: &
+      ta_Ww = (/0.01, 0.0316, 0.1, 0.316, 1.0, 3.16, 10.0, 31.6, 100.0/)
+      REAL, DIMENSION(ntb_art), PARAMETER, PRIVATE:: &
+      ta_Tk = (/243.15, 253.15, 263.15, 273.15, 283.15, 293.15, 303.15/)
+      REAL, DIMENSION(ntb_arr), PARAMETER, PRIVATE:: &
+      ta_Ra = (/0.01, 0.02, 0.04, 0.08, 0.16/)
+      REAL, DIMENSION(ntb_ark), PARAMETER, PRIVATE:: &
+      ta_Ka = (/0.2, 0.4, 0.6, 0.8/)
+
+!..Lookup tables for IN concentration (/m**3) from 0.001 to 1000/Liter.
+      REAL, DIMENSION(ntb_IN), PARAMETER, PRIVATE:: &
+      Nt_IN = (/1.0,2.0,3.0,4.0,5.0,6.0,7.0,8.0,9.0, &
+               1.e1,2.e1,3.e1,4.e1,5.e1,6.e1,7.e1,8.e1,9.e1, &
+               1.e2,2.e2,3.e2,4.e2,5.e2,6.e2,7.e2,8.e2,9.e2, &
+               1.e3,2.e3,3.e3,4.e3,5.e3,6.e3,7.e3,8.e3,9.e3, &
+               1.e4,2.e4,3.e4,4.e4,5.e4,6.e4,7.e4,8.e4,9.e4, &
+               1.e5,2.e5,3.e5,4.e5,5.e5,6.e5,7.e5,8.e5,9.e5, &
+               1.e6/)
+
+!..For snow moments conversions (from Field et al. 2005)
+      REAL, DIMENSION(10), PARAMETER, PRIVATE:: &
+      sa = (/ 5.065339, -0.062659, -3.032362, 0.029469, -0.000285, &
+              0.31255,   0.000204,  0.003199, 0.0,      -0.015952/)
+      REAL, DIMENSION(10), PARAMETER, PRIVATE:: &
+      sb = (/ 0.476221, -0.015896,  0.165977, 0.007468, -0.000141, &
+              0.060366,  0.000079,  0.000594, 0.0,      -0.003577/)
+
+!..Temperatures (5 C interval 0 to -40) used in lookup tables.
+      REAL, DIMENSION(ntb_t), PARAMETER, PRIVATE:: &
+      Tc = (/-0.01, -5., -10., -15., -20., -25., -30., -35., -40./)
+
+!..Lookup tables for various accretion/collection terms.
+!.. ntb_x refers to the number of elements for rain, snow, graupel,
+!.. and temperature array indices.  Variables beginning with t-p/c/m/n
+!.. represent lookup tables.  Save compile-time memory by making
+!.. allocatable (2009Jun12, J. Michalakes).
+      INTEGER, PARAMETER, PRIVATE:: R8SIZE = 8
+      INTEGER, PARAMETER, PRIVATE:: R4SIZE = 4
+      REAL (KIND=R8SIZE), ALLOCATABLE, DIMENSION(:,:,:,:)::             &
+                tcg_racg, tmr_racg, tcr_gacr, tmg_gacr,                 &
+                tnr_racg, tnr_gacr
+      REAL (KIND=R8SIZE), ALLOCATABLE, DIMENSION(:,:,:,:)::             &
+                tcs_racs1, tmr_racs1, tcs_racs2, tmr_racs2,             &
+                tcr_sacr1, tms_sacr1, tcr_sacr2, tms_sacr2,             &
+                tnr_racs1, tnr_racs2, tnr_sacr1, tnr_sacr2
+      REAL (KIND=R8SIZE), ALLOCATABLE, DIMENSION(:,:,:,:)::             &
+                tpi_qcfz, tni_qcfz
+      REAL (KIND=R8SIZE), ALLOCATABLE, DIMENSION(:,:,:,:)::             &
+                tpi_qrfz, tpg_qrfz, tni_qrfz, tnr_qrfz
+      REAL (KIND=R8SIZE), ALLOCATABLE, DIMENSION(:,:)::                 &
+                tps_iaus, tni_iaus, tpi_ide
+      REAL (KIND=R8SIZE), ALLOCATABLE, DIMENSION(:,:):: t_Efrw
+      REAL (KIND=R8SIZE), ALLOCATABLE, DIMENSION(:,:):: t_Efsw
+      REAL (KIND=R8SIZE), ALLOCATABLE, DIMENSION(:,:,:):: tnr_rev
+      REAL (KIND=R8SIZE), ALLOCATABLE, DIMENSION(:,:,:)::               &
+                tpc_wev, tnc_wev
+      REAL (KIND=R4SIZE), ALLOCATABLE, DIMENSION(:,:,:,:,:):: tnccn_act
+
+!..Variables holding a bunch of exponents and gamma values (cloud water,
+!.. cloud ice, rain, snow, then graupel).
+      REAL, DIMENSION(5,15), PRIVATE:: cce, ccg
+      REAL, DIMENSION(15), PRIVATE::  ocg1, ocg2
+      REAL, DIMENSION(7), PRIVATE:: cie, cig
+      REAL, PRIVATE:: oig1, oig2, obmi
+      REAL, DIMENSION(13), PRIVATE:: cre, crg
+      REAL, PRIVATE:: ore1, org1, org2, org3, obmr
+      REAL, DIMENSION(18), PRIVATE:: cse, csg
+      REAL, PRIVATE:: oams, obms, ocms
+      REAL, DIMENSION(12), PRIVATE:: cge, cgg
+      REAL, PRIVATE:: oge1, ogg1, ogg2, ogg3, oamg, obmg, ocmg
+
+!..Declaration of precomputed constants in various rate eqns.
+      REAL:: t1_qr_qc, t1_qr_qi, t2_qr_qi, t1_qg_qc, t1_qs_qc, t1_qs_qi
+      REAL:: t1_qr_ev, t2_qr_ev
+      REAL:: t1_qs_sd, t2_qs_sd, t1_qg_sd, t2_qg_sd
+      REAL:: t1_qs_me, t2_qs_me, t1_qg_me, t2_qg_me
+
+!+---+
+!+---+-----------------------------------------------------------------+
+!..END DECLARATIONS
+!+---+-----------------------------------------------------------------+
+!+---+
+!ctrlL
+
+      CONTAINS
+
+      SUBROUTINE thompson_init(hgt, nwfa2d, nwfa, nifa, dx, dy,         &
+                          is_start,                                     &
+                          ids, ide, jds, jde, kds, kde,                 &
+                          ims, ime, jms, jme, kms, kme,                 &
+                          its, ite, jts, jte, kts, kte)
+
+      IMPLICIT NONE
+
+      INTEGER, INTENT(IN):: ids,ide, jds,jde, kds,kde, &
+                            ims,ime, jms,jme, kms,kme, &
+                            its,ite, jts,jte, kts,kte
+      REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(IN):: hgt
+
+!..OPTIONAL variables that control application of aerosol-aware scheme
+
+      REAL, DIMENSION(ims:ime,kms:kme,jms:jme), OPTIONAL, INTENT(INOUT) :: nwfa, nifa
+      REAL, DIMENSION(ims:ime,jms:jme), OPTIONAL, INTENT(INOUT) :: nwfa2d
+      REAL, OPTIONAL, INTENT(IN) :: DX, DY
+      LOGICAL, OPTIONAL, INTENT(IN) :: is_start
+      CHARACTER*256:: mp_debug
+
+
+      INTEGER:: i, j, k, l, m, n
+      REAL:: h_01, niIN3, niCCN3, max_test
+      LOGICAL:: micro_init, has_CCN, has_IN
+
+      is_aerosol_aware = .FALSE.
+      micro_init = .FALSE.
+      has_CCN    = .FALSE.
+      has_IN     = .FALSE.
+
+      write(mp_debug,*) ' DEBUG  checking column of hgt ', its+1,jts+1
+      CALL wrf_debug(250, mp_debug)
+      do k = kts, kte
+         write(mp_debug,*) ' DEBUGT  k, hgt = ', k, hgt(its+1,k,jts+1)
+         CALL wrf_debug(250, mp_debug)
+      enddo
+
+      if (PRESENT(nwfa2d) .AND. PRESENT(nwfa) .AND. PRESENT(nifa)) is_aerosol_aware = .TRUE.
+
+      if (is_aerosol_aware) then
+
+!..Check for existing aerosol data, both CCN and IN aerosols.  If missing
+!.. fill in just a basic vertical profile, somewhat boundary-layer following.
+
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
+      max_test = wrf_dm_max_real ( MAXVAL(nwfa(its:ite-1,:,jts:jte-1)) )
+#else
+      max_test = MAXVAL ( nwfa(its:ite-1,:,jts:jte-1) )
+#endif
+
+      if (max_test .lt. eps) then
+         write(mp_debug,*) ' Apparently there are no initial CCN aerosols.'
+         CALL wrf_debug(100, mp_debug)
+         write(mp_debug,*) '   checked column at point (i,j) = ', its,jts
+         CALL wrf_debug(100, mp_debug)
+         do j = jts, min(jde-1,jte)
+         do i = its, min(ide-1,ite)
+            if (hgt(i,1,j).le.1000.0) then
+               h_01 = 0.8
+            elseif (hgt(i,1,j).ge.2500.0) then
+               h_01 = 0.01
+            else
+               h_01 = 0.8*cos(hgt(i,1,j)*0.001 - 1.0)
+            endif
+            niCCN3 = -1.0*ALOG(naCCN1/naCCN0)/h_01
+            nwfa(i,1,j) = naCCN1+naCCN0*exp(-((hgt(i,2,j)-hgt(i,1,j))/1000.)*niCCN3)
+            do k = 2, kte
+               nwfa(i,k,j) = naCCN1+naCCN0*exp(-((hgt(i,k,j)-hgt(i,1,j))/1000.)*niCCN3)
+            enddo
+         enddo
+         enddo
+      else
+         has_CCN    = .TRUE.
+         write(mp_debug,*) ' Apparently initial CCN aerosols are present.'
+         CALL wrf_debug(100, mp_debug)
+         write(mp_debug,*) '   column sum at point (i,j) = ', its,jts, SUM(nwfa(its,:,jts))
+         CALL wrf_debug(100, mp_debug)
+      endif
+
+
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
+      max_test = wrf_dm_max_real ( MAXVAL(nifa(its:ite-1,:,jts:jte-1)) )
+#else
+      max_test = MAXVAL ( nifa(its:ite-1,:,jts:jte-1) )
+#endif
+
+      if (max_test .lt. eps) then
+         write(mp_debug,*) ' Apparently there are no initial IN aerosols.'
+         CALL wrf_debug(100, mp_debug)
+         write(mp_debug,*) '   checked column at point (i,j) = ', its,jts
+         CALL wrf_debug(100, mp_debug)
+         do j = jts, min(jde-1,jte)
+         do i = its, min(ide-1,ite)
+            if (hgt(i,1,j).le.1000.0) then
+               h_01 = 0.8
+            elseif (hgt(i,1,j).ge.2500.0) then
+               h_01 = 0.01
+            else
+               h_01 = 0.8*cos(hgt(i,1,j)*0.001 - 1.0)
+            endif
+            niIN3 = -1.0*ALOG(naIN1/naIN0)/h_01
+            nifa(i,1,j) = naIN1+naIN0*exp(-((hgt(i,2,j)-hgt(i,1,j))/1000.)*niIN3)
+            do k = 2, kte
+               nifa(i,k,j) = naIN1+naIN0*exp(-((hgt(i,k,j)-hgt(i,1,j))/1000.)*niIN3)
+            enddo
+         enddo
+         enddo
+      else
+         has_IN     = .TRUE.
+         write(mp_debug,*) ' Apparently initial IN aerosols are present.'
+         CALL wrf_debug(100, mp_debug)
+         write(mp_debug,*) '   column sum at point (i,j) = ', its,jts, SUM(nifa(its,:,jts))
+         CALL wrf_debug(100, mp_debug)
+      endif
+
+!..Capture initial state lowest level CCN aerosol data in 2D array.
+
+!     do j = jts, min(jde-1,jte)
+!     do i = its, min(ide-1,ite)
+!        nwfa2d(i,j) = nwfa(i,kts,j)
+!     enddo
+!     enddo
+
+!..Scale the lowest level aerosol data into an emissions rate.  This is
+!.. very far from ideal, but need higher emissions where larger amount
+!.. of existing and lesser emissions where not already lots of aerosols
+!.. for first-order simplistic approach.  Later, proper connection to
+!.. emission inventory would be better, but, for now, scale like this:
+!.. where: Nwfa=50 per cc, emit 0.875E4 aerosols per kg per second
+!..        Nwfa=500 per cc, emit 0.875E5 aerosols per kg per second
+!..        Nwfa=5000 per cc, emit 0.875E6 aerosols per kg per second
+!.. for a grid with 20km spacing and scale accordingly for other spacings.
+
+      if (is_start) then
+         if (SQRT(DX*DY)/20000.0 .ge. 1.0) then
+            h_01 = 0.875
+         else
+            h_01 = (0.875 + 0.125*((20000.-SQRT(DX*DY))/16000.)) * SQRT(DX*DY)/20000.
+         endif
+         write(mp_debug,*) '   aerosol surface flux emission scale factor is: ', h_01
+         CALL wrf_debug(100, mp_debug)
+         do j = jts, min(jde-1,jte)
+         do i = its, min(ide-1,ite)
+            nwfa2d(i,j) = 10.0**(LOG10(nwfa(i,kts,j)*1.E-6)-3.69897)
+            nwfa2d(i,j) = nwfa2d(i,j)*h_01 * 1.E6
+         enddo
+         enddo
+!     else
+!        write(mp_debug,*) '   sample (lower-left) aerosol surface flux emission rate: ', nwfa2d(1,1)
+!        CALL wrf_debug(100, mp_debug)
+      endif
+
+      endif
+
+
+!..Allocate space for lookup tables (J. Michalakes 2009Jun08).
+
+      if (.NOT. ALLOCATED(tcg_racg) ) then
+         ALLOCATE(tcg_racg(ntb_g1,ntb_g,ntb_r1,ntb_r))
+         micro_init = .TRUE.
+      endif
+
+      if (.NOT. ALLOCATED(tmr_racg)) ALLOCATE(tmr_racg(ntb_g1,ntb_g,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tcr_gacr)) ALLOCATE(tcr_gacr(ntb_g1,ntb_g,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tmg_gacr)) ALLOCATE(tmg_gacr(ntb_g1,ntb_g,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tnr_racg)) ALLOCATE(tnr_racg(ntb_g1,ntb_g,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tnr_gacr)) ALLOCATE(tnr_gacr(ntb_g1,ntb_g,ntb_r1,ntb_r))
+
+      if (.NOT. ALLOCATED(tcs_racs1)) ALLOCATE(tcs_racs1(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tmr_racs1)) ALLOCATE(tmr_racs1(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tcs_racs2)) ALLOCATE(tcs_racs2(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tmr_racs2)) ALLOCATE(tmr_racs2(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tcr_sacr1)) ALLOCATE(tcr_sacr1(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tms_sacr1)) ALLOCATE(tms_sacr1(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tcr_sacr2)) ALLOCATE(tcr_sacr2(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tms_sacr2)) ALLOCATE(tms_sacr2(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tnr_racs1)) ALLOCATE(tnr_racs1(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tnr_racs2)) ALLOCATE(tnr_racs2(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tnr_sacr1)) ALLOCATE(tnr_sacr1(ntb_s,ntb_t,ntb_r1,ntb_r))
+      if (.NOT. ALLOCATED(tnr_sacr2)) ALLOCATE(tnr_sacr2(ntb_s,ntb_t,ntb_r1,ntb_r))
+
+      if (.NOT. ALLOCATED(tpi_qcfz)) ALLOCATE(tpi_qcfz(ntb_c,nbc,45,ntb_IN))
+      if (.NOT. ALLOCATED(tni_qcfz)) ALLOCATE(tni_qcfz(ntb_c,nbc,45,ntb_IN))
+
+      if (.NOT. ALLOCATED(tpi_qrfz)) ALLOCATE(tpi_qrfz(ntb_r,ntb_r1,45,ntb_IN))
+      if (.NOT. ALLOCATED(tpg_qrfz)) ALLOCATE(tpg_qrfz(ntb_r,ntb_r1,45,ntb_IN))
+      if (.NOT. ALLOCATED(tni_qrfz)) ALLOCATE(tni_qrfz(ntb_r,ntb_r1,45,ntb_IN))
+      if (.NOT. ALLOCATED(tnr_qrfz)) ALLOCATE(tnr_qrfz(ntb_r,ntb_r1,45,ntb_IN))
+
+      if (.NOT. ALLOCATED(tps_iaus)) ALLOCATE(tps_iaus(ntb_i,ntb_i1))
+      if (.NOT. ALLOCATED(tni_iaus)) ALLOCATE(tni_iaus(ntb_i,ntb_i1))
+      if (.NOT. ALLOCATED(tpi_ide)) ALLOCATE(tpi_ide(ntb_i,ntb_i1))
+
+      if (.NOT. ALLOCATED(t_Efrw)) ALLOCATE(t_Efrw(nbr,nbc))
+      if (.NOT. ALLOCATED(t_Efsw)) ALLOCATE(t_Efsw(nbs,nbc))
+
+      if (.NOT. ALLOCATED(tnr_rev)) ALLOCATE(tnr_rev(nbr, ntb_r1, ntb_r))
+      if (.NOT. ALLOCATED(tpc_wev)) ALLOCATE(tpc_wev(nbc,ntb_c,nbc))
+      if (.NOT. ALLOCATED(tnc_wev)) ALLOCATE(tnc_wev(nbc,ntb_c,nbc))
+
+      if (.NOT. ALLOCATED(tnccn_act))                                   &
+            ALLOCATE(tnccn_act(ntb_arc,ntb_arw,ntb_art,ntb_arr,ntb_ark))
+
+      if (micro_init) then
+
+!..From Martin et al. (1994), assign gamma shape parameter mu for cloud
+!.. drops according to general dispersion characteristics (disp=~0.25
+!.. for Maritime and 0.45 for Continental).
+!.. disp=SQRT((mu+2)/(mu+1) - 1) so mu varies from 15 for Maritime
+!.. to 2 for really dirty air.  This not used in 2-moment cloud water
+!.. scheme and nu_c used instead and varies from 2 to 15 (integer-only).
+      mu_c = MIN(15., (1000.E6/Nt_c + 2.))
+
+!..Schmidt number to one-third used numerous times.
+      Sc3 = Sc**(1./3.)
+
+!..Compute min ice diam from mass, min snow/graupel mass from diam.
+      D0i = (xm0i/am_i)**(1./bm_i)
+      xm0s = am_s * D0s**bm_s
+      xm0g = am_g * D0g**bm_g
+
+!..These constants various exponents and gamma() assoc with cloud,
+!.. rain, snow, and graupel.
+      do n = 1, 15
+         cce(1,n) = n + 1.
+         cce(2,n) = bm_r + n + 1.
+         cce(3,n) = bm_r + n + 4.
+         cce(4,n) = n + bv_c + 1.
+         cce(5,n) = bm_r + n + bv_c + 1.
+         ccg(1,n) = WGAMMA(cce(1,n))
+         ccg(2,n) = WGAMMA(cce(2,n))
+         ccg(3,n) = WGAMMA(cce(3,n))
+         ccg(4,n) = WGAMMA(cce(4,n))
+         ccg(5,n) = WGAMMA(cce(5,n))
+         ocg1(n) = 1./ccg(1,n)
+         ocg2(n) = 1./ccg(2,n)
+      enddo
+
+      cie(1) = mu_i + 1.
+      cie(2) = bm_i + mu_i + 1.
+      cie(3) = bm_i + mu_i + bv_i + 1.
+      cie(4) = mu_i + bv_i + 1.
+      cie(5) = mu_i + 2.
+      cie(6) = bm_i*0.5 + mu_i + bv_i + 1.
+      cie(7) = bm_i*0.5 + mu_i + 1.
+      cig(1) = WGAMMA(cie(1))
+      cig(2) = WGAMMA(cie(2))
+      cig(3) = WGAMMA(cie(3))
+      cig(4) = WGAMMA(cie(4))
+      cig(5) = WGAMMA(cie(5))
+      cig(6) = WGAMMA(cie(6))
+      cig(7) = WGAMMA(cie(7))
+      oig1 = 1./cig(1)
+      oig2 = 1./cig(2)
+      obmi = 1./bm_i
+
+      cre(1) = bm_r + 1.
+      cre(2) = mu_r + 1.
+      cre(3) = bm_r + mu_r + 1.
+      cre(4) = bm_r*2. + mu_r + 1.
+      cre(5) = mu_r + bv_r + 1.
+      cre(6) = bm_r + mu_r + bv_r + 1.
+      cre(7) = bm_r*0.5 + mu_r + bv_r + 1.
+      cre(8) = bm_r + mu_r + bv_r + 3.
+      cre(9) = mu_r + bv_r + 3.
+      cre(10) = mu_r + 2.
+      cre(11) = 0.5*(bv_r + 5. + 2.*mu_r)
+      cre(12) = bm_r*0.5 + mu_r + 1.
+      cre(13) = bm_r*2. + mu_r + bv_r + 1.
+      do n = 1, 13
+         crg(n) = WGAMMA(cre(n))
+      enddo
+      obmr = 1./bm_r
+      ore1 = 1./cre(1)
+      org1 = 1./crg(1)
+      org2 = 1./crg(2)
+      org3 = 1./crg(3)
+
+      cse(1) = bm_s + 1.
+      cse(2) = bm_s + 2.
+      cse(3) = bm_s*2.
+      cse(4) = bm_s + bv_s + 1.
+      cse(5) = bm_s*2. + bv_s + 1.
+      cse(6) = bm_s*2. + 1.
+      cse(7) = bm_s + mu_s + 1.
+      cse(8) = bm_s + mu_s + 2.
+      cse(9) = bm_s + mu_s + 3.
+      cse(10) = bm_s + mu_s + bv_s + 1.
+      cse(11) = bm_s*2. + mu_s + bv_s + 1.
+      cse(12) = bm_s*2. + mu_s + 1.
+      cse(13) = bv_s + 2.
+      cse(14) = bm_s + bv_s
+      cse(15) = mu_s + 1.
+      cse(16) = 1.0 + (1.0 + bv_s)/2.
+      cse(17) = cse(16) + mu_s + 1.
+      cse(18) = bv_s + mu_s + 3.
+      do n = 1, 18
+         csg(n) = WGAMMA(cse(n))
+      enddo
+      oams = 1./am_s
+      obms = 1./bm_s
+      ocms = oams**obms
+
+      cge(1) = bm_g + 1.
+      cge(2) = mu_g + 1.
+      cge(3) = bm_g + mu_g + 1.
+      cge(4) = bm_g*2. + mu_g + 1.
+      cge(5) = bm_g*2. + mu_g + bv_g + 1.
+      cge(6) = bm_g + mu_g + bv_g + 1.
+      cge(7) = bm_g + mu_g + bv_g + 2.
+      cge(8) = bm_g + mu_g + bv_g + 3.
+      cge(9) = mu_g + bv_g + 3.
+      cge(10) = mu_g + 2.
+      cge(11) = 0.5*(bv_g + 5. + 2.*mu_g)
+      cge(12) = 0.5*(bv_g + 5.) + mu_g
+      do n = 1, 12
+         cgg(n) = WGAMMA(cge(n))
+      enddo    
+      oamg = 1./am_g
+      obmg = 1./bm_g
+      ocmg = oamg**obmg
+      oge1 = 1./cge(1)
+      ogg1 = 1./cgg(1)
+      ogg2 = 1./cgg(2)
+      ogg3 = 1./cgg(3)
+!$acc enter data copyin(cgg,cge,csg,cse,crg,cre,cig,cie,cce,ccg,ocg1,ocg2)
+!+---+-----------------------------------------------------------------+
+!..Simplify various rate eqns the best we can now.
+!+---+-----------------------------------------------------------------+
+
+!..Rain collecting cloud water and cloud ice
+      t1_qr_qc = PI*.25*av_r * crg(9)
+      t1_qr_qi = PI*.25*av_r * crg(9)
+      t2_qr_qi = PI*.25*am_r*av_r * crg(8)
+
+!..Graupel collecting cloud water
+      t1_qg_qc = PI*.25*av_g * cgg(9)
+
+!..Snow collecting cloud water
+      t1_qs_qc = PI*.25*av_s
+
+!..Snow collecting cloud ice
+      t1_qs_qi = PI*.25*av_s
+
+!..Evaporation of rain; ignore depositional growth of rain.
+      t1_qr_ev = 0.78 * crg(10)
+      t2_qr_ev = 0.308*Sc3*SQRT(av_r) * crg(11)
+
+!..Sublimation/depositional growth of snow
+      t1_qs_sd = 0.86
+      t2_qs_sd = 0.28*Sc3*SQRT(av_s)
+
+!..Melting of snow
+      t1_qs_me = PI*4.*C_sqrd*olfus * 0.86
+      t2_qs_me = PI*4.*C_sqrd*olfus * 0.28*Sc3*SQRT(av_s)
+
+!..Sublimation/depositional growth of graupel
+      t1_qg_sd = 0.86 * cgg(10)
+      t2_qg_sd = 0.28*Sc3*SQRT(av_g) * cgg(11)
+
+!..Melting of graupel
+      t1_qg_me = PI*4.*C_cube*olfus * 0.86 * cgg(10)
+      t2_qg_me = PI*4.*C_cube*olfus * 0.28*Sc3*SQRT(av_g) * cgg(11)
+
+!..Constants for helping find lookup table indexes.
+      nic2 = NINT(ALOG10(r_c(1)))
+      nii2 = NINT(ALOG10(r_i(1)))
+      nii3 = NINT(ALOG10(Nt_i(1)))
+      nir2 = NINT(ALOG10(r_r(1)))
+      nir3 = NINT(ALOG10(N0r_exp(1)))
+      nis2 = NINT(ALOG10(r_s(1)))
+      nig2 = NINT(ALOG10(r_g(1)))
+      nig3 = NINT(ALOG10(N0g_exp(1)))
+      niIN2 = NINT(ALOG10(Nt_IN(1)))
+
+!..Create bins of cloud water (from min diameter up to 100 microns).
+      Dc(1) = D0c*1.0d0
+      dtc(1) = D0c*1.0d0
+      do n = 2, nbc
+         Dc(n) = Dc(n-1) + 1.0D-6
+         dtc(n) = (Dc(n) - Dc(n-1))
+      enddo
+
+!..Create bins of cloud ice (from min diameter up to 5x min snow size).
+      xDx(1) = D0i*1.0d0
+      xDx(nbi+1) = 5.0d0*D0s
+      do n = 2, nbi
+         xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbi) &
+                  *DLOG(xDx(nbi+1)/xDx(1)) +DLOG(xDx(1)))
+      enddo
+      do n = 1, nbi
+         Di(n) = DSQRT(xDx(n)*xDx(n+1))
+         dti(n) = xDx(n+1) - xDx(n)
+      enddo
+
+!..Create bins of rain (from min diameter up to 5 mm).
+      xDx(1) = D0r*1.0d0
+      xDx(nbr+1) = 0.005d0
+      do n = 2, nbr
+         xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbr) &
+                  *DLOG(xDx(nbr+1)/xDx(1)) +DLOG(xDx(1)))
+      enddo
+      do n = 1, nbr
+         Dr(n) = DSQRT(xDx(n)*xDx(n+1))
+         dtr(n) = xDx(n+1) - xDx(n)
+      enddo
+
+!..Create bins of snow (from min diameter up to 2 cm).
+      xDx(1) = D0s*1.0d0
+      xDx(nbs+1) = 0.02d0
+      do n = 2, nbs
+         xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbs) &
+                  *DLOG(xDx(nbs+1)/xDx(1)) +DLOG(xDx(1)))
+      enddo
+      do n = 1, nbs
+         Ds(n) = DSQRT(xDx(n)*xDx(n+1))
+         dts(n) = xDx(n+1) - xDx(n)
+      enddo
+
+!..Create bins of graupel (from min diameter up to 5 cm).
+      xDx(1) = D0g*1.0d0
+      xDx(nbg+1) = 0.05d0
+      do n = 2, nbg
+         xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbg) &
+                  *DLOG(xDx(nbg+1)/xDx(1)) +DLOG(xDx(1)))
+      enddo
+      do n = 1, nbg
+         Dg(n) = DSQRT(xDx(n)*xDx(n+1))
+         dtg(n) = xDx(n+1) - xDx(n)
+      enddo
+
+!..Create bins of cloud droplet number concentration (1 to 3000 per cc).
+      xDx(1) = 1.0d0
+      xDx(nbc+1) = 3000.0d0
+      do n = 2, nbc
+         xDx(n) = DEXP(DFLOAT(n-1)/DFLOAT(nbc)                          &
+                  *DLOG(xDx(nbc+1)/xDx(1)) +DLOG(xDx(1)))
+      enddo
+      do n = 1, nbc
+         t_Nc(n) = DSQRT(xDx(n)*xDx(n+1)) * 1.D6
+      enddo
+!$acc enter data copyin(t_Nc,xDx,dtg,Dg,dts,Ds,dtr,Dr,dti,Di,dtc,Dc)      
+      nic1 = DLOG(t_Nc(nbc)/t_Nc(1))
+
+!+---+-----------------------------------------------------------------+
+!..Create lookup tables for most costly calculations.
+!+---+-----------------------------------------------------------------+
+
+      do m = 1, ntb_r
+         do k = 1, ntb_r1
+            do j = 1, ntb_g
+               do i = 1, ntb_g1
+                  tcg_racg(i,j,k,m) = 0.0d0
+                  tmr_racg(i,j,k,m) = 0.0d0
+                  tcr_gacr(i,j,k,m) = 0.0d0
+                  tmg_gacr(i,j,k,m) = 0.0d0
+                  tnr_racg(i,j,k,m) = 0.0d0
+                  tnr_gacr(i,j,k,m) = 0.0d0
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do m = 1, ntb_r
+         do k = 1, ntb_r1
+            do j = 1, ntb_t
+               do i = 1, ntb_s
+                  tcs_racs1(i,j,k,m) = 0.0d0
+                  tmr_racs1(i,j,k,m) = 0.0d0
+                  tcs_racs2(i,j,k,m) = 0.0d0
+                  tmr_racs2(i,j,k,m) = 0.0d0
+                  tcr_sacr1(i,j,k,m) = 0.0d0
+                  tms_sacr1(i,j,k,m) = 0.0d0
+                  tcr_sacr2(i,j,k,m) = 0.0d0
+                  tms_sacr2(i,j,k,m) = 0.0d0
+                  tnr_racs1(i,j,k,m) = 0.0d0
+                  tnr_racs2(i,j,k,m) = 0.0d0
+                  tnr_sacr1(i,j,k,m) = 0.0d0
+                  tnr_sacr2(i,j,k,m) = 0.0d0
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do m = 1, ntb_IN
+         do k = 1, 45
+            do j = 1, ntb_r1
+               do i = 1, ntb_r
+                  tpi_qrfz(i,j,k,m) = 0.0d0
+                  tni_qrfz(i,j,k,m) = 0.0d0
+                  tpg_qrfz(i,j,k,m) = 0.0d0
+                  tnr_qrfz(i,j,k,m) = 0.0d0
+               enddo
+            enddo
+            do j = 1, nbc
+               do i = 1, ntb_c
+                  tpi_qcfz(i,j,k,m) = 0.0d0
+                  tni_qcfz(i,j,k,m) = 0.0d0
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do j = 1, ntb_i1
+         do i = 1, ntb_i
+            tps_iaus(i,j) = 0.0d0
+            tni_iaus(i,j) = 0.0d0
+            tpi_ide(i,j) = 0.0d0
+         enddo
+      enddo
+
+      do j = 1, nbc
+         do i = 1, nbr
+            t_Efrw(i,j) = 0.0
+         enddo
+         do i = 1, nbs
+            t_Efsw(i,j) = 0.0
+         enddo
+      enddo
+
+      do k = 1, ntb_r
+         do j = 1, ntb_r1
+            do i = 1, nbr
+               tnr_rev(i,j,k) = 0.0d0
+            enddo
+         enddo
+      enddo
+
+      do k = 1, nbc
+         do j = 1, ntb_c
+            do i = 1, nbc
+               tpc_wev(i,j,k) = 0.0d0
+               tnc_wev(i,j,k) = 0.0d0
+            enddo
+         enddo
+      enddo
+
+      do m = 1, ntb_ark
+         do l = 1, ntb_arr
+            do k = 1, ntb_art
+               do j = 1, ntb_arw
+                  do i = 1, ntb_arc
+                     tnccn_act(i,j,k,l,m) = 1.0
+                  enddo
+               enddo
+            enddo
+         enddo
+      enddo
+
+      CALL wrf_debug(150, 'CREATING MICROPHYSICS LOOKUP TABLES ... ')
+      WRITE (wrf_err_message, '(a, f5.2, a, f5.2, a, f5.2, a, f5.2)') &
+          ' using: mu_c=',mu_c,' mu_i=',mu_i,' mu_r=',mu_r,' mu_g=',mu_g
+      CALL wrf_debug(150, wrf_err_message)
+
+!..Read a static file containing CCN activation of aerosols. The
+!.. data were created from a parcel model by Feingold & Heymsfield with
+!.. further changes by Eidhammer and Kriedenweis.
+      if (is_aerosol_aware) then
+         CALL wrf_debug(200, '  calling table_ccnAct routine')
+         call table_ccnAct
+!$acc enter data copyin(tnccn_act)
+      endif
+
+!..Collision efficiency between rain/snow and cloud water.
+      CALL wrf_debug(200, '  creating qc collision eff tables')
+      call table_Efrw
+      call table_Efsw
+
+!..Drop evaporation.
+      CALL wrf_debug(200, '  creating rain evap table')
+      call table_dropEvap
+
+!..Initialize various constants for computing radar reflectivity.
+      xam_r = am_r
+      xbm_r = bm_r
+      xmu_r = mu_r
+      xam_s = am_s
+      xbm_s = bm_s
+      xmu_s = mu_s
+      xam_g = am_g
+      xbm_g = bm_g
+      xmu_g = mu_g
+      call radar_init
+
+      if (.not. iiwarm) then
+
+!..Rain collecting graupel & graupel collecting rain.
+      CALL wrf_debug(200, '  creating rain collecting graupel table')
+      call qr_acr_qg
+!$acc enter data copyin(tcg_racg,tmr_racg,tcr_gacr,tmg_gacr,tnr_racg,tnr_gacr)
+
+!..Rain collecting snow & snow collecting rain.
+      CALL wrf_debug(200, '  creating rain collecting snow table')
+      call qr_acr_qs
+!$acc enter data copyin(tcs_racs1,tmr_racs1,tcs_racs2,tmr_racs2, &
+!$acc                   tcr_sacr1,tms_sacr1,tcr_sacr2,tms_sacr2, &
+!$acc                   tnr_racs1,tnr_racs2,tnr_sacr1,tnr_sacr2)
+
+!..Cloud water and rain freezing (Bigg, 1953).
+      CALL wrf_debug(200, '  creating freezing of water drops table')
+      call freezeH2O
+!$acc enter data copyin(tpi_qrfz,tni_qrfz,tpg_qrfz,tnr_qrfz,tpi_qcfz,tni_qcfz)
+
+!..Conversion of some ice mass into snow category.
+      CALL wrf_debug(200, '  creating ice converting to snow table')
+      call qi_aut_qs
+!$acc enter data copyin(tni_iaus,tps_iaus,tpi_ide)
+
+      endif
+
+      CALL wrf_debug(150, ' ... DONE microphysical lookup tables')
+
+      endif
+
+      END SUBROUTINE thompson_init
+!+---+-----------------------------------------------------------------+
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!..This is a wrapper routine designed to transfer values from 3D to 1D.
+!+---+-----------------------------------------------------------------+
+      SUBROUTINE mp_gt_driver(qv, qc, qr, qi, qs, qg, ni, nr, nc,       &
+                              nwfa, nifa, nwfa2d,                       &
+                              th, pii, p, w, dz, dt_in, itimestep,      &
+                              RAINNC, RAINNCV, &
+                              SNOWNC, SNOWNCV, &
+                              GRAUPELNC, GRAUPELNCV, SR, &
+#if ( WRF_CHEM == 1 )
+                              rainprod, evapprod, &
+#endif
+                              refl_10cm, diagflag, do_radar_ref,      &
+                              re_cloud, re_ice, re_snow,              &
+                              has_reqc, has_reqi, has_reqs,           &
+                              ids,ide, jds,jde, kds,kde, &             ! domain dims
+                              ims,ime, jms,jme, kms,kme, &             ! memory dims
+                              its,ite, jts,jte, kts,kte)               ! tile dims
+
+      implicit none
+
+!..Subroutine arguments
+      INTEGER, INTENT(IN):: ids,ide, jds,jde, kds,kde, &
+                            ims,ime, jms,jme, kms,kme, &
+                            its,ite, jts,jte, kts,kte
+      REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT):: &
+                          qv, qc, qr, qi, qs, qg, ni, nr, th
+      REAL, DIMENSION(ims:ime, kms:kme, jms:jme), OPTIONAL, INTENT(INOUT):: &
+                          nc, nwfa, nifa
+      REAL, DIMENSION(ims:ime, jms:jme), OPTIONAL, INTENT(IN):: nwfa2d
+      REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT):: &
+                          re_cloud, re_ice, re_snow
+      INTEGER, INTENT(IN):: has_reqc, has_reqi, has_reqs
+#if ( WRF_CHEM == 1 )
+      REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT):: &
+                          rainprod, evapprod
+#endif
+      REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(IN):: &
+                          pii, p, w, dz
+      REAL, DIMENSION(ims:ime, jms:jme), INTENT(INOUT):: &
+                          RAINNC, RAINNCV, SR
+      REAL, DIMENSION(ims:ime, jms:jme), OPTIONAL, INTENT(INOUT)::      &
+                          SNOWNC, SNOWNCV, GRAUPELNC, GRAUPELNCV
+      REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(INOUT)::       &
+                          refl_10cm
+      REAL, INTENT(IN):: dt_in
+      INTEGER, INTENT(IN):: itimestep
+
+!..Local variables
+      REAL, DIMENSION(kts:kte,CHNK):: &
+                          qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, ni1d,     &
+                          nr1d, nc1d, nwfa1d, nifa1d,                   &
+                          t1d, p1d, w1d, dz1d, dBZ
+      REAL, DIMENSION(kts:kte,CHNK):: re_qc1d, re_qi1d, re_qs1d
+#if ( WRF_CHEM == 1 )
+      REAL, DIMENSION(kts:kte,CHNK):: &
+                          rainprod1d, evapprod1d
+#endif
+      REAL, DIMENSION(its:ite, jts:jte):: pcp_ra, pcp_sn, pcp_gr, pcp_ic
+      REAL:: dt
+      REAL, DIMENSION(CHNK) ::pptrain, pptsnow, pptgraul, pptice
+      REAL:: qc_max, qr_max, qs_max, qi_max, qg_max, ni_max, nr_max
+      REAL:: nwfa1
+      INTEGER:: i, j, k
+      INTEGER:: imax_qc,imax_qr,imax_qi,imax_qs,imax_qg,imax_ni,imax_nr
+      INTEGER:: jmax_qc,jmax_qr,jmax_qi,jmax_qs,jmax_qg,jmax_ni,jmax_nr
+      INTEGER:: kmax_qc,kmax_qr,kmax_qi,kmax_qs,kmax_qg,kmax_ni,kmax_nr
+      INTEGER:: i_start, j_start, i_end, j_end
+      LOGICAL, OPTIONAL, INTENT(IN) :: diagflag
+      INTEGER, OPTIONAL, INTENT(IN) :: do_radar_ref
+      CHARACTER*256:: mp_debug
+      INTEGER:: icol, col, ncol, nlon
+
+!+---+
+
+      i_start = its
+      j_start = jts
+      i_end   = MIN(ite, ide-1)
+      j_end   = MIN(jte, jde-1)
+
+!..For idealized testing by developer.
+!     if ( (ide-ids+1).gt.4 .and. (jde-jds+1).lt.4 .and.                &
+!          ids.eq.its.and.ide.eq.ite.and.jds.eq.jts.and.jde.eq.jte) then
+!        i_start = its + 2
+!        i_end   = ite
+!        j_start = jts
+!        j_end   = jte
+!     endif
+
+      dt = dt_in
+#ifndef _OPENACC
+      qc_max = 0.
+      qr_max = 0.
+      qs_max = 0.
+      qi_max = 0.
+      qg_max = 0
+      ni_max = 0.
+      nr_max = 0.
+      imax_qc = 0
+      imax_qr = 0
+      imax_qi = 0
+      imax_qs = 0
+      imax_qg = 0
+      imax_ni = 0
+      imax_nr = 0
+      jmax_qc = 0
+      jmax_qr = 0
+      jmax_qi = 0
+      jmax_qs = 0
+      jmax_qg = 0
+      jmax_ni = 0
+      jmax_nr = 0
+      kmax_qc = 0
+      kmax_qr = 0
+      kmax_qi = 0
+      kmax_qs = 0
+      kmax_qg = 0
+      kmax_ni = 0
+      kmax_nr = 0
+      do i = 1, 256
+         mp_debug(i:i) = char(0)
+      enddo
+#endif
+
+      if (.NOT. is_aerosol_aware .AND. PRESENT(nc) .AND. PRESENT(nwfa)  &
+                .AND. PRESENT(nifa) .AND. PRESENT(nwfa2d)) then
+         write(mp_debug,*) 'WARNING, nc-nwfa-nifa-nwfa2d present but is_aerosol_aware is FALSE'
+         CALL wrf_debug(0, mp_debug)
+      endif
+
+      ncol = (j_end - j_start + 1)*(i_end - i_start + 1)
+      nlon = (i_end - i_start + 1)
+
+
+!$acc data create(t1d,p1d,w1d,dz1d,qv1d,qc1d,qi1d,qr1d,qs1d,qg1d,ni1d,nr1d, &
+!$acc         nc1d,nwfa1d,nifa1d,pptrain, pptsnow, pptgraul, pptice) &
+!$acc      pcreate(th,pii,p,w,dz,qv,qc,qi,qr,qs,qg,ni,nr)
+      do icol = 1,ceiling(real(ncol)/real(CHNK))
+!$acc kernels
+
+! ARom move reseting of ppt*  into mp_thompson()
+      do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK    
+         pptrain(col) = 0.
+         pptsnow(col) = 0.
+         pptgraul(col) = 0.
+         pptice(col) = 0.
+      enddo
+!$acc end kernels      
+
+! ARom we dont need this sins this arrays will be overwriten         
+!         RAINNCV(i,j) = 0.
+!         IF ( PRESENT (snowncv) ) THEN
+!            SNOWNCV(i,j) = 0.
+!         ENDIF
+!         IF ( PRESENT (graupelncv) ) THEN
+!            GRAUPELNCV(i,j) = 0.
+!         ENDIF
+!         SR(i,j) = 0.
+
+!$acc  kernels      
+      do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK    
+         i = MOD((icol-1)*CHNK + col-1, nlon) + i_start
+         j = ((icol-1)*CHNK + col-1)/nlon + j_start
+         do k = kts, kte
+            t1d(k,col) = th(i,k,j)*pii(i,k,j)
+            p1d(k,col) = p(i,k,j)
+            w1d(k,col) = w(i,k,j)
+            dz1d(k,col) = dz(i,k,j)
+            qv1d(k,col) = qv(i,k,j)
+            qc1d(k,col) = qc(i,k,j)
+            qi1d(k,col) = qi(i,k,j)
+            qr1d(k,col) = qr(i,k,j)
+            qs1d(k,col) = qs(i,k,j)
+            qg1d(k,col) = qg(i,k,j)
+            ni1d(k,col) = ni(i,k,j)
+            nr1d(k,col) = nr(i,k,j)
+         enddo
+      enddo
+!$acc end kernels      
+      if (is_aerosol_aware) then
+!$acc data copy(nc,nwfa,nifa)
+!$acc kernels
+      do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK    
+         i = MOD((icol-1)*CHNK + col-1, nlon) + i_start
+         j = ((icol-1)*CHNK + col-1)/nlon + j_start
+            do k = kts, kte
+               nc1d(k,col) = nc(i,k,j)
+               nwfa1d(k,col) = nwfa(i,k,j)
+               nifa1d(k,col) = nifa(i,k,j)
+            enddo
+!            nwfa1 = nwfa2d(i,j)
+      enddo
+!$acc end kernels
+!$acc end data
+      else
+!$acc kernels      
+      do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK    
+            do k = kts, kte
+               nc1d(k,col) = Nt_c
+               nwfa1d(k,col) = 11.1E6
+               nifa1d(k,col) = naIN1*0.01
+            enddo
+!            nwfa1 = 11.1E6
+      enddo
+!$acc end kernels      
+      endif
+
+         call mp_thompson(qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, ni1d,     &
+                      nr1d, nc1d, nwfa1d, nifa1d, t1d, p1d, w1d, dz1d,  &
+                      pptrain, pptsnow, pptgraul, pptice, &
+#if ( WRF_CHEM == 1 )
+                      rainprod1d, evapprod1d, &
+#endif
+                      kts, kte, dt, MIN(icol*CHNK, ncol) - (icol-1)*CHNK)
+!$acc update host ( qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, ni1d, &
+#if ( WRF_CHEM == 1 )
+!$acc        rainprod, evapprod, &
+#endif
+!$acc           nr1d, nc1d, nwfa1d, nifa1d, t1d, &
+!$acc    pptrain, pptsnow, pptgraul, pptice)
+
+
+!$acc update host(pii) ! we have the next loop on CPU side
+      do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK    
+         i = MOD((icol-1)*CHNK + col-1, nlon) + i_start
+         j = ((icol-1)*CHNK + col-1)/nlon + j_start
+
+! ARom those arrays will not used futher
+!         pcp_ra(i,j) = pptrain(col)
+!         pcp_sn(i,j) = pptsnow(col)
+!         pcp_gr(i,j) = pptgraul(col)
+!         pcp_ic(i,j) = pptice(col)
+         RAINNCV(i,j) = pptrain(col) + pptsnow(col) + pptgraul(col) + pptice(col)
+         RAINNC(i,j) = RAINNC(i,j) + pptrain(col) + pptsnow(col) + pptgraul(col) + pptice(col)
+         IF ( PRESENT(snowncv) .AND. PRESENT(snownc) ) THEN
+            SNOWNCV(i,j) = pptsnow(col) + pptice(col)
+            SNOWNC(i,j) = SNOWNC(i,j) + pptsnow(col) + pptice(col)
+         ENDIF
+         IF ( PRESENT(graupelncv) .AND. PRESENT(graupelnc) ) THEN
+            GRAUPELNCV(i,j) = pptgraul(col)
+            GRAUPELNC(i,j) = GRAUPELNC(i,j) + pptgraul(col)
+         ENDIF
+         SR(i,j) = (pptsnow(col) + pptgraul(col) + pptice(col))/(RAINNCV(i,j)+1.e-12)
+
+
+
+!..Reset lowest model level to initial state aerosols (fake sfc source).
+!.. Changed 13 May 2013 to fake emissions in which nwfa2d is aerosol
+!.. number tendency (number per kg per second).
+         if (is_aerosol_aware) then
+!-GT        nwfa1d(kts,col) = nwfa1
+            nwfa1d(kts,col) = nwfa1d(kts,col) + nwfa2d(i,j)*dt_in
+
+            do k = kts, kte
+               nc(i,k,j) = nc1d(k,col)
+               nwfa(i,k,j) = nwfa1d(k,col)
+               nifa(i,k,j) = nifa1d(k,col)
+            enddo
+         endif
+
+         do k = kts, kte
+            qv(i,k,j) = qv1d(k,col)
+            qc(i,k,j) = qc1d(k,col)
+            qi(i,k,j) = qi1d(k,col)
+            qr(i,k,j) = qr1d(k,col)
+            qs(i,k,j) = qs1d(k,col)
+            qg(i,k,j) = qg1d(k,col)
+            ni(i,k,j) = ni1d(k,col)
+            nr(i,k,j) = nr1d(k,col)
+            th(i,k,j) = t1d(k,col)/pii(i,k,j)
+#if ( WRF_CHEM == 1 )
+            rainprod(i,k,j) = rainprod1d(k,col)
+            evapprod(i,k,j) = evapprod1d(k,col)
+#endif
+#ifndef _OPENACC
+            if (qc1d(k,col) .gt. qc_max) then
+             imax_qc = i
+             jmax_qc = j
+             kmax_qc = k
+             qc_max = qc1d(k,col)
+            elseif (qc1d(k,col) .lt. 0.0) then
+             write(mp_debug,*) 'WARNING, negative qc ', qc1d(k,col),        &
+                        ' at i,j,k=', i,j,k
+             CALL wrf_debug(150, mp_debug)
+            endif
+            if (qr1d(k,col) .gt. qr_max) then
+             imax_qr = i
+             jmax_qr = j
+             kmax_qr = k
+             qr_max = qr1d(k,col)
+            elseif (qr1d(k,col) .lt. 0.0) then
+             write(mp_debug,*) 'WARNING, negative qr ', qr1d(k,col),        &
+                        ' at i,j,k=', i,j,k
+             CALL wrf_debug(150, mp_debug)
+            endif
+            if (nr1d(k,col) .gt. nr_max) then
+             imax_nr = i
+             jmax_nr = j
+             kmax_nr = k
+             nr_max = nr1d(k,col)
+            elseif (nr1d(k,col) .lt. 0.0) then
+             write(mp_debug,*) 'WARNING, negative nr ', nr1d(k,col),        &
+                        ' at i,j,k=', i,j,k
+             CALL wrf_debug(150, mp_debug)
+            endif
+            if (qs1d(k,col) .gt. qs_max) then
+             imax_qs = i
+             jmax_qs = j
+             kmax_qs = k
+             qs_max = qs1d(k,col)
+            elseif (qs1d(k,col) .lt. 0.0) then
+             write(mp_debug,*) 'WARNING, negative qs ', qs1d(k,col),        &
+                        ' at i,j,k=', i,j,k
+             CALL wrf_debug(150, mp_debug)
+            endif
+            if (qi1d(k,col) .gt. qi_max) then
+             imax_qi = i
+             jmax_qi = j
+             kmax_qi = k
+             qi_max = qi1d(k,col)
+            elseif (qi1d(k,col) .lt. 0.0) then
+             write(mp_debug,*) 'WARNING, negative qi ', qi1d(k,col),        &
+                        ' at i,j,k=', i,j,k
+             CALL wrf_debug(150, mp_debug)
+            endif
+            if (qg1d(k,col) .gt. qg_max) then
+             imax_qg = i
+             jmax_qg = j
+             kmax_qg = k
+             qg_max = qg1d(k,col)
+            elseif (qg1d(k,col) .lt. 0.0) then
+             write(mp_debug,*) 'WARNING, negative qg ', qg1d(k,col),        &
+                        ' at i,j,k=', i,j,k
+             CALL wrf_debug(150, mp_debug)
+            endif
+            if (ni1d(k,col) .gt. ni_max) then
+             imax_ni = i
+             jmax_ni = j
+             kmax_ni = k
+             ni_max = ni1d(k,col)
+            elseif (ni1d(k,col) .lt. 0.0) then
+             write(mp_debug,*) 'WARNING, negative ni ', ni1d(k,col),        &
+                        ' at i,j,k=', i,j,k
+             CALL wrf_debug(150, mp_debug)
+            endif
+#endif
+            if (qv1d(k,col) .lt. 0.0) then
+#ifndef _OPENACC             
+             write(mp_debug,*) 'WARNING, negative qv ', qv1d(k,col),        &
+                        ' at i,j,k=', i,j,k
+             CALL wrf_debug(150, mp_debug)
+#endif             
+             if (k.lt.kte-2 .and. k.gt.kts+1) then
+#ifndef _OPENACC             
+                write(mp_debug,*) '   below and above are: ', qv(i,k-1,j), qv(i,k+1,j)
+                CALL wrf_debug(150, mp_debug)
+#endif                
+                qv(i,k,j) = MAX(1.E-7, 0.5*(qv(i,k-1,j) + qv(i,k+1,j)))
+             else
+                qv(i,k,j) = 1.E-7
+             endif
+            endif
+         enddo
+       enddo
+         
+       IF ( PRESENT (diagflag) ) THEN
+       if (diagflag .and. do_radar_ref == 1) then
+          call calc_refl10cm (qv1d, qc1d, qr1d, nr1d, qs1d, qg1d,       &
+                      t1d, p1d, dBZ, kts, kte, MIN(icol*CHNK,ncol) - (icol-1)*CHNK)
+       do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK    
+         i = MOD((icol-1)*CHNK + col-1, nlon) + i_start
+         j = ((icol-1)*CHNK + col-1)/nlon + j_start
+          do k = kts, kte
+             refl_10cm(i,k,j) = MAX(-35., dBZ(k,col))
+          enddo
+       enddo
+       endif
+       ENDIF
+
+       IF (has_reqc.ne.0 .and. has_reqi.ne.0 .and. has_reqs.ne.0) THEN
+       do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK
+          do k = kts, kte
+             re_qc1d(k,col) = 2.51E-6
+             re_qi1d(k,col) = 10.01E-6
+             re_qs1d(k,col) = 10.01E-6
+          enddo
+       enddo    
+       call calc_effectRad (t1d, p1d, qv1d, qc1d, nc1d, qi1d, ni1d, qs1d,  &
+                      re_qc1d, re_qi1d, re_qs1d, kts, kte,MIN(icol*CHNK,ncol) - (icol-1)*CHNK)
+       do col = 1,MIN(icol*CHNK, ncol) - (icol-1)*CHNK    
+         i = MOD((icol-1)*CHNK + col-1, nlon) + i_start
+         j = ((icol-1)*CHNK + col-1)/nlon + j_start
+          do k = kts, kte
+             re_cloud(i,k,j) = MAX( 2.51E-6, MIN(re_qc1d(k,col), 50.E-6))
+             re_ice(i,k,j)   = MAX(10.01E-6, MIN(re_qi1d(k,col), 125.E-6))
+             re_snow(i,k,j)  = MAX(10.01E-6, MIN(re_qs1d(k,col), 999.E-6))
+          enddo
+       enddo
+       ENDIF
+
+       enddo
+!$acc update device(qv,qc,qr,qi,qs,qg,ni,nr,th)       
+!$acc update device(re_cloud,re_snow,re_ice)
+!$acc end data
+#ifndef _OPENACC             
+
+! DEBUG - GT
+      write(mp_debug,'(a,7(a,e13.6,1x,a,i3,a,i3,a,i3,a,1x))') 'MP-GT:', &
+         'qc: ', qc_max, '(', imax_qc, ',', jmax_qc, ',', kmax_qc, ')', &
+         'qr: ', qr_max, '(', imax_qr, ',', jmax_qr, ',', kmax_qr, ')', &
+         'qi: ', qi_max, '(', imax_qi, ',', jmax_qi, ',', kmax_qi, ')', &
+         'qs: ', qs_max, '(', imax_qs, ',', jmax_qs, ',', kmax_qs, ')', &
+         'qg: ', qg_max, '(', imax_qg, ',', jmax_qg, ',', kmax_qg, ')', &
+         'ni: ', ni_max, '(', imax_ni, ',', jmax_ni, ',', kmax_ni, ')', &
+         'nr: ', nr_max, '(', imax_nr, ',', jmax_nr, ',', kmax_nr, ')'
+      CALL wrf_debug(150, mp_debug)
+! END DEBUG - GT
+
+      do i = 1, 256
+         mp_debug(i:i) = char(0)
+      enddo
+#endif
+
+      END SUBROUTINE mp_gt_driver
+
+!+---+-----------------------------------------------------------------+
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!+---+-----------------------------------------------------------------+
+!.. This subroutine computes the moisture tendencies of water vapor,
+!.. cloud droplets, rain, cloud ice (pristine), snow, and graupel.
+!.. Previously this code was based on Reisner et al (1998), but few of
+!.. those pieces remain.  A complete description is now found in
+!.. Thompson et al. (2004, 2008).
+!+---+-----------------------------------------------------------------+
+!
+      subroutine mp_thompson (qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, ni1d, &
+                          nr1d, nc1d, nwfa1d, nifa1d, t1d, p1d, w1d, dzq, &
+                          pptrain, pptsnow, pptgraul, pptice, &
+#if ( WRF_CHEM == 1 )
+                          rainprod, evapprod, &
+#endif
+                          kts, kte, dt, ncol)
+
+      implicit none
+
+!..Sub arguments
+      INTEGER, INTENT(IN):: kts, kte, ncol
+      REAL, DIMENSION(kts:kte,CHNK), INTENT(INOUT):: &
+                          qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, ni1d, &
+                          nr1d, nc1d, nwfa1d, nifa1d, t1d
+      REAL, DIMENSION(kts:kte,CHNK), INTENT(IN):: p1d, w1d, dzq
+      REAL, DIMENSION(CHNK), INTENT(INOUT):: pptrain, pptsnow, pptgraul, pptice
+      REAL, INTENT(IN):: dt
+#if ( WRF_CHEM == 1 )
+      REAL, DIMENSION(kts:kte,CHNK), INTENT(INOUT):: &
+                          rainprod, evapprod
+#endif
+
+!..Local variables
+      INTEGER :: ii, jj
+      REAL, DIMENSION(kts:kte,CHNK):: tten, qvten, qcten, qiten, &
+           qrten, qsten, qgten, niten, nrten, ncten, nwfaten, nifaten
+
+      DOUBLE PRECISION, DIMENSION(kts:kte,CHNK):: prw_vcd
+
+      DOUBLE PRECISION, DIMENSION(kts:kte,CHNK):: pnc_wcd, pnc_wau, pnc_rcw, &
+           pnc_scw, pnc_gcw
+
+      DOUBLE PRECISION, DIMENSION(kts:kte,CHNK):: pna_rca, pna_sca, pna_gca, &
+           pnd_rcd, pnd_scd, pnd_gcd
+
+      DOUBLE PRECISION, DIMENSION(kts:kte,CHNK):: prr_wau, prr_rcw, prr_rcs, &
+           prr_rcg, prr_sml, prr_gml, &
+           prr_rci, prv_rev,          &
+           pnr_wau, pnr_rcs, pnr_rcg, &
+           pnr_rci, pnr_sml, pnr_gml, &
+           pnr_rev, pnr_rcr, pnr_rfz
+
+      DOUBLE PRECISION, DIMENSION(kts:kte,CHNK):: pri_inu, pni_inu, pri_ihm, &
+           pni_ihm, pri_wfz, pni_wfz, &
+           pri_rfz, pni_rfz, pri_ide, &
+           pni_ide, pri_rci, pni_rci, &
+           pni_sci, pni_iau, pri_iha, pni_iha
+
+      DOUBLE PRECISION, DIMENSION(kts:kte,CHNK):: prs_iau, prs_sci, prs_rcs, &
+           prs_scw, prs_sde, prs_ihm, &
+           prs_ide
+
+      DOUBLE PRECISION, DIMENSION(kts:kte,CHNK):: prg_scw, prg_rfz, prg_gde, &
+           prg_gcw, prg_rci, prg_rcs, &
+           prg_rcg, prg_ihm
+
+      DOUBLE PRECISION, PARAMETER:: zeroD0 = 0.0d0
+
+      REAL, DIMENSION(kts:kte,CHNK):: temp, pres, qv
+      REAL, DIMENSION(kts:kte,CHNK):: rc, ri, rr, rs, rg, ni, nr, nc, nwfa, nifa
+      REAL, DIMENSION(kts:kte,CHNK):: rho, rhof, rhof2
+      REAL, DIMENSION(kts:kte,CHNK):: qvs, qvsi, delQvs
+      REAL, DIMENSION(kts:kte,CHNK):: satw, sati, ssatw, ssati
+      REAL, DIMENSION(kts:kte,CHNK):: diffu, visco, vsc2, &
+           tcond, lvap, ocp, lvt2
+
+      DOUBLE PRECISION, DIMENSION(kts:kte,CHNK):: ilamr, ilamg, N0_r, N0_g
+      REAL, DIMENSION(kts:kte,CHNK):: mvd_r, mvd_c
+      REAL :: mvd_r_k
+      REAL, DIMENSION(kts:kte,CHNK):: smob, smo2, smo1, smo0, &
+           smoc, smod, smoe, smof
+
+      REAL, DIMENSION(kts:kte):: sed_r, sed_s, sed_g, sed_i, sed_n,sed_c
+
+      REAL:: rgvm, delta_tp, orho, lfus2
+      REAL:: onstep1,onstep2,onstep3,onstep4,onstep5
+      DOUBLE PRECISION:: N0_exp, N0_min, lam_exp, lamc, lamr, lamg
+      DOUBLE PRECISION:: lami, ilami, ilamc
+      REAL:: xDc, Dc_b, Dc_g, xDi, xDr, xDs, xDg, Ds_m, Dg_m
+      DOUBLE PRECISION:: Dr_star, Dc_star
+      REAL:: zeta1, zeta, taud, tau
+      REAL:: stoke_r, stoke_s, stoke_g, stoke_i
+      REAL:: vti, vtr, vts, vtg, vtc
+      REAL, DIMENSION(kts:kte+1):: vtik, vtnik, vtrk, vtnrk, vtsk, vtgk,  &
+           vtck, vtnck
+      REAL, DIMENSION(kts:kte,CHNK):: vts_boost,act_ncloud
+      REAL:: Mrat, ils1, ils2, t1_vts, t2_vts, t3_vts, t4_vts, C_snow
+      REAL:: a_, b_, loga_, A1, A2, tf
+      REAL:: tempc, tc0, r_mvd1, r_mvd2, xkrat
+      REAL:: xnc, xri, xni, xmi, oxmi, xrc, xrr, xnr
+      REAL:: xsat, rate_max, sump, ratio
+      REAL:: clap, fcd, dfcd
+      REAL:: otemp, rvs, rvs_p, rvs_pp, gamsc, alphsc, t1_evap, t1_subl
+      REAL:: r_frac, g_frac
+      REAL:: Ef_rw, Ef_sw, Ef_gw, Ef_rr
+      REAL:: Ef_ra, Ef_sa, Ef_ga
+      REAL:: dtsave, odts, odt, odzq, hgt_agl
+      REAL:: xslw1, ygra1, zans1, eva_factor
+      INTEGER:: i, k, k2, n, nn, nstep, k_0, kbot, IT, iexfrq
+      INTEGER:: ksed11,ksed12,ksed13,ksed14,ksed15
+      INTEGER:: nir, nis, nig, nii, nic, niin
+      INTEGER:: idx_tc, idx_t, idx_s, idx_g1, idx_g, idx_r1, idx_r,     &
+                idx_i1, idx_i, idx_c, idx, idx_d, idx_n, idx_in
+
+!      LOGICAL:: melti 
+      LOGICAL,DIMENSION(CHNK) ::no_micro
+      LOGICAL :: no_micro_
+      LOGICAL, DIMENSION(kts:kte,CHNK):: L_qc, L_qi, L_qr, L_qs, L_qg
+      LOGICAL:: debug_flag
+      CHARACTER*256:: mp_debug
+      INTEGER:: nu_c, col
+!$acc routine(rslf) seq
+!$acc routine(rsif) seq
+!$acc routine(Eff_aero) seq
+!$acc routine(icedemott) seq
+!$acc routine(icekoop) seq
+
+!+---+
+
+      dtsave = dt
+      odt = 1./dt
+      odts = 1./dtsave
+!      iexfrq = 1
+
+
+!$acc data present( qv1d, qc1d, qi1d, qr1d, qs1d, qg1d, ni1d, &
+#if ( WRF_CHEM == 1 )
+!$acc        rainprod, evapprod, &
+#endif
+!$acc           nr1d, nc1d, nwfa1d, nifa1d, t1d) &
+!$acc     present(pptrain, pptsnow, pptgraul, pptice) &
+!$acc     present(p1d, w1d, dzq) &
+!$acc     create( tten, qvten, qcten, qiten, prw_vcd, &
+!$acc        qrten, qsten, qgten, niten, nrten, ncten, nwfaten, nifaten, &
+!$acc        pnc_wcd, pnc_wau, pnc_rcw, pnc_scw, pnc_gcw, &
+!$acc        pna_rca, pna_sca, pna_gca, pnd_rcd, pnd_scd, pnd_gcd, &
+!$acc        prr_wau, prr_rcw, prr_rcs, &
+!$acc        prr_rcg, prr_sml, prr_gml, &
+!$acc        prr_rci, prv_rev,          &
+!$acc        pnr_wau, pnr_rcs, pnr_rcg, &
+!$acc        pnr_rci, pnr_sml, pnr_gml, &
+!$acc        pnr_rev, pnr_rcr, pnr_rfz, &
+!$acc        pri_inu, pni_inu, pri_ihm, &
+!$acc        pni_ihm, pri_wfz, pni_wfz, &
+!$acc        pri_rfz, pni_rfz, pri_ide, &
+!$acc        pni_ide, pri_rci, pni_rci, &
+!$acc        pni_sci, pni_iau, pri_iha, pni_iha, &
+!$acc        prs_iau, prs_sci, prs_rcs, &
+!$acc        prs_scw, prs_sde, prs_ihm, &
+!$acc        prs_ide, &
+!$acc        prg_scw, prg_rfz, prg_gde, &
+!$acc        prg_gcw, prg_rci, prg_rcs, &
+!$acc        prg_rcg, prg_ihm, &
+!$acc        rc, ri, rr, rs, rg, ni, nr, nc, nwfa, nifa, &
+!$acc        temp, pres, qv, rho, rhof, rhof2, &
+!$acc        qvs, qvsi, delQvs, satw, sati, ssatw, ssati, &
+!$acc        diffu, visco, vsc2, tcond, lvap, ocp, lvt2, &
+!$acc        ilamr, ilamg, N0_r, N0_g, mvd_r, mvd_c, &
+!$acc        smob, smo2, smo1, smo0, smoc, smod, smoe, smof, &
+!$acc        vts_boost, no_micro, L_qc, L_qi, L_qr, L_qs, L_qg, &
+!$acc        act_ncloud)
+
+!$acc kernels
+      do col = 1,ncol    
+
+#ifndef _OPENACC
+      debug_flag = .false.
+!     if (ii.eq.901 .and. jj.eq.379) debug_flag = .true.
+      if(debug_flag) then
+        write(mp_debug, *) 'DEBUG INFO, mp_thompson at (i,j) ', ii, ', ', jj
+        CALL wrf_debug(550, mp_debug)
+      endif
+#endif
+!+---+-----------------------------------------------------------------+
+!.. Source/sink terms.  First 2 chars: "pr" represents source/sink of
+!.. mass while "pn" represents source/sink of number.  Next char is one
+!.. of "v" for water vapor, "r" for rain, "i" for cloud ice, "w" for
+!.. cloud water, "s" for snow, and "g" for graupel.  Next chars
+!.. represent processes: "de" for sublimation/deposition, "ev" for
+!.. evaporation, "fz" for freezing, "ml" for melting, "au" for
+!.. autoconversion, "nu" for ice nucleation, "hm" for Hallet/Mossop
+!.. secondary ice production, and "c" for collection followed by the
+!.. character for the species being collected.  ALL of these terms are
+!.. positive (except for deposition/sublimation terms which can switch
+!.. signs based on super/subsaturation) and are treated as negatives
+!.. where necessary in the tendency equations.
+!+---+-----------------------------------------------------------------+
+
+      do k = kts, kte
+         tten(k,col) = 0.
+         qvten(k,col) = 0.
+         qcten(k,col) = 0.
+         qiten(k,col) = 0.
+         qrten(k,col) = 0.
+         qsten(k,col) = 0.
+         qgten(k,col) = 0.
+         niten(k,col) = 0.
+         nrten(k,col) = 0.
+         ncten(k,col) = 0.
+         nwfaten(k,col) = 0.
+         nifaten(k,col) = 0.
+
+         prw_vcd(k,col) = 0.
+
+         pnc_wcd(k,col) = 0.
+         pnc_wau(k,col) = 0.
+         pnc_rcw(k,col) = 0.
+         pnc_scw(k,col) = 0.
+         pnc_gcw(k,col) = 0.
+
+         prv_rev(k,col) = 0.
+         prr_wau(k,col) = 0.
+         prr_rcw(k,col) = 0.
+         prr_rcs(k,col) = 0.
+         prr_rcg(k,col) = 0.
+         prr_sml(k,col) = 0.
+         prr_gml(k,col) = 0.
+         prr_rci(k,col) = 0.
+         pnr_wau(k,col) = 0.
+         pnr_rcs(k,col) = 0.
+         pnr_rcg(k,col) = 0.
+         pnr_rci(k,col) = 0.
+         pnr_sml(k,col) = 0.
+         pnr_gml(k,col) = 0.
+         pnr_rev(k,col) = 0.
+         pnr_rcr(k,col) = 0.
+         pnr_rfz(k,col) = 0.
+
+         pri_inu(k,col) = 0.
+         pni_inu(k,col) = 0.
+         pri_ihm(k,col) = 0.
+         pni_ihm(k,col) = 0.
+         pri_wfz(k,col) = 0.
+         pni_wfz(k,col) = 0.
+         pri_rfz(k,col) = 0.
+         pni_rfz(k,col) = 0.
+         pri_ide(k,col) = 0.
+         pni_ide(k,col) = 0.
+         pri_rci(k,col) = 0.
+         pni_rci(k,col) = 0.
+         pni_sci(k,col) = 0.
+         pni_iau(k,col) = 0.
+         pri_iha(k,col) = 0.
+         pni_iha(k,col) = 0.
+
+         prs_iau(k,col) = 0.
+         prs_sci(k,col) = 0.
+         prs_rcs(k,col) = 0.
+         prs_scw(k,col) = 0.
+         prs_sde(k,col) = 0.
+         prs_ihm(k,col) = 0.
+         prs_ide(k,col) = 0.
+
+         prg_scw(k,col) = 0.
+         prg_rfz(k,col) = 0.
+         prg_gde(k,col) = 0.
+         prg_gcw(k,col) = 0.
+         prg_rci(k,col) = 0.
+         prg_rcs(k,col) = 0.
+         prg_rcg(k,col) = 0.
+         prg_ihm(k,col) = 0.
+
+         pna_rca(k,col) = 0.
+         pna_sca(k,col) = 0.
+         pna_gca(k,col) = 0.
+
+         pnd_rcd(k,col) = 0.
+         pnd_scd(k,col) = 0.
+         pnd_gcd(k,col) = 0.
+      enddo
+#if ( WRF_CHEM == 1 )
+      do k = kts, kte
+         rainprod(k,col) = 0.
+         evapprod(k,col) = 0.
+      enddo
+#endif
+      enddo ! col
+
+      do col = 1,ncol
+
+      no_micro_ = .true.
+
+!+---+-----------------------------------------------------------------+
+!..Put column of data into local arrays.
+!+---+-----------------------------------------------------------------+
+!$acc loop reduction(.and.:no_micro_)  private(lamc,xDc,nu_c)      
+      do k = kts, kte
+         temp(k,col) = t1d(k,col)
+         qv(k,col) = MAX(1.E-10, qv1d(k,col))
+         pres(k,col) = p1d(k,col)
+         rho(k,col) = 0.622*pres(k,col)/(R*temp(k,col)*(qv(k,col)+0.622))
+         nwfa(k,col) = MAX(11.1E6, MIN(9999.E6, nwfa1d(k,col)*rho(k,col)))
+         nifa(k,col) = MAX(naIN1*0.01, MIN(9999.E6, nifa1d(k,col)*rho(k,col)))
+
+         if (qc1d(k,col) .gt. R1) then
+            no_micro_ = .false.
+            rc(k,col) = qc1d(k,col)*rho(k,col)
+            nc(k,col) = MAX(2., nc1d(k,col)*rho(k,col))
+            L_qc(k,col) = .true.
+            nu_c = MIN(15, NINT(1000.E6/nc(k,col)) + 2)
+            lamc = (nc(k,col)*am_r*ccg(2,nu_c)*ocg1(nu_c)/rc(k,col))**obmr
+            xDc = (bm_r + nu_c + 1.) / lamc
+            if (xDc.lt. D0c) then
+             lamc = cce(2,nu_c)/D0c
+            elseif (xDc.gt. D0r*2.) then
+             lamc = cce(2,nu_c)/(D0r*2.)
+            endif
+            nc(k,col) = MIN( DBLE(Nt_c_max), ccg(1,nu_c)*ocg2(nu_c)*rc(k,col)   &
+                  / am_r*lamc**bm_r)
+            if (.NOT. is_aerosol_aware) nc(k,col) = Nt_c
+         else
+            qc1d(k,col) = 0.0
+            nc1d(k,col) = 0.0
+            rc(k,col) = R1
+            nc(k,col) = 2.
+            L_qc(k,col) = .false.
+         endif
+
+         if (qi1d(k,col) .gt. R1) then
+            no_micro_ = .false.
+            ri(k,col) = qi1d(k,col)*rho(k,col)
+            ni(k,col) = MAX(R2, ni1d(k,col)*rho(k,col))
+            L_qi(k,col) = .true.
+            lami = (am_i*cig(2)*oig1*ni(k,col)/ri(k,col))**obmi
+            ilami = 1./lami
+            xDi = (bm_i + mu_i + 1.) * ilami
+            if (xDi.lt. 20.E-6) then
+             lami = cie(2)/20.E-6
+             ni(k,col) = MIN(499.D3, cig(1)*oig2*ri(k,col)/am_i*lami**bm_i)
+            elseif (xDi.gt. 300.E-6) then
+             lami = cie(2)/300.E-6
+             ni(k,col) = cig(1)*oig2*ri(k,col)/am_i*lami**bm_i
+            endif
+         else
+            qi1d(k,col) = 0.0
+            ni1d(k,col) = 0.0
+            ri(k,col) = R1
+            ni(k,col) = R2
+            L_qi(k,col) = .false.
+         endif
+
+         if (qr1d(k,col) .gt. R1) then
+            no_micro_ = .false.
+            rr(k,col) = qr1d(k,col)*rho(k,col)
+            nr(k,col) = MAX(R2, nr1d(k,col)*rho(k,col))
+            L_qr(k,col) = .true.
+            lamr = (am_r*crg(3)*org2*nr(k,col)/rr(k,col))**obmr
+            mvd_r(k,col) = (3.0 + mu_r + 0.672) / lamr
+            if (mvd_r(k,col) .gt. 2.5E-3) then
+               mvd_r(k,col) = 2.5E-3
+               lamr = (3.0 + mu_r + 0.672) / mvd_r(k,col)
+               nr(k,col) = crg(2)*org3*rr(k,col)*lamr**bm_r / am_r
+            elseif (mvd_r(k,col) .lt. D0r*0.75) then
+               mvd_r(k,col) = D0r*0.75
+               lamr = (3.0 + mu_r + 0.672) / mvd_r(k,col)
+               nr(k,col) = crg(2)*org3*rr(k,col)*lamr**bm_r / am_r
+            endif
+         else
+            qr1d(k,col) = 0.0
+            nr1d(k,col) = 0.0
+            rr(k,col) = R1
+            nr(k,col) = R2
+            L_qr(k,col) = .false.
+         endif
+         if (qs1d(k,col) .gt. R1) then
+            no_micro_ = .false.
+            rs(k,col) = qs1d(k,col)*rho(k,col)
+            L_qs(k,col) = .true.
+         else
+            qs1d(k,col) = 0.0
+            rs(k,col) = R1
+            L_qs(k,col) = .false.
+         endif
+         if (qg1d(k,col) .gt. R1) then
+            no_micro_ = .false.
+            rg(k,col) = qg1d(k,col)*rho(k,col)
+            L_qg(k,col) = .true.
+         else
+            qg1d(k,col) = 0.0
+            rg(k,col) = R1
+            L_qg(k,col) = .false.
+         endif
+      enddo
+
+      no_micro(col) = no_micro_
+
+!+---+-----------------------------------------------------------------+
+!     if (debug_flag) then
+!      write(mp_debug,*) 'DEBUG-VERBOSE at (i,j) ', ii, ', ', jj
+!      CALL wrf_debug(550, mp_debug)
+!      do k = kts, kte
+!        write(mp_debug, '(a,i3,f8.2,1x,f7.2,1x, 11(1x,e13.6))')        &
+!    &              'VERBOSE: ', k, pres(k,col)*0.01, temp(k,col)-273.15, qv(k,col), rc(k,col), rr(k,col), ri(k,col), rs(k,col), rg(k,col), nc(k,col), nr(k,col), ni(k,col), nwfa(k,col), nifa(k,col)
+!        CALL wrf_debug(550, mp_debug)
+!      enddo
+!     endif
+!+---+-----------------------------------------------------------------+
+
+!+---+-----------------------------------------------------------------+
+!..Derive various thermodynamic variables frequently used.
+!.. Saturation vapor pressure (mixing ratio) over liquid/ice comes from
+!.. Flatau et al. 1992; enthalpy (latent heat) of vaporization from
+!.. Bohren & Albrecht 1998; others from Pruppacher & Klett 1978.
+!+---+-----------------------------------------------------------------+
+      no_micro_ = .true.
+!$acc loop reduction(.and.:no_micro_)       
+      do k = kts, kte
+         tempc = temp(k,col) - 273.15
+         rhof(k,col) = SQRT(RHO_NOT/rho(k,col))
+         rhof2(k,col) = SQRT(rhof(k,col))
+         qvs(k,col) = rslf(pres(k,col), temp(k,col))
+         delQvs(k,col) = MAX(0.0, rslf(pres(k,col), 273.15)-qv(k,col))
+         if (tempc .le. 0.0) then
+          qvsi(k,col) = rsif(pres(k,col), temp(k,col))
+         else
+          qvsi(k,col) = qvs(k,col)
+         endif
+         satw(k,col) = qv(k,col)/qvs(k,col)
+         sati(k,col) = qv(k,col)/qvsi(k,col)
+         ssatw(k,col) = satw(k,col) - 1.
+         ssati(k,col) = sati(k,col) - 1.
+         if (abs(ssatw(k,col)).lt. eps) ssatw(k,col) = 0.0
+         if (abs(ssati(k,col)).lt. eps) ssati(k,col) = 0.0
+         if (no_micro_ .and. ssati(k,col).gt. 0.0) no_micro_ = .false.
+         diffu(k,col) = 2.11E-5*(temp(k,col)/273.15)**1.94 * (101325./pres(k,col))
+         if (tempc .ge. 0.0) then
+            visco(k,col) = (1.718+0.0049*tempc)*1.0E-5
+         else
+            visco(k,col) = (1.718+0.0049*tempc-1.2E-5*tempc*tempc)*1.0E-5
+         endif
+         ocp(k,col) = 1./(Cp*(1.+0.887*qv(k,col)))
+         vsc2(k,col) = SQRT(rho(k,col)/visco(k,col))
+         lvap(k,col) = lvap0 + (2106.0 - 4218.0)*tempc
+         tcond(k,col) = (5.69 + 0.0168*tempc)*1.0E-5 * 418.936
+      enddo
+      no_micro(col) = no_micro(col).and.no_micro_
+      enddo ! col
+!$acc end kernels
+!+---+-----------------------------------------------------------------+
+!..If no existing hydrometeor species and no chance to initiate ice or
+!.. condense cloud water, just exit quickly!
+!+---+-----------------------------------------------------------------+
+
+!+---+-----------------------------------------------------------------+
+!..Calculate y-intercept, slope, and useful moments for snow.
+!+---+-----------------------------------------------------------------+
+      if (.not. iiwarm) then
+!$acc kernels      
+      do col = 1,ncol
+      if (no_micro(col)) CYCLE
+
+      do k = kts, kte
+         if (.not. L_qs(k,col)) CYCLE
+         tc0 = MIN(-0.1, temp(k,col)-273.15)
+         smob(k,col) = rs(k,col)*oams
+
+!..All other moments based on reference, 2nd moment.  If bm_s.ne.2,
+!.. then we must compute actual 2nd moment and use as reference.
+         if (bm_s.gt.(2.0-1.e-3) .and. bm_s.lt.(2.0+1.e-3)) then
+            smo2(k,col) = smob(k,col)
+         else
+            loga_ = sa(1) + sa(2)*tc0 + sa(3)*bm_s &
+               + sa(4)*tc0*bm_s + sa(5)*tc0*tc0 &
+               + sa(6)*bm_s*bm_s + sa(7)*tc0*tc0*bm_s &
+               + sa(8)*tc0*bm_s*bm_s + sa(9)*tc0*tc0*tc0 &
+               + sa(10)*bm_s*bm_s*bm_s
+            a_ = 10.0**loga_
+            b_ = sb(1) + sb(2)*tc0 + sb(3)*bm_s &
+               + sb(4)*tc0*bm_s + sb(5)*tc0*tc0 &
+               + sb(6)*bm_s*bm_s + sb(7)*tc0*tc0*bm_s &
+               + sb(8)*tc0*bm_s*bm_s + sb(9)*tc0*tc0*tc0 &
+               + sb(10)*bm_s*bm_s*bm_s
+            smo2(k,col) = (smob(k,col)/a_)**(1./b_)
+         endif
+
+!..Calculate 0th moment.  Represents snow number concentration.
+         loga_ = sa(1) + sa(2)*tc0 + sa(5)*tc0*tc0 + sa(9)*tc0*tc0*tc0
+         a_ = 10.0**loga_
+         b_ = sb(1) + sb(2)*tc0 + sb(5)*tc0*tc0 + sb(9)*tc0*tc0*tc0
+         smo0(k,col) = a_ * smo2(k,col)**b_
+
+!..Calculate 1st moment.  Useful for depositional growth and melting.
+         loga_ = sa(1) + sa(2)*tc0 + sa(3) &
+               + sa(4)*tc0 + sa(5)*tc0*tc0 &
+               + sa(6) + sa(7)*tc0*tc0 &
+               + sa(8)*tc0 + sa(9)*tc0*tc0*tc0 &
+               + sa(10)
+         a_ = 10.0**loga_
+         b_ = sb(1)+ sb(2)*tc0 + sb(3) + sb(4)*tc0 &
+              + sb(5)*tc0*tc0 + sb(6) &
+              + sb(7)*tc0*tc0 + sb(8)*tc0 &
+              + sb(9)*tc0*tc0*tc0 + sb(10)
+         smo1(k,col) = a_ * smo2(k,col)**b_
+
+!..Calculate bm_s+1 (th) moment.  Useful for diameter calcs.
+         loga_ = sa(1) + sa(2)*tc0 + sa(3)*cse(1) &
+               + sa(4)*tc0*cse(1) + sa(5)*tc0*tc0 &
+               + sa(6)*cse(1)*cse(1) + sa(7)*tc0*tc0*cse(1) &
+               + sa(8)*tc0*cse(1)*cse(1) + sa(9)*tc0*tc0*tc0 &
+               + sa(10)*cse(1)*cse(1)*cse(1)
+         a_ = 10.0**loga_
+         b_ = sb(1)+ sb(2)*tc0 + sb(3)*cse(1) + sb(4)*tc0*cse(1) &
+              + sb(5)*tc0*tc0 + sb(6)*cse(1)*cse(1) &
+              + sb(7)*tc0*tc0*cse(1) + sb(8)*tc0*cse(1)*cse(1) &
+              + sb(9)*tc0*tc0*tc0 + sb(10)*cse(1)*cse(1)*cse(1)
+         smoc(k,col) = a_ * smo2(k,col)**b_
+
+!..Calculate bv_s+2 (th) moment.  Useful for riming.
+         loga_ = sa(1) + sa(2)*tc0 + sa(3)*cse(13) &
+               + sa(4)*tc0*cse(13) + sa(5)*tc0*tc0 &
+               + sa(6)*cse(13)*cse(13) + sa(7)*tc0*tc0*cse(13) &
+               + sa(8)*tc0*cse(13)*cse(13) + sa(9)*tc0*tc0*tc0 &
+               + sa(10)*cse(13)*cse(13)*cse(13)
+         a_ = 10.0**loga_
+         b_ = sb(1)+ sb(2)*tc0 + sb(3)*cse(13) + sb(4)*tc0*cse(13) &
+              + sb(5)*tc0*tc0 + sb(6)*cse(13)*cse(13) &
+              + sb(7)*tc0*tc0*cse(13) + sb(8)*tc0*cse(13)*cse(13) &
+              + sb(9)*tc0*tc0*tc0 + sb(10)*cse(13)*cse(13)*cse(13)
+         smoe(k,col) = a_ * smo2(k,col)**b_
+
+!..Calculate 1+(bv_s+1)/2 (th) moment.  Useful for depositional growth.
+         loga_ = sa(1) + sa(2)*tc0 + sa(3)*cse(16) &
+               + sa(4)*tc0*cse(16) + sa(5)*tc0*tc0 &
+               + sa(6)*cse(16)*cse(16) + sa(7)*tc0*tc0*cse(16) &
+               + sa(8)*tc0*cse(16)*cse(16) + sa(9)*tc0*tc0*tc0 &
+               + sa(10)*cse(16)*cse(16)*cse(16)
+         a_ = 10.0**loga_
+         b_ = sb(1)+ sb(2)*tc0 + sb(3)*cse(16) + sb(4)*tc0*cse(16) &
+              + sb(5)*tc0*tc0 + sb(6)*cse(16)*cse(16) &
+              + sb(7)*tc0*tc0*cse(16) + sb(8)*tc0*cse(16)*cse(16) &
+              + sb(9)*tc0*tc0*tc0 + sb(10)*cse(16)*cse(16)*cse(16)
+         smof(k,col) = a_ * smo2(k,col)**b_
+
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Calculate y-intercept, slope values for graupel.
+!+---+-----------------------------------------------------------------+
+      N0_min = gonv_max
+      do k = kte, kts, -1
+         if (temp(k,col).lt.270.65 .and. L_qr(k,col) .and. mvd_r(k,col).gt.100.E-6) then
+            xslw1 = 4.01 + alog10(mvd_r(k,col))
+         else
+            xslw1 = 0.01
+         endif
+         ygra1 = 4.31 + alog10(max(5.E-5, rg(k,col)))
+         zans1 = 3.1 + (100./(300.*xslw1*ygra1/(10./xslw1+1.+0.25*ygra1)+30.+10.*ygra1))
+         N0_exp = 10.**(zans1)
+         N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
+         N0_min = MIN(N0_exp, N0_min)
+         N0_exp = N0_min
+         lam_exp = (N0_exp*am_g*cgg(1)/rg(k,col))**oge1
+         lamg = lam_exp * (cgg(3)*ogg2*ogg1)**obmg
+         ilamg(k,col) = 1./lamg
+         N0_g(k,col) = N0_exp/(cgg(2)*lam_exp) * lamg**cge(2)
+      enddo
+      enddo
+!$acc end kernels
+      endif
+
+!$acc kernels
+      do col = 1,ncol
+      if (no_micro(col)) CYCLE
+!+---+-----------------------------------------------------------------+
+!..Calculate y-intercept, slope values for rain.
+!+---+-----------------------------------------------------------------+
+      do k = kte, kts, -1
+         lamr = (am_r*crg(3)*org2*nr(k,col)/rr(k,col))**obmr
+         ilamr(k,col) = 1./lamr
+         mvd_r(k,col) = (3.0 + mu_r + 0.672) / lamr
+         N0_r(k,col) = nr(k,col)*org2*lamr**cre(2)
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Compute warm-rain process terms (except evap done later).
+!+---+-----------------------------------------------------------------+
+!$acc loop private(nu_c,xDc,lamc)
+      do k = kts, kte
+
+!..Rain self-collection follows Seifert, 1994 and drop break-up
+!.. follows Verlinde and Cotton, 1993.                                        RAIN2M
+         if (L_qr(k,col) .and. mvd_r(k,col).gt. D0r) then
+!-GT      Ef_rr = 1.0
+!-GT      if (mvd_r(k,col) .gt. 1500.0E-6) then
+             Ef_rr = 2.0 - EXP(2300.0*(mvd_r(k,col)-1600.0E-6))
+!-GT      endif
+          pnr_rcr(k,col) = Ef_rr * 0.5*nr(k,col)*rr(k,col)
+         endif
+
+         mvd_c(k,col) = D0c
+         if (L_qc(k,col)) then
+          nu_c = MIN(15, NINT(1000.E6/nc(k,col)) + 2)
+          xDc = MAX(D0c*1.E6, ((rc(k,col)/(am_r*nc(k,col)))**obmr) * 1.E6)
+          lamc = (nc(k,col)*am_r* ccg(2,nu_c) * ocg1(nu_c) / rc(k,col))**obmr
+          mvd_c(k,col) = (3.0+nu_c+0.672) / lamc
+         endif
+
+!..Autoconversion follows Berry & Reinhardt (1974) with characteristic
+!.. diameters correctly computed from gamma distrib of cloud droplets.
+         if (rc(k,col).gt. 0.01e-3) then
+          Dc_g = ((ccg(3,nu_c)*ocg2(nu_c))**obmr / lamc) * 1.E6
+          Dc_b = (xDc*xDc*xDc*Dc_g*Dc_g*Dc_g - xDc*xDc*xDc*xDc*xDc*xDc) &
+                 **(1./6.)
+          zeta1 = 0.5*((6.25E-6*xDc*Dc_b*Dc_b*Dc_b - 0.4) &
+                     + abs(6.25E-6*xDc*Dc_b*Dc_b*Dc_b - 0.4))
+          zeta = 0.027*rc(k,col)*zeta1
+          taud = 0.5*((0.5*Dc_b - 7.5) + abs(0.5*Dc_b - 7.5)) + R1
+          tau  = 3.72/(rc(k,col)*taud)
+          prr_wau(k,col) = zeta/tau
+          prr_wau(k,col) = MIN(DBLE(rc(k,col)*odts), prr_wau(k,col))
+          pnr_wau(k,col) = prr_wau(k,col) / (am_r*nu_c*D0r*D0r*D0r)              ! RAIN2M
+          pnc_wau(k,col) = MIN(DBLE(nc(k,col)*odts), prr_wau(k,col)                 &
+                     / (am_r*mvd_c(k,col)*mvd_c(k,col)*mvd_c(k,col)))                   ! Qc2M
+         endif
+
+!..Rain collecting cloud water.  In CE, assume Dc<<Dr and vtc=~0.
+         if (L_qr(k,col) .and. mvd_r(k,col).gt. D0r .and. mvd_c(k,col).gt. D0c) then
+          lamr = 1./ilamr(k,col)
+          idx = 1 + INT(nbr*DLOG(mvd_r(k,col)/Dr(1))/DLOG(Dr(nbr)/Dr(1)))
+          idx = MIN(idx, nbr)
+          Ef_rw = t_Efrw(idx, INT(mvd_c(k,col)*1.E6))
+          prr_rcw(k,col) = rhof(k,col)*t1_qr_qc*Ef_rw*rc(k,col)*N0_r(k,col) &
+                         *((lamr+fv_r)**(-cre(9)))
+          prr_rcw(k,col) = MIN(DBLE(rc(k,col)*odts), prr_rcw(k,col))
+          pnc_rcw(k,col) = rhof(k,col)*t1_qr_qc*Ef_rw*nc(k,col)*N0_r(k,col)             &
+                         *((lamr+fv_r)**(-cre(9)))                          ! Qc2M
+          pnc_rcw(k,col) = MIN(DBLE(nc(k,col)*odts), pnc_rcw(k,col))
+         endif
+
+!..Rain collecting aerosols, wet scavenging.
+         if (L_qr(k,col) .and. mvd_r(k,col).gt. D0r) then
+          Ef_ra = Eff_aero(mvd_r(k,col),0.04E-6,visco(k,col),rho(k,col),temp(k,col),'r')
+          lamr = 1./ilamr(k,col)
+          pna_rca(k,col) = rhof(k,col)*t1_qr_qc*Ef_ra*nwfa(k,col)*N0_r(k,col)           &
+                         *((lamr+fv_r)**(-cre(9)))
+          pna_rca(k,col) = MIN(DBLE(nwfa(k,col)*odts), pna_rca(k,col))
+
+          Ef_ra = Eff_aero(mvd_r(k,col),0.8E-6,visco(k,col),rho(k,col),temp(k,col),'r')
+          pnd_rcd(k,col) = rhof(k,col)*t1_qr_qc*Ef_ra*nifa(k,col)*N0_r(k,col)           &
+                         *((lamr+fv_r)**(-cre(9)))
+          pnd_rcd(k,col) = MIN(DBLE(nifa(k,col)*odts), pnd_rcd(k,col))
+         endif
+
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Compute all frozen hydrometeor species' process terms.
+!+---+-----------------------------------------------------------------+
+      if (.not. iiwarm) then
+!$acc loop private(ef_gw,tempc)      
+      do k = kts, kte
+         vts_boost(k,col) = 1.5
+
+!..Temperature lookup table indexes.
+         tempc = temp(k,col) - 273.15
+         idx_tc = MAX(1, MIN(NINT(-tempc), 45) )
+         idx_t = INT( (tempc-2.5)/5. ) - 1
+         idx_t = MAX(1, -idx_t)
+         idx_t = MIN(idx_t, ntb_t)
+         IT = MAX(1, MIN(NINT(-tempc), 31) )
+
+!..Cloud water lookup table index.
+         if (rc(k,col).gt. r_c(1)) then
+          nic = NINT(ALOG10(rc(k,col)))
+          do nn = nic-1, nic+1
+             n = nn
+             if ( (rc(k,col)/10.**nn).ge.1.0 .and. &
+                  (rc(k,col)/10.**nn).lt.10.0) goto 141
+          enddo
+ 141      continue
+          idx_c = INT(rc(k,col)/10.**n) + 10*(n-nic2) - (n-nic2)
+          idx_c = MAX(1, MIN(idx_c, ntb_c))
+         else
+          idx_c = 1
+         endif
+
+!..Cloud droplet number lookup table index.
+         idx_n = NINT(1.0 + FLOAT(nbc) * DLOG(nc(k,col)/t_Nc(1)) / nic1)
+         idx_n = MAX(1, MIN(idx_n, nbc))
+
+!..Cloud ice lookup table indexes.
+         if (ri(k,col).gt. r_i(1)) then
+          nii = NINT(ALOG10(ri(k,col)))
+          do nn = nii-1, nii+1
+             n = nn
+             if ( (ri(k,col)/10.**nn).ge.1.0 .and. &
+                  (ri(k,col)/10.**nn).lt.10.0) goto 142
+          enddo
+ 142      continue
+          idx_i = INT(ri(k,col)/10.**n) + 10*(n-nii2) - (n-nii2)
+          idx_i = MAX(1, MIN(idx_i, ntb_i))
+         else
+          idx_i = 1
+         endif
+
+         if (ni(k,col).gt. Nt_i(1)) then
+          nii = NINT(ALOG10(ni(k,col)))
+          do nn = nii-1, nii+1
+             n = nn
+             if ( (ni(k,col)/10.**nn).ge.1.0 .and. &
+                  (ni(k,col)/10.**nn).lt.10.0) goto 143
+          enddo
+ 143      continue
+          idx_i1 = INT(ni(k,col)/10.**n) + 10*(n-nii3) - (n-nii3)
+          idx_i1 = MAX(1, MIN(idx_i1, ntb_i1))
+         else
+          idx_i1 = 1
+         endif
+
+!..Rain lookup table indexes.
+         if (rr(k,col).gt. r_r(1)) then
+          nir = NINT(ALOG10(rr(k,col)))
+          do nn = nir-1, nir+1
+             n = nn
+             if ( (rr(k,col)/10.**nn).ge.1.0 .and. &
+                  (rr(k,col)/10.**nn).lt.10.0) goto 144
+          enddo
+ 144      continue
+          idx_r = INT(rr(k,col)/10.**n) + 10*(n-nir2) - (n-nir2)
+          idx_r = MAX(1, MIN(idx_r, ntb_r))
+
+          lamr = 1./ilamr(k,col)
+          lam_exp = lamr * (crg(3)*org2*org1)**bm_r
+          N0_exp = org1*rr(k,col)/am_r * lam_exp**cre(1)
+          nir = NINT(DLOG10(N0_exp))
+          do nn = nir-1, nir+1
+             n = nn
+             if ( (N0_exp/10.**nn).ge.1.0 .and. &
+                  (N0_exp/10.**nn).lt.10.0) goto 145
+          enddo
+ 145      continue
+          idx_r1 = INT(N0_exp/10.**n) + 10*(n-nir3) - (n-nir3)
+          idx_r1 = MAX(1, MIN(idx_r1, ntb_r1))
+         else
+          idx_r = 1
+          idx_r1 = ntb_r1
+         endif
+
+!..Snow lookup table index.
+         if (rs(k,col).gt. r_s(1)) then
+          nis = NINT(ALOG10(rs(k,col)))
+          do nn = nis-1, nis+1
+             n = nn
+             if ( (rs(k,col)/10.**nn).ge.1.0 .and. &
+                  (rs(k,col)/10.**nn).lt.10.0) goto 146
+          enddo
+ 146      continue
+          idx_s = INT(rs(k,col)/10.**n) + 10*(n-nis2) - (n-nis2)
+          idx_s = MAX(1, MIN(idx_s, ntb_s))
+         else
+          idx_s = 1
+         endif
+
+!..Graupel lookup table index.
+         if (rg(k,col).gt. r_g(1)) then
+          nig = NINT(ALOG10(rg(k,col)))
+          do nn = nig-1, nig+1
+             n = nn
+             if ( (rg(k,col)/10.**nn).ge.1.0 .and. &
+                  (rg(k,col)/10.**nn).lt.10.0) goto 147
+          enddo
+ 147      continue
+          idx_g = INT(rg(k,col)/10.**n) + 10*(n-nig2) - (n-nig2)
+          idx_g = MAX(1, MIN(idx_g, ntb_g))
+
+          lamg = 1./ilamg(k,col)
+          lam_exp = lamg * (cgg(3)*ogg2*ogg1)**bm_g
+          N0_exp = ogg1*rg(k,col)/am_g * lam_exp**cge(1)
+          nig = NINT(DLOG10(N0_exp))
+          do nn = nig-1, nig+1
+             n = nn
+             if ( (N0_exp/10.**nn).ge.1.0 .and. &
+                  (N0_exp/10.**nn).lt.10.0) goto 148
+          enddo
+ 148      continue
+          idx_g1 = INT(N0_exp/10.**n) + 10*(n-nig3) - (n-nig3)
+          idx_g1 = MAX(1, MIN(idx_g1, ntb_g1))
+         else
+          idx_g = 1
+          idx_g1 = ntb_g1
+         endif
+
+!..Deposition/sublimation prefactor (from Srivastava & Coen 1992).
+         otemp = 1./temp(k,col)
+         rvs = rho(k,col)*qvsi(k,col)
+         rvs_p = rvs*otemp*(lsub*otemp*oRv - 1.)
+         rvs_pp = rvs * ( otemp*(lsub*otemp*oRv - 1.) &
+                         *otemp*(lsub*otemp*oRv - 1.) &
+                         + (-2.*lsub*otemp*otemp*otemp*oRv) &
+                         + otemp*otemp)
+         gamsc = lsub*diffu(k,col)/tcond(k,col) * rvs_p
+         alphsc = 0.5*(gamsc/(1.+gamsc))*(gamsc/(1.+gamsc)) &
+                    * rvs_pp/rvs_p * rvs/rvs_p
+         alphsc = MAX(1.E-9, alphsc)
+         xsat = ssati(k,col)
+         if (abs(xsat).lt. 1.E-9) xsat=0.
+         t1_subl = 4.*PI*( 1.0 - alphsc*xsat &
+                + 2.*alphsc*alphsc*xsat*xsat &
+                - 5.*alphsc*alphsc*alphsc*xsat*xsat*xsat ) &
+                / (1.+gamsc)
+
+!..Snow collecting cloud water.  In CE, assume Dc<<Ds and vtc=~0.
+         if (L_qc(k,col) .and. mvd_c(k,col).gt. D0c) then
+          xDs = 0.0
+          if (L_qs(k,col)) xDs = smoc(k,col) / smob(k,col)
+          if (xDs .gt. D0s) then
+           idx = 1 + INT(nbs*DLOG(xDs/Ds(1))/DLOG(Ds(nbs)/Ds(1)))
+           idx = MIN(idx, nbs)
+           Ef_sw = t_Efsw(idx, INT(mvd_c(k,col)*1.E6))
+           prs_scw(k,col) = rhof(k,col)*t1_qs_qc*Ef_sw*rc(k,col)*smoe(k,col)
+           pnc_scw(k,col) = rhof(k,col)*t1_qs_qc*Ef_sw*nc(k,col)*smoe(k,col)                ! Qc2M
+           pnc_scw(k,col) = MIN(DBLE(nc(k,col)*odts), pnc_scw(k,col))
+          endif
+
+!..Graupel collecting cloud water.  In CE, assume Dc<<Dg and vtc=~0.
+          if (rg(k,col).ge. r_g(1) .and. mvd_c(k,col).gt. D0c) then
+           xDg = (bm_g + mu_g + 1.) * ilamg(k,col)
+           vtg = rhof(k,col)*av_g*cgg(6)*ogg3 * ilamg(k,col)**bv_g
+           stoke_g = mvd_c(k,col)*mvd_c(k,col)*vtg*rho_w/(9.*visco(k,col)*xDg)
+           if (xDg.gt. D0g) then
+            if (stoke_g.ge.0.4 .and. stoke_g.le.10.) then
+             Ef_gw = 0.55*ALOG10(2.51*stoke_g)
+            elseif (stoke_g.lt.0.4) then
+             Ef_gw = 0.0
+            elseif (stoke_g.gt.10) then
+             Ef_gw = 0.77
+            endif
+            prg_gcw(k,col) = rhof(k,col)*t1_qg_qc*Ef_gw*rc(k,col)*N0_g(k,col) &
+                          *ilamg(k,col)**cge(9)
+            pnc_gcw(k,col) = rhof(k,col)*t1_qg_qc*Ef_gw*nc(k,col)*N0_g(k,col)           &
+                          *ilamg(k,col)**cge(9)                                 ! Qc2M
+            pnc_gcw(k,col) = MIN(DBLE(nc(k,col)*odts), pnc_gcw(k,col))
+           endif
+          endif
+         endif
+
+!..Snow and graupel collecting aerosols, wet scavenging.
+         if (rs(k,col) .gt. r_s(1)) then
+          xDs = smoc(k,col) / smob(k,col)
+          Ef_sa = Eff_aero(xDs,0.04E-6,visco(k,col),rho(k,col),temp(k,col),'s')
+          pna_sca(k,col) = rhof(k,col)*t1_qs_qc*Ef_sa*nwfa(k,col)*smoe(k,col)
+          pna_sca(k,col) = MIN(DBLE(nwfa(k,col)*odts), pna_sca(k,col))
+
+          Ef_sa = Eff_aero(xDs,0.8E-6,visco(k,col),rho(k,col),temp(k,col),'s')
+          pnd_scd(k,col) = rhof(k,col)*t1_qs_qc*Ef_sa*nifa(k,col)*smoe(k,col)
+          pnd_scd(k,col) = MIN(DBLE(nifa(k,col)*odts), pnd_scd(k,col))
+         endif
+         if (rg(k,col) .gt. r_g(1)) then
+          xDg = (bm_g + mu_g + 1.) * ilamg(k,col)
+          Ef_ga = Eff_aero(xDg,0.04E-6,visco(k,col),rho(k,col),temp(k,col),'g')
+          pna_gca(k,col) = rhof(k,col)*t1_qg_qc*Ef_ga*nwfa(k,col)*N0_g(k,col)           &
+                        *ilamg(k,col)**cge(9)
+          pna_gca(k,col) = MIN(DBLE(nwfa(k,col)*odts), pna_gca(k,col))
+
+          Ef_ga = Eff_aero(xDg,0.8E-6,visco(k,col),rho(k,col),temp(k,col),'g')
+          pnd_gcd(k,col) = rhof(k,col)*t1_qg_qc*Ef_ga*nifa(k,col)*N0_g(k,col)           &
+                        *ilamg(k,col)**cge(9)
+          pnd_gcd(k,col) = MIN(DBLE(nifa(k,col)*odts), pnd_gcd(k,col))
+         endif
+
+!..Rain collecting snow.  Cannot assume Wisner (1972) approximation
+!.. or Mizuno (1990) approach so we solve the CE explicitly and store
+!.. results in lookup table.
+         if (rr(k,col).ge. r_r(1)) then
+          if (rs(k,col).ge. r_s(1)) then
+           if (temp(k,col).lt.T_0) then
+            prr_rcs(k,col) = -(tmr_racs2(idx_s,idx_t,idx_r1,idx_r) &
+                           + tcr_sacr2(idx_s,idx_t,idx_r1,idx_r) &
+                           + tmr_racs1(idx_s,idx_t,idx_r1,idx_r) &
+                           + tcr_sacr1(idx_s,idx_t,idx_r1,idx_r))
+            prs_rcs(k,col) = tmr_racs2(idx_s,idx_t,idx_r1,idx_r) &
+                         + tcr_sacr2(idx_s,idx_t,idx_r1,idx_r) &
+                         - tcs_racs1(idx_s,idx_t,idx_r1,idx_r) &
+                         - tms_sacr1(idx_s,idx_t,idx_r1,idx_r)
+            prg_rcs(k,col) = tmr_racs1(idx_s,idx_t,idx_r1,idx_r) &
+                         + tcr_sacr1(idx_s,idx_t,idx_r1,idx_r) &
+                         + tcs_racs1(idx_s,idx_t,idx_r1,idx_r) &
+                         + tms_sacr1(idx_s,idx_t,idx_r1,idx_r)
+            prr_rcs(k,col) = MAX(DBLE(-rr(k,col)*odts), prr_rcs(k,col))
+            prs_rcs(k,col) = MAX(DBLE(-rs(k,col)*odts), prs_rcs(k,col))
+            prg_rcs(k,col) = MIN(DBLE((rr(k,col)+rs(k,col))*odts), prg_rcs(k,col))
+            pnr_rcs(k,col) = tnr_racs1(idx_s,idx_t,idx_r1,idx_r)            &   ! RAIN2M
+                         + tnr_racs2(idx_s,idx_t,idx_r1,idx_r)          &
+                         + tnr_sacr1(idx_s,idx_t,idx_r1,idx_r)          &
+                         + tnr_sacr2(idx_s,idx_t,idx_r1,idx_r)
+           else
+            prs_rcs(k,col) = -tcs_racs1(idx_s,idx_t,idx_r1,idx_r)           &
+                         - tms_sacr1(idx_s,idx_t,idx_r1,idx_r)          &
+                         + tmr_racs2(idx_s,idx_t,idx_r1,idx_r)          &
+                         + tcr_sacr2(idx_s,idx_t,idx_r1,idx_r)
+            prs_rcs(k,col) = MAX(DBLE(-rs(k,col)*odts), prs_rcs(k,col))
+            prr_rcs(k,col) = -prs_rcs(k,col)
+            pnr_rcs(k,col) = tnr_racs2(idx_s,idx_t,idx_r1,idx_r)            &   ! RAIN2M
+                         + tnr_sacr2(idx_s,idx_t,idx_r1,idx_r)
+           endif
+           pnr_rcs(k,col) = MIN(DBLE(nr(k,col)*odts), pnr_rcs(k,col))
+          endif
+
+!..Rain collecting graupel.  Cannot assume Wisner (1972) approximation
+!.. or Mizuno (1990) approach so we solve the CE explicitly and store
+!.. results in lookup table.
+          if (rg(k,col).ge. r_g(1)) then
+           if (temp(k,col).lt.T_0) then
+            prg_rcg(k,col) = tmr_racg(idx_g1,idx_g,idx_r1,idx_r) &
+                         + tcr_gacr(idx_g1,idx_g,idx_r1,idx_r)
+            prg_rcg(k,col) = MIN(DBLE(rr(k,col)*odts), prg_rcg(k,col))
+            prr_rcg(k,col) = -prg_rcg(k,col)
+            pnr_rcg(k,col) = tnr_racg(idx_g1,idx_g,idx_r1,idx_r)            &   ! RAIN2M
+                         + tnr_gacr(idx_g1,idx_g,idx_r1,idx_r)
+            pnr_rcg(k,col) = MIN(DBLE(nr(k,col)*odts), pnr_rcg(k,col))
+           else
+            prr_rcg(k,col) = tcg_racg(idx_g1,idx_g,idx_r1,idx_r)
+            prr_rcg(k,col) = MIN(DBLE(rg(k,col)*odts), prr_rcg(k,col))
+            prg_rcg(k,col) = -prr_rcg(k,col)
+!..Put in explicit drop break-up due to collisions.
+            pnr_rcg(k,col) = -5.*tnr_gacr(idx_g1,idx_g,idx_r1,idx_r)         ! RAIN2M
+           endif
+          endif
+         endif
+
+!+---+-----------------------------------------------------------------+
+!..Next IF block handles only those processes below 0C.
+!+---+-----------------------------------------------------------------+
+
+         if (temp(k,col).lt.T_0) then
+
+          vts_boost(k,col) = 1.0
+          rate_max = (qv(k,col)-qvsi(k,col))*rho(k,col)*odts*0.999
+
+!+---+---------------- BEGIN NEW ICE NUCLEATION -----------------------+
+!..Freezing of supercooled water (rain or cloud) is influenced by dust
+!.. but still using Bigg 1953 with a temperature adjustment of a few
+!.. degrees depending on dust concentration.  A default value by way
+!.. of idx_IN is 1.0 per Liter of air is used when dustyIce flag is
+!.. false.  Next, a combination of deposition/condensation freezing
+!.. using DeMott et al (2010) dust nucleation when water saturated or
+!.. Phillips et al (2008) when below water saturation; else, without
+!.. dustyIce flag, use the previous Cooper (1986) temperature-dependent
+!.. value.  Lastly, allow homogeneous freezing of deliquesced aerosols
+!.. following Koop et al. (2001, Nature).
+!.. Implemented by T. Eidhammer and G. Thompson 2012Dec18
+!+---+-----------------------------------------------------------------+
+
+          if (dustyIce .AND. is_aerosol_aware) then
+           xni = iceDeMott(tempc,qvs(k,col),qvs(k,col),qvsi(k,col),rho(k,col),nifa(k,col))
+          else
+           xni = 1.0 *1000.                                               ! Default is 1.0 per Liter
+          endif
+
+!..Ice nuclei lookup table index.
+          if (xni.gt. Nt_IN(1)) then
+           niin = NINT(ALOG10(xni))
+           do nn = niin-1, niin+1
+              n = nn
+              if ( (xni/10.**nn).ge.1.0 .and. &
+                   (xni/10.**nn).lt.10.0) goto 149
+           enddo
+ 149       continue
+           idx_IN = INT(xni/10.**n) + 10*(n-niin2) - (n-niin2)
+           idx_IN = MAX(1, MIN(idx_IN, ntb_IN))
+          else
+           idx_IN = 1
+          endif
+
+!..Freezing of water drops into graupel/cloud ice (Bigg 1953).
+          if (rr(k,col).gt. r_r(1)) then
+           prg_rfz(k,col) = tpg_qrfz(idx_r,idx_r1,idx_tc,idx_IN)*odts
+           pri_rfz(k,col) = tpi_qrfz(idx_r,idx_r1,idx_tc,idx_IN)*odts
+           pni_rfz(k,col) = tni_qrfz(idx_r,idx_r1,idx_tc,idx_IN)*odts
+           pnr_rfz(k,col) = tnr_qrfz(idx_r,idx_r1,idx_tc,idx_IN)*odts          ! RAIN2M
+           pnr_rfz(k,col) = MIN(DBLE(nr(k,col)*odts), pnr_rfz(k,col))
+          elseif (rr(k,col).gt. R1 .and. temp(k,col).lt.HGFR) then
+           pri_rfz(k,col) = rr(k,col)*odts
+           pnr_rfz(k,col) = nr(k,col)*odts                                         ! RAIN2M
+           pni_rfz(k,col) = pnr_rfz(k,col)
+          endif
+
+          if (rc(k,col).gt. r_c(1)) then
+           pri_wfz(k,col) = tpi_qcfz(idx_c,idx_n,idx_tc,idx_IN)*odts
+           pri_wfz(k,col) = MIN(DBLE(rc(k,col)*odts), pri_wfz(k,col))
+           pni_wfz(k,col) = tni_qcfz(idx_c,idx_n,idx_tc,idx_IN)*odts
+           pni_wfz(k,col) = MIN(DBLE(nc(k,col)*odts), pri_wfz(k,col)/(2.*xm0i),     &
+                                pni_wfz(k,col))
+          elseif (rc(k,col).gt. R1 .and. temp(k,col).lt.HGFR) then
+           pri_wfz(k,col) = rc(k,col)*odts
+           pni_wfz(k,col) = nc(k,col)*odts
+          endif
+
+!..Deposition nucleation of dust/mineral from DeMott et al (2010)
+!.. we may need to relax the temperature and ssati constraints.
+          if ( (ssati(k,col).ge. 0.25) .or. (ssatw(k,col).gt. eps &
+                                .and. temp(k,col).lt.261.15) ) then
+           if (dustyIce .AND. is_aerosol_aware) then
+            xnc = iceDeMott(tempc,qv(k,col),qvs(k,col),qvsi(k,col),rho(k,col),nifa(k,col))
+           else
+            xnc = MIN(250.E3, TNO*EXP(ATO*(T_0-temp(k,col))))
+           endif
+           xni = ni(k,col) + (pni_rfz(k,col)+pni_wfz(k,col))*dtsave
+           pni_inu(k,col) = 0.5*(xnc-xni + abs(xnc-xni))*odts
+           pri_inu(k,col) = MIN(DBLE(rate_max), xm0i*pni_inu(k,col))
+           pni_inu(k,col) = pri_inu(k,col)/xm0i
+          endif
+
+!..Freezing of aqueous aerosols based on Koop et al (2001, Nature)
+          xni = smo0(k,col)+ni(k,col) + (pni_rfz(k,col)+pni_wfz(k,col)+pni_inu(k,col))*dtsave
+          if (is_aerosol_aware .AND. homogIce .AND. (xni.le.500.E3)     &
+     &                .AND.(temp(k,col).lt.238).AND.(ssati(k,col).ge.0.4) ) then
+            xnc = iceKoop(temp(k,col),qv(k,col),qvs(k,col),nwfa(k,col), dtsave)
+            pni_iha(k,col) = xnc*odts
+            pri_iha(k,col) = MIN(DBLE(rate_max), xm0i*0.1*pni_iha(k,col))
+            pni_iha(k,col) = pri_iha(k,col)/(xm0i*0.1)
+          endif
+!+---+------------------ END NEW ICE NUCLEATION -----------------------+
+
+
+!..Deposition/sublimation of cloud ice (Srivastava & Coen 1992).
+          if (L_qi(k,col)) then
+           lami = (am_i*cig(2)*oig1*ni(k,col)/ri(k,col))**obmi
+           ilami = 1./lami
+           xDi = MAX(DBLE(D0i), (bm_i + mu_i + 1.) * ilami)
+           xmi = am_i*xDi**bm_i
+           oxmi = 1./xmi
+           pri_ide(k,col) = C_cube*t1_subl*diffu(k,col)*ssati(k,col)*rvs &
+                  *oig1*cig(5)*ni(k,col)*ilami
+
+           if (pri_ide(k,col) .lt. 0.0) then
+            pri_ide(k,col) = MAX(DBLE(-ri(k,col)*odts), pri_ide(k,col), DBLE(rate_max))
+            pni_ide(k,col) = pri_ide(k,col)*oxmi
+            pni_ide(k,col) = MAX(DBLE(-ni(k,col)*odts), pni_ide(k,col))
+           else
+            pri_ide(k,col) = MIN(pri_ide(k,col), DBLE(rate_max))
+            prs_ide(k,col) = (1.0D0-tpi_ide(idx_i,idx_i1))*pri_ide(k,col)
+            pri_ide(k,col) = tpi_ide(idx_i,idx_i1)*pri_ide(k,col)
+           endif
+
+!..Some cloud ice needs to move into the snow category.  Use lookup
+!.. table that resulted from explicit bin representation of distrib.
+           if ( (idx_i.eq. ntb_i) .or. (xDi.gt. 5.0*D0s) ) then
+            prs_iau(k,col) = ri(k,col)*.99*odts
+            pni_iau(k,col) = ni(k,col)*.95*odts
+           elseif (xDi.lt. 0.1*D0s) then
+            prs_iau(k,col) = 0.
+            pni_iau(k,col) = 0.
+           else
+            prs_iau(k,col) = tps_iaus(idx_i,idx_i1)*odts
+            prs_iau(k,col) = MIN(DBLE(ri(k,col)*.99*odts), prs_iau(k,col))
+            pni_iau(k,col) = tni_iaus(idx_i,idx_i1)*odts
+            pni_iau(k,col) = MIN(DBLE(ni(k,col)*.95*odts), pni_iau(k,col))
+           endif
+          endif
+
+!..Deposition/sublimation of snow/graupel follows Srivastava & Coen
+!.. (1992).
+          if (L_qs(k,col)) then
+           C_snow = C_sqrd + (tempc+15.)*(C_cube-C_sqrd)/(-30.+15.)
+           C_snow = MAX(C_sqrd, MIN(C_snow, C_cube))
+           prs_sde(k,col) = C_snow*t1_subl*diffu(k,col)*ssati(k,col)*rvs &
+                        * (t1_qs_sd*smo1(k,col) &
+                         + t2_qs_sd*rhof2(k,col)*vsc2(k,col)*smof(k,col))
+           if (prs_sde(k,col).lt. 0.) then
+            prs_sde(k,col) = MAX(DBLE(-rs(k,col)*odts), prs_sde(k,col), DBLE(rate_max))
+           else
+            prs_sde(k,col) = MIN(prs_sde(k,col), DBLE(rate_max))
+           endif
+          endif
+
+          if (L_qg(k,col) .and. ssati(k,col).lt. -eps) then
+           prg_gde(k,col) = C_cube*t1_subl*diffu(k,col)*ssati(k,col)*rvs &
+               * N0_g(k,col) * (t1_qg_sd*ilamg(k,col)**cge(10) &
+               + t2_qg_sd*vsc2(k,col)*rhof2(k,col)*ilamg(k,col)**cge(11))
+           if (prg_gde(k,col).lt. 0.) then
+            prg_gde(k,col) = MAX(DBLE(-rg(k,col)*odts), prg_gde(k,col), DBLE(rate_max))
+           else
+            prg_gde(k,col) = MIN(prg_gde(k,col), DBLE(rate_max))
+           endif
+          endif
+
+!..Snow collecting cloud ice.  In CE, assume Di<<Ds and vti=~0.
+          if (L_qi(k,col)) then
+           lami = (am_i*cig(2)*oig1*ni(k,col)/ri(k,col))**obmi
+           ilami = 1./lami
+           xDi = MAX(DBLE(D0i), (bm_i + mu_i + 1.) * ilami)
+           xmi = am_i*xDi**bm_i
+           oxmi = 1./xmi
+           if (rs(k,col).ge. r_s(1)) then
+            prs_sci(k,col) = t1_qs_qi*rhof(k,col)*Ef_si*ri(k,col)*smoe(k,col)
+            pni_sci(k,col) = prs_sci(k,col) * oxmi
+           endif
+
+!..Rain collecting cloud ice.  In CE, assume Di<<Dr and vti=~0.
+           if (rr(k,col).ge. r_r(1) .and. mvd_r(k,col).gt. 4.*xDi) then
+            lamr = 1./ilamr(k,col)
+            pri_rci(k,col) = rhof(k,col)*t1_qr_qi*Ef_ri*ri(k,col)*N0_r(k,col) &
+                           *((lamr+fv_r)**(-cre(9)))
+            pnr_rci(k,col) = rhof(k,col)*t1_qr_qi*Ef_ri*ni(k,col)*N0_r(k,col)           &   ! RAIN2M
+                           *((lamr+fv_r)**(-cre(9)))
+            pni_rci(k,col) = pri_rci(k,col) * oxmi
+            prr_rci(k,col) = rhof(k,col)*t2_qr_qi*Ef_ri*ni(k,col)*N0_r(k,col) &
+                           *((lamr+fv_r)**(-cre(8)))
+            prr_rci(k,col) = MIN(DBLE(rr(k,col)*odts), prr_rci(k,col))
+            prg_rci(k,col) = pri_rci(k,col) + prr_rci(k,col)
+           endif
+          endif
+
+!..Ice multiplication from rime-splinters (Hallet & Mossop 1974).
+          if (prg_gcw(k,col).gt. eps .and. tempc.gt.-8.0) then
+           tf = 0.
+           if (tempc.ge.-5.0 .and. tempc.lt.-3.0) then
+            tf = 0.5*(-3.0 - tempc)
+           elseif (tempc.gt.-8.0 .and. tempc.lt.-5.0) then
+            tf = 0.33333333*(8.0 + tempc)
+           endif
+           pni_ihm(k,col) = 3.5E8*tf*prg_gcw(k,col)
+           pri_ihm(k,col) = xm0i*pni_ihm(k,col)
+           prs_ihm(k,col) = prs_scw(k,col)/(prs_scw(k,col)+prg_gcw(k,col)) &
+                          * pri_ihm(k,col)
+           prg_ihm(k,col) = prg_gcw(k,col)/(prs_scw(k,col)+prg_gcw(k,col)) &
+                          * pri_ihm(k,col)
+          endif
+
+!..A portion of rimed snow converts to graupel but some remains snow.
+!.. Interp from 5 to 75% as riming factor increases from 5.0 to 30.0
+!.. 0.028 came from (.75-.05)/(30.-5.).  This remains ad-hoc and should
+!.. be revisited.
+          if (prs_scw(k,col).gt.5.0*prs_sde(k,col) .and. &
+                         prs_sde(k,col).gt.eps) then
+           r_frac = MIN(30.0D0, prs_scw(k,col)/prs_sde(k,col))
+           g_frac = MIN(0.75, 0.05 + (r_frac-5.)*.028)
+           vts_boost(k,col) = MIN(1.5, 1.1 + (r_frac-5.)*.016)
+           prg_scw(k,col) = g_frac*prs_scw(k,col)
+           prs_scw(k,col) = (1. - g_frac)*prs_scw(k,col)
+          endif
+
+         else
+
+!..Melt snow and graupel and enhance from collisions with liquid.
+!.. We also need to sublimate snow and graupel if subsaturated.
+          if (L_qs(k,col)) then
+           prr_sml(k,col) = (tempc*tcond(k,col)-lvap0*diffu(k,col)*delQvs(k,col))       &
+                      * (t1_qs_me*smo1(k,col) + t2_qs_me*rhof2(k,col)*vsc2(k,col)*smof(k,col))
+           prr_sml(k,col) = prr_sml(k,col) + 4218.*olfus*tempc &
+                                   * (prr_rcs(k,col)+prs_scw(k,col))
+           prr_sml(k,col) = MIN(DBLE(rs(k,col)*odts), MAX(0.D0, prr_sml(k,col)))
+           pnr_sml(k,col) = smo0(k,col)/rs(k,col)*prr_sml(k,col) * 10.0**(-0.75*tempc)      ! RAIN2M
+           pnr_sml(k,col) = MIN(DBLE(smo0(k,col)*odts), pnr_sml(k,col))
+           if (tempc.gt.3.5 .or. rs(k,col).lt.0.005E-3) pnr_sml(k,col)=0.0
+
+           if (ssati(k,col).lt. 0.) then
+            prs_sde(k,col) = C_cube*t1_subl*diffu(k,col)*ssati(k,col)*rvs &
+                         * (t1_qs_sd*smo1(k,col) &
+                          + t2_qs_sd*rhof2(k,col)*vsc2(k,col)*smof(k,col))
+            prs_sde(k,col) = MAX(DBLE(-rs(k,col)*odts), prs_sde(k,col))
+           endif
+          endif
+
+          if (L_qg(k,col)) then
+           prr_gml(k,col) = (tempc*tcond(k,col)-lvap0*diffu(k,col)*delQvs(k,col))       &
+                      * N0_g(k,col)*(t1_qg_me*ilamg(k,col)**cge(10)             &
+                      + t2_qg_me*rhof2(k,col)*vsc2(k,col)*ilamg(k,col)**cge(11))
+!-GT       prr_gml(k,col) = prr_gml(k,col) + 4218.*olfus*tempc &
+!-GT                               * (prr_rcg(k,col)+prg_gcw(k,col))
+           prr_gml(k,col) = MIN(DBLE(rg(k,col)*odts), MAX(0.D0, prr_gml(k,col)))
+           pnr_gml(k,col) = N0_g(k,col)*cgg(2)*ilamg(k,col)**cge(2) / rg(k,col)         &   ! RAIN2M
+                      * prr_gml(k,col) * 10.0**(-0.25*tempc)
+           if (tempc.gt.7.5 .or. rg(k,col).lt.0.005E-3) pnr_gml(k,col)=0.0
+
+           if (ssati(k,col).lt. 0.) then
+            prg_gde(k,col) = C_cube*t1_subl*diffu(k,col)*ssati(k,col)*rvs &
+                * N0_g(k,col) * (t1_qg_sd*ilamg(k,col)**cge(10) &
+                + t2_qg_sd*vsc2(k,col)*rhof2(k,col)*ilamg(k,col)**cge(11))
+            prg_gde(k,col) = MAX(DBLE(-rg(k,col)*odts), prg_gde(k,col))
+           endif
+          endif
+
+!.. This change will be required if users run adaptive time step that
+!.. results in delta-t that is generally too long to allow cloud water
+!.. collection by snow/graupel above melting temperature.
+!.. Credit to Bjorn-Egil Nygaard for discovering.
+          if (dt .gt. 120.) then
+             prr_rcw(k,col)=prr_rcw(k,col)+prs_scw(k,col)+prg_gcw(k,col)
+             prs_scw(k,col)=0.
+             prg_gcw(k,col)=0.
+          endif
+
+         endif
+
+      enddo
+      endif
+
+!+---+-----------------------------------------------------------------+
+!..Ensure we do not deplete more hydrometeor species than exists.
+!+---+-----------------------------------------------------------------+
+      do k = kts, kte
+
+!..If ice supersaturated, ensure sum of depos growth terms does not
+!.. deplete more vapor than possibly exists.  If subsaturated, limit
+!.. sum of sublimation terms such that vapor does not reproduce ice
+!.. supersat again.
+         sump = pri_inu(k,col) + pri_ide(k,col) + prs_ide(k,col) &
+              + prs_sde(k,col) + prg_gde(k,col) + pri_iha(k,col)
+         rate_max = (qv(k,col)-qvsi(k,col))*odts*0.999
+         if ( (sump.gt. eps .and. sump.gt. rate_max) .or. &
+              (sump.lt. -eps .and. sump.lt. rate_max) ) then
+          ratio = rate_max/sump
+          pri_inu(k,col) = pri_inu(k,col) * ratio
+          pri_ide(k,col) = pri_ide(k,col) * ratio
+          pni_ide(k,col) = pni_ide(k,col) * ratio
+          prs_ide(k,col) = prs_ide(k,col) * ratio
+          prs_sde(k,col) = prs_sde(k,col) * ratio
+          prg_gde(k,col) = prg_gde(k,col) * ratio
+          pri_iha(k,col) = pri_iha(k,col) * ratio
+         endif
+
+!..Cloud water conservation.
+         sump = -prr_wau(k,col) - pri_wfz(k,col) - prr_rcw(k,col) &
+                - prs_scw(k,col) - prg_scw(k,col) - prg_gcw(k,col)
+         rate_max = -rc(k,col)*odts
+         if (sump.lt. rate_max .and. L_qc(k,col)) then
+          ratio = rate_max/sump
+          prr_wau(k,col) = prr_wau(k,col) * ratio
+          pri_wfz(k,col) = pri_wfz(k,col) * ratio
+          prr_rcw(k,col) = prr_rcw(k,col) * ratio
+          prs_scw(k,col) = prs_scw(k,col) * ratio
+          prg_scw(k,col) = prg_scw(k,col) * ratio
+          prg_gcw(k,col) = prg_gcw(k,col) * ratio
+         endif
+
+!..Cloud ice conservation.
+         sump = pri_ide(k,col) - prs_iau(k,col) - prs_sci(k,col) &
+                - pri_rci(k,col)
+         rate_max = -ri(k,col)*odts
+         if (sump.lt. rate_max .and. L_qi(k,col)) then
+          ratio = rate_max/sump
+          pri_ide(k,col) = pri_ide(k,col) * ratio
+          prs_iau(k,col) = prs_iau(k,col) * ratio
+          prs_sci(k,col) = prs_sci(k,col) * ratio
+          pri_rci(k,col) = pri_rci(k,col) * ratio
+         endif
+
+!..Rain conservation.
+         sump = -prg_rfz(k,col) - pri_rfz(k,col) - prr_rci(k,col) &
+                + prr_rcs(k,col) + prr_rcg(k,col)
+         rate_max = -rr(k,col)*odts
+         if (sump.lt. rate_max .and. L_qr(k,col)) then
+          ratio = rate_max/sump
+          prg_rfz(k,col) = prg_rfz(k,col) * ratio
+          pri_rfz(k,col) = pri_rfz(k,col) * ratio
+          prr_rci(k,col) = prr_rci(k,col) * ratio
+          prr_rcs(k,col) = prr_rcs(k,col) * ratio
+          prr_rcg(k,col) = prr_rcg(k,col) * ratio
+         endif
+
+!..Snow conservation.
+         sump = prs_sde(k,col) - prs_ihm(k,col) - prr_sml(k,col) &
+                + prs_rcs(k,col)
+         rate_max = -rs(k,col)*odts
+         if (sump.lt. rate_max .and. L_qs(k,col)) then
+          ratio = rate_max/sump
+          prs_sde(k,col) = prs_sde(k,col) * ratio
+          prs_ihm(k,col) = prs_ihm(k,col) * ratio
+          prr_sml(k,col) = prr_sml(k,col) * ratio
+          prs_rcs(k,col) = prs_rcs(k,col) * ratio
+         endif
+
+!..Graupel conservation.
+         sump = prg_gde(k,col) - prg_ihm(k,col) - prr_gml(k,col) &
+              + prg_rcg(k,col)
+         rate_max = -rg(k,col)*odts
+         if (sump.lt. rate_max .and. L_qg(k,col)) then
+          ratio = rate_max/sump
+          prg_gde(k,col) = prg_gde(k,col) * ratio
+          prg_ihm(k,col) = prg_ihm(k,col) * ratio
+          prr_gml(k,col) = prr_gml(k,col) * ratio
+          prg_rcg(k,col) = prg_rcg(k,col) * ratio
+         endif
+
+!..Re-enforce proper mass conservation for subsequent elements in case
+!.. any of the above terms were altered.  Thanks P. Blossey. 2009Sep28
+         pri_ihm(k,col) = prs_ihm(k,col) + prg_ihm(k,col)
+         ratio = MIN( ABS(prr_rcg(k,col)), ABS(prg_rcg(k,col)) )
+         prr_rcg(k,col) = ratio * SIGN(1.0, SNGL(prr_rcg(k,col)))
+         prg_rcg(k,col) = -prr_rcg(k,col)
+         if (temp(k,col).gt.T_0) then
+            ratio = MIN( ABS(prr_rcs(k,col)), ABS(prs_rcs(k,col)) )
+            prr_rcs(k,col) = ratio * SIGN(1.0, SNGL(prr_rcs(k,col)))
+            prs_rcs(k,col) = -prr_rcs(k,col)
+         endif
+
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Calculate tendencies of all species but constrain the number of ice
+!.. to reasonable values.
+!+---+-----------------------------------------------------------------+
+      do k = kts, kte
+         orho = 1./rho(k,col)
+         lfus2 = lsub - lvap(k,col)
+
+!..Aerosol number tendency
+         if (is_aerosol_aware) then
+            nwfaten(k,col) = nwfaten(k,col) - (pna_rca(k,col) + pna_sca(k,col)          &
+                       + pna_gca(k,col) + pni_iha(k,col)) * orho
+            nifaten(k,col) = nifaten(k,col) - (pnd_rcd(k,col) + pnd_scd(k,col)          &
+                       + pnd_gcd(k,col)) * orho
+            if (dustyIce) then
+               nifaten(k,col) = nifaten(k,col) - pni_inu(k,col)*orho
+            else
+               nifaten(k,col) = 0.
+            endif
+         endif
+
+!..Water vapor tendency
+         qvten(k,col) = qvten(k,col) + (-pri_inu(k,col) - pri_iha(k,col) - pri_ide(k,col)   &
+                      - prs_ide(k,col) - prs_sde(k,col) - prg_gde(k,col)) &
+                      * orho
+
+!..Cloud water tendency
+         qcten(k,col) = qcten(k,col) + (-prr_wau(k,col) - pri_wfz(k,col) &
+                      - prr_rcw(k,col) - prs_scw(k,col) - prg_scw(k,col) &
+                      - prg_gcw(k,col)) &
+                      * orho
+
+!..Cloud water number tendency
+         ncten(k,col) = ncten(k,col) + (-pnc_wau(k,col) - pnc_rcw(k,col) &
+                      - pni_wfz(k,col) - pnc_scw(k,col) - pnc_gcw(k,col)) &
+                      * orho
+
+!..Cloud water mass/number balance; keep mass-wt mean size between
+!.. 1 and 50 microns.  Also no more than Nt_c_max drops total.
+         xrc=MAX(R1, (qc1d(k,col) + qcten(k,col)*dtsave)*rho(k,col))
+         xnc=MAX(2., (nc1d(k,col) + ncten(k,col)*dtsave)*rho(k,col))
+         if (xrc .gt. R1) then
+          nu_c = MIN(15, NINT(1000.E6/xnc) + 2)
+          lamc = (xnc*am_r*ccg(2,nu_c)*ocg1(nu_c)/rc(k,col))**obmr
+          xDc = (bm_r + nu_c + 1.) / lamc
+          if (xDc.lt. D0c) then
+           lamc = cce(2,nu_c)/D0c
+           xnc = ccg(1,nu_c)*ocg2(nu_c)*xrc/am_r*lamc**bm_r
+           ncten(k,col) = (xnc-nc1d(k,col)*rho(k,col))*odts*orho
+          elseif (xDc.gt. D0r*2.) then
+           lamc = cce(2,nu_c)/(D0r*2.)
+           xnc = ccg(1,nu_c)*ocg2(nu_c)*xrc/am_r*lamc**bm_r
+           ncten(k,col) = (xnc-nc1d(k,col)*rho(k,col))*odts*orho
+          endif
+         else
+          ncten(k,col) = -nc1d(k,col)*odts
+         endif
+         xnc=MAX(0.,(nc1d(k,col) + ncten(k,col)*dtsave)*rho(k,col))
+         if (xnc.gt.Nt_c_max) &
+                ncten(k,col) = (Nt_c_max-nc1d(k,col)*rho(k,col))*odts*orho
+
+!..Cloud ice mixing ratio tendency
+         qiten(k,col) = qiten(k,col) + (pri_inu(k,col) + pri_iha(k,col) + pri_ihm(k,col)    &
+                      + pri_wfz(k,col) + pri_rfz(k,col) + pri_ide(k,col) &
+                      - prs_iau(k,col) - prs_sci(k,col) - pri_rci(k,col)) &
+                      * orho
+
+!..Cloud ice number tendency.
+         niten(k,col) = niten(k,col) + (pni_inu(k,col) + pni_iha(k,col) + pni_ihm(k,col)    &
+                      + pni_wfz(k,col) + pni_rfz(k,col) + pni_ide(k,col) &
+                      - pni_iau(k,col) - pni_sci(k,col) - pni_rci(k,col)) &
+                      * orho
+
+!..Cloud ice mass/number balance; keep mass-wt mean size between
+!.. 20 and 300 microns.  Also no more than 250 xtals per liter.
+         xri=MAX(R1,(qi1d(k,col) + qiten(k,col)*dtsave)*rho(k,col))
+         xni=MAX(R2,(ni1d(k,col) + niten(k,col)*dtsave)*rho(k,col))
+         if (xri.gt. R1) then
+           lami = (am_i*cig(2)*oig1*xni/xri)**obmi
+           ilami = 1./lami
+           xDi = (bm_i + mu_i + 1.) * ilami
+           if (xDi.lt. 20.E-6) then
+            lami = cie(2)/20.E-6
+            xni = MIN(499.D3, cig(1)*oig2*xri/am_i*lami**bm_i)
+            niten(k,col) = (xni-ni1d(k,col)*rho(k,col))*odts*orho
+           elseif (xDi.gt. 300.E-6) then
+            lami = cie(2)/300.E-6
+            xni = cig(1)*oig2*xri/am_i*lami**bm_i
+            niten(k,col) = (xni-ni1d(k,col)*rho(k,col))*odts*orho
+           endif
+         else
+          niten(k,col) = -ni1d(k,col)*odts
+         endif
+         xni=MAX(0.,(ni1d(k,col) + niten(k,col)*dtsave)*rho(k,col))
+         if (xni.gt.499.E3) &
+                niten(k,col) = (499.E3-ni1d(k,col)*rho(k,col))*odts*orho
+
+!..Rain tendency
+         qrten(k,col) = qrten(k,col) + (prr_wau(k,col) + prr_rcw(k,col) &
+                      + prr_sml(k,col) + prr_gml(k,col) + prr_rcs(k,col) &
+                      + prr_rcg(k,col) - prg_rfz(k,col) &
+                      - pri_rfz(k,col) - prr_rci(k,col)) &
+                      * orho
+
+!..Rain number tendency
+         nrten(k,col) = nrten(k,col) + (pnr_wau(k,col) + pnr_sml(k,col) + pnr_gml(k,col)    &
+                      - (pnr_rfz(k,col) + pnr_rcr(k,col) + pnr_rcg(k,col)           &
+                      + pnr_rcs(k,col) + pnr_rci(k,col)) )                      &
+                      * orho
+
+!..Rain mass/number balance; keep median volume diameter between
+!.. 37 microns (D0r*0.75) and 2.5 mm.
+         xrr=MAX(R1,(qr1d(k,col) + qrten(k,col)*dtsave)*rho(k,col))
+         xnr=MAX(R2,(nr1d(k,col) + nrten(k,col)*dtsave)*rho(k,col))
+         if (xrr.gt. R1) then
+           lamr = (am_r*crg(3)*org2*xnr/xrr)**obmr
+           mvd_r(k,col) = (3.0 + mu_r + 0.672) / lamr
+           if (mvd_r(k,col) .gt. 2.5E-3) then
+              mvd_r(k,col) = 2.5E-3
+              lamr = (3.0 + mu_r + 0.672) / mvd_r(k,col)
+              xnr = crg(2)*org3*xrr*lamr**bm_r / am_r
+              nrten(k,col) = (xnr-nr1d(k,col)*rho(k,col))*odts*orho
+           elseif (mvd_r(k,col) .lt. D0r*0.75) then
+              mvd_r(k,col) = D0r*0.75
+              lamr = (3.0 + mu_r + 0.672) / mvd_r(k,col)
+              xnr = crg(2)*org3*xrr*lamr**bm_r / am_r
+              nrten(k,col) = (xnr-nr1d(k,col)*rho(k,col))*odts*orho
+           endif
+         else
+           qrten(k,col) = -qr1d(k,col)*odts
+           nrten(k,col) = -nr1d(k,col)*odts
+         endif
+
+!..Snow tendency
+         qsten(k,col) = qsten(k,col) + (prs_iau(k,col) + prs_sde(k,col) &
+                      + prs_sci(k,col) + prs_scw(k,col) + prs_rcs(k,col) &
+                      + prs_ide(k,col) - prs_ihm(k,col) - prr_sml(k,col)) &
+                      * orho
+
+!..Graupel tendency
+         qgten(k,col) = qgten(k,col) + (prg_scw(k,col) + prg_rfz(k,col) &
+                      + prg_gde(k,col) + prg_rcg(k,col) + prg_gcw(k,col) &
+                      + prg_rci(k,col) + prg_rcs(k,col) - prg_ihm(k,col) &
+                      - prr_gml(k,col)) &
+                      * orho
+
+!..Temperature tendency
+         if (temp(k,col).lt.T_0) then
+          tten(k,col) = tten(k,col) &
+                    + ( lsub*ocp(k,col)*(pri_inu(k,col) + pri_ide(k,col) &
+                                     + prs_ide(k,col) + prs_sde(k,col) &
+                                     + prg_gde(k,col) + pri_iha(k,col)) &
+                     + lfus2*ocp(k,col)*(pri_wfz(k,col) + pri_rfz(k,col) &
+                                     + prg_rfz(k,col) + prs_scw(k,col) &
+                                     + prg_scw(k,col) + prg_gcw(k,col) &
+                                     + prg_rcs(k,col) + prs_rcs(k,col) &
+                                     + prr_rci(k,col) + prg_rcg(k,col)) &
+                       )*orho * (1-IFDRY)
+         else
+          tten(k,col) = tten(k,col) &
+                    + ( lfus*ocp(k,col)*(-prr_sml(k,col) - prr_gml(k,col) &
+                                     - prr_rcg(k,col) - prr_rcs(k,col)) &
+                      + lsub*ocp(k,col)*(prs_sde(k,col) + prg_gde(k,col)) &
+                       )*orho * (1-IFDRY)
+         endif
+
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Update variables for TAU+1 before condensation & sedimention.
+!+---+-----------------------------------------------------------------+
+      do k = kts, kte
+         temp(k,col) = t1d(k,col) + DT*tten(k,col)
+         otemp = 1./temp(k,col)
+         tempc = temp(k,col) - 273.15
+         qv(k,col) = MAX(1.E-10, qv1d(k,col) + DT*qvten(k,col))
+         rho(k,col) = 0.622*pres(k,col)/(R*temp(k,col)*(qv(k,col)+0.622))
+         rhof(k,col) = SQRT(RHO_NOT/rho(k,col))
+         rhof2(k,col) = SQRT(rhof(k,col))
+         qvs(k,col) = rslf(pres(k,col), temp(k,col))
+         ssatw(k,col) = qv(k,col)/qvs(k,col) - 1.
+         if (abs(ssatw(k,col)).lt. eps) ssatw(k,col) = 0.0
+         diffu(k,col) = 2.11E-5*(temp(k,col)/273.15)**1.94 * (101325./pres(k,col))
+         if (tempc .ge. 0.0) then
+            visco(k,col) = (1.718+0.0049*tempc)*1.0E-5
+         else
+            visco(k,col) = (1.718+0.0049*tempc-1.2E-5*tempc*tempc)*1.0E-5
+         endif
+         vsc2(k,col) = SQRT(rho(k,col)/visco(k,col))
+         lvap(k,col) = lvap0 + (2106.0 - 4218.0)*tempc
+         tcond(k,col) = (5.69 + 0.0168*tempc)*1.0E-5 * 418.936
+         ocp(k,col) = 1./(Cp*(1.+0.887*qv(k,col)))
+         lvt2(k,col)=lvap(k,col)*lvap(k,col)*ocp(k,col)*oRv*otemp*otemp
+
+         nwfa(k,col) = MAX(11.1E6, (nwfa1d(k,col) + nwfaten(k,col)*DT)*rho(k,col))
+
+         if ((qc1d(k,col) + qcten(k,col)*DT) .gt. R1) then
+            rc(k,col) = (qc1d(k,col) + qcten(k,col)*DT)*rho(k,col)
+            nc(k,col) = MAX(2., (nc1d(k,col) + ncten(k,col)*DT)*rho(k,col))
+            if (.NOT. is_aerosol_aware) nc(k,col) = Nt_c
+            L_qc(k,col) = .true.
+         else
+            rc(k,col) = R1
+            nc(k,col) = 2.
+            L_qc(k,col) = .false.
+         endif
+
+         if ((qi1d(k,col) + qiten(k,col)*DT) .gt. R1) then
+            ri(k,col) = (qi1d(k,col) + qiten(k,col)*DT)*rho(k,col)
+            ni(k,col) = MAX(R2, (ni1d(k,col) + niten(k,col)*DT)*rho(k,col))
+            L_qi(k,col) = .true. 
+         else
+            ri(k,col) = R1
+            ni(k,col) = R2
+            L_qi(k,col) = .false.
+         endif
+
+         if ((qr1d(k,col) + qrten(k,col)*DT) .gt. R1) then
+            rr(k,col) = (qr1d(k,col) + qrten(k,col)*DT)*rho(k,col)
+            nr(k,col) = MAX(R2, (nr1d(k,col) + nrten(k,col)*DT)*rho(k,col))
+            L_qr(k,col) = .true.
+            lamr = (am_r*crg(3)*org2*nr(k,col)/rr(k,col))**obmr
+            mvd_r(k,col) = (3.0 + mu_r + 0.672) / lamr
+            if (mvd_r(k,col) .gt. 2.5E-3) then
+               mvd_r(k,col) = 2.5E-3
+               lamr = (3.0 + mu_r + 0.672) / mvd_r(k,col)
+               nr(k,col) = crg(2)*org3*rr(k,col)*lamr**bm_r / am_r
+            elseif (mvd_r(k,col) .lt. D0r*0.75) then
+               mvd_r(k,col) = D0r*0.75
+               lamr = (3.0 + mu_r + 0.672) / mvd_r(k,col)
+               nr(k,col) = crg(2)*org3*rr(k,col)*lamr**bm_r / am_r
+            endif
+         else
+            rr(k,col) = R1
+            nr(k,col) = R2
+            L_qr(k,col) = .false.
+         endif
+               
+         if ((qs1d(k,col) + qsten(k,col)*DT) .gt. R1) then
+            rs(k,col) = (qs1d(k,col) + qsten(k,col)*DT)*rho(k,col)
+            L_qs(k,col) = .true.
+         else
+            rs(k,col) = R1
+            L_qs(k,col) = .false.
+         endif
+
+         if ((qg1d(k,col) + qgten(k,col)*DT) .gt. R1) then
+            rg(k,col) = (qg1d(k,col) + qgten(k,col)*DT)*rho(k,col)
+            L_qg(k,col) = .true.
+         else
+            rg(k,col) = R1
+            L_qg(k,col) = .false.
+         endif
+      enddo
+      enddo
+!$acc end kernels
+
+!+---+-----------------------------------------------------------------+
+!..With tendency-updated mixing ratios, recalculate snow moments and
+!.. intercepts/slopes of graupel and rain.
+!+---+-----------------------------------------------------------------+
+      if (.not. iiwarm) then
+!$acc kernels      
+      do col = 1,ncol
+      if (no_micro(col)) CYCLE
+
+    
+      do k = kts, kte
+         if (.not. L_qs(k,col)) CYCLE
+         tc0 = MIN(-0.1, temp(k,col)-273.15)
+         smob(k,col) = rs(k,col)*oams
+
+!..All other moments based on reference, 2nd moment.  If bm_s.ne.2,
+!.. then we must compute actual 2nd moment and use as reference.
+         if (bm_s.gt.(2.0-1.e-3) .and. bm_s.lt.(2.0+1.e-3)) then
+            smo2(k,col) = smob(k,col)
+         else
+            loga_ = sa(1) + sa(2)*tc0 + sa(3)*bm_s &
+               + sa(4)*tc0*bm_s + sa(5)*tc0*tc0 &
+               + sa(6)*bm_s*bm_s + sa(7)*tc0*tc0*bm_s &
+               + sa(8)*tc0*bm_s*bm_s + sa(9)*tc0*tc0*tc0 &
+               + sa(10)*bm_s*bm_s*bm_s
+            a_ = 10.0**loga_
+            b_ = sb(1) + sb(2)*tc0 + sb(3)*bm_s &
+               + sb(4)*tc0*bm_s + sb(5)*tc0*tc0 &
+               + sb(6)*bm_s*bm_s + sb(7)*tc0*tc0*bm_s &
+               + sb(8)*tc0*bm_s*bm_s + sb(9)*tc0*tc0*tc0 &
+               + sb(10)*bm_s*bm_s*bm_s
+            smo2(k,col) = (smob(k,col)/a_)**(1./b_)
+         endif
+
+!..Calculate bm_s+1 (th) moment.  Useful for diameter calcs.
+         loga_ = sa(1) + sa(2)*tc0 + sa(3)*cse(1) &
+               + sa(4)*tc0*cse(1) + sa(5)*tc0*tc0 &
+               + sa(6)*cse(1)*cse(1) + sa(7)*tc0*tc0*cse(1) &
+               + sa(8)*tc0*cse(1)*cse(1) + sa(9)*tc0*tc0*tc0 &
+               + sa(10)*cse(1)*cse(1)*cse(1)
+         a_ = 10.0**loga_
+         b_ = sb(1)+ sb(2)*tc0 + sb(3)*cse(1) + sb(4)*tc0*cse(1) &
+              + sb(5)*tc0*tc0 + sb(6)*cse(1)*cse(1) &
+              + sb(7)*tc0*tc0*cse(1) + sb(8)*tc0*cse(1)*cse(1) &
+              + sb(9)*tc0*tc0*tc0 + sb(10)*cse(1)*cse(1)*cse(1)
+         smoc(k,col) = a_ * smo2(k,col)**b_
+
+!..Calculate bm_s+bv_s (th) moment.  Useful for sedimentation.
+         loga_ = sa(1) + sa(2)*tc0 + sa(3)*cse(14) &
+               + sa(4)*tc0*cse(14) + sa(5)*tc0*tc0 &
+               + sa(6)*cse(14)*cse(14) + sa(7)*tc0*tc0*cse(14) &
+               + sa(8)*tc0*cse(14)*cse(14) + sa(9)*tc0*tc0*tc0 &
+               + sa(10)*cse(14)*cse(14)*cse(14)
+         a_ = 10.0**loga_
+         b_ = sb(1)+ sb(2)*tc0 + sb(3)*cse(14) + sb(4)*tc0*cse(14) &
+              + sb(5)*tc0*tc0 + sb(6)*cse(14)*cse(14) &
+              + sb(7)*tc0*tc0*cse(14) + sb(8)*tc0*cse(14)*cse(14) &
+              + sb(9)*tc0*tc0*tc0 + sb(10)*cse(14)*cse(14)*cse(14)
+         smod(k,col) = a_ * smo2(k,col)**b_
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Calculate y-intercept, slope values for graupel.
+!+---+-----------------------------------------------------------------+
+      N0_min = gonv_max
+      do k = kte, kts, -1
+         if (temp(k,col).lt.270.65 .and. L_qr(k,col) .and. mvd_r(k,col).gt.100.E-6) then
+            xslw1 = 4.01 + alog10(mvd_r(k,col))
+         else
+            xslw1 = 0.01
+         endif
+         ygra1 = 4.31 + alog10(max(5.E-5, rg(k,col)))
+         zans1 = 3.1 + (100./(300.*xslw1*ygra1/(10./xslw1+1.+0.25*ygra1)+30.+10.*ygra1))
+         N0_exp = 10.**(zans1)
+         N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
+         N0_min = MIN(N0_exp, N0_min)
+         N0_exp = N0_min
+         lam_exp = (N0_exp*am_g*cgg(1)/rg(k,col))**oge1
+         lamg = lam_exp * (cgg(3)*ogg2*ogg1)**obmg
+         ilamg(k,col) = 1./lamg
+         N0_g(k,col) = N0_exp/(cgg(2)*lam_exp) * lamg**cge(2)
+      enddo
+      enddo !col
+!$acc end kernels
+      endif
+      
+!$acc update host(temp,w1d,nwfa)
+      do col = 1,ncol
+      do k = kts, kte
+        if (no_micro(col)) CYCLE
+        act_ncloud(k,col) = activ_ncloud(temp(k,col), w1d(k,col), nwfa(k,col))
+      enddo
+      enddo
+!$acc update device(act_ncloud)      
+
+!$acc kernels
+      do col = 1,ncol
+      if (no_micro(col)) CYCLE
+
+
+!+---+-----------------------------------------------------------------+
+!..Calculate y-intercept, slope values for rain.
+!+---+-----------------------------------------------------------------+
+      do k = kte, kts, -1
+         lamr = (am_r*crg(3)*org2*nr(k,col)/rr(k,col))**obmr
+         ilamr(k,col) = 1./lamr
+         mvd_r(k,col) = (3.0 + mu_r + 0.672) / lamr
+         N0_r(k,col) = nr(k,col)*org2*lamr**cre(2)
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Cloud water condensation and evaporation.  Nucleate cloud droplets
+!.. using explicit CCN aerosols with hygroscopicity like sulfates using
+!.. parcel model lookup table results provided by T. Eidhammer.  Evap
+!.. drops using calculation of max drop size capable of evaporating in
+!.. single timestep and explicit number of drops smaller than Dc_star
+!.. from lookup table.
+!+---+-----------------------------------------------------------------+
+      do k = kts, kte
+         orho = 1./rho(k,col)
+         if ( (ssatw(k,col).gt. eps) .or. (ssatw(k,col).lt. -eps .and. &
+                   L_qc(k,col)) ) then
+          clap = (qv(k,col)-qvs(k,col))/(1. + lvt2(k,col)*qvs(k,col))
+          do n = 1, 3
+             fcd = qvs(k,col)* EXP(lvt2(k,col)*clap) - qv(k,col) + clap
+             dfcd = qvs(k,col)*lvt2(k,col)* EXP(lvt2(k,col)*clap) + 1.
+             clap = clap - fcd/dfcd
+          enddo
+          xrc = rc(k,col) + clap*rho(k,col)
+          xnc = 0.
+          if (xrc.gt. R1) then
+           prw_vcd(k,col) = clap*odt
+!+---+-----------------------------------------------------------------+ !  DROPLET NUCLEATION
+           if (clap .gt. eps) then
+            if (is_aerosol_aware) then
+               xnc = MAX(2., act_ncloud(k,col)) !activ_ncloud(temp(k,col), w1d(k,col), nwfa(k,col)))
+            else
+               xnc = Nt_c
+            endif
+            pnc_wcd(k,col) = 0.5*(xnc-nc(k,col) + abs(xnc-nc(k,col)))*odts*orho
+
+!+---+-----------------------------------------------------------------+ !  EVAPORATION
+           elseif (clap .lt. -eps .AND. ssatw(k,col).lt.-1.E-6 .AND. is_aerosol_aware) then
+            tempc = temp(k,col) - 273.15
+            otemp = 1./temp(k,col)
+            rvs = rho(k,col)*qvs(k,col)
+            rvs_p = rvs*otemp*(lvap(k,col)*otemp*oRv - 1.)
+            rvs_pp = rvs * ( otemp*(lvap(k,col)*otemp*oRv - 1.) &
+                            *otemp*(lvap(k,col)*otemp*oRv - 1.) &
+                            + (-2.*lvap(k,col)*otemp*otemp*otemp*oRv) &
+                            + otemp*otemp)
+            gamsc = lvap(k,col)*diffu(k,col)/tcond(k,col) * rvs_p
+            alphsc = 0.5*(gamsc/(1.+gamsc))*(gamsc/(1.+gamsc)) &
+                       * rvs_pp/rvs_p * rvs/rvs_p
+            alphsc = MAX(1.E-9, alphsc)
+            xsat = ssatw(k,col)
+            if (abs(xsat).lt. 1.E-9) xsat=0.
+            t1_evap = 2.*PI*( 1.0 - alphsc*xsat  &
+                   + 2.*alphsc*alphsc*xsat*xsat  &
+                   - 5.*alphsc*alphsc*alphsc*xsat*xsat*xsat ) &
+                   / (1.+gamsc)
+
+            Dc_star = DSQRT(-2.D0*DT * t1_evap/(2.*PI) &
+                    * 4.*diffu(k,col)*ssatw(k,col)*rvs/rho_w)
+            idx_d = MAX(1, MIN(INT(1.E6*Dc_star), nbc))
+
+            idx_n = NINT(1.0 + FLOAT(nbc) * DLOG(nc(k,col)/t_Nc(1)) / nic1)
+            idx_n = MAX(1, MIN(idx_n, nbc))
+
+!..Cloud water lookup table index.
+            if (rc(k,col).gt. r_c(1)) then
+             nic = NINT(ALOG10(rc(k,col)))
+             do nn = nic-1, nic+1
+                n = nn
+                if ( (rc(k,col)/10.**nn).ge.1.0 .and. &
+                     (rc(k,col)/10.**nn).lt.10.0) goto 159
+             enddo
+ 159         continue
+             idx_c = INT(rc(k,col)/10.**n) + 10*(n-nic2) - (n-nic2)
+             idx_c = MAX(1, MIN(idx_c, ntb_c))
+            else
+             idx_c = 1
+            endif
+
+           !prw_vcd(k,col) = MAX(DBLE(-rc(k,col)*orho*odt),                     &
+           !           -tpc_wev(idx_d, idx_c, idx_n)*orho*odt)
+            prw_vcd(k,col) = MAX(DBLE(-rc(k,col)*0.99*orho*odt), prw_vcd(k,col))
+            pnc_wcd(k,col) = MAX(DBLE(-nc(k,col)*0.99*orho*odt),                &
+                       -tnc_wev(idx_d, idx_c, idx_n)*orho*odt)
+
+           endif
+          else
+           prw_vcd(k,col) = -rc(k,col)*orho*odt
+           pnc_wcd(k,col) = -nc(k,col)*orho*odt
+          endif
+
+!+---+-----------------------------------------------------------------+
+
+          qvten(k,col) = qvten(k,col) - prw_vcd(k,col)
+          qcten(k,col) = qcten(k,col) + prw_vcd(k,col)
+          ncten(k,col) = ncten(k,col) + pnc_wcd(k,col)
+          nwfaten(k,col) = nwfaten(k,col) - pnc_wcd(k,col)
+          tten(k,col) = tten(k,col) + lvap(k,col)*ocp(k,col)*prw_vcd(k,col)*(1-IFDRY)
+          rc(k,col) = MAX(R1, (qc1d(k,col) + DT*qcten(k,col))*rho(k,col))
+          nc(k,col) = MAX(2., (nc1d(k,col) + DT*ncten(k,col))*rho(k,col))
+          if (.NOT. is_aerosol_aware) nc(k,col) = Nt_c
+          qv(k,col) = MAX(1.E-10, qv1d(k,col) + DT*qvten(k,col))
+          temp(k,col) = t1d(k,col) + DT*tten(k,col)
+          rho(k,col) = 0.622*pres(k,col)/(R*temp(k,col)*(qv(k,col)+0.622))
+          qvs(k,col) = rslf(pres(k,col), temp(k,col))
+          ssatw(k,col) = qv(k,col)/qvs(k,col) - 1.
+         endif
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!.. If still subsaturated, allow rain to evaporate, following
+!.. Srivastava & Coen (1992).
+!+---+-----------------------------------------------------------------+
+      do k = kts, kte
+         if ( (ssatw(k,col).lt. -eps) .and. L_qr(k,col) &
+                     .and. (.not.(prw_vcd(k,col).gt. 0.)) ) then
+          tempc = temp(k,col) - 273.15
+          otemp = 1./temp(k,col)
+          orho = 1./rho(k,col)
+          rhof(k,col) = SQRT(RHO_NOT*orho)
+          rhof2(k,col) = SQRT(rhof(k,col))
+          diffu(k,col) = 2.11E-5*(temp(k,col)/273.15)**1.94 * (101325./pres(k,col))
+          if (tempc .ge. 0.0) then
+             visco(k,col) = (1.718+0.0049*tempc)*1.0E-5
+          else
+             visco(k,col) = (1.718+0.0049*tempc-1.2E-5*tempc*tempc)*1.0E-5
+          endif
+          vsc2(k,col) = SQRT(rho(k,col)/visco(k,col))
+          lvap(k,col) = lvap0 + (2106.0 - 4218.0)*tempc
+          tcond(k,col) = (5.69 + 0.0168*tempc)*1.0E-5 * 418.936
+          ocp(k,col) = 1./(Cp*(1.+0.887*qv(k,col)))
+
+          rvs = rho(k,col)*qvs(k,col)
+          rvs_p = rvs*otemp*(lvap(k,col)*otemp*oRv - 1.)
+          rvs_pp = rvs * ( otemp*(lvap(k,col)*otemp*oRv - 1.) &
+                          *otemp*(lvap(k,col)*otemp*oRv - 1.) &
+                          + (-2.*lvap(k,col)*otemp*otemp*otemp*oRv) &
+                          + otemp*otemp)
+          gamsc = lvap(k,col)*diffu(k,col)/tcond(k,col) * rvs_p
+          alphsc = 0.5*(gamsc/(1.+gamsc))*(gamsc/(1.+gamsc)) &
+                     * rvs_pp/rvs_p * rvs/rvs_p
+          alphsc = MAX(1.E-9, alphsc)
+          xsat   = MIN(-1.E-9, ssatw(k,col))
+          t1_evap = 2.*PI*( 1.0 - alphsc*xsat  &
+                 + 2.*alphsc*alphsc*xsat*xsat  &
+                 - 5.*alphsc*alphsc*alphsc*xsat*xsat*xsat ) &
+                 / (1.+gamsc)
+
+          lamr = 1./ilamr(k,col)
+!..Rapidly eliminate near zero values when low humidity (<95%)
+          if (qv(k,col)/qvs(k,col) .lt. 0.95 .AND. rr(k,col)*orho.le.1.E-8) then
+          prv_rev(k,col) = rr(k,col)*orho*odts
+          else
+          prv_rev(k,col) = t1_evap*diffu(k,col)*(-ssatw(k,col))*N0_r(k,col)*rvs &
+              * (t1_qr_ev*ilamr(k,col)**cre(10) &
+              + t2_qr_ev*vsc2(k,col)*rhof2(k,col)*((lamr+0.5*fv_r)**(-cre(11))))
+          rate_max = MIN((rr(k,col)*orho*odts), (qvs(k,col)-qv(k,col))*odts)
+          prv_rev(k,col) = MIN(DBLE(rate_max), prv_rev(k,col)*orho)
+
+!..TEST: G. Thompson  10 May 2013
+!..Reduce the rain evaporation in same places as melting graupel occurs. 
+!..Rationale: falling and simultaneous melting graupel in subsaturated
+!..regions will not melt as fast because particle temperature stays
+!..at 0C.  Also not much shedding of the water from the graupel so
+!..likely that the water-coated graupel evaporating much slower than
+!..if the water was immediately shed off.
+          IF (prr_gml(k,col).gt.0.0) THEN
+             eva_factor = MIN(1.0, 0.01+(0.99-0.01)*(tempc/20.0))
+             prv_rev(k,col) = prv_rev(k,col)*eva_factor
+          ENDIF
+          endif
+
+          pnr_rev(k,col) = MIN(DBLE(nr(k,col)*0.99*orho*odts),                  &   ! RAIN2M
+                       prv_rev(k,col) * nr(k,col)/rr(k,col))
+
+          qrten(k,col) = qrten(k,col) - prv_rev(k,col)
+          qvten(k,col) = qvten(k,col) + prv_rev(k,col)
+          nrten(k,col) = nrten(k,col) - pnr_rev(k,col)
+          nwfaten(k,col) = nwfaten(k,col) + pnr_rev(k,col)
+          tten(k,col) = tten(k,col) - lvap(k,col)*ocp(k,col)*prv_rev(k,col)*(1-IFDRY)
+
+          rr(k,col) = MAX(R1, (qr1d(k,col) + DT*qrten(k,col))*rho(k,col))
+          qv(k,col) = MAX(1.E-10, qv1d(k,col) + DT*qvten(k,col))
+          nr(k,col) = MAX(R2, (nr1d(k,col) + DT*nrten(k,col))*rho(k,col))
+          temp(k,col) = t1d(k,col) + DT*tten(k,col)
+          rho(k,col) = 0.622*pres(k,col)/(R*temp(k,col)*(qv(k,col)+0.622))
+         endif
+      enddo
+#if ( WRF_CHEM == 1 )
+      do k = kts, kte
+         evapprod(k,col) = prv_rev(k,col) - (min(zeroD0,prs_sde(k,col)) + &
+                                     min(zeroD0,prg_gde(k,col)))
+         rainprod(k,col) = prr_wau(k,col) + prr_rcw(k,col) + prs_scw(k,col) + &
+                                    prg_scw(k,col) + prs_iau(k,col) + &
+                                    prg_gcw(k,col) + prs_sci(k,col) + &
+                                    pri_rci(k,col)
+      enddo
+#endif
+      enddo !col
+
+!+---+-----------------------------------------------------------------+
+!..Find max terminal fallspeed (distribution mass-weighted mean
+!.. velocity) and use it to determine if we need to split the timestep
+!.. (var nstep>1).  Either way, only bother to do sedimentation below
+!.. 1st level that contains any sedimenting particles (k=ksed1 on down).
+!.. New in v3.0+ is computing separate for rain, ice, snow, and
+!.. graupel species thus making code faster with credit to J. Schmidt.
+!+---+-----------------------------------------------------------------+
+!$acc loop private( sed_r, sed_s, sed_g, sed_i, sed_n,sed_c, &
+!$acc      vtik, vtnik, vtrk, vtnrk, vtsk, vtgk, vtck, vtnck)
+      do col = 1,ncol
+      if (no_micro(col)) CYCLE
+
+      nstep = 0
+      onstep1=1.0;onstep2=1.0;onstep3=1.0;onstep4=1.0;onstep5=1.0;
+      ksed11 = 1;ksed12 = 1;ksed13 = 1;ksed14 = 1;ksed15 = 1;
+      do k = kte+1, kts, -1
+         vtrk(k) = 0.
+         vtnrk(k) = 0.
+         vtik(k) = 0.
+         vtnik(k) = 0.
+         vtsk(k) = 0.
+         vtgk(k) = 0.
+         vtck(k) = 0.
+         vtnck(k) = 0.
+      enddo
+      do k = kte, kts, -1
+         vtr = 0.
+         rhof(k,col) = SQRT(RHO_NOT/rho(k,col))
+
+         if (rr(k,col).gt. R1) then
+          lamr = (am_r*crg(3)*org2*nr(k,col)/rr(k,col))**obmr
+          vtr = rhof(k,col)*av_r*crg(6)*org3 * lamr**cre(3)                 &
+                      *((lamr+fv_r)**(-cre(6)))
+          vtrk(k) = vtr
+! First below is technically correct:
+!         vtr = rhof(k,col)*av_r*crg(5)*org2 * lamr**cre(2)                 &
+!                     *((lamr+fv_r)**(-cre(5)))
+! Test: make number fall faster (but still slower than mass)
+! Goal: less prominent size sorting
+          vtr = rhof(k,col)*av_r*crg(7)/crg(12) * lamr**cre(12)             &
+                      *((lamr+fv_r)**(-cre(7)))
+          vtnrk(k) = vtr
+         else
+          vtrk(k) = vtrk(k+1)
+          vtnrk(k) = vtnrk(k+1)
+         endif
+
+         if (MAX(vtrk(k),vtnrk(k)) .gt. 1.E-3) then
+            ksed11 = MAX(ksed11, k)
+            delta_tp = dzq(k,col)/(MAX(vtrk(k),vtnrk(k)))
+            nstep = MAX(nstep, INT(DT/delta_tp + 1.))
+         endif
+      enddo
+      if (ksed11 .eq. kte) ksed11 = kte-1
+      if (nstep .gt. 0) onstep1 = 1./REAL(nstep)
+
+!+---+-----------------------------------------------------------------+
+
+      hgt_agl = 0.
+      do k = kts, kte-1
+         if (rc(k,col) .gt. R2) ksed15 = k
+         hgt_agl = hgt_agl + dzq(k,col)
+         if (hgt_agl .gt. 500.0) goto 151
+      enddo
+ 151  continue
+
+      do k = ksed15, kts, -1
+         vtc = 0.
+         if (rc(k,col) .gt. R1 .and. w1d(k,col) .lt. 1.E-1) then
+          nu_c = MIN(15, NINT(1000.E6/nc(k,col)) + 2)
+          lamc = (nc(k,col)*am_r*ccg(2,nu_c)*ocg1(nu_c)/rc(k,col))**obmr
+          ilamc = 1./lamc
+          vtc = rhof(k,col)*av_c*ccg(5,nu_c)*ocg2(nu_c) * ilamc**bv_c
+          vtck(k) = vtc
+          vtc = rhof(k,col)*av_c*ccg(4,nu_c)*ocg1(nu_c) * ilamc**bv_c
+          vtnck(k) = vtc
+         endif
+      enddo
+
+!+---+-----------------------------------------------------------------+
+
+      if (.not. iiwarm) then
+
+       nstep = 0
+       do k = kte, kts, -1
+          vti = 0.
+
+          if (ri(k,col).gt. R1) then
+           lami = (am_i*cig(2)*oig1*ni(k,col)/ri(k,col))**obmi
+           ilami = 1./lami
+           vti = rhof(k,col)*av_i*cig(3)*oig2 * ilami**bv_i
+           vtik(k) = vti
+! First below is technically correct:
+!          vti = rhof(k,col)*av_i*cig(4)*oig1 * ilami**bv_i
+! Goal: less prominent size sorting
+           vti = rhof(k,col)*av_i*cig(6)/cig(7) * ilami**bv_i
+           vtnik(k) = vti
+          else
+           vtik(k) = vtik(k+1)
+           vtnik(k) = vtnik(k+1)
+          endif
+
+          if (vtik(k) .gt. 1.E-3) then
+             ksed12 = MAX(ksed12, k)
+             delta_tp = dzq(k,col)/vtik(k)
+             nstep = MAX(nstep, INT(DT/delta_tp + 1.))
+          endif
+       enddo
+       if (ksed12 .eq. kte) ksed12 = kte-1
+       if (nstep .gt. 0) onstep2 = 1./REAL(nstep)
+
+!+---+-----------------------------------------------------------------+
+
+       nstep = 0
+       do k = kte, kts, -1
+          vts = 0.
+
+          if (rs(k,col).gt. R1) then
+           xDs = smoc(k,col) / smob(k,col)
+           Mrat = 1./xDs
+           ils1 = 1./(Mrat*Lam0 + fv_s)
+           ils2 = 1./(Mrat*Lam1 + fv_s)
+           t1_vts = Kap0*csg(4)*ils1**cse(4)
+           t2_vts = Kap1*Mrat**mu_s*csg(10)*ils2**cse(10)
+           ils1 = 1./(Mrat*Lam0)
+           ils2 = 1./(Mrat*Lam1)
+           t3_vts = Kap0*csg(1)*ils1**cse(1)
+           t4_vts = Kap1*Mrat**mu_s*csg(7)*ils2**cse(7)
+           vts = rhof(k,col)*av_s * (t1_vts+t2_vts)/(t3_vts+t4_vts)
+           if (temp(k,col).gt. T_0) then
+            vtsk(k) = MAX(vts*vts_boost(k,col), vtrk(k))
+           else
+            vtsk(k) = vts*vts_boost(k,col)
+           endif
+          else
+            vtsk(k) = vtsk(k+1)
+          endif
+
+          if (vtsk(k) .gt. 1.E-3) then
+             ksed13 = MAX(ksed13, k)
+             delta_tp = dzq(k,col)/vtsk(k)
+             nstep = MAX(nstep, INT(DT/delta_tp + 1.))
+          endif
+       enddo
+       if (ksed13 .eq. kte) ksed13 = kte-1
+       if (nstep .gt. 0) onstep3 = 1./REAL(nstep)
+
+!+---+-----------------------------------------------------------------+
+
+       nstep = 0
+       do k = kte, kts, -1
+          vtg = 0.
+
+          if (rg(k,col).gt. R1) then
+           vtg = rhof(k,col)*av_g*cgg(6)*ogg3 * ilamg(k,col)**bv_g
+           if (temp(k,col).gt. T_0) then
+            vtgk(k) = MAX(vtg, vtrk(k))
+           else
+            vtgk(k) = vtg
+           endif
+          else
+            vtgk(k) = vtgk(k+1)
+          endif
+
+          if (vtgk(k) .gt. 1.E-3) then
+             ksed14 = MAX(ksed14, k)
+             delta_tp = dzq(k,col)/vtgk(k)
+             nstep = MAX(nstep, INT(DT/delta_tp + 1.))
+          endif
+       enddo
+       if (ksed14 .eq. kte) ksed14 = kte-1
+       if (nstep .gt. 0) onstep4 = 1./REAL(nstep)
+      endif
+
+!+---+-----------------------------------------------------------------+
+!..Sedimentation of mixing ratio is the integral of v(D)*m(D)*N(D)*dD,
+!.. whereas neglect m(D) term for number concentration.  Therefore,
+!.. cloud ice has proper differential sedimentation.
+!.. New in v3.0+ is computing separate for rain, ice, snow, and
+!.. graupel species thus making code faster with credit to J. Schmidt.
+!.. Bug fix, 2013Nov01 to tendencies using rho(k+1,col) correction thanks to
+!.. Eric Skyllingstad.
+!+---+-----------------------------------------------------------------+
+
+      nstep = NINT(1./onstep1)
+      do n = 1, nstep
+         do k = kte, kts, -1
+            sed_r(k) = vtrk(k)*rr(k,col)
+            sed_n(k) = vtnrk(k)*nr(k,col)
+         enddo
+         k = kte
+         odzq = 1./dzq(k,col)
+         orho = 1./rho(k,col)
+         qrten(k,col) = qrten(k,col) - sed_r(k)*odzq*onstep1*orho
+         nrten(k,col) = nrten(k,col) - sed_n(k)*odzq*onstep1*orho
+         rr(k,col) = MAX(R1, rr(k,col) - sed_r(k)*odzq*DT*onstep1)
+         nr(k,col) = MAX(R2, nr(k,col) - sed_n(k)*odzq*DT*onstep1)
+         do k = ksed11, kts, -1
+            odzq = 1./dzq(k,col)
+            orho = 1./rho(k,col)
+            qrten(k,col) = qrten(k,col) + (sed_r(k+1)-sed_r(k))                 &
+                                               *odzq*onstep1*orho
+            nrten(k,col) = nrten(k,col) + (sed_n(k+1)-sed_n(k))                 &
+                                               *odzq*onstep1*orho
+            rr(k,col) = MAX(R1, rr(k,col) + (sed_r(k+1)-sed_r(k)) &
+                                           *odzq*DT*onstep1)
+            nr(k,col) = MAX(R2, nr(k,col) + (sed_n(k+1)-sed_n(k)) &
+                                           *odzq*DT*onstep1)
+         enddo
+
+         if (rr(kts,col).gt.R1*10.) &
+         pptrain(col) = pptrain(col) + sed_r(kts)*DT*onstep1
+      enddo
+
+!+---+-----------------------------------------------------------------+
+
+      do k = kte, kts, -1
+         sed_c(k) = vtck(k)*rc(k,col)
+         sed_n(k) = vtnck(k)*nc(k,col)
+      enddo
+      do k = ksed15, kts, -1
+         odzq = 1./dzq(k,col)
+         orho = 1./rho(k,col)
+         qcten(k,col) = qcten(k,col) + (sed_c(k+1)-sed_c(k)) *odzq*orho
+         ncten(k,col) = ncten(k,col) + (sed_n(k+1)-sed_n(k)) *odzq*orho
+         rc(k,col) = MAX(R1, rc(k,col) + (sed_c(k+1)-sed_c(k)) *odzq*DT)
+         nc(k,col) = MAX(10., nc(k,col) + (sed_n(k+1)-sed_n(k)) *odzq*DT)
+      enddo
+
+!+---+-----------------------------------------------------------------+
+
+      nstep = NINT(1./onstep2)
+      do n = 1, nstep
+         do k = kte, kts, -1
+            sed_i(k) = vtik(k)*ri(k,col)
+            sed_n(k) = vtnik(k)*ni(k,col)
+         enddo
+         k = kte
+         odzq = 1./dzq(k,col)
+         orho = 1./rho(k,col)
+         qiten(k,col) = qiten(k,col) - sed_i(k)*odzq*onstep2*orho
+         niten(k,col) = niten(k,col) - sed_n(k)*odzq*onstep2*orho
+         ri(k,col) = MAX(R1, ri(k,col) - sed_i(k)*odzq*DT*onstep2)
+         ni(k,col) = MAX(R2, ni(k,col) - sed_n(k)*odzq*DT*onstep2)
+         do k = ksed12, kts, -1
+            odzq = 1./dzq(k,col)
+            orho = 1./rho(k,col)
+            qiten(k,col) = qiten(k,col) + (sed_i(k+1)-sed_i(k))                 &
+                                               *odzq*onstep2*orho
+            niten(k,col) = niten(k,col) + (sed_n(k+1)-sed_n(k))                 &
+                                               *odzq*onstep2*orho
+            ri(k,col) = MAX(R1, ri(k,col) + (sed_i(k+1)-sed_i(k)) &
+                                           *odzq*DT*onstep2)
+            ni(k,col) = MAX(R2, ni(k,col) + (sed_n(k+1)-sed_n(k)) &
+                                           *odzq*DT*onstep2)
+         enddo
+
+         if (ri(kts,col).gt.R1*10.) &
+         pptice(col) = pptice(col) + sed_i(kts)*DT*onstep2
+      enddo
+
+!+---+-----------------------------------------------------------------+
+
+      nstep = NINT(1./onstep3)
+      do n = 1, nstep
+         do k = kte, kts, -1
+            sed_s(k) = vtsk(k)*rs(k,col)
+         enddo
+         k = kte
+         odzq = 1./dzq(k,col)
+         orho = 1./rho(k,col)
+         qsten(k,col) = qsten(k,col) - sed_s(k)*odzq*onstep3*orho
+         rs(k,col) = MAX(R1, rs(k,col) - sed_s(k)*odzq*DT*onstep3)
+         do k = ksed13, kts, -1
+            odzq = 1./dzq(k,col)
+            orho = 1./rho(k,col)
+            qsten(k,col) = qsten(k,col) + (sed_s(k+1)-sed_s(k))                 &
+                                               *odzq*onstep3*orho
+            rs(k,col) = MAX(R1, rs(k,col) + (sed_s(k+1)-sed_s(k)) &
+                                           *odzq*DT*onstep3)
+         enddo
+
+         if (rs(kts,col).gt.R1*10.) &
+         pptsnow(col) = pptsnow(col) + sed_s(kts)*DT*onstep3
+      enddo
+
+!+---+-----------------------------------------------------------------+
+
+      nstep = NINT(1./onstep4)
+      do n = 1, nstep
+         do k = kte, kts, -1
+            sed_g(k) = vtgk(k)*rg(k,col)
+         enddo
+         k = kte
+         odzq = 1./dzq(k,col)
+         orho = 1./rho(k,col)
+         qgten(k,col) = qgten(k,col) - sed_g(k)*odzq*onstep4*orho
+         rg(k,col) = MAX(R1, rg(k,col) - sed_g(k)*odzq*DT*onstep4)
+         do k = ksed14, kts, -1
+            odzq = 1./dzq(k,col)
+            orho = 1./rho(k,col)
+            qgten(k,col) = qgten(k,col) + (sed_g(k+1)-sed_g(k))                 &
+                                               *odzq*onstep4*orho
+            rg(k,col) = MAX(R1, rg(k,col) + (sed_g(k+1)-sed_g(k)) &
+                                           *odzq*DT*onstep4)
+         enddo
+
+         if (rg(kts,col).gt.R1*10.) &
+         pptgraul(col) = pptgraul(col) + sed_g(kts)*DT*onstep4
+      enddo
+      enddo  ! col
+!$acc end kernels
+
+!+---+-----------------------------------------------------------------+
+!.. Instantly melt any cloud ice into cloud water if above 0C and
+!.. instantly freeze any cloud water found below HGFR.
+!+---+-----------------------------------------------------------------+
+      if (.not. iiwarm) then
+!$acc kernels      
+      do col = 1,ncol
+      if (no_micro(col)) CYCLE
+
+      do k = kts, kte
+         xri = MAX(0.0, qi1d(k,col) + qiten(k,col)*DT)
+         if ( (temp(k,col).gt. T_0) .and. (xri.gt. 0.0) ) then
+          qcten(k,col) = qcten(k,col) + xri*odt
+          ncten(k,col) = ncten(k,col) + ni1d(k,col)*odt
+          qiten(k,col) = qiten(k,col) - xri*odt
+          niten(k,col) = -ni1d(k,col)*odt
+          tten(k,col) = tten(k,col) - lfus*ocp(k,col)*xri*odt*(1-IFDRY)
+         endif
+
+         xrc = MAX(0.0, qc1d(k,col) + qcten(k,col)*DT)
+         if ( (temp(k,col).lt. HGFR) .and. (xrc.gt. 0.0) ) then
+          lfus2 = lsub - lvap(k,col)
+          xnc = nc1d(k,col) + ncten(k,col)*DT
+          qiten(k,col) = qiten(k,col) + xrc*odt
+          niten(k,col) = niten(k,col) + xnc*odt
+          qcten(k,col) = qcten(k,col) - xrc*odt
+          ncten(k,col) = ncten(k,col) - xnc*odt
+          tten(k,col) = tten(k,col) + lfus2*ocp(k,col)*xrc*odt*(1-IFDRY)
+         endif
+      enddo
+      enddo  ! col
+!$acc end kernels      
+      endif
+
+!+---+-----------------------------------------------------------------+
+!.. All tendencies computed, apply and pass back final values to parent.
+!+---+-----------------------------------------------------------------+
+!$acc kernels      
+      do col = 1,ncol
+      if (no_micro(col)) CYCLE
+      
+      do k = kts, kte
+         t1d(k,col)  = t1d(k,col) + tten(k,col)*DT
+         qv1d(k,col) = MAX(1.E-10, qv1d(k,col) + qvten(k,col)*DT)
+         qc1d(k,col) = qc1d(k,col) + qcten(k,col)*DT
+         nc1d(k,col) = MAX(2./rho(k,col), nc1d(k,col) + ncten(k,col)*DT)
+         nwfa1d(k,col) = MAX(11.1E6/rho(k,col), MIN(9999.E6/rho(k,col),             &
+                       (nwfa1d(k,col)+nwfaten(k,col)*DT)))
+         nifa1d(k,col) = MAX(naIN1*0.01, MIN(9999.E6/rho(k,col),                &
+                       (nifa1d(k,col)+nifaten(k,col)*DT)))
+
+         if (qc1d(k,col) .le. R1) then
+           qc1d(k,col) = 0.0
+           nc1d(k,col) = 0.0
+         else
+           nu_c = MIN(15, NINT(1000.E6/(nc1d(k,col)*rho(k,col))) + 2)
+           lamc = (am_r*ccg(2,nu_c)*ocg1(nu_c)*nc1d(k,col)/qc1d(k,col))**obmr
+           xDc = (bm_r + nu_c + 1.) / lamc
+           if (xDc.lt. D0c) then
+            lamc = cce(2,nu_c)/D0c
+           elseif (xDc.gt. D0r*2.) then
+            lamc = cce(2,nu_c)/(D0r*2.)
+           endif
+           nc1d(k,col) = MIN(ccg(1,nu_c)*ocg2(nu_c)*qc1d(k,col)/am_r*lamc**bm_r,&
+                         DBLE(Nt_c_max)/rho(k,col))
+         endif
+
+         qi1d(k,col) = qi1d(k,col) + qiten(k,col)*DT
+         ni1d(k,col) = MAX(R2/rho(k,col), ni1d(k,col) + niten(k,col)*DT)
+         if (qi1d(k,col) .le. R1) then
+           qi1d(k,col) = 0.0
+           ni1d(k,col) = 0.0
+         else
+           lami = (am_i*cig(2)*oig1*ni1d(k,col)/qi1d(k,col))**obmi
+           ilami = 1./lami
+           xDi = (bm_i + mu_i + 1.) * ilami
+           if (xDi.lt. 20.E-6) then
+            lami = cie(2)/20.E-6
+           elseif (xDi.gt. 300.E-6) then
+            lami = cie(2)/300.E-6
+           endif
+           ni1d(k,col) = MIN(cig(1)*oig2*qi1d(k,col)/am_i*lami**bm_i,           &
+                         499.D3/rho(k,col))
+         endif
+         qr1d(k,col) = qr1d(k,col) + qrten(k,col)*DT
+         nr1d(k,col) = MAX(R2/rho(k,col), nr1d(k,col) + nrten(k,col)*DT)
+         if (qr1d(k,col) .le. R1) then
+           qr1d(k,col) = 0.0
+           nr1d(k,col) = 0.0
+         else
+           lamr = (am_r*crg(3)*org2*nr1d(k,col)/qr1d(k,col))**obmr
+           mvd_r_k = (3.0 + mu_r + 0.672) / lamr
+           if (mvd_r_k .gt. 2.5E-3) then
+              mvd_r_k = 2.5E-3
+           elseif (mvd_r_k .lt. D0r*0.75) then
+              mvd_r_k = D0r*0.75
+           endif
+           lamr = (3.0 + mu_r + 0.672) / mvd_r_k
+           nr1d(k,col) = crg(2)*org3*qr1d(k,col)*lamr**bm_r / am_r
+         endif
+         qs1d(k,col) = qs1d(k,col) + qsten(k,col)*DT
+         if (qs1d(k,col) .le. R1) qs1d(k,col) = 0.0
+         qg1d(k,col) = qg1d(k,col) + qgten(k,col)*DT
+         if (qg1d(k,col) .le. R1) qg1d(k,col) = 0.0
+      enddo
+      enddo ! col
+!$acc end kernels
+!$acc end data
+      end subroutine mp_thompson
+!+---+-----------------------------------------------------------------+
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!..Creation of the lookup tables and support functions found below here.
+!+---+-----------------------------------------------------------------+
+!..Rain collecting graupel (and inverse).  Explicit CE integration.
+!+---+-----------------------------------------------------------------+
+
+      subroutine qr_acr_qg
+
+      implicit none
+
+!..Local variables
+      INTEGER:: i, j, k, m, n, n2
+      INTEGER:: km, km_s, km_e
+      DOUBLE PRECISION, DIMENSION(nbg):: vg, N_g
+      DOUBLE PRECISION, DIMENSION(nbr):: vr, N_r
+      DOUBLE PRECISION:: N0_r, N0_g, lam_exp, lamg, lamr
+      DOUBLE PRECISION:: massg, massr, dvg, dvr, t1, t2, z1, z2, y1, y2
+      LOGICAL force_read_thompson, write_thompson_tables
+      LOGICAL lexist,lopen
+      INTEGER good
+      LOGICAL, EXTERNAL :: wrf_dm_on_monitor
+
+!+---+
+
+      CALL nl_get_force_read_thompson(1,force_read_thompson)
+      CALL nl_get_write_thompson_tables(1,write_thompson_tables)
+
+      good = 0
+      IF ( wrf_dm_on_monitor() ) THEN
+        INQUIRE(FILE="qr_acr_qg.dat",EXIST=lexist)
+        IF ( lexist ) THEN
+          CALL wrf_message("ThompMP: read qr_acr_qg.dat stead of computing")
+          OPEN(63,file="qr_acr_qg.dat",form="unformatted",err=1234)
+          READ(63,err=1234) tcg_racg
+          READ(63,err=1234) tmr_racg
+          READ(63,err=1234) tcr_gacr
+          READ(63,err=1234) tmg_gacr
+          READ(63,err=1234) tnr_racg
+          READ(63,err=1234) tnr_gacr
+          good = 1
+ 1234     CONTINUE
+          IF ( good .NE. 1 ) THEN
+            INQUIRE(63,opened=lopen)
+            IF (lopen) THEN
+              IF( force_read_thompson ) THEN
+                CALL wrf_error_fatal("Error reading qr_acr_qg.dat. Aborting because force_read_thompson is .true.")
+              ENDIF
+              CLOSE(63)
+            ELSE
+              IF( force_read_thompson ) THEN
+                CALL wrf_error_fatal("Error opening qr_acr_qg.dat. Aborting because force_read_thompson is .true.")
+              ENDIF
+            ENDIF
+          ENDIF
+        ELSE
+          IF( force_read_thompson ) THEN
+            CALL wrf_error_fatal("Non-existent qr_acr_qg.dat. Aborting because force_read_thompson is .true.")
+          ENDIF
+        ENDIF
+      ENDIF
+#if defined(DM_PARALLEL) && !defined(STUBMPI)
+      CALL wrf_dm_bcast_integer(good,1)
+#endif
+
+      IF ( good .EQ. 1 ) THEN
+#if defined(DM_PARALLEL) && !defined(STUBMPI)
+        CALL wrf_dm_bcast_double(tcg_racg,SIZE(tcg_racg))
+        CALL wrf_dm_bcast_double(tmr_racg,SIZE(tmr_racg))
+        CALL wrf_dm_bcast_double(tcr_gacr,SIZE(tcr_gacr))
+        CALL wrf_dm_bcast_double(tmg_gacr,SIZE(tmg_gacr))
+        CALL wrf_dm_bcast_double(tnr_racg,SIZE(tnr_racg))
+        CALL wrf_dm_bcast_double(tnr_gacr,SIZE(tnr_gacr))
+#endif
+      ELSE
+        CALL wrf_message("ThompMP: computing qr_acr_qg")
+        do n2 = 1, nbr
+!        vr(n2) = av_r*Dr(n2)**bv_r * DEXP(-fv_r*Dr(n2))
+         vr(n2) = -0.1021 + 4.932E3*Dr(n2) - 0.9551E6*Dr(n2)*Dr(n2)     &
+              + 0.07934E9*Dr(n2)*Dr(n2)*Dr(n2)                          &
+              - 0.002362E12*Dr(n2)*Dr(n2)*Dr(n2)*Dr(n2)
+        enddo
+        do n = 1, nbg
+         vg(n) = av_g*Dg(n)**bv_g
+        enddo
+
+!..Note values returned from wrf_dm_decomp1d are zero-based, add 1 for
+!.. fortran indices.  J. Michalakes, 2009Oct30.
+
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
+        CALL wrf_dm_decomp1d ( ntb_r*ntb_r1, km_s, km_e )
+#else
+        km_s = 0
+        km_e = ntb_r*ntb_r1 - 1
+#endif
+
+        do km = km_s, km_e
+         m = km / ntb_r1 + 1
+         k = mod( km , ntb_r1 ) + 1
+
+         lam_exp = (N0r_exp(k)*am_r*crg(1)/r_r(m))**ore1
+         lamr = lam_exp * (crg(3)*org2*org1)**obmr
+         N0_r = N0r_exp(k)/(crg(2)*lam_exp) * lamr**cre(2)
+         do n2 = 1, nbr
+            N_r(n2) = N0_r*Dr(n2)**mu_r *DEXP(-lamr*Dr(n2))*dtr(n2)
+         enddo
+
+         do j = 1, ntb_g
+         do i = 1, ntb_g1
+            lam_exp = (N0g_exp(i)*am_g*cgg(1)/r_g(j))**oge1
+            lamg = lam_exp * (cgg(3)*ogg2*ogg1)**obmg
+            N0_g = N0g_exp(i)/(cgg(2)*lam_exp) * lamg**cge(2)
+            do n = 1, nbg
+               N_g(n) = N0_g*Dg(n)**mu_g * DEXP(-lamg*Dg(n))*dtg(n)
+            enddo
+
+            t1 = 0.0d0
+            t2 = 0.0d0
+            z1 = 0.0d0
+            z2 = 0.0d0
+            y1 = 0.0d0
+            y2 = 0.0d0
+            do n2 = 1, nbr
+               massr = am_r * Dr(n2)**bm_r
+               do n = 1, nbg
+                  massg = am_g * Dg(n)**bm_g
+
+                  dvg = 0.5d0*((vr(n2) - vg(n)) + DABS(vr(n2)-vg(n)))
+                  dvr = 0.5d0*((vg(n) - vr(n2)) + DABS(vg(n)-vr(n2)))
+
+                  t1 = t1+ PI*.25*Ef_rg*(Dg(n)+Dr(n2))*(Dg(n)+Dr(n2)) &
+                      *dvg*massg * N_g(n)* N_r(n2)
+                  z1 = z1+ PI*.25*Ef_rg*(Dg(n)+Dr(n2))*(Dg(n)+Dr(n2)) &
+                      *dvg*massr * N_g(n)* N_r(n2)
+                  y1 = y1+ PI*.25*Ef_rg*(Dg(n)+Dr(n2))*(Dg(n)+Dr(n2)) &
+                      *dvg       * N_g(n)* N_r(n2)
+
+                  t2 = t2+ PI*.25*Ef_rg*(Dg(n)+Dr(n2))*(Dg(n)+Dr(n2)) &
+                      *dvr*massr * N_g(n)* N_r(n2)
+                  y2 = y2+ PI*.25*Ef_rg*(Dg(n)+Dr(n2))*(Dg(n)+Dr(n2)) &
+                      *dvr       * N_g(n)* N_r(n2)
+                  z2 = z2+ PI*.25*Ef_rg*(Dg(n)+Dr(n2))*(Dg(n)+Dr(n2)) &
+                      *dvr*massg * N_g(n)* N_r(n2)
+               enddo
+ 97            continue
+            enddo
+            tcg_racg(i,j,k,m) = t1
+            tmr_racg(i,j,k,m) = DMIN1(z1, r_r(m)*1.0d0)
+            tcr_gacr(i,j,k,m) = t2
+            tmg_gacr(i,j,k,m) = z2
+            tnr_racg(i,j,k,m) = y1
+            tnr_gacr(i,j,k,m) = y2
+         enddo
+         enddo
+        enddo
+
+!..Note wrf_dm_gatherv expects zero-based km_s, km_e (J. Michalakes, 2009Oct30).
+
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
+        CALL wrf_dm_gatherv(tcg_racg, ntb_g*ntb_g1, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tmr_racg, ntb_g*ntb_g1, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tcr_gacr, ntb_g*ntb_g1, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tmg_gacr, ntb_g*ntb_g1, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tnr_racg, ntb_g*ntb_g1, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tnr_gacr, ntb_g*ntb_g1, km_s, km_e, R8SIZE)
+#endif
+
+        IF ( write_thompson_tables .AND. wrf_dm_on_monitor() ) THEN
+          CALL wrf_message("Writing qr_acr_qg.dat in Thompson MP init")
+          OPEN(63,file="qr_acr_qg.dat",form="unformatted",err=9234)
+          WRITE(63,err=9234) tcg_racg
+          WRITE(63,err=9234) tmr_racg
+          WRITE(63,err=9234) tcr_gacr
+          WRITE(63,err=9234) tmg_gacr
+          WRITE(63,err=9234) tnr_racg
+          WRITE(63,err=9234) tnr_gacr
+          CLOSE(63)
+          RETURN    ! ----- RETURN
+ 9234     CONTINUE
+          CALL wrf_error_fatal("Error writing qr_acr_qg.dat")
+        ENDIF
+      ENDIF
+
+      end subroutine qr_acr_qg
+!+---+-----------------------------------------------------------------+
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!..Rain collecting snow (and inverse).  Explicit CE integration.
+!+---+-----------------------------------------------------------------+
+
+      subroutine qr_acr_qs
+
+      implicit none
+
+!..Local variables
+      INTEGER:: i, j, k, m, n, n2
+      INTEGER:: km, km_s, km_e
+      DOUBLE PRECISION, DIMENSION(nbr):: vr, D1, N_r
+      DOUBLE PRECISION, DIMENSION(nbs):: vs, N_s
+      DOUBLE PRECISION:: loga_, a_, b_, second, M0, M2, M3, Mrat, oM3
+      DOUBLE PRECISION:: N0_r, lam_exp, lamr, slam1, slam2
+      DOUBLE PRECISION:: dvs, dvr, masss, massr
+      DOUBLE PRECISION:: t1, t2, t3, t4, z1, z2, z3, z4
+      DOUBLE PRECISION:: y1, y2, y3, y4
+      LOGICAL force_read_thompson, write_thompson_tables
+      LOGICAL lexist,lopen
+      INTEGER good
+      LOGICAL, EXTERNAL :: wrf_dm_on_monitor
+
+!+---+
+
+      CALL nl_get_force_read_thompson(1,force_read_thompson)
+      CALL nl_get_write_thompson_tables(1,write_thompson_tables)
+
+      good = 0
+      IF ( wrf_dm_on_monitor() ) THEN
+        INQUIRE(FILE="qr_acr_qs.dat",EXIST=lexist)
+        IF ( lexist ) THEN
+          CALL wrf_message("ThompMP: read qr_acr_qs.dat instead of computing")
+          OPEN(63,file="qr_acr_qs.dat",form="unformatted",err=1234)
+          READ(63,err=1234)tcs_racs1
+          READ(63,err=1234)tmr_racs1
+          READ(63,err=1234)tcs_racs2
+          READ(63,err=1234)tmr_racs2
+          READ(63,err=1234)tcr_sacr1
+          READ(63,err=1234)tms_sacr1
+          READ(63,err=1234)tcr_sacr2
+          READ(63,err=1234)tms_sacr2
+          READ(63,err=1234)tnr_racs1
+          READ(63,err=1234)tnr_racs2
+          READ(63,err=1234)tnr_sacr1
+          READ(63,err=1234)tnr_sacr2
+          good = 1
+ 1234     CONTINUE
+          IF ( good .NE. 1 ) THEN
+            INQUIRE(63,opened=lopen)
+            IF (lopen) THEN
+              IF( force_read_thompson ) THEN
+                CALL wrf_error_fatal("Error reading qr_acr_qs.dat. Aborting because force_read_thompson is .true.")
+              ENDIF
+              CLOSE(63)
+            ELSE
+              IF( force_read_thompson ) THEN
+                CALL wrf_error_fatal("Error opening qr_acr_qs.dat. Aborting because force_read_thompson is .true.")
+              ENDIF
+            ENDIF
+          ENDIF
+        ELSE
+          IF( force_read_thompson ) THEN
+            CALL wrf_error_fatal("Non-existent qr_acr_qs.dat. Aborting because force_read_thompson is .true.")
+          ENDIF
+        ENDIF
+      ENDIF
+#if defined(DM_PARALLEL) && !defined(STUBMPI)
+      CALL wrf_dm_bcast_integer(good,1)
+#endif
+
+      IF ( good .EQ. 1 ) THEN
+#if defined(DM_PARALLEL) && !defined(STUBMPI)
+        CALL wrf_dm_bcast_double(tcs_racs1,SIZE(tcs_racs1))
+        CALL wrf_dm_bcast_double(tmr_racs1,SIZE(tmr_racs1))
+        CALL wrf_dm_bcast_double(tcs_racs2,SIZE(tcs_racs2))
+        CALL wrf_dm_bcast_double(tmr_racs2,SIZE(tmr_racs2))
+        CALL wrf_dm_bcast_double(tcr_sacr1,SIZE(tcr_sacr1))
+        CALL wrf_dm_bcast_double(tms_sacr1,SIZE(tms_sacr1))
+        CALL wrf_dm_bcast_double(tcr_sacr2,SIZE(tcr_sacr2))
+        CALL wrf_dm_bcast_double(tms_sacr2,SIZE(tms_sacr2))
+        CALL wrf_dm_bcast_double(tnr_racs1,SIZE(tnr_racs1))
+        CALL wrf_dm_bcast_double(tnr_racs2,SIZE(tnr_racs2))
+        CALL wrf_dm_bcast_double(tnr_sacr1,SIZE(tnr_sacr1))
+        CALL wrf_dm_bcast_double(tnr_sacr2,SIZE(tnr_sacr2))
+#endif
+      ELSE
+        CALL wrf_message("ThompMP: computing qr_acr_qs")
+        do n2 = 1, nbr
+!        vr(n2) = av_r*Dr(n2)**bv_r * DEXP(-fv_r*Dr(n2))
+         vr(n2) = -0.1021 + 4.932E3*Dr(n2) - 0.9551E6*Dr(n2)*Dr(n2)     &
+              + 0.07934E9*Dr(n2)*Dr(n2)*Dr(n2)                          &
+              - 0.002362E12*Dr(n2)*Dr(n2)*Dr(n2)*Dr(n2)
+         D1(n2) = (vr(n2)/av_s)**(1./bv_s)
+        enddo
+        do n = 1, nbs
+         vs(n) = 1.5*av_s*Ds(n)**bv_s * DEXP(-fv_s*Ds(n))
+        enddo
+
+!..Note values returned from wrf_dm_decomp1d are zero-based, add 1 for
+!.. fortran indices.  J. Michalakes, 2009Oct30.
+
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
+        CALL wrf_dm_decomp1d ( ntb_r*ntb_r1, km_s, km_e )
+#else
+        km_s = 0
+        km_e = ntb_r*ntb_r1 - 1
+#endif
+
+        do km = km_s, km_e
+         m = km / ntb_r1 + 1
+         k = mod( km , ntb_r1 ) + 1
+
+         lam_exp = (N0r_exp(k)*am_r*crg(1)/r_r(m))**ore1
+         lamr = lam_exp * (crg(3)*org2*org1)**obmr
+         N0_r = N0r_exp(k)/(crg(2)*lam_exp) * lamr**cre(2)
+         do n2 = 1, nbr
+            N_r(n2) = N0_r*Dr(n2)**mu_r * DEXP(-lamr*Dr(n2))*dtr(n2)
+         enddo
+
+         do j = 1, ntb_t
+            do i = 1, ntb_s
+
+!..From the bm_s moment, compute plus one moment.  If we are not
+!.. using bm_s=2, then we must transform to the pure 2nd moment
+!.. (variable called "second") and then to the bm_s+1 moment.
+
+               M2 = r_s(i)*oams *1.0d0
+               if (bm_s.gt.2.0-1.E-3 .and. bm_s.lt.2.0+1.E-3) then
+                  loga_ = sa(1) + sa(2)*Tc(j) + sa(3)*bm_s &
+                     + sa(4)*Tc(j)*bm_s + sa(5)*Tc(j)*Tc(j) &
+                     + sa(6)*bm_s*bm_s + sa(7)*Tc(j)*Tc(j)*bm_s &
+                     + sa(8)*Tc(j)*bm_s*bm_s + sa(9)*Tc(j)*Tc(j)*Tc(j) &
+                     + sa(10)*bm_s*bm_s*bm_s
+                  a_ = 10.0**loga_
+                  b_ = sb(1) + sb(2)*Tc(j) + sb(3)*bm_s &
+                     + sb(4)*Tc(j)*bm_s + sb(5)*Tc(j)*Tc(j) &
+                     + sb(6)*bm_s*bm_s + sb(7)*Tc(j)*Tc(j)*bm_s &
+                     + sb(8)*Tc(j)*bm_s*bm_s + sb(9)*Tc(j)*Tc(j)*Tc(j) &
+                     + sb(10)*bm_s*bm_s*bm_s
+                  second = (M2/a_)**(1./b_)
+               else
+                  second = M2
+               endif
+
+               loga_ = sa(1) + sa(2)*Tc(j) + sa(3)*cse(1) &
+                  + sa(4)*Tc(j)*cse(1) + sa(5)*Tc(j)*Tc(j) &
+                  + sa(6)*cse(1)*cse(1) + sa(7)*Tc(j)*Tc(j)*cse(1) &
+                  + sa(8)*Tc(j)*cse(1)*cse(1) + sa(9)*Tc(j)*Tc(j)*Tc(j) &
+                  + sa(10)*cse(1)*cse(1)*cse(1)
+               a_ = 10.0**loga_
+               b_ = sb(1)+sb(2)*Tc(j)+sb(3)*cse(1) + sb(4)*Tc(j)*cse(1) &
+                  + sb(5)*Tc(j)*Tc(j) + sb(6)*cse(1)*cse(1) &
+                  + sb(7)*Tc(j)*Tc(j)*cse(1) + sb(8)*Tc(j)*cse(1)*cse(1) &
+                  + sb(9)*Tc(j)*Tc(j)*Tc(j)+sb(10)*cse(1)*cse(1)*cse(1)
+               M3 = a_ * second**b_
+
+               oM3 = 1./M3
+               Mrat = M2*(M2*oM3)*(M2*oM3)*(M2*oM3)
+               M0   = (M2*oM3)**mu_s
+               slam1 = M2 * oM3 * Lam0
+               slam2 = M2 * oM3 * Lam1
+
+               do n = 1, nbs
+                  N_s(n) = Mrat*(Kap0*DEXP(-slam1*Ds(n)) &
+                      + Kap1*M0*Ds(n)**mu_s * DEXP(-slam2*Ds(n)))*dts(n)
+               enddo
+
+               t1 = 0.0d0
+               t2 = 0.0d0
+               t3 = 0.0d0
+               t4 = 0.0d0
+               z1 = 0.0d0
+               z2 = 0.0d0
+               z3 = 0.0d0
+               z4 = 0.0d0
+               y1 = 0.0d0
+               y2 = 0.0d0
+               y3 = 0.0d0
+               y4 = 0.0d0
+               do n2 = 1, nbr
+                  massr = am_r * Dr(n2)**bm_r
+                  do n = 1, nbs
+                     masss = am_s * Ds(n)**bm_s
+      
+                     dvs = 0.5d0*((vr(n2) - vs(n)) + DABS(vr(n2)-vs(n)))
+                     dvr = 0.5d0*((vs(n) - vr(n2)) + DABS(vs(n)-vr(n2)))
+
+                     if (massr .gt. 1.5*masss) then
+                     t1 = t1+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvs*masss * N_s(n)* N_r(n2)
+                     z1 = z1+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvs*massr * N_s(n)* N_r(n2)
+                     y1 = y1+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvs       * N_s(n)* N_r(n2)
+                     else
+                     t3 = t3+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvs*masss * N_s(n)* N_r(n2)
+                     z3 = z3+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvs*massr * N_s(n)* N_r(n2)
+                     y3 = y3+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvs       * N_s(n)* N_r(n2)
+                     endif
+
+                     if (massr .gt. 1.5*masss) then
+                     t2 = t2+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvr*massr * N_s(n)* N_r(n2)
+                     y2 = y2+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvr       * N_s(n)* N_r(n2)
+                     z2 = z2+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvr*masss * N_s(n)* N_r(n2)
+                     else
+                     t4 = t4+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvr*massr * N_s(n)* N_r(n2)
+                     y4 = y4+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvr       * N_s(n)* N_r(n2)
+                     z4 = z4+ PI*.25*Ef_rs*(Ds(n)+Dr(n2))*(Ds(n)+Dr(n2)) &
+                         *dvr*masss * N_s(n)* N_r(n2)
+                     endif
+
+                  enddo
+               enddo
+               tcs_racs1(i,j,k,m) = t1
+               tmr_racs1(i,j,k,m) = DMIN1(z1, r_r(m)*1.0d0)
+               tcs_racs2(i,j,k,m) = t3
+               tmr_racs2(i,j,k,m) = z3
+               tcr_sacr1(i,j,k,m) = t2
+               tms_sacr1(i,j,k,m) = z2
+               tcr_sacr2(i,j,k,m) = t4
+               tms_sacr2(i,j,k,m) = z4
+               tnr_racs1(i,j,k,m) = y1
+               tnr_racs2(i,j,k,m) = y3
+               tnr_sacr1(i,j,k,m) = y2
+               tnr_sacr2(i,j,k,m) = y4
+            enddo
+         enddo
+        enddo
+
+!..Note wrf_dm_gatherv expects zero-based km_s, km_e (J. Michalakes, 2009Oct30).
+
+#if ( defined( DM_PARALLEL ) && ( ! defined( STUBMPI ) ) )
+        CALL wrf_dm_gatherv(tcs_racs1, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tmr_racs1, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tcs_racs2, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tmr_racs2, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tcr_sacr1, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tms_sacr1, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tcr_sacr2, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tms_sacr2, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tnr_racs1, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tnr_racs2, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tnr_sacr1, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+        CALL wrf_dm_gatherv(tnr_sacr2, ntb_s*ntb_t, km_s, km_e, R8SIZE)
+#endif
+        IF ( write_thompson_tables .AND. wrf_dm_on_monitor() ) THEN
+          CALL wrf_message("Writing qr_acr_qs.dat in Thompson MP init")
+          OPEN(63,file="qr_acr_qs.dat",form="unformatted",err=9234)
+          WRITE(63,err=9234)tcs_racs1
+          WRITE(63,err=9234)tmr_racs1
+          WRITE(63,err=9234)tcs_racs2
+          WRITE(63,err=9234)tmr_racs2
+          WRITE(63,err=9234)tcr_sacr1
+          WRITE(63,err=9234)tms_sacr1
+          WRITE(63,err=9234)tcr_sacr2
+          WRITE(63,err=9234)tms_sacr2
+          WRITE(63,err=9234)tnr_racs1
+          WRITE(63,err=9234)tnr_racs2
+          WRITE(63,err=9234)tnr_sacr1
+          WRITE(63,err=9234)tnr_sacr2
+          CLOSE(63)
+          RETURN    ! ----- RETURN
+ 9234     CONTINUE
+          CALL wrf_error_fatal("Error writing qr_acr_qs.dat")
+        ENDIF
+      ENDIF
+
+      end subroutine qr_acr_qs
+!+---+-----------------------------------------------------------------+
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!..This is a literal adaptation of Bigg (1954) probability of drops of
+!..a particular volume freezing.  Given this probability, simply freeze
+!..the proportion of drops summing their masses.
+!+---+-----------------------------------------------------------------+
+
+      subroutine freezeH2O
+
+      implicit none
+
+!..Local variables
+      INTEGER:: i, j, k, m, n, n2
+      DOUBLE PRECISION, DIMENSION(nbr):: N_r, massr
+      DOUBLE PRECISION, DIMENSION(nbc):: N_c, massc
+      DOUBLE PRECISION:: sum1, sum2, sumn1, sumn2, &
+                         prob, vol, Texp, orho_w, &
+                         lam_exp, lamr, N0_r, lamc, N0_c, y
+      INTEGER:: nu_c
+      REAL:: T_adjust
+      LOGICAL force_read_thompson, write_thompson_tables
+      LOGICAL lexist,lopen
+      INTEGER good
+      LOGICAL, EXTERNAL :: wrf_dm_on_monitor
+
+!+---+
+      CALL nl_get_force_read_thompson(1,force_read_thompson)
+      CALL nl_get_write_thompson_tables(1,write_thompson_tables)
+
+      good = 0
+      IF ( wrf_dm_on_monitor() ) THEN
+        INQUIRE(FILE="freezeH2O.dat",EXIST=lexist)
+        IF ( lexist ) THEN
+          CALL wrf_message("ThompMP: read freezeH2O.dat stead of computing")
+          OPEN(63,file="freezeH2O.dat",form="unformatted",err=1234)
+          READ(63,err=1234)tpi_qrfz
+          READ(63,err=1234)tni_qrfz
+          READ(63,err=1234)tpg_qrfz
+          READ(63,err=1234)tnr_qrfz
+          READ(63,err=1234)tpi_qcfz
+          READ(63,err=1234)tni_qcfz
+          good = 1
+ 1234     CONTINUE
+          IF ( good .NE. 1 ) THEN
+            INQUIRE(63,opened=lopen)
+            IF (lopen) THEN
+              IF( force_read_thompson ) THEN
+                CALL wrf_error_fatal("Error reading freezeH2O.dat. Aborting because force_read_thompson is .true.")
+              ENDIF
+              CLOSE(63)
+            ELSE
+              IF( force_read_thompson ) THEN
+                CALL wrf_error_fatal("Error opening freezeH2O.dat. Aborting because force_read_thompson is .true.")
+              ENDIF
+            ENDIF
+          ENDIF
+        ELSE
+          IF( force_read_thompson ) THEN
+            CALL wrf_error_fatal("Non-existent freezeH2O.dat. Aborting because force_read_thompson is .true.")
+          ENDIF
+        ENDIF
+      ENDIF
+
+#if defined(DM_PARALLEL) && !defined(STUBMPI)
+      CALL wrf_dm_bcast_integer(good,1)
+#endif
+
+      IF ( good .EQ. 1 ) THEN
+#if defined(DM_PARALLEL) && !defined(STUBMPI)
+        CALL wrf_dm_bcast_double(tpi_qrfz,SIZE(tpi_qrfz))
+        CALL wrf_dm_bcast_double(tni_qrfz,SIZE(tni_qrfz))
+        CALL wrf_dm_bcast_double(tpg_qrfz,SIZE(tpg_qrfz))
+        CALL wrf_dm_bcast_double(tnr_qrfz,SIZE(tnr_qrfz))
+        CALL wrf_dm_bcast_double(tpi_qcfz,SIZE(tpi_qcfz))
+        CALL wrf_dm_bcast_double(tni_qcfz,SIZE(tni_qcfz))
+#endif
+      ELSE
+        CALL wrf_message("ThompMP: computing freezeH2O")
+
+        orho_w = 1./rho_w
+
+        do n2 = 1, nbr
+         massr(n2) = am_r*Dr(n2)**bm_r
+        enddo
+        do n = 1, nbc
+         massc(n) = am_r*Dc(n)**bm_r
+        enddo
+
+!..Freeze water (smallest drops become cloud ice, otherwise graupel).
+        do m = 1, ntb_IN
+        T_adjust = MAX(-3.0, MIN(3.0 - ALOG10(Nt_IN(m)), 3.0))
+        do k = 1, 45
+!         print*, ' Freezing water for temp = ', -k
+         Texp = DEXP( DFLOAT(k) - T_adjust*1.0D0 ) - 1.0D0
+         do j = 1, ntb_r1
+            do i = 1, ntb_r
+               lam_exp = (N0r_exp(j)*am_r*crg(1)/r_r(i))**ore1
+               lamr = lam_exp * (crg(3)*org2*org1)**obmr
+               N0_r = N0r_exp(j)/(crg(2)*lam_exp) * lamr**cre(2)
+               sum1 = 0.0d0
+               sum2 = 0.0d0
+               sumn1 = 0.0d0
+               sumn2 = 0.0d0
+               do n2 = nbr, 1, -1
+                  N_r(n2) = N0_r*Dr(n2)**mu_r*DEXP(-lamr*Dr(n2))*dtr(n2)
+                  vol = massr(n2)*orho_w
+                  prob = 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp)
+                  if (massr(n2) .lt. xm0g) then
+                     sumn1 = sumn1 + prob*N_r(n2)
+                     sum1 = sum1 + prob*N_r(n2)*massr(n2)
+                  else
+                     sumn2 = sumn2 + prob*N_r(n2)
+                     sum2 = sum2 + prob*N_r(n2)*massr(n2)
+                  endif
+                  if ((sum1+sum2).ge.r_r(i)) EXIT
+               enddo
+               tpi_qrfz(i,j,k,m) = sum1
+               tni_qrfz(i,j,k,m) = sumn1
+               tpg_qrfz(i,j,k,m) = sum2
+               tnr_qrfz(i,j,k,m) = sumn2
+            enddo
+         enddo
+
+         do j = 1, nbc
+            nu_c = MIN(15, NINT(1000.E6/t_Nc(j)) + 2)
+            do i = 1, ntb_c
+               lamc = (t_Nc(j)*am_r* ccg(2,nu_c) * ocg1(nu_c) / r_c(i))**obmr
+               N0_c = t_Nc(j)*ocg1(nu_c) * lamc**cce(1,nu_c)
+               sum1 = 0.0d0
+               sumn2 = 0.0d0
+               do n = nbc, 1, -1
+                  vol = massc(n)*orho_w
+                  prob = 1.0D0 - DEXP(-120.0D0*vol*5.2D-4 * Texp)
+                  N_c(n) = N0_c*Dc(n)**nu_c*EXP(-lamc*Dc(n))*dtc(n)
+                  sumn2 = MIN(t_Nc(j), sumn2 + prob*N_c(n))
+                  sum1 = sum1 + prob*N_c(n)*massc(n)
+                  if (sum1 .ge. r_c(i)) EXIT
+               enddo
+               tpi_qcfz(i,j,k,m) = sum1
+               tni_qcfz(i,j,k,m) = sumn2
+            enddo
+         enddo
+        enddo
+        enddo
+        IF ( write_thompson_tables .AND. wrf_dm_on_monitor() ) THEN
+          CALL wrf_message("Writing freezeH2O.dat in Thompson MP init")
+          OPEN(63,file="freezeH2O.dat",form="unformatted",err=9234)
+          WRITE(63,err=9234)tpi_qrfz
+          WRITE(63,err=9234)tni_qrfz
+          WRITE(63,err=9234)tpg_qrfz
+          WRITE(63,err=9234)tnr_qrfz
+          WRITE(63,err=9234)tpi_qcfz
+          WRITE(63,err=9234)tni_qcfz
+          CLOSE(63)
+          RETURN    ! ----- RETURN
+ 9234     CONTINUE
+          CALL wrf_error_fatal("Error writing freezeH2O.dat")
+        ENDIF
+      ENDIF
+
+      end subroutine freezeH2O
+!+---+-----------------------------------------------------------------+
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!..Cloud ice converting to snow since portion greater than min snow
+!.. size.  Given cloud ice content (kg/m**3), number concentration
+!.. (#/m**3) and gamma shape parameter, mu_i, break the distrib into
+!.. bins and figure out the mass/number of ice with sizes larger than
+!.. D0s.  Also, compute incomplete gamma function for the integration
+!.. of ice depositional growth from diameter=0 to D0s.  Amount of
+!.. ice depositional growth is this portion of distrib while larger
+!.. diameters contribute to snow growth (as in Harrington et al. 1995).
+!+---+-----------------------------------------------------------------+
+
+      subroutine qi_aut_qs
+
+      implicit none
+
+!..Local variables
+      INTEGER:: i, j, n2
+      DOUBLE PRECISION, DIMENSION(nbi):: N_i
+      DOUBLE PRECISION:: N0_i, lami, Di_mean, t1, t2
+      REAL:: xlimit_intg
+
+!+---+
+
+      do j = 1, ntb_i1
+         do i = 1, ntb_i
+            lami = (am_i*cig(2)*oig1*Nt_i(j)/r_i(i))**obmi
+            Di_mean = (bm_i + mu_i + 1.) / lami
+            N0_i = Nt_i(j)*oig1 * lami**cie(1)
+            t1 = 0.0d0
+            t2 = 0.0d0
+            if (SNGL(Di_mean) .gt. 5.*D0s) then
+             t1 = r_i(i)
+             t2 = Nt_i(j)
+             tpi_ide(i,j) = 0.0D0
+            elseif (SNGL(Di_mean) .lt. D0i) then
+             t1 = 0.0D0
+             t2 = 0.0D0
+             tpi_ide(i,j) = 1.0D0
+            else
+             xlimit_intg = lami*D0s
+             tpi_ide(i,j) = GAMMP(mu_i+2.0, xlimit_intg) * 1.0D0
+             do n2 = 1, nbi
+               N_i(n2) = N0_i*Di(n2)**mu_i * DEXP(-lami*Di(n2))*dti(n2)
+               if (Di(n2).ge.D0s) then
+                  t1 = t1 + N_i(n2) * am_i*Di(n2)**bm_i
+                  t2 = t2 + N_i(n2)
+               endif
+             enddo
+            endif
+            tps_iaus(i,j) = t1
+            tni_iaus(i,j) = t2
+         enddo
+      enddo
+      end subroutine qi_aut_qs
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!..Variable collision efficiency for rain collecting cloud water using
+!.. method of Beard and Grover, 1974 if a/A less than 0.25; otherwise
+!.. uses polynomials to get close match of Pruppacher & Klett Fig 14-9.
+!+---+-----------------------------------------------------------------+
+
+      subroutine table_Efrw
+
+      implicit none
+
+!..Local variables
+      DOUBLE PRECISION:: vtr, stokes, reynolds, Ef_rw
+      DOUBLE PRECISION:: p, yc0, F, G, H, z, K0, X
+      INTEGER:: i, j
+
+      do j = 1, nbc
+      do i = 1, nbr
+         Ef_rw = 0.0
+         p = Dc(j)/Dr(i)
+         if (Dr(i).lt.50.E-6 .or. Dc(j).lt.3.E-6) then
+          t_Efrw(i,j) = 0.0
+         elseif (p.gt.0.25) then
+          X = Dc(j)*1.D6
+          if (Dr(i) .lt. 75.e-6) then
+             Ef_rw = 0.026794*X - 0.20604
+          elseif (Dr(i) .lt. 125.e-6) then
+             Ef_rw = -0.00066842*X*X + 0.061542*X - 0.37089
+          elseif (Dr(i) .lt. 175.e-6) then
+             Ef_rw = 4.091e-06*X*X*X*X - 0.00030908*X*X*X               &
+                   + 0.0066237*X*X - 0.0013687*X - 0.073022
+          elseif (Dr(i) .lt. 250.e-6) then
+             Ef_rw = 9.6719e-5*X*X*X - 0.0068901*X*X + 0.17305*X        &
+                   - 0.65988
+          elseif (Dr(i) .lt. 350.e-6) then
+             Ef_rw = 9.0488e-5*X*X*X - 0.006585*X*X + 0.16606*X         &
+                   - 0.56125
+          else
+             Ef_rw = 0.00010721*X*X*X - 0.0072962*X*X + 0.1704*X        &
+                   - 0.46929
+          endif
+         else
+          vtr = -0.1021 + 4.932E3*Dr(i) - 0.9551E6*Dr(i)*Dr(i) &
+              + 0.07934E9*Dr(i)*Dr(i)*Dr(i) &
+              - 0.002362E12*Dr(i)*Dr(i)*Dr(i)*Dr(i)
+          stokes = Dc(j)*Dc(j)*vtr*rho_w/(9.*1.718E-5*Dr(i))
+          reynolds = 9.*stokes/(p*p*rho_w)
+
+          F = DLOG(reynolds)
+          G = -0.1007D0 - 0.358D0*F + 0.0261D0*F*F
+          K0 = DEXP(G)
+          z = DLOG(stokes/(K0+1.D-15))
+          H = 0.1465D0 + 1.302D0*z - 0.607D0*z*z + 0.293D0*z*z*z
+          yc0 = 2.0D0/PI * ATAN(H)
+          Ef_rw = (yc0+p)*(yc0+p) / ((1.+p)*(1.+p))
+
+         endif
+
+         t_Efrw(i,j) = MAX(0.0, MIN(SNGL(Ef_rw), 0.95))
+
+      enddo
+      enddo
+!$acc enter data copyin(t_Efrw)
+      end subroutine table_Efrw
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!..Variable collision efficiency for snow collecting cloud water using
+!.. method of Wang and Ji, 2000 except equate melted snow diameter to
+!.. their "effective collision cross-section."
+!+---+-----------------------------------------------------------------+
+
+      subroutine table_Efsw
+
+      implicit none
+
+!..Local variables
+      DOUBLE PRECISION:: Ds_m, vts, vtc, stokes, reynolds, Ef_sw
+      DOUBLE PRECISION:: p, yc0, F, G, H, z, K0
+      INTEGER:: i, j
+
+      do j = 1, nbc
+      vtc = 1.19D4 * (1.0D4*Dc(j)*Dc(j)*0.25D0)
+      do i = 1, nbs
+         vts = av_s*Ds(i)**bv_s * DEXP(-fv_s*Ds(i)) - vtc
+         Ds_m = (am_s*Ds(i)**bm_s / am_r)**obmr
+         p = Dc(j)/Ds_m
+         if (p.gt.0.25 .or. Ds(i).lt.D0s .or. Dc(j).lt.6.E-6 &
+               .or. vts.lt.1.E-3) then
+          t_Efsw(i,j) = 0.0
+         else
+          stokes = Dc(j)*Dc(j)*vts*rho_w/(9.*1.718E-5*Ds_m)
+          reynolds = 9.*stokes/(p*p*rho_w)
+
+          F = DLOG(reynolds)
+          G = -0.1007D0 - 0.358D0*F + 0.0261D0*F*F
+          K0 = DEXP(G)
+          z = DLOG(stokes/(K0+1.D-15))
+          H = 0.1465D0 + 1.302D0*z - 0.607D0*z*z + 0.293D0*z*z*z
+          yc0 = 2.0D0/PI * ATAN(H)
+          Ef_sw = (yc0+p)*(yc0+p) / ((1.+p)*(1.+p))
+
+          t_Efsw(i,j) = MAX(0.0, MIN(SNGL(Ef_sw), 0.95))
+         endif
+
+      enddo
+      enddo
+!$acc enter data copyin(t_Efsw)
+      end subroutine table_Efsw
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!..Function to compute collision efficiency of collector species (rain,
+!.. snow, graupel) of aerosols.  Follows Wang et al, 2010, ACP, which
+!.. follows Slinn (1983).
+!+---+-----------------------------------------------------------------+
+
+      real function Eff_aero(D, Da, visc,rhoa,Temp,species)
+!$acc routine seq
+      implicit none
+      real:: D, Da, visc, rhoa, Temp
+      character(LEN=1):: species
+      real:: aval, Cc, diff, Re, Sc, St, St2, vt, Eff
+      real, parameter:: boltzman = 1.3806503E-23
+      real, parameter:: meanPath = 0.0256E-6
+
+      vt = 1.
+      if (species .eq. 'r') then
+         vt = -0.1021 + 4.932E3*D - 0.9551E6*D*D                        &
+              + 0.07934E9*D*D*D - 0.002362E12*D*D*D*D
+      elseif (species .eq. 's') then
+         vt = av_s*D**bv_s
+      elseif (species .eq. 'g') then
+         vt = av_g*D**bv_g
+      endif
+
+      Cc    = 1. + 2.*meanPath/Da *(1.257+0.4*exp(-0.55*Da/meanPath))
+      diff  = boltzman*Temp*Cc/(3.*PI*visc*Da)
+
+      Re    = 0.5*rhoa*D*vt/visc
+      Sc    = visc/(rhoa*diff)
+
+      St    = Da*Da*vt*1000./(9.*visc*D)
+      aval  = 1.+LOG(1.+Re)
+      St2   = (1.2 + 1./12.*aval)/(1.+aval)
+
+      Eff = 4./(Re*Sc) * (1. + 0.4*SQRT(Re)*Sc**0.3333                  &
+                             + 0.16*SQRT(Re)*SQRT(Sc))                  &
+               + 4.*Da/D * (0.02 + Da/D*(1.+2.*SQRT(Re)))
+
+      if (St.gt.St2) Eff = Eff  + ( (St-St2)/(St-St2+0.666667))**1.5
+      Eff_aero = MAX(1.E-5, MIN(Eff, 1.0))
+
+      end function Eff_aero
+
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!..Integrate rain size distribution from zero to D-star to compute the
+!.. number of drops smaller than D-star that evaporate in a single
+!.. timestep.  Drops larger than D-star dont evaporate entirely so do
+!.. not affect number concentration.
+!+---+-----------------------------------------------------------------+
+
+      subroutine table_dropEvap
+
+      implicit none
+
+!..Local variables
+      INTEGER:: i, j, k, n
+      DOUBLE PRECISION, DIMENSION(nbc):: N_c, massc
+      DOUBLE PRECISION:: summ, summ2, lamc, N0_c
+      INTEGER:: nu_c
+!      DOUBLE PRECISION:: Nt_r, N0, lam_exp, lam
+!      REAL:: xlimit_intg
+
+      do n = 1, nbc
+         massc(n) = am_r*Dc(n)**bm_r
+      enddo
+
+      do k = 1, nbc
+         nu_c = MIN(15, NINT(1000.E6/t_Nc(k)) + 2)
+         do j = 1, ntb_c
+            lamc = (t_Nc(k)*am_r* ccg(2,nu_c)*ocg1(nu_c) / r_c(j))**obmr
+            N0_c = t_Nc(k)*ocg1(nu_c) * lamc**cce(1,nu_c)
+            do i = 1, nbc
+!-GT           tnc_wev(i,j,k) = GAMMP(nu_c+1., SNGL(Dc(i)*lamc))*t_Nc(k)
+               N_c(i) = N0_c* Dc(i)**nu_c*EXP(-lamc*Dc(i))*dtc(i)
+!     if(j.eq.18 .and. k.eq.50) print*, ' N_c = ', N_c(i)
+               summ = 0.
+               summ2 = 0.
+               do n = 1, i
+                  summ = summ + massc(n)*N_c(n)
+                  summ2 = summ2 + N_c(n)
+               enddo
+!      if(j.eq.18 .and. k.eq.50) print*, '  DEBUG-TABLE: ', r_c(j), t_Nc(k), summ2, summ
+               tpc_wev(i,j,k) = summ
+               tnc_wev(i,j,k) = summ2
+            enddo
+         enddo
+      enddo
+!$acc enter data copyin(tnc_wev,tpc_wev)
+!
+!..To do the same thing for rain.
+!
+!     do k = 1, ntb_r
+!     do j = 1, ntb_r1
+!        lam_exp = (N0r_exp(j)*am_r*crg(1)/r_r(k))**ore1
+!        lam = lam_exp * (crg(3)*org2*org1)**obmr
+!        N0 = N0r_exp(j)/(crg(2)*lam_exp) * lam**cre(2)
+!        Nt_r = N0 * crg(2) / lam**cre(2)
+!        do i = 1, nbr
+!           xlimit_intg = lam*Dr(i)
+!           tnr_rev(i,j,k) = GAMMP(mu_r+1.0, xlimit_intg) * Nt_r
+!        enddo
+!     enddo
+!     enddo
+
+! TO APPLY TABLE ABOVE
+!..Rain lookup table indexes.
+!         Dr_star = DSQRT(-2.D0*DT * t1_evap/(2.*PI) &
+!                 * 0.78*4.*diffu(k)*xsat*rvs/rho_w)
+!         idx_d = NINT(1.0 + FLOAT(nbr) * DLOG(Dr_star/D0r)             &
+!               / DLOG(Dr(nbr)/D0r))
+!         idx_d = MAX(1, MIN(idx_d, nbr))
+!
+!         nir = NINT(ALOG10(rr(k)))
+!         do nn = nir-1, nir+1
+!            n = nn
+!            if ( (rr(k)/10.**nn).ge.1.0 .and. &
+!                 (rr(k)/10.**nn).lt.10.0) goto 154
+!         enddo
+!154      continue
+!         idx_r = INT(rr(k)/10.**n) + 10*(n-nir2) - (n-nir2)
+!         idx_r = MAX(1, MIN(idx_r, ntb_r))
+!
+!         lamr = (am_r*crg(3)*org2*nr(k)/rr(k))**obmr
+!         lam_exp = lamr * (crg(3)*org2*org1)**bm_r
+!         N0_exp = org1*rr(k)/am_r * lam_exp**cre(1)
+!         nir = NINT(DLOG10(N0_exp))
+!         do nn = nir-1, nir+1
+!            n = nn
+!            if ( (N0_exp/10.**nn).ge.1.0 .and. &
+!                 (N0_exp/10.**nn).lt.10.0) goto 155
+!         enddo
+!155      continue
+!         idx_r1 = INT(N0_exp/10.**n) + 10*(n-nir3) - (n-nir3)
+!         idx_r1 = MAX(1, MIN(idx_r1, ntb_r1))
+!
+!         pnr_rev(k) = MIN(nr(k)*odts, SNGL(tnr_rev(idx_d,idx_r1,idx_r) &   ! RAIN2M
+!                    * odts))
+
+      end subroutine table_dropEvap
+!
+!ctrlL
+!+---+-----------------------------------------------------------------+
+!..Fill the table of CCN activation data created from parcel model run
+!.. by Trude Eidhammer with inputs of aerosol number concentration,
+!.. vertical velocity, temperature, lognormal mean aerosol radius, and
+!.. hygroscopicity, kappa.  The data are read from external file and
+!.. contain activated fraction of CCN for given conditions.
+!+---+-----------------------------------------------------------------+
+
+      subroutine table_ccnAct
+
+      USE module_domain
+      USE module_dm
+      implicit none
+
+      LOGICAL, EXTERNAL:: wrf_dm_on_monitor
+
+!..Local variables
+      INTEGER:: iunit_mp_th1, i
+      LOGICAL:: opened
+      CHARACTER*64 errmess
+
+      iunit_mp_th1 = -1
+      IF ( wrf_dm_on_monitor() ) THEN
+        DO i = 20,99
+          INQUIRE ( i , OPENED = opened )
+          IF ( .NOT. opened ) THEN
+            iunit_mp_th1 = i
+            GOTO 2010
+          ENDIF
+        ENDDO
+ 2010   CONTINUE
+      ENDIF
+#if defined(DM_PARALLEL) && !defined(STUBMPI)
+      CALL wrf_dm_bcast_bytes ( iunit_mp_th1 , IWORDSIZE )
+#endif
+      IF ( iunit_mp_th1 < 0 ) THEN
+        CALL wrf_error_fatal ( 'module_mp_thompson: table_ccnAct: '//   &
+           'Can not find unused fortran unit to read in lookup table.')
+      ENDIF
+
+      IF ( wrf_dm_on_monitor() ) THEN
+        WRITE(errmess, '(A,I2)') 'module_mp_thompson: opening CCN_ACTIVATE.BIN on unit ',iunit_mp_th1
+        CALL wrf_debug(150, errmess)
+        OPEN(iunit_mp_th1,FILE='CCN_ACTIVATE.BIN',                      &
+             FORM='UNFORMATTED',STATUS='OLD',ERR=9009)
+      ENDIF
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes(A, size(A)*R4SIZE)
+
+      IF ( wrf_dm_on_monitor() ) READ(iunit_mp_th1,ERR=9010) tnccn_act
+#if defined(DM_PARALLEL) && !defined(STUBMPI)
+      DM_BCAST_MACRO(tnccn_act)
+#endif
+
+      RETURN
+ 9009 CONTINUE
+      WRITE( errmess , '(A,I2)' ) 'module_mp_thompson: error opening CCN_ACTIVATE.BIN on unit ',iunit_mp_th1
+      CALL wrf_error_fatal(errmess)
+      RETURN
+ 9010 CONTINUE
+      WRITE( errmess , '(A,I2)' ) 'module_mp_thompson: error reading CCN_ACTIVATE.BIN on unit ',iunit_mp_th1
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine table_ccnAct
+!^L
+!+---+-----------------------------------------------------------------+
+!..Retrieve fraction of CCN that gets activated given the model temp,
+!.. vertical velocity, and available CCN concentration.  The lookup
+!.. table (read from external file) has CCN concentration varying the
+!.. quickest, then updraft, then temperature, then mean aerosol radius,
+!.. and finally hygroscopicity, kappa.
+!.. TO_DO ITEM:  For radiation cooling producing fog, in which case the
+!.. updraft velocity could easily be negative, we could use the temp
+!.. and its tendency to diagnose a pretend postive updraft velocity.
+!+---+-----------------------------------------------------------------+
+      real function activ_ncloud(Tt, Ww, NCCN)
+      implicit none
+      REAL, INTENT(IN):: Tt, Ww, NCCN
+      REAL:: n_local, w_local
+      INTEGER:: i, j, k, l, m, n
+      REAL:: A, B, C, D, t, u, x1, x2, y1, y2, nx, wy, fraction
+
+
+!     ta_Na = (/10.0, 31.6, 100.0, 316.0, 1000.0, 3160.0, 10000.0/)  ntb_arc
+!     ta_Ww = (/0.01, 0.0316, 0.1, 0.316, 1.0, 3.16, 10.0, 31.6, 100.0/)  ntb_arw
+!     ta_Tk = (/243.15, 253.15, 263.15, 273.15, 283.15, 293.15, 303.15/)  ntb_art
+!     ta_Ra = (/0.01, 0.02, 0.04, 0.08, 0.16/)  ntb_arr
+!     ta_Ka = (/0.2, 0.4, 0.6, 0.8/)  ntb_ark
+
+      n_local = NCCN * 1.E-6
+      w_local = Ww
+
+      if (n_local .ge. ta_Na(ntb_arc)) then
+         n_local = ta_Na(ntb_arc) - 1.0
+      elseif (n_local .le. ta_Na(1)) then
+         n_local = ta_Na(1) + 1.0
+      endif
+      do n = 2, ntb_arc
+         if (n_local.ge.ta_Na(n-1) .and. n_local.lt.ta_Na(n)) goto 8003
+      enddo
+ 8003 continue
+      i = n
+      x1 = LOG(ta_Na(i-1))
+      x2 = LOG(ta_Na(i))
+
+      if (w_local .ge. ta_Ww(ntb_arw)) then
+         w_local = ta_Ww(ntb_arw) - 1.0
+      elseif (w_local .le. ta_Ww(1)) then
+         w_local = ta_Ww(1) + 0.001
+      endif
+      do n = 2, ntb_arw
+         if (w_local.ge.ta_Ww(n-1) .and. w_local.lt.ta_Ww(n)) goto 8005
+      enddo
+ 8005 continue
+      j = n
+      y1 = LOG(ta_Ww(j-1))
+      y2 = LOG(ta_Ww(j))
+
+      k = MAX(1, MIN( NINT( (Tt - ta_Tk(1))*0.1) + 1, ntb_art))
+
+!..The next two values are indexes of mean aerosol radius and
+!.. hygroscopicity.  Currently these are constant but a future version
+!.. should implement other variables to allow more freedom such as
+!.. at least simple separation of tiny size sulfates from larger
+!.. sea salts.
+      l = 3
+      m = 2
+
+      A = tnccn_act(i-1,j-1,k,l,m)
+      B = tnccn_act(i,j-1,k,l,m)
+      C = tnccn_act(i,j,k,l,m)
+      D = tnccn_act(i-1,j,k,l,m)
+      nx = LOG(n_local)
+      wy = LOG(w_local)
+
+      t = (nx-x1)/(x2-x1)
+      u = (wy-y1)/(y2-y1)
+
+!     t = (n_local-ta(Na(i-1))/(ta_Na(i)-ta_Na(i-1))
+!     u = (w_local-ta_Ww(j-1))/(ta_Ww(j)-ta_Ww(j-1))
+
+      fraction = (1.0-t)*(1.0-u)*A + t*(1.0-u)*B + t*u*C + (1.0-t)*u*D
+
+!     if (NCCN*fraction .gt. 0.75*Nt_c_max) then
+!        write(*,*) ' DEBUG-GT ', n_local, w_local, Tt, i, j, k
+!     endif
+
+      activ_ncloud = NCCN*fraction
+
+      end function activ_ncloud
+
+!+---+-----------------------------------------------------------------+
+!+---+-----------------------------------------------------------------+
+      SUBROUTINE GCF(GAMMCF,A,X,GLN)
+!     --- RETURNS THE INCOMPLETE GAMMA FUNCTION Q(A,X) EVALUATED BY ITS
+!     --- CONTINUED FRACTION REPRESENTATION AS GAMMCF.  ALSO RETURNS
+!     --- LN(GAMMA(A)) AS GLN.  THE CONTINUED FRACTION IS EVALUATED BY
+!     --- A MODIFIED LENTZ METHOD.
+!     --- USES GAMMLN
+      IMPLICIT NONE
+      INTEGER, PARAMETER:: ITMAX=100
+      REAL, PARAMETER:: gEPS=3.E-7
+      REAL, PARAMETER:: FPMIN=1.E-30
+      REAL, INTENT(IN):: A, X
+      REAL:: GAMMCF,GLN
+      INTEGER:: I
+      REAL:: AN,B,C,D,DEL,H
+      GLN=GAMMLN(A)
+      B=X+1.-A
+      C=1./FPMIN
+      D=1./B
+      H=D
+      DO 11 I=1,ITMAX
+        AN=-I*(I-A)
+        B=B+2.
+        D=AN*D+B
+        IF(ABS(D).LT.FPMIN)D=FPMIN
+        C=B+AN/C
+        IF(ABS(C).LT.FPMIN)C=FPMIN
+        D=1./D
+        DEL=D*C
+        H=H*DEL
+        IF(ABS(DEL-1.).LT.gEPS)GOTO 1
+ 11   CONTINUE
+      PRINT *, 'A TOO LARGE, ITMAX TOO SMALL IN GCF'
+ 1    GAMMCF=EXP(-X+A*LOG(X)-GLN)*H
+      END SUBROUTINE GCF
+!  (C) Copr. 1986-92 Numerical Recipes Software 2.02
+!+---+-----------------------------------------------------------------+
+      SUBROUTINE GSER(GAMSER,A,X,GLN)
+!     --- RETURNS THE INCOMPLETE GAMMA FUNCTION P(A,X) EVALUATED BY ITS
+!     --- ITS SERIES REPRESENTATION AS GAMSER.  ALSO RETURNS LN(GAMMA(A)) 
+!     --- AS GLN.
+!     --- USES GAMMLN
+      IMPLICIT NONE
+      INTEGER, PARAMETER:: ITMAX=100
+      REAL, PARAMETER:: gEPS=3.E-7
+      REAL, INTENT(IN):: A, X
+      REAL:: GAMSER,GLN
+      INTEGER:: N
+      REAL:: AP,DEL,SUM
+      GLN=GAMMLN(A)
+      IF(X.LE.0.)THEN
+        IF(X.LT.0.) PRINT *, 'X < 0 IN GSER'
+        GAMSER=0.
+        RETURN
+      ENDIF
+      AP=A
+      SUM=1./A
+      DEL=SUM
+      DO 11 N=1,ITMAX
+        AP=AP+1.
+        DEL=DEL*X/AP
+        SUM=SUM+DEL
+        IF(ABS(DEL).LT.ABS(SUM)*gEPS)GOTO 1
+ 11   CONTINUE
+      PRINT *,'A TOO LARGE, ITMAX TOO SMALL IN GSER'
+ 1    GAMSER=SUM*EXP(-X+A*LOG(X)-GLN)
+      END SUBROUTINE GSER
+!  (C) Copr. 1986-92 Numerical Recipes Software 2.02
+!+---+-----------------------------------------------------------------+
+      REAL FUNCTION GAMMLN(XX)
+!     --- RETURNS THE VALUE LN(GAMMA(XX)) FOR XX > 0.
+      IMPLICIT NONE
+      REAL, INTENT(IN):: XX
+      DOUBLE PRECISION, PARAMETER:: STP = 2.5066282746310005D0
+      DOUBLE PRECISION, DIMENSION(6), PARAMETER:: &
+               COF = (/76.18009172947146D0, -86.50532032941677D0, &
+                       24.01409824083091D0, -1.231739572450155D0, &
+                      .1208650973866179D-2, -.5395239384953D-5/)
+      DOUBLE PRECISION:: SER,TMP,X,Y
+      INTEGER:: J
+
+      X=XX
+      Y=X
+      TMP=X+5.5D0
+      TMP=(X+0.5D0)*LOG(TMP)-TMP
+      SER=1.000000000190015D0
+      DO 11 J=1,6
+        Y=Y+1.D0
+        SER=SER+COF(J)/Y
+11    CONTINUE
+      GAMMLN=TMP+LOG(STP*SER/X)
+      END FUNCTION GAMMLN
+!  (C) Copr. 1986-92 Numerical Recipes Software 2.02
+!+---+-----------------------------------------------------------------+
+      REAL FUNCTION GAMMP(A,X)
+!     --- COMPUTES THE INCOMPLETE GAMMA FUNCTION P(A,X)
+!     --- SEE ABRAMOWITZ AND STEGUN 6.5.1
+!     --- USES GCF,GSER
+      IMPLICIT NONE
+      REAL, INTENT(IN):: A,X
+      REAL:: GAMMCF,GAMSER,GLN
+      GAMMP = 0.
+      IF((X.LT.0.) .OR. (A.LE.0.)) THEN
+        PRINT *, 'BAD ARGUMENTS IN GAMMP'
+        RETURN
+      ELSEIF(X.LT.A+1.)THEN
+        CALL GSER(GAMSER,A,X,GLN)
+        GAMMP=GAMSER
+      ELSE
+        CALL GCF(GAMMCF,A,X,GLN)
+        GAMMP=1.-GAMMCF
+      ENDIF
+      END FUNCTION GAMMP
+!  (C) Copr. 1986-92 Numerical Recipes Software 2.02
+!+---+-----------------------------------------------------------------+
+      REAL FUNCTION WGAMMA(y)
+
+      IMPLICIT NONE
+      REAL, INTENT(IN):: y
+
+      WGAMMA = EXP(GAMMLN(y))
+
+      END FUNCTION WGAMMA
+!+---+-----------------------------------------------------------------+
+! THIS FUNCTION CALCULATES THE LIQUID SATURATION VAPOR MIXING RATIO AS
+! A FUNCTION OF TEMPERATURE AND PRESSURE
+!
+      REAL FUNCTION RSLF(P,T)
+!$acc routine seq
+      IMPLICIT NONE
+      REAL, INTENT(IN):: P, T
+      REAL:: ESL,X
+      REAL, PARAMETER:: C0= .611583699E03
+      REAL, PARAMETER:: C1= .444606896E02
+      REAL, PARAMETER:: C2= .143177157E01
+      REAL, PARAMETER:: C3= .264224321E-1
+      REAL, PARAMETER:: C4= .299291081E-3
+      REAL, PARAMETER:: C5= .203154182E-5
+      REAL, PARAMETER:: C6= .702620698E-8
+      REAL, PARAMETER:: C7= .379534310E-11
+      REAL, PARAMETER:: C8=-.321582393E-13
+
+      X=MAX(-80.,T-273.16)
+
+!      ESL=612.2*EXP(17.67*X/(T-29.65))
+      ESL=C0+X*(C1+X*(C2+X*(C3+X*(C4+X*(C5+X*(C6+X*(C7+X*C8)))))))
+      RSLF=.622*ESL/(P-ESL)
+
+!    ALTERNATIVE
+!  ; Source: Murphy and Koop, Review of the vapour pressure of ice and
+!             supercooled water for atmospheric applications, Q. J. R.
+!             Meteorol. Soc (2005), 131, pp. 1539-1565.
+!    ESL = EXP(54.842763 - 6763.22 / T - 4.210 * ALOG(T) + 0.000367 * T
+!        + TANH(0.0415 * (T - 218.8)) * (53.878 - 1331.22
+!        / T - 9.44523 * ALOG(T) + 0.014025 * T))
+
+      END FUNCTION RSLF
+!+---+-----------------------------------------------------------------+
+! THIS FUNCTION CALCULATES THE ICE SATURATION VAPOR MIXING RATIO AS A
+! FUNCTION OF TEMPERATURE AND PRESSURE
+!
+      REAL FUNCTION RSIF(P,T)
+!$acc routine seq
+      IMPLICIT NONE
+      REAL, INTENT(IN):: P, T
+      REAL:: ESI,X
+      REAL, PARAMETER:: C0= .609868993E03
+      REAL, PARAMETER:: C1= .499320233E02
+      REAL, PARAMETER:: C2= .184672631E01
+      REAL, PARAMETER:: C3= .402737184E-1
+      REAL, PARAMETER:: C4= .565392987E-3
+      REAL, PARAMETER:: C5= .521693933E-5
+      REAL, PARAMETER:: C6= .307839583E-7
+      REAL, PARAMETER:: C7= .105785160E-9
+      REAL, PARAMETER:: C8= .161444444E-12
+
+      X=MAX(-80.,T-273.16)
+      ESI=C0+X*(C1+X*(C2+X*(C3+X*(C4+X*(C5+X*(C6+X*(C7+X*C8)))))))
+      RSIF=.622*ESI/(P-ESI)
+
+!    ALTERNATIVE
+!  ; Source: Murphy and Koop, Review of the vapour pressure of ice and
+!             supercooled water for atmospheric applications, Q. J. R.
+!             Meteorol. Soc (2005), 131, pp. 1539-1565.
+!     ESI = EXP(9.550426 - 5723.265/T + 3.53068*ALOG(T) - 0.00728332*T)
+
+      END FUNCTION RSIF
+
+!+---+-----------------------------------------------------------------+
+      real function iceDeMott(tempc, qv, qvs, qvsi, rho, nifa)
+!$acc routine seq      
+      implicit none
+
+      REAL, INTENT(IN):: tempc, qv, qvs, qvsi, rho, nifa
+
+!..Local vars
+      REAL:: satw, sati, siw, p_x, si0x, dtt, dsi, dsw, dab, fc, hx
+      REAL:: ntilde, n_in, nmax, nhat, mux, xni, nifa_cc
+      REAL, PARAMETER:: p_c1    = 1000.
+      REAL, PARAMETER:: p_rho_c = 0.76
+      REAL, PARAMETER:: p_alpha = 1.0
+      REAL, PARAMETER:: p_gam   = 2.
+      REAL, PARAMETER:: delT    = 5.
+      REAL, PARAMETER:: T0x     = -40.
+      REAL, PARAMETER:: Sw0x    = 0.97
+      REAL, PARAMETER:: delSi   = 0.1
+      REAL, PARAMETER:: hdm     = 0.15
+      REAL, PARAMETER:: p_psi   = 0.058707*p_gam/p_rho_c
+      REAL, PARAMETER:: aap     = 1.
+      REAL, PARAMETER:: bbp     = 0.
+      REAL, PARAMETER:: y1p     = -35.
+      REAL, PARAMETER:: y2p     = -25.
+      REAL, PARAMETER:: rho_not0 = 101325./(287.05*273.15)
+!$acc routine(delta_p) seq
+!+---+
+
+      xni = 0.0
+      satw = qv/qvs
+      sati = qv/qvsi
+      siw = qvs/qvsi
+      p_x = -1.0261+(3.1656e-3*tempc)+(5.3938e-4*(tempc*tempc))         &
+                 +  (8.2584e-6*(tempc*tempc*tempc))
+      si0x = 1.+(10.**p_x)
+      if (sati.ge.si0x .and. satw.lt.0.985) then
+         dtt = delta_p (tempc, T0x, T0x+delT, 1., hdm)
+         dsi = delta_p (sati, Si0x, Si0x+delSi, 0., 1.)
+         dsw = delta_p (satw, Sw0x, 1., 0., 1.)
+         fc = dtt*dsi*0.5
+         hx = min(fc+((1.-fc)*dsw), 1.)
+         ntilde = p_c1*p_gam*((exp(12.96*(sati-1.1)))**0.3) / p_rho_c
+         if (tempc .le. y1p) then
+            n_in = ntilde
+         elseif (tempc .ge. y2p) then
+            n_in = p_psi*p_c1*exp(12.96*(sati-1.)-0.639)
+         else
+            if (tempc .le. -30.) then
+               nmax = p_c1*p_gam*(exp(12.96*(siw-1.1)))**0.3/p_rho_c
+            else
+               nmax = p_psi*p_c1*exp(12.96*(siw-1.)-0.639)
+            endif
+            ntilde = MIN(ntilde, nmax)
+            nhat = MIN(p_psi*p_c1*exp(12.96*(sati-1.)-0.639), nmax)
+            dab = delta_p (tempc, y1p, y2p, aap, bbp)
+            n_in = MIN(nhat*(ntilde/nhat)**dab, nmax)
+         endif
+         mux = hx*p_alpha*n_in*rho
+         xni = mux*((6700.*nifa)-200.)/((6700.*5.E5)-200.)
+      elseif (satw.ge.0.985 .and. tempc.gt.HGFR-273.15) then
+         nifa_cc = nifa*RHO_NOT0*1.E-6/rho
+         xni  = 3.*nifa_cc**(1.25)*exp((0.46*(-tempc))-11.6)             !  [DeMott, 2015]
+!        xni = (5.94e-5*(-tempc)**3.33)                                 &
+!                   * (nifa_cc**((-0.0264*(tempc))+0.0033))
+         xni = xni*rho/RHO_NOT0 * 1000.
+      endif
+
+      iceDeMott = MAX(0., xni)
+
+      end FUNCTION iceDeMott
+
+!+---+-----------------------------------------------------------------+
+!..Newer research since Koop et al (2001) suggests that the freezing
+!.. rate should be lower than original paper, so J_rate is reduced
+!.. by two orders of magnitude.
+
+      real function iceKoop(temp, qv, qvs, naero, dt)
+!$acc routine seq      
+      implicit none
+
+      REAL, INTENT(IN):: temp, qv, qvs, naero, DT
+      REAL:: mu_diff, a_w_i, delta_aw, log_J_rate, J_rate, prob_h, satw
+      REAL:: xni
+
+      xni = 0.0
+      satw = qv/qvs
+      mu_diff    = 210368.0 + (131.438*temp) - (3.32373E6/temp)         &
+     &           - (41729.1*alog(temp))
+      a_w_i      = exp(mu_diff/(R_uni*temp))
+      delta_aw   = satw - a_w_i
+      log_J_rate = -906.7 + (8502.0*delta_aw)                           &
+     &           - (26924.0*delta_aw*delta_aw)                          &
+     &           + (29180.0*delta_aw*delta_aw*delta_aw)
+      log_J_rate = MIN(20.0, log_J_rate)
+      J_rate     = 0.01*(10.**log_J_rate)                                ! cm-3 s-1
+      prob_h     = MIN(1.-exp(-J_rate*ar_volume*DT), 1.)
+      if (prob_h .gt. 0.) then
+         xni     = MIN(prob_h*naero, 1000.E3)
+      endif
+
+      iceKoop = MAX(0.0, xni)
+
+      end FUNCTION iceKoop
+
+!+---+-----------------------------------------------------------------+
+!.. Helper routine for Phillips et al (2008) ice nucleation.  Trude
+
+      REAL FUNCTION delta_p (yy, y1, y2, aa, bb)
+!$acc routine seq      
+      IMPLICIT NONE
+
+      REAL, INTENT(IN):: yy, y1, y2, aa, bb
+      REAL:: dab, A, B, a0, a1, a2, a3
+
+      A   = 6.*(aa-bb)/((y2-y1)*(y2-y1)*(y2-y1))
+      B   = aa+(A*y1*y1*y1/6.)-(A*y1*y1*y2*0.5)
+      a0  = B
+      a1  = A*y1*y2
+      a2  = -A*(y1+y2)*0.5
+      a3  = A/3.
+
+      if (yy.le.y1) then 
+         dab = aa
+      else if (yy.ge.y2) then
+         dab = bb
+      else
+         dab = a0+(a1*yy)+(a2*yy*yy)+(a3*yy*yy*yy)
+      endif
+
+      if (dab.lt.aa) then 
+         dab = aa
+      endif
+      if (dab.gt.bb) then 
+         dab = bb
+      endif
+      delta_p = dab
+
+      END FUNCTION delta_p 
+
+!+---+-----------------------------------------------------------------+
+!ctrlL
+
+!+---+-----------------------------------------------------------------+
+!..Compute _radiation_ effective radii of cloud water, ice, and snow.
+!.. These are entirely consistent with microphysics assumptions, not
+!.. constant or otherwise ad hoc as is internal to most radiation
+!.. schemes.  Since only the smallest snowflakes should impact
+!.. radiation, compute from first portion of complicated Field number
+!.. distribution, not the second part, which is the larger sizes.
+!+---+-----------------------------------------------------------------+
+
+      subroutine calc_effectRad (t1d, p1d, qv1d, qc1d, nc1d, qi1d, ni1d, qs1d,   &
+     &                re_qc1d, re_qi1d, re_qs1d, kts, kte, ncols)
+
+      IMPLICIT NONE
+
+!..Sub arguments
+      INTEGER, INTENT(IN):: kts, kte, ncols
+      REAL, DIMENSION(kts:kte,CHNK), INTENT(IN)::                            &
+     &                    t1d, p1d, qv1d, qc1d, nc1d, qi1d, ni1d, qs1d
+      REAL, DIMENSION(kts:kte,CHNK), INTENT(INOUT):: re_qc1d, re_qi1d, re_qs1d
+!..Local variables
+      INTEGER:: k, col
+      REAL, DIMENSION(kts:kte):: rho, rc, nc, ri, ni, rs
+      REAL:: smo2, smob, smoc
+      REAL:: tc0, loga_, a_, b_
+      DOUBLE PRECISION:: lamc, lami
+      LOGICAL:: has_qc, has_qi, has_qs
+      INTEGER:: inu_c
+      real, dimension(15), parameter:: g_ratio = (/24,60,120,210,336,   &
+     &                504,720,990,1320,1716,2184,2730,3360,4080,4896/)
+
+
+      do col=1,ncols
+
+      has_qc = .false.
+      has_qi = .false.
+      has_qs = .false.
+
+      do k = kts, kte
+         rho(k) = 0.622*p1d(k,col)/(R*t1d(k,col)*(qv1d(k,col)+0.622))
+         rc(k) = MAX(R1, qc1d(k,col)*rho(k))
+         nc(k) = MAX(R2, nc1d(k,col)*rho(k))
+         if (.NOT. is_aerosol_aware) nc(k) = Nt_c
+         if (rc(k).gt.R1 .and. nc(k).gt.R2) has_qc = .true.
+         ri(k) = MAX(R1, qi1d(k,col)*rho(k))
+         ni(k) = MAX(R2, ni1d(k,col)*rho(k))
+         if (ri(k).gt.R1 .and. ni(k).gt.R2) has_qi = .true.
+         rs(k) = MAX(R1, qs1d(k,col)*rho(k))
+         if (rs(k).gt.R1) has_qs = .true.
+      enddo
+
+      if (has_qc) then
+      do k = kts, kte
+         if (rc(k).le.R1 .or. nc(k).le.R2) CYCLE
+         if (nc(k).lt.100) then
+            inu_c = 15
+         elseif (nc(k).gt.1.E10) then
+            inu_c = 2
+         else
+            inu_c = MIN(15, NINT(1000.E6/nc(k)) + 2)
+         endif
+         lamc = (nc(k)*am_r*g_ratio(inu_c)/rc(k))**obmr
+         re_qc1d(k,col) = MAX(2.51E-6, MIN(SNGL(0.5D0 * DBLE(3.+inu_c)/lamc), 50.E-6))
+      enddo
+      endif
+
+      if (has_qi) then
+      do k = kts, kte
+         if (ri(k).le.R1 .or. ni(k).le.R2) CYCLE
+         lami = (am_i*cig(2)*oig1*ni(k)/ri(k))**obmi
+         re_qi1d(k,col) = MAX(10.01E-6, MIN(SNGL(0.5D0 * DBLE(3.+mu_i)/lami), 125.E-6))
+      enddo
+      endif
+
+      if (has_qs) then
+      do k = kts, kte
+         if (rs(k).le.R1) CYCLE
+         tc0 = MIN(-0.1, t1d(k,col)-273.15)
+         smob = rs(k)*oams
+
+!..All other moments based on reference, 2nd moment.  If bm_s.ne.2,
+!.. then we must compute actual 2nd moment and use as reference.
+         if (bm_s.gt.(2.0-1.e-3) .and. bm_s.lt.(2.0+1.e-3)) then
+            smo2 = smob
+         else
+            loga_ = sa(1) + sa(2)*tc0 + sa(3)*bm_s &
+     &         + sa(4)*tc0*bm_s + sa(5)*tc0*tc0 &
+     &         + sa(6)*bm_s*bm_s + sa(7)*tc0*tc0*bm_s &
+     &         + sa(8)*tc0*bm_s*bm_s + sa(9)*tc0*tc0*tc0 &
+     &         + sa(10)*bm_s*bm_s*bm_s
+            a_ = 10.0**loga_
+            b_ = sb(1) + sb(2)*tc0 + sb(3)*bm_s &
+     &         + sb(4)*tc0*bm_s + sb(5)*tc0*tc0 &
+     &         + sb(6)*bm_s*bm_s + sb(7)*tc0*tc0*bm_s &
+     &         + sb(8)*tc0*bm_s*bm_s + sb(9)*tc0*tc0*tc0 &
+     &         + sb(10)*bm_s*bm_s*bm_s
+            smo2 = (smob/a_)**(1./b_)
+         endif
+!..Calculate bm_s+1 (th) moment.  Useful for diameter calcs.
+         loga_ = sa(1) + sa(2)*tc0 + sa(3)*cse(1) &
+     &         + sa(4)*tc0*cse(1) + sa(5)*tc0*tc0 &
+     &         + sa(6)*cse(1)*cse(1) + sa(7)*tc0*tc0*cse(1) &
+     &         + sa(8)*tc0*cse(1)*cse(1) + sa(9)*tc0*tc0*tc0 &
+     &         + sa(10)*cse(1)*cse(1)*cse(1)
+         a_ = 10.0**loga_
+         b_ = sb(1)+ sb(2)*tc0 + sb(3)*cse(1) + sb(4)*tc0*cse(1) &
+     &        + sb(5)*tc0*tc0 + sb(6)*cse(1)*cse(1) &
+     &        + sb(7)*tc0*tc0*cse(1) + sb(8)*tc0*cse(1)*cse(1) &
+     &        + sb(9)*tc0*tc0*tc0 + sb(10)*cse(1)*cse(1)*cse(1)
+         smoc = a_ * smo2**b_
+         re_qs1d(k,col) = MAX(10.E-6, MIN(0.5*(smoc/smob), 999.E-6))
+      enddo
+      endif
+      
+      enddo !cols
+
+      end subroutine calc_effectRad
+
+!+---+-----------------------------------------------------------------+
+!..Compute radar reflectivity assuming 10 cm wavelength radar and using
+!.. Rayleigh approximation.  Only complication is melted snow/graupel
+!.. which we treat as water-coated ice spheres and use Uli Blahak's
+!.. library of routines.  The meltwater fraction is simply the amount
+!.. of frozen species remaining from what initially existed at the
+!.. melting level interface.
+!+---+-----------------------------------------------------------------+
+
+      subroutine calc_refl10cm (qv1d, qc1d, qr1d, nr1d, qs1d, qg1d,     &
+                          t1d, p1d, dBZ, kts, kte, ncols)
+
+      IMPLICIT NONE
+
+!..Sub arguments
+      INTEGER, INTENT(IN):: kts, kte, ncols
+      REAL, DIMENSION(kts:kte, CHNK), INTENT(IN)::                            &
+                          qv1d, qc1d, qr1d, nr1d, qs1d, qg1d, t1d, p1d
+      REAL, DIMENSION(kts:kte,CHNK), INTENT(INOUT):: dBZ
+!     REAL, DIMENSION(kts:kte), INTENT(INOUT):: vt_dBZ
+
+!..Local variables
+      REAL, DIMENSION(kts:kte):: temp, pres, qv, rho, rhof
+      REAL, DIMENSION(kts:kte):: rc, rr, nr, rs, rg
+
+      DOUBLE PRECISION, DIMENSION(kts:kte):: ilamr, ilamg, N0_r, N0_g
+      REAL, DIMENSION(kts:kte):: mvd_r
+      REAL, DIMENSION(kts:kte):: smob, smo2, smoc, smoz
+      REAL:: oM3, M0, Mrat, slam1, slam2, xDs
+      REAL:: ils1, ils2, t1_vts, t2_vts, t3_vts, t4_vts
+      REAL:: vtr_dbz_wt, vts_dbz_wt, vtg_dbz_wt
+
+      REAL, DIMENSION(kts:kte):: ze_rain, ze_snow, ze_graupel
+
+      DOUBLE PRECISION:: N0_exp, N0_min, lam_exp, lamr, lamg
+      REAL:: a_, b_, loga_, tc0
+      DOUBLE PRECISION:: fmelt_s, fmelt_g
+
+      INTEGER:: i, k, k_0, kbot, n, col
+      LOGICAL:: melti
+      LOGICAL, DIMENSION(kts:kte):: L_qr, L_qs, L_qg
+
+      DOUBLE PRECISION:: cback, x, eta, f_d
+      REAL:: xslw1, ygra1, zans1
+
+!+---+
+
+      do col=1,ncols
+      do k = kts, kte
+         dBZ(k,col) = -35.0
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Put column of data into local arrays.
+!+---+-----------------------------------------------------------------+
+      do k = kts, kte
+         temp(k) = t1d(k,col)
+         qv(k) = MAX(1.E-10, qv1d(k,col))
+         pres(k) = p1d(k,col)
+         rho(k) = 0.622*pres(k)/(R*temp(k)*(qv(k)+0.622))
+         rhof(k) = SQRT(RHO_NOT/rho(k))
+         rc(k) = MAX(R1, qc1d(k,col)*rho(k))
+         if (qr1d(k,col) .gt. R1) then
+            rr(k) = qr1d(k,col)*rho(k)
+            nr(k) = MAX(R2, nr1d(k,col)*rho(k))
+            lamr = (am_r*crg(3)*org2*nr(k)/rr(k))**obmr
+            ilamr(k) = 1./lamr
+            N0_r(k) = nr(k)*org2*lamr**cre(2)
+            mvd_r(k) = (3.0 + mu_r + 0.672) * ilamr(k)
+            L_qr(k) = .true.
+         else
+            rr(k) = R1
+            nr(k) = R1
+            mvd_r(k) = 50.E-6
+            L_qr(k) = .false.
+         endif
+         if (qs1d(k,col) .gt. R2) then
+            rs(k) = qs1d(k,col)*rho(k)
+            L_qs(k) = .true.
+         else
+            rs(k) = R1
+            L_qs(k) = .false.
+         endif
+         if (qg1d(k,col) .gt. R2) then
+            rg(k) = qg1d(k,col)*rho(k)
+            L_qg(k) = .true.
+         else
+            rg(k) = R1
+            L_qg(k) = .false.
+         endif
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Calculate y-intercept, slope, and useful moments for snow.
+!+---+-----------------------------------------------------------------+
+      do k = kts, kte
+         tc0 = MIN(-0.1, temp(k)-273.15)
+         smob(k) = rs(k)*oams
+
+!..All other moments based on reference, 2nd moment.  If bm_s.ne.2,
+!.. then we must compute actual 2nd moment and use as reference.
+         if (bm_s.gt.(2.0-1.e-3) .and. bm_s.lt.(2.0+1.e-3)) then
+            smo2(k) = smob(k)
+         else
+            loga_ = sa(1) + sa(2)*tc0 + sa(3)*bm_s &
+     &         + sa(4)*tc0*bm_s + sa(5)*tc0*tc0 &
+     &         + sa(6)*bm_s*bm_s + sa(7)*tc0*tc0*bm_s &
+     &         + sa(8)*tc0*bm_s*bm_s + sa(9)*tc0*tc0*tc0 &
+     &         + sa(10)*bm_s*bm_s*bm_s
+            a_ = 10.0**loga_
+            b_ = sb(1) + sb(2)*tc0 + sb(3)*bm_s &
+     &         + sb(4)*tc0*bm_s + sb(5)*tc0*tc0 &
+     &         + sb(6)*bm_s*bm_s + sb(7)*tc0*tc0*bm_s &
+     &         + sb(8)*tc0*bm_s*bm_s + sb(9)*tc0*tc0*tc0 &
+     &         + sb(10)*bm_s*bm_s*bm_s
+            smo2(k) = (smob(k)/a_)**(1./b_)
+         endif
+
+!..Calculate bm_s+1 (th) moment.  Useful for diameter calcs.
+         loga_ = sa(1) + sa(2)*tc0 + sa(3)*cse(1) &
+     &         + sa(4)*tc0*cse(1) + sa(5)*tc0*tc0 &
+     &         + sa(6)*cse(1)*cse(1) + sa(7)*tc0*tc0*cse(1) &
+     &         + sa(8)*tc0*cse(1)*cse(1) + sa(9)*tc0*tc0*tc0 &
+     &         + sa(10)*cse(1)*cse(1)*cse(1)
+         a_ = 10.0**loga_
+         b_ = sb(1)+ sb(2)*tc0 + sb(3)*cse(1) + sb(4)*tc0*cse(1) &
+     &        + sb(5)*tc0*tc0 + sb(6)*cse(1)*cse(1) &
+     &        + sb(7)*tc0*tc0*cse(1) + sb(8)*tc0*cse(1)*cse(1) &
+     &        + sb(9)*tc0*tc0*tc0 + sb(10)*cse(1)*cse(1)*cse(1)
+         smoc(k) = a_ * smo2(k)**b_
+
+!..Calculate bm_s*2 (th) moment.  Useful for reflectivity.
+         loga_ = sa(1) + sa(2)*tc0 + sa(3)*cse(3) &
+     &         + sa(4)*tc0*cse(3) + sa(5)*tc0*tc0 &
+     &         + sa(6)*cse(3)*cse(3) + sa(7)*tc0*tc0*cse(3) &
+     &         + sa(8)*tc0*cse(3)*cse(3) + sa(9)*tc0*tc0*tc0 &
+     &         + sa(10)*cse(3)*cse(3)*cse(3)
+         a_ = 10.0**loga_
+         b_ = sb(1)+ sb(2)*tc0 + sb(3)*cse(3) + sb(4)*tc0*cse(3) &
+     &        + sb(5)*tc0*tc0 + sb(6)*cse(3)*cse(3) &
+     &        + sb(7)*tc0*tc0*cse(3) + sb(8)*tc0*cse(3)*cse(3) &
+     &        + sb(9)*tc0*tc0*tc0 + sb(10)*cse(3)*cse(3)*cse(3)
+         smoz(k) = a_ * smo2(k)**b_
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Calculate y-intercept, slope values for graupel.
+!+---+-----------------------------------------------------------------+
+
+      N0_min = gonv_max
+      do k = kte, kts, -1
+         if (temp(k).lt.270.65 .and. L_qr(k) .and. mvd_r(k).gt.100.E-6) then
+            xslw1 = 4.01 + alog10(mvd_r(k))
+         else
+            xslw1 = 0.01
+         endif
+         ygra1 = 4.31 + alog10(max(5.E-5, rg(k)))
+         zans1 = 3.1 + (100./(300.*xslw1*ygra1/(10./xslw1+1.+0.25*ygra1)+30.+10.*ygra1))
+         N0_exp = 10.**(zans1)
+         N0_exp = MAX(DBLE(gonv_min), MIN(N0_exp, DBLE(gonv_max)))
+         N0_min = MIN(N0_exp, N0_min)
+         N0_exp = N0_min
+         lam_exp = (N0_exp*am_g*cgg(1)/rg(k))**oge1
+         lamg = lam_exp * (cgg(3)*ogg2*ogg1)**obmg
+         ilamg(k) = 1./lamg
+         N0_g(k) = N0_exp/(cgg(2)*lam_exp) * lamg**cge(2)
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Locate K-level of start of melting (k_0 is level above).
+!+---+-----------------------------------------------------------------+
+      melti = .false.
+      k_0 = kts
+      do k = kte-1, kts, -1
+         if ( (temp(k).gt.273.15) .and. L_qr(k)                         &
+     &                            .and. (L_qs(k+1).or.L_qg(k+1)) ) then
+            k_0 = MAX(k+1, k_0)
+            melti=.true.
+            goto 195
+         endif
+      enddo
+ 195  continue
+
+!+---+-----------------------------------------------------------------+
+!..Assume Rayleigh approximation at 10 cm wavelength. Rain (all temps)
+!.. and non-water-coated snow and graupel when below freezing are
+!.. simple. Integrations of m(D)*m(D)*N(D)*dD.
+!+---+-----------------------------------------------------------------+
+
+      do k = kts, kte
+         ze_rain(k) = 1.e-22
+         ze_snow(k) = 1.e-22
+         ze_graupel(k) = 1.e-22
+         if (L_qr(k)) ze_rain(k) = N0_r(k)*crg(4)*ilamr(k)**cre(4)
+         if (L_qs(k)) ze_snow(k) = (0.176/0.93) * (6.0/PI)*(6.0/PI)     &
+     &                           * (am_s/900.0)*(am_s/900.0)*smoz(k)
+         if (L_qg(k)) ze_graupel(k) = (0.176/0.93) * (6.0/PI)*(6.0/PI)  &
+     &                              * (am_g/900.0)*(am_g/900.0)         &
+     &                              * N0_g(k)*cgg(4)*ilamg(k)**cge(4)
+      enddo
+
+!+---+-----------------------------------------------------------------+
+!..Special case of melting ice (snow/graupel) particles.  Assume the
+!.. ice is surrounded by the liquid water.  Fraction of meltwater is
+!.. extremely simple based on amount found above the melting level.
+!.. Uses code from Uli Blahak (rayleigh_soak_wetgraupel and supporting
+!.. routines).
+!+---+-----------------------------------------------------------------+
+
+      if (.not. iiwarm .and. melti .and. k_0.ge.2) then
+       do k = k_0-1, kts, -1
+
+!..Reflectivity contributed by melting snow
+          if (L_qs(k) .and. L_qs(k_0) ) then
+           fmelt_s = MAX(0.05d0, MIN(1.0d0-rs(k)/rs(k_0), 0.99d0))
+           eta = 0.d0
+           oM3 = 1./smoc(k)
+           M0 = (smob(k)*oM3)
+           Mrat = smob(k)*M0*M0*M0
+           slam1 = M0 * Lam0
+           slam2 = M0 * Lam1
+           do n = 1, nrbins
+              x = am_s * xxDs(n)**bm_s
+              call rayleigh_soak_wetgraupel (x, DBLE(ocms), DBLE(obms), &
+     &              fmelt_s, melt_outside_s, m_w_0, m_i_0, lamda_radar, &
+     &              CBACK, mixingrulestring_s, matrixstring_s,          &
+     &              inclusionstring_s, hoststring_s,                    &
+     &              hostmatrixstring_s, hostinclusionstring_s)
+              f_d = Mrat*(Kap0*DEXP(-slam1*xxDs(n))                     &
+     &              + Kap1*(M0*xxDs(n))**mu_s * DEXP(-slam2*xxDs(n)))
+              eta = eta + f_d * CBACK * simpson(n) * xdts(n)
+           enddo
+           ze_snow(k) = SNGL(lamda4 / (pi5 * K_w) * eta)
+          endif
+
+!..Reflectivity contributed by melting graupel
+
+          if (L_qg(k) .and. L_qg(k_0) ) then
+           fmelt_g = MAX(0.05d0, MIN(1.0d0-rg(k)/rg(k_0), 0.99d0))
+           eta = 0.d0
+           lamg = 1./ilamg(k)
+           do n = 1, nrbins
+              x = am_g * xxDg(n)**bm_g
+              call rayleigh_soak_wetgraupel (x, DBLE(ocmg), DBLE(obmg), &
+     &              fmelt_g, melt_outside_g, m_w_0, m_i_0, lamda_radar, &
+     &              CBACK, mixingrulestring_g, matrixstring_g,          &
+     &              inclusionstring_g, hoststring_g,                    &
+     &              hostmatrixstring_g, hostinclusionstring_g)
+              f_d = N0_g(k)*xxDg(n)**mu_g * DEXP(-lamg*xxDg(n))
+              eta = eta + f_d * CBACK * simpson(n) * xdtg(n)
+           enddo
+           ze_graupel(k) = SNGL(lamda4 / (pi5 * K_w) * eta)
+          endif
+
+       enddo
+      endif
+
+      do k = kte, kts, -1
+         dBZ(k,col) = 10.*log10((ze_rain(k)+ze_snow(k)+ze_graupel(k))*1.d18)
+      enddo
+
+
+!..Reflectivity-weighted terminal velocity (snow, rain, graupel, mix).
+!     do k = kte, kts, -1
+!        vt_dBZ(k) = 1.E-3
+!        if (rs(k).gt.R2) then
+!         Mrat = smob(k) / smoc(k)
+!         ils1 = 1./(Mrat*Lam0 + fv_s)
+!         ils2 = 1./(Mrat*Lam1 + fv_s)
+!         t1_vts = Kap0*csg(5)*ils1**cse(5)
+!         t2_vts = Kap1*Mrat**mu_s*csg(11)*ils2**cse(11)
+!         ils1 = 1./(Mrat*Lam0)
+!         ils2 = 1./(Mrat*Lam1)
+!         t3_vts = Kap0*csg(6)*ils1**cse(6)
+!         t4_vts = Kap1*Mrat**mu_s*csg(12)*ils2**cse(12)
+!         vts_dbz_wt = rhof(k)*av_s * (t1_vts+t2_vts)/(t3_vts+t4_vts)
+!         if (temp(k).ge.273.15 .and. temp(k).lt.275.15) then
+!            vts_dbz_wt = vts_dbz_wt*1.5
+!         elseif (temp(k).ge.275.15) then
+!            vts_dbz_wt = vts_dbz_wt*2.0
+!         endif
+!        else
+!         vts_dbz_wt = 1.E-3
+!        endif
+
+!        if (rr(k).gt.R1) then
+!         lamr = 1./ilamr(k)
+!         vtr_dbz_wt = rhof(k)*av_r*crg(13)*(lamr+fv_r)**(-cre(13))      &
+!    &               / (crg(4)*lamr**(-cre(4)))
+!        else
+!         vtr_dbz_wt = 1.E-3
+!        endif
+
+!        if (rg(k).gt.R2) then
+!         lamg = 1./ilamg(k)
+!         vtg_dbz_wt = rhof(k)*av_g*cgg(5)*lamg**(-cge(5))               &
+!    &               / (cgg(4)*lamg**(-cge(4)))
+!        else
+!         vtg_dbz_wt = 1.E-3
+!        endif
+
+!        vt_dBZ(k) = (vts_dbz_wt*ze_snow(k) + vtr_dbz_wt*ze_rain(k)      &
+!    &                + vtg_dbz_wt*ze_graupel(k))                        &
+!    &                / (ze_rain(k)+ze_snow(k)+ze_graupel(k))
+!     enddo
+      enddo !col
+      end subroutine calc_refl10cm
+!
+!+---+-----------------------------------------------------------------+
+
+!+---+-----------------------------------------------------------------+
+END MODULE module_mp_thompson
+!+---+-----------------------------------------------------------------+

--- a/src/fromNVIDIA/module_ra_rrtmg_lwf.F
+++ b/src/fromNVIDIA/module_ra_rrtmg_lwf.F
@@ -1,0 +1,18782 @@
+!MODULE module_ra_rrtmg_lwf
+!#define CHNK 8
+
+#define CHNK 512
+!#define CHNK 43
+
+! --------------------------------------------------------------------------
+! | |
+! | Copyright 2002-2013, Atmospheric & Environmental Research, Inc. (AER). |
+! | This software may be used, copied, or redistributed as long as it is |
+! | not sold and this copyright notice is reproduced on each copy made. |
+! | This model is provided as is without any express or implied warranties. |
+! | (http:
+! | |
+! --------------------------------------------------------------------------
+
+! Uncomment to use GPU, or comment to use CPU
+!#define _ACCEL
+
+module memory
+end module
+
+
+
+      module parrrtm_f
+
+! use parkind ,only : im => kind
+
+! implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_lw main parameters
+!
+! Initial version: JJMorcrette, ECMWF, Jul 1998
+! Revised: MJIacono, AER, Jun 2006
+! Revised: MJIacono, AER, Aug 2007
+! Revised: MJIacono, AER, Aug 2008
+!------------------------------------------------------------------
+
+! name type purpose
+! ----- : ---- : ----------------------------------------------
+! mxlay : integer: maximum number of layers
+! mg : integer: number of original g-intervals per spectral band
+! nbndlw : integer: number of spectral bands
+! maxxsec: integer: maximum number of cross-section molecules
+! (e.g. cfcs)
+! maxinpx: integer:
+! ngptlw : integer: total number of reduced g-intervals for rrtmg_lw
+! ngNN : integer: number of reduced g-intervals per spectral band
+! ngsNN : integer: cumulative number of g-intervals per band
+!------------------------------------------------------------------
+
+      integer , parameter :: mxlay = 100
+      integer , parameter :: mg = 16
+      integer , parameter :: nbndlw = 16
+      integer , parameter :: maxxsec= 4
+      integer , parameter :: mxmol = 38
+      integer , parameter :: maxinpx= 38
+      integer , parameter :: nmol = 7
+! Use for 140 g-point model
+      integer , parameter :: ngptlw = 140
+! Use for 256 g-point model
+! integer , parameter :: ngptlw = 256
+
+! Use for 140 g-point model
+      integer , parameter :: ng1 = 10
+      integer , parameter :: ng2 = 12
+      integer , parameter :: ng3 = 16
+      integer , parameter :: ng4 = 14
+      integer , parameter :: ng5 = 16
+      integer , parameter :: ng6 = 8
+      integer , parameter :: ng7 = 12
+      integer , parameter :: ng8 = 8
+      integer , parameter :: ng9 = 12
+      integer , parameter :: ng10 = 6
+      integer , parameter :: ng11 = 8
+      integer , parameter :: ng12 = 8
+      integer , parameter :: ng13 = 4
+      integer , parameter :: ng14 = 2
+      integer , parameter :: ng15 = 2
+      integer , parameter :: ng16 = 2
+
+      integer , parameter :: ngs1 = 10
+      integer , parameter :: ngs2 = 22
+      integer , parameter :: ngs3 = 38
+      integer , parameter :: ngs4 = 52
+      integer , parameter :: ngs5 = 68
+      integer , parameter :: ngs6 = 76
+      integer , parameter :: ngs7 = 88
+      integer , parameter :: ngs8 = 96
+      integer , parameter :: ngs9 = 108
+      integer , parameter :: ngs10 = 114
+      integer , parameter :: ngs11 = 122
+      integer , parameter :: ngs12 = 130
+      integer , parameter :: ngs13 = 134
+      integer , parameter :: ngs14 = 136
+      integer , parameter :: ngs15 = 138
+
+! Use for 256 g-point model
+! integer , parameter :: ng1 = 16
+! integer , parameter :: ng2 = 16
+! integer , parameter :: ng3 = 16
+! integer , parameter :: ng4 = 16
+! integer , parameter :: ng5 = 16
+! integer , parameter :: ng6 = 16
+! integer , parameter :: ng7 = 16
+! integer , parameter :: ng8 = 16
+! integer , parameter :: ng9 = 16
+! integer , parameter :: ng10 = 16
+! integer , parameter :: ng11 = 16
+! integer , parameter :: ng12 = 16
+! integer , parameter :: ng13 = 16
+! integer , parameter :: ng14 = 16
+! integer , parameter :: ng15 = 16
+! integer , parameter :: ng16 = 16
+
+! integer , parameter :: ngs1 = 16
+! integer , parameter :: ngs2 = 32
+! integer , parameter :: ngs3 = 48
+! integer , parameter :: ngs4 = 64
+! integer , parameter :: ngs5 = 80
+! integer , parameter :: ngs6 = 96
+! integer , parameter :: ngs7 = 112
+! integer , parameter :: ngs8 = 128
+! integer , parameter :: ngs9 = 144
+! integer , parameter :: ngs10 = 160
+! integer , parameter :: ngs11 = 176
+! integer , parameter :: ngs12 = 192
+! integer , parameter :: ngs13 = 208
+! integer , parameter :: ngs14 = 224
+! integer , parameter :: ngs15 = 240
+! integer , parameter :: ngs16 = 256
+
+      end module parrrtm_f
+
+      module rrlw_cld_f
+
+! use parkind, only : rb => kind
+
+! implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_lw cloud property coefficients
+
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+! name type purpose
+! ----- : ---- : ----------------------------------------------
+! abscld1: real :
+! absice0: real :
+! absice1: real :
+! absice2: real :
+! absice3: real :
+! absliq0: real :
+! absliq1: real :
+!------------------------------------------------------------------
+
+      real :: abscld1
+      real , dimension(2) :: absice0
+      real , dimension(2,5) :: absice1
+      real , dimension(43,16) :: absice2
+      real , dimension(46,16) :: absice3
+      real :: absliq0
+      real , dimension(58,16) :: absliq1
+
+      end module rrlw_cld_f
+
+      module rrlw_con_f
+
+! use parkind, only : rb => kind
+
+! implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_lw constants
+
+! Initial version: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+! name type purpose
+! ----- : ---- : ----------------------------------------------
+! fluxfac: real : radiance to flux conversion factor
+! heatfac: real : flux to heating rate conversion factor
+!oneminus: real : 1.-1.e-6
+! pi : real : pi
+! grav : real : acceleration of gravity
+! planck : real : planck constant
+! boltz : real : boltzmann constant
+! clight : real : speed of light
+! avogad : real : avogadro constant
+! alosmt : real : loschmidt constant
+! gascon : real : molar gas constant
+! radcn1 : real : first radiation constant
+! radcn2 : real : second radiation constant
+! sbcnst : real : stefan-boltzmann constant
+! secdy : real : seconds per day
+!------------------------------------------------------------------
+
+      real :: fluxfac, heatfac
+      real :: oneminus, pi, grav
+      real :: planck, boltz, clight
+      real :: avogad, alosmt, gascon
+      real :: radcn1, radcn2
+      real :: sbcnst, secdy
+
+      end module rrlw_con_f
+
+      module rrlw_kg01_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 1
+! band 1: 10-250 cm-1 (low - h2o; high - h2o)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! kao_mn2 : real
+! kbo_mn2 : real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no1 = 16
+
+      real :: fracrefao(no1) , fracrefbo(no1)
+      real :: kao(5,13,no1)
+      real :: kbo(5,13:59,no1)
+      real :: kao_mn2(19,no1) , kbo_mn2(19,no1)
+      real :: selfrefo(10,no1), forrefo(4,no1)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 1
+! band 1: 10-250 cm-1 (low - h2o; high - h2o)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+!fracrefb : real
+! ka : real
+! kb : real
+! absa : real
+! absb : real
+! ka_mn2 : real
+! kb_mn2 : real
+! selfref : real
+! forref : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng1 = 10
+
+
+      real :: ka(5,13,ng1) , absa(65,ng1)
+      real :: kb(5,13:59,ng1), absb(235,ng1)
+      real ,target :: fracrefa(ng1) , fracrefb(ng1)
+      real ,target :: ka_mn2(19,ng1) , kb_mn2(19,ng1)
+      real ,target :: selfref(10,ng1), forref(4,ng1)
+
+
+      real ,allocatable :: kad(:,:,:), absad(:,:), absbd(:,:)
+      real ,allocatable :: kbd(:,:,:)
+
+      real ,pointer :: fracrefad(:) , fracrefbd(:)
+      real ,pointer :: ka_mn2d(:,:) , kb_mn2d(:,:)
+      real ,pointer :: selfrefd(:,:), forrefd(:,:)
+
+      equivalence (ka(1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU1
+
+        fracrefad=>fracrefa
+        fracrefbd=>fracrefb
+        ka_mn2d=>ka_mn2
+        kb_mn2d=>kb_mn2
+        selfrefd=>selfref
+        forrefd=>forref
+
+        if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 65, ng1)); absad=absa
+        if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 235, ng1)); absbd=absb
+!$acc enter data copyin(absad,absbd)
+      end subroutine
+
+      subroutine reg1
+
+       
+       
+       
+       
+       
+       
+       
+       
+
+      end subroutine
+
+      end module rrlw_kg01_f
+
+      module rrlw_kg02_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 2
+! band 2: 250-500 cm-1 (low - h2o; high - h2o)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no2 = 16
+      real ,target :: kao(5,13,no2)
+      real ,target :: kbo(5,13:59,no2)
+      real ,target :: fracrefao(no2) , fracrefbo(no2)
+      real ,target :: selfrefo(10,no2) , forrefo(4,no2)
+
+      real ,pointer :: fracrefaod(:) , fracrefbod(:)
+      real ,pointer :: selfrefod(:,:) , forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 2
+! band 2: 250-500 cm-1 (low - h2o; high - h2o)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+!fracrefb : real
+! ka : real
+! kb : real
+! absa : real
+! absb : real
+! selfref : real
+! forref : real
+!
+! refparam: real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng2 = 12
+
+      real ,target :: fracrefa(ng2) , fracrefb(ng2)
+      real :: ka(5,13,ng2) , absa(65,ng2)
+      real :: kb(5,13:59,ng2), absb(235,ng2)
+      real ,target :: selfref(10,ng2), forref(4,ng2)
+
+      real ,pointer :: fracrefad(:) , fracrefbd(:)
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: selfrefd(:,:), forrefd(:,:)
+
+      real :: refparam(13)
+
+      equivalence (ka(1,1,1),absa(1,1)),(kb(1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU2
+
+        fracrefaod=>fracrefao
+        fracrefbod=>fracrefbo
+        selfrefod=>selfrefo
+        forrefod=>forrefo
+
+        fracrefad=>fracrefa
+        fracrefbd=>fracrefb
+
+        if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 65, ng2)); absad=absa
+        if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 235, ng2)); absbd=absb
+
+        selfrefd=>selfref
+        forrefd=>forref
+!$acc enter data copyin(absad,absbd)
+      end subroutine
+
+      subroutine reg2
+         ! 9
+       
+       
+       
+       
+
+       
+       
+       
+       
+       
+       
+
+      end subroutine
+
+      end module rrlw_kg02_f
+
+      module rrlw_kg03_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 3
+! band 3: 500-630 cm-1 (low - h2o,co2; high - h2o,co2)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! kao_mn2o: real
+! kbo_mn2o: real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no3 = 16
+
+      real ,target :: fracrefao(no3,9) ,fracrefbo(no3,5)
+      real ,target :: kao(9,5,13,no3)
+      real ,target :: kbo(5,5,13:59,no3)
+      real ,target :: kao_mn2o(9,19,no3), kbo_mn2o(5,19,no3)
+      real ,target :: selfrefo(10,no3)
+      real ,target :: forrefo(4,no3)
+
+      real ,pointer :: fracrefaod(:,:) ,fracrefbod(:,:)
+      !real ,pointer :: kaod(9,5,13,no3)
+      !real ,pointer :: kbod(5,5,13:59,no3)
+      real ,pointer :: kao_mn2od(:,:,:), kbo_mn2od(:,:,:)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 3
+! band 3: 500-630 cm-1 (low - h2o,co2; high - h2o,co2)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+!fracrefb : real
+! ka : real
+! kb : real
+! ka_mn2o : real
+! kb_mn2o : real
+! selfref : real
+! forref : real
+!
+! absa : real
+! absb : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng3 = 16
+
+      real ,target :: fracrefa(ng3,9) ,fracrefb(ng3,5)
+      real :: ka(9,5,13,ng3) ,absa(585,ng3)
+      real :: kb(5,5,13:59,ng3),absb(1175,ng3)
+      real ,target :: ka_mn2o(9,19,ng3), kb_mn2o(5,19,ng3)
+      real ,target :: selfref(10,ng3)
+      real ,target :: forref(4,ng3)
+
+      real ,pointer :: fracrefad(:,:) ,fracrefbd(:,:)
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: ka_mn2od(:,:,:), kb_mn2od(:,:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      equivalence (ka(1,1,1,1),absa(1,1)),(kb(1,1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU3
+
+       fracrefaod=>fracrefao
+       fracrefbod=>fracrefbo
+       kao_mn2od=>kao_mn2o
+       kbo_mn2od=>kbo_mn2o
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+
+       fracrefad=>fracrefa
+       fracrefbd=>fracrefb
+
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 585, ng3)); absad=absa
+       if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 1175, ng3)); absbd=absb
+
+       ka_mn2od=>ka_mn2o
+       kb_mn2od=>kb_mn2o
+       selfrefd=>selfref
+       forrefd=>forref
+!$acc enter data copyin(absad,absbd)
+      end subroutine
+
+      subroutine reg3
+       !19
+      
+      
+
+      
+      
+      
+      
+
+      
+      
+
+      
+
+      
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg03_f
+
+      module rrlw_kg04_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 4
+! band 4: 630-700 cm-1 (low - h2o,co2; high - o3,co2)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+      integer , parameter :: ng4 = 14
+      integer , parameter :: no4 = 16
+
+      real ,target :: kao(9,5,13,no4)
+      real ,target :: kbo(5,5,13:59,no4)
+      real :: ka(9,5,13,ng4) ,absa(585,ng4)
+      real :: kb(5,5,13:59,ng4),absb(1175,ng4)
+
+      real ,target :: fracrefao(no4,9) ,fracrefbo(no4,5)
+
+      real ,target :: selfrefo(10,no4) ,forrefo(4,no4)
+
+      real ,pointer :: fracrefaod(:,:) ,fracrefbod(:,:)
+      !real :: kaod(9,5,13,no4)
+      !real :: kbod(5,5,13:59,no4)
+      real ,pointer :: selfrefod(:,:) ,forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 4
+! band 4: 630-700 cm-1 (low - h2o,co2; high - o3,co2)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+! absa : real
+! absb : real
+!fracrefa : real
+!fracrefb : real
+! ka : real
+! kb : real
+! selfref : real
+! forref : real
+!-----------------------------------------------------------------
+
+      real ,target :: fracrefa(ng4,9) ,fracrefb(ng4,5)
+
+      real ,target :: selfref(10,ng4) ,forref(4,ng4)
+
+      real ,pointer :: fracrefad(:,:) ,fracrefbd(:,:)
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: selfrefd(:,:) ,forrefd(:,:)
+
+      equivalence (ka(1,1,1,1),absa(1,1)),(kb(1,1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU4
+
+       fracrefad=>fracrefa
+       fracrefbd=>fracrefb
+
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 585, ng4)); absad=absa
+       if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 1175, ng4)); absbd=absb
+
+       selfrefd=>selfref
+       forrefd=>forref
+!$acc enter data copyin(absad,absbd)
+      end subroutine
+
+      subroutine reg4
+       !33
+      
+      
+
+      
+
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg04_f
+
+      module rrlw_kg05_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 5
+! band 5: 700-820 cm-1 (low - h2o,co2; high - o3,co2)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! kao_mo3 : real
+! selfrefo: real
+! forrefo : real
+! ccl4o : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no5 = 16
+      integer , parameter :: ng5 = 16
+      real :: ka(9,5,13,ng5),kb(5,5,13:59,ng5)
+      real ,target :: kao(9,5,13,no5)
+      real ,target :: kbo(5,5,13:59,no5)
+
+      real ,target :: fracrefao(no5,9) ,fracrefbo(no5,5)
+      real :: absa(585,ng5)
+
+      real ,target :: kao_mo3(9,19,no5)
+      real ,target :: selfrefo(10,no5)
+      real ,target :: forrefo(4,no5)
+      real ,target :: ccl4o(no5)
+
+
+      real ,pointer :: fracrefaod(:,:) ,fracrefbod(:,:)
+      real :: kaod(9,5,13,no5)
+      real :: kbod(5,5,13:59,no5)
+      real ,pointer :: kao_mo3d(:,:,:)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+      real ,pointer :: ccl4od(:)
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 5
+! band 5: 700-820 cm-1 (low - h2o,co2; high - o3,co2)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+!fracrefb : real
+! ka : real
+! kb : real
+! ka_mo3 : real
+! selfref : real
+! forref : real
+! ccl4 : real
+!
+! absa : real
+! absb : real
+!-----------------------------------------------------------------
+
+      real :: absb(1175,ng5)
+
+      real ,target :: fracrefa(ng5,9) ,fracrefb(ng5,5)
+
+      real ,target :: ka_mo3(9,19,ng5)
+      real ,target :: selfref(10,ng5)
+      real ,target :: forref(4,ng5)
+      real ,target :: ccl4(ng5)
+
+      real ,pointer :: fracrefad(:,:) ,fracrefbd(:,:)
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: ka_mo3d(:,:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+      real ,pointer :: ccl4d(:)
+
+      equivalence (ka(1,1,1,1),absa(1,1)),(kb(1,1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU5
+
+       fracrefaod=>fracrefao
+       fracrefbod=>fracrefbo
+
+       kao_mo3d=>kao_mo3
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+       ccl4od=>ccl4o
+
+       fracrefad=>fracrefa
+       fracrefbd=>fracrefb
+
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 585, ng5)); absad=absa
+       if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 1175, ng5)); absbd=absb
+
+       ka_mo3d=>ka_mo3
+       selfrefd=>selfref
+       forrefd=>forref
+       ccl4d=>ccl4
+!$acc enter data copyin(absad,absbd)
+      end subroutine
+
+      subroutine reg5
+
+      
+      
+
+      
+      
+      
+      
+
+      
+      
+
+      
+
+      
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg05_f
+
+      module rrlw_kg06_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 6
+! band 6: 820-980 cm-1 (low - h2o; high - nothing)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+! kao : real
+! kao_mco2: real
+! selfrefo: real
+! forrefo : real
+!cfc11adjo: real
+! cfc12o : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no6 = 16
+      integer , parameter :: ng6 = 8
+
+      real :: ka(5,13,ng6),absa(65,ng6)
+      real ,target, dimension(no6) :: fracrefao
+      real ,target :: kao(5,13,no6)
+      real ,target :: kao_mco2(19,no6)
+      real ,target :: selfrefo(10,no6)
+      real ,target :: forrefo(4,no6)
+
+      real ,target, dimension(no6) :: cfc11adjo
+      real ,target, dimension(no6) :: cfc12o
+
+      real ,pointer , dimension(:) :: fracrefaod
+      real ,pointer :: kaod(:,:,:)
+      real ,pointer :: kao_mco2d(:,:)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+      real ,pointer , dimension(:) :: cfc11adjod
+      real ,pointer , dimension(:) :: cfc12od
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 6
+! band 6: 820-980 cm-1 (low - h2o; high - nothing)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+! ka : real
+! ka_mco2 : real
+! selfref : real
+! forref : real
+!cfc11adj : real
+! cfc12 : real
+!
+! absa : real
+!-----------------------------------------------------------------
+
+      real ,target, dimension(ng6) :: fracrefa
+
+      real ,target :: ka_mco2(19,ng6)
+      real ,target :: selfref(10,ng6)
+      real ,target :: forref(4,ng6)
+
+      real ,target, dimension(ng6) :: cfc11adj
+      real ,target, dimension(ng6) :: cfc12
+
+      real ,pointer , dimension(:) :: fracrefad
+      real ,allocatable :: absad(:,:)
+      real ,pointer :: ka_mco2d(:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      real ,pointer , dimension(:) :: cfc11adjd
+      real ,pointer , dimension(:) :: cfc12d
+
+      equivalence (ka(1,1,1),absa(1,1))
+
+      contains
+
+      subroutine copyToGPU6
+
+       fracrefaod=>fracrefao
+       kaod=>kao
+       kao_mco2d=>kao_mco2
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+       cfc11adjod=>cfc11adjo
+       cfc12od=>cfc12o
+
+       fracrefad=>fracrefa
+
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 65, ng6)); absad=absa
+       ka_mco2d=>ka_mco2
+       selfrefd=>selfref
+       forrefd=>forref
+       cfc11adjd=>cfc11adj
+       cfc12d=>cfc12
+!$acc enter data copyin(absad)
+      end subroutine
+
+      subroutine reg6
+       !53
+      
+      
+      
+      
+      
+      
+      
+
+      
+
+      
+      
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg06_f
+
+      module rrlw_kg07_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 7
+! band 7: 980-1080 cm-1 (low - h2o,o3; high - o3)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! kao_mco2: real
+! kbo_mco2: real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no7 = 16
+      integer , parameter :: ng7 = 12
+      real :: kaod(9,5,13,no7)
+      real :: kbod(5,13:59,no7)
+      real :: ka(9,5,13,ng7) ,kb(5,13:59,ng7),absa(585,ng7)
+      real :: absb(235,ng7)
+
+      real ,target, dimension(no7) :: fracrefbo
+      real ,target :: fracrefao(no7,9)
+      real ,target :: kao(9,5,13,no7)
+      real ,target :: kbo(5,13:59,no7)
+      real ,target :: kao_mco2(9,19,no7)
+      real ,target :: kbo_mco2(19,no7)
+      real ,target :: selfrefo(10,no7)
+      real ,target :: forrefo(4,no7)
+
+      real ,pointer , dimension(:) :: fracrefbod
+      real ,pointer :: fracrefaod(:,:)
+
+      real ,pointer :: kao_mco2d(:,:,:)
+      real ,pointer :: kbo_mco2d(:,:)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 7
+! band 7: 980-1080 cm-1 (low - h2o,o3; high - o3)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+!fracrefb : real
+! ka : real
+! kb : real
+! ka_mco2 : real
+! kb_mco2 : real
+! selfref : real
+! forref : real
+!
+! absa : real
+!-----------------------------------------------------------------
+
+      real ,target, dimension(ng7) :: fracrefb
+      real ,target :: fracrefa(ng7,9)
+
+      real ,target :: ka_mco2(9,19,ng7)
+      real ,target :: kb_mco2(19,ng7)
+      real ,target :: selfref(10,ng7)
+      real ,target :: forref(4,ng7)
+
+      real ,pointer , dimension(:) :: fracrefbd
+      real ,pointer :: fracrefad(:,:)
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: ka_mco2d(:,:,:)
+      real ,pointer :: kb_mco2d(:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+      equivalence (ka(1,1,1,1),absa(1,1)),(kb(1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU7
+
+       fracrefbd=>fracrefb
+       fracrefad=>fracrefa
+
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 585, ng7)); absad=absa
+       if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 235, ng7)); absbd=absb
+
+       ka_mco2d=>ka_mco2
+       kb_mco2d=>kb_mco2
+       selfrefd=>selfref
+       forrefd=>forref
+
+       fracrefbod=>fracrefbo
+       fracrefaod=>fracrefao
+
+       kao_mco2d=>kao_mco2
+       kbo_mco2d=>kbo_mco2
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+!$acc enter data copyin(absad,absbd)
+      end subroutine
+
+      subroutine reg7
+       !67
+      
+      
+
+       !
+      
+       !
+      
+      
+      
+      
+      
+
+      
+      
+       !
+       !
+       !
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg07_f
+
+      module rrlw_kg08_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 8
+! band 8: 1080-1180 cm-1 (low (i.e.>~300mb) - h2o; high - o3)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! kao_mco2: real
+! kbo_mco2: real
+! kao_mn2o: real
+! kbo_mn2o: real
+! kao_mo3 : real
+! selfrefo: real
+! forrefo : real
+! cfc12o : real
+!cfc22adjo: real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no8 = 16
+
+      real ,target, dimension(no8) :: fracrefao
+      real ,target, dimension(no8) :: fracrefbo
+      real ,target, dimension(no8) :: cfc12o
+      real ,target, dimension(no8) :: cfc22adjo
+
+      real ,target :: kao(5,13,no8)
+      real ,target :: kao_mco2(19,no8)
+      real ,target :: kao_mn2o(19,no8)
+      real ,target :: kao_mo3(19,no8)
+      real ,target :: kbo(5,13:59,no8)
+      real ,target :: kbo_mco2(19,no8)
+      real ,target :: kbo_mn2o(19,no8)
+      real ,target :: selfrefo(10,no8)
+      real ,target :: forrefo(4,no8)
+
+      real ,pointer , dimension(:) :: fracrefaod
+      real ,pointer , dimension(:) :: fracrefbod
+      real ,pointer , dimension(:) :: cfc12od
+      real ,pointer , dimension(:) :: cfc22adjod
+
+      real :: kaod(5,13,no8)
+      real ,pointer :: kao_mco2d(:,:)
+      real ,pointer :: kao_mn2od(:,:)
+      real ,pointer :: kao_mo3d(:,:)
+      real :: kbod(5,13:59,no8)
+      real ,pointer :: kbo_mco2d(:,:)
+      real ,pointer :: kbo_mn2od(:,:)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 8
+! band 8: 1080-1180 cm-1 (low (i.e.>~300mb) - h2o; high - o3)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+!fracrefb : real
+! ka : real
+! kb : real
+! ka_mco2 : real
+! kb_mco2 : real
+! ka_mn2o : real
+! kb_mn2o : real
+! ka_mo3 : real
+! selfref : real
+! forref : real
+! cfc12 : real
+! cfc22adj: real
+!
+! absa : real
+! absb : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng8 = 8
+
+      real ,target, dimension(ng8) :: fracrefa
+      real ,target, dimension(ng8) :: fracrefb
+      real ,target, dimension(ng8) :: cfc12
+      real ,target, dimension(ng8) :: cfc22adj
+
+      real :: ka(5,13,ng8) ,absa(65,ng8)
+      real :: kb(5,13:59,ng8) ,absb(235,ng8)
+      real ,target :: ka_mco2(19,ng8)
+      real ,target :: ka_mn2o(19,ng8)
+      real ,target :: ka_mo3(19,ng8)
+      real ,target :: kb_mco2(19,ng8)
+      real ,target :: kb_mn2o(19,ng8)
+      real ,target :: selfref(10,ng8)
+      real ,target :: forref(4,ng8)
+
+      real ,pointer , dimension(:) :: fracrefad
+      real ,pointer , dimension(:) :: fracrefbd
+      real ,pointer , dimension(:) :: cfc12d
+      real ,pointer , dimension(:) :: cfc22adjd
+
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: ka_mco2d(:,:)
+      real ,pointer :: ka_mn2od(:,:)
+      real ,pointer :: ka_mo3d(:,:)
+      real ,pointer :: kb_mco2d(:,:)
+      real ,pointer :: kb_mn2od(:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      equivalence (ka(1,1,1),absa(1,1)),(kb(1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU8
+
+       kaod = kao
+       kbod = kbo
+
+       fracrefaod=>fracrefao
+       fracrefbod=>fracrefbo
+       cfc12od=>cfc12o
+       cfc22adjod=>cfc22adjo
+
+       kao_mco2d=>kao_mco2
+       kao_mn2od=>kao_mn2o
+       kao_mo3d=>kao_mo3
+
+       kbo_mco2d=>kbo_mco2
+       kbo_mn2od=>kbo_mn2o
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+
+       fracrefad=>fracrefa
+       fracrefbd=>fracrefb
+       cfc12d=>cfc12
+       cfc22adjd=>cfc22adj
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 65, ng8)); absad=absa
+       if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 235, ng8)); absbd=absb
+
+       ka_mco2d=>ka_mco2
+       ka_mn2od=>ka_mn2o
+       ka_mo3d=>ka_mo3
+       kb_mco2d=>kb_mco2
+       kb_mn2od=>kb_mn2o
+       selfrefd=>selfref
+       forrefd=>forref
+!$acc  enter data copyin(absad,absbd)
+      end subroutine
+
+      subroutine reg8
+
+      
+      
+      
+      
+
+      
+      
+      
+
+      
+      
+      
+      
+
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg08_f
+
+      module rrlw_kg09_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 9
+! band 9: 1180-1390 cm-1 (low - h2o,ch4; high - ch4)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! kao_mn2o: real
+! kbo_mn2o: real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no9 = 16
+
+      real ,target, dimension(no9) :: fracrefbo
+
+      real ,target :: fracrefao(no9,9)
+      real ,target :: kao(9,5,13,no9)
+      real ,target :: kbo(5,13:59,no9)
+      real ,target :: kao_mn2o(9,19,no9)
+      real ,target :: kbo_mn2o(19,no9)
+      real ,target :: selfrefo(10,no9)
+      real ,target :: forrefo(4,no9)
+
+      real ,pointer , dimension(:) :: fracrefbod
+
+      real ,pointer :: fracrefaod(:,:)
+      real :: kaod(9,5,13,no9)
+      real :: kbod(5,13:59,no9)
+      real ,pointer :: kao_mn2od(:,:,:)
+      real ,pointer :: kbo_mn2od(:,:)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 9
+! band 9: 1180-1390 cm-1 (low - h2o,ch4; high - ch4)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+!fracrefb : real
+! ka : real
+! kb : real
+! ka_mn2o : real
+! kb_mn2o : real
+! selfref : real
+! forref : real
+!
+! absa : real
+! absb : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng9 = 12
+
+      real ,target, dimension(ng9) :: fracrefb
+      real ,target :: fracrefa(ng9,9)
+      real :: ka(9,5,13,ng9) ,absa(585,ng9)
+      real :: kb(5,13:59,ng9) ,absb(235,ng9)
+      real ,target :: ka_mn2o(9,19,ng9)
+      real ,target :: kb_mn2o(19,ng9)
+      real ,target :: selfref(10,ng9)
+      real ,target :: forref(4,ng9)
+
+      real ,pointer , dimension(:) :: fracrefbd
+      real ,pointer :: fracrefad(:,:)
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: ka_mn2od(:,:,:)
+      real ,pointer :: kb_mn2od(:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      equivalence (ka(1,1,1,1),absa(1,1)),(kb(1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU9
+
+       kaod = kao
+       kbod = kbo
+
+       fracrefaod=>fracrefao
+       fracrefbod=>fracrefbo
+
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 585, ng9)); absad=absa
+       if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 235, ng9)); absbd=absb
+
+       kao_mn2od=>kao_mn2o
+       kbo_mn2od=>kbo_mn2o
+       selfrefd=>selfref
+       forrefd=>forref
+
+       fracrefad=>fracrefa
+       fracrefbd=>fracrefb
+
+       ka_mn2od=>ka_mn2o
+       kb_mn2od=>kb_mn2o
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+!$acc enter data copyin(kaod,kbod,absad,absbd)
+      end subroutine
+
+      subroutine reg9
+
+       !105
+      
+      
+
+      
+      
+      
+      
+
+      
+      
+
+      
+      
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg09_f
+
+      module rrlw_kg10_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 10
+! band 10: 1390-1480 cm-1 (low - h2o; high - h2o)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no10 = 16
+
+      real ,target, dimension(no10) :: fracrefao
+      real ,target, dimension(no10) :: fracrefbo
+
+      real ,target :: kao(5,13,no10)
+      real ,target :: kbo(5,13:59,no10)
+      real ,target :: selfrefo(10,no10)
+      real ,target :: forrefo(4,no10)
+
+      real ,pointer , dimension(:) :: fracrefaod
+      real ,pointer , dimension(:) :: fracrefbod
+
+      real :: kaod(5,13,no10)
+      real :: kbod(5,13:59,no10)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 10
+! band 10: 1390-1480 cm-1 (low - h2o; high - h2o)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! selfref : real
+! forref : real
+!
+! absa : real
+! absb : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng10 = 6
+
+      real ,target , dimension(ng10) :: fracrefa
+      real ,target , dimension(ng10) :: fracrefb
+
+      real :: ka(5,13,ng10) , absa(65,ng10)
+      real :: kb(5,13:59,ng10), absb(235,ng10)
+      real ,target :: selfref(10,ng10)
+      real ,target :: forref(4,ng10)
+
+      real ,pointer , dimension(:) :: fracrefad
+      real ,pointer , dimension(:) :: fracrefbd
+
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      equivalence (ka(1,1,1),absa(1,1)),(kb(1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU10
+
+       kaod = kao
+       kbod = kbo
+
+       fracrefaod=>fracrefao
+       fracrefbod=>fracrefbo
+
+       !kaod=>kao
+       !kbod=>kbo
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+
+       fracrefad=>fracrefa
+       fracrefbd=>fracrefb
+
+       !kad=>ka
+       !kbd=>kb
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 65, ng10)); absad=absa
+       if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 235, ng10)); absbd=absb
+
+       selfrefd=>selfref
+       forrefd=>forref
+!$acc enter data copyin (kaod,kbod,absad,absbd)
+      end subroutine
+
+      subroutine reg10
+
+      
+      
+
+       !
+       !
+      
+      
+
+      
+      
+
+       !
+       !
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg10_f
+
+      module rrlw_kg11_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 11
+! band 11: 1480-1800 cm-1 (low - h2o; high - h2o)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! kao_mo2 : real
+! kbo_mo2 : real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no11 = 16
+
+      real ,target, dimension(no11) :: fracrefao
+      real ,target, dimension(no11) :: fracrefbo
+
+      real ,target :: kao(5,13,no11)
+      real ,target :: kbo(5,13:59,no11)
+      real ,target :: kao_mo2(19,no11)
+      real ,target :: kbo_mo2(19,no11)
+      real ,target :: selfrefo(10,no11)
+      real ,target :: forrefo(4,no11)
+
+      real ,pointer , dimension(:) :: fracrefaod
+      real ,pointer , dimension(:) :: fracrefbod
+
+      real :: kaod(5,13,no11)
+      real :: kbod(5,13:59,no11)
+      real ,pointer :: kao_mo2d(:,:)
+      real ,pointer :: kbo_mo2d(:,:)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 11
+! band 11: 1480-1800 cm-1 (low - h2o; high - h2o)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+!fracrefb : real
+! ka : real
+! kb : real
+! ka_mo2 : real
+! kb_mo2 : real
+! selfref : real
+! forref : real
+!
+! absa : real
+! absb : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng11 = 8
+
+      real ,target, dimension(ng11) :: fracrefa
+      real ,target, dimension(ng11) :: fracrefb
+
+      real :: ka(5,13,ng11) , absa(65,ng11)
+      real :: kb(5,13:59,ng11), absb(235,ng11)
+      real ,target :: ka_mo2(19,ng11)
+      real ,target :: kb_mo2(19,ng11)
+      real ,target :: selfref(10,ng11)
+      real ,target :: forref(4,ng11)
+
+      real ,pointer , dimension(:) :: fracrefad
+      real ,pointer , dimension(:) :: fracrefbd
+
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: ka_mo2d(:,:)
+      real ,pointer :: kb_mo2d(:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      equivalence (ka(1,1,1),absa(1,1)),(kb(1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU11
+
+       fracrefad=>fracrefa
+       fracrefbd=>fracrefb
+
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 65, ng11)); absad=absa
+       if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 235, ng11)); absbd=absb
+
+       ka_mo2d=>ka_mo2
+       kb_mo2d=>kb_mo2
+       selfrefd=>selfref
+       forrefd=>forref
+!$acc enter data copyin(absad,absbd)
+      end subroutine
+
+      subroutine reg11
+
+      
+      
+
+       !
+      
+       !
+      
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg11_f
+
+      module rrlw_kg12_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 12
+! band 12: 1800-2080 cm-1 (low - h2o,co2; high - nothing)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+! kao : real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no12 = 16
+
+      real ,target :: fracrefao(no12,9)
+      real ,target :: kao(9,5,13,no12)
+      real ,target :: selfrefo(10,no12)
+      real ,target :: forrefo(4,no12)
+
+      real ,pointer :: fracrefaod(:,:)
+      real :: kaod(9,5,13,no12)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 12
+! band 12: 1800-2080 cm-1 (low - h2o,co2; high - nothing)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+! ka : real
+! selfref : real
+! forref : real
+!
+! absa : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng12 = 8
+
+      real ,target :: fracrefa(ng12,9)
+      real :: ka(9,5,13,ng12) ,absa(585,ng12)
+      real ,target :: selfref(10,ng12)
+      real ,target :: forref(4,ng12)
+
+      real ,pointer :: fracrefad(:,:)
+      real ,allocatable :: absad(:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      equivalence (ka(1,1,1,1),absa(1,1))
+
+      contains
+
+      subroutine copyToGPU12
+
+       kao = kaod
+
+       fracrefaod=>fracrefao
+       !kaod=>kao
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+
+       fracrefad=>fracrefa
+       !kad=>ka
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 585, ng12)); absad=absa
+
+       selfrefd=>selfref
+       forrefd=>forref
+!$acc enter data copyin(kao,absad)
+
+      end subroutine
+
+      subroutine reg12
+
+      
+       !
+      
+      
+
+      
+       !
+      
+
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg12_f
+
+      module rrlw_kg13_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 13
+! band 13: 2080-2250 cm-1 (low - h2o,n2o; high - nothing)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+! kao : real
+! kao_mco2: real
+! kao_mco : real
+! kbo_mo3 : real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no13 = 16
+
+      real ,target, dimension(no13) :: fracrefbo
+
+      real ,target :: fracrefao(no13,9)
+      real ,target :: kao(9,5,13,no13)
+      real ,target :: kao_mco2(9,19,no13)
+      real ,target :: kao_mco(9,19,no13)
+      real ,target :: kbo_mo3(19,no13)
+      real ,target :: selfrefo(10,no13)
+      real ,target :: forrefo(4,no13)
+
+      real ,pointer , dimension(:) :: fracrefbod
+
+      real ,pointer :: fracrefaod(:,:)
+      real :: kaod(9,5,13,no13)
+      real ,pointer :: kao_mco2d(:,:,:)
+      real ,pointer :: kao_mcod(:,:,:)
+      real ,pointer :: kbo_mo3d(:,:)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 13
+! band 13: 2080-2250 cm-1 (low - h2o,n2o; high - nothing)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+! ka : real
+! ka_mco2 : real
+! ka_mco : real
+! kb_mo3 : real
+! selfref : real
+! forref : real
+!
+! absa : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng13 = 4
+
+      real ,target, dimension(ng13) :: fracrefb
+
+      real ,target :: fracrefa(ng13,9)
+      real :: ka(9,5,13,ng13) ,absa(585,ng13)
+      real ,target :: ka_mco2(9,19,ng13)
+      real ,target :: ka_mco(9,19,ng13)
+      real ,target :: kb_mo3(19,ng13)
+      real ,target :: selfref(10,ng13)
+      real ,target :: forref(4,ng13)
+
+      real ,pointer , dimension(:) :: fracrefbd
+
+      real ,pointer :: fracrefad(:,:)
+      real ,allocatable :: absad(:,:)
+      real ,pointer :: ka_mco2d(:,:,:)
+      real ,pointer :: ka_mcod(:,:,:)
+      real ,pointer :: kb_mo3d(:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      equivalence (ka(1,1,1,1),absa(1,1))
+
+      contains
+
+      subroutine copyToGPU13
+
+       kaod = kao
+
+       fracrefbod=>fracrefbo
+       fracrefaod=>fracrefao
+
+       kao_mco2d=>kao_mco2
+       kao_mcod=>kao_mco
+       kbo_mo3d=>kbo_mo3
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+
+       fracrefbd=>fracrefb
+       fracrefad=>fracrefa
+
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 585, ng13)); absad=absa
+
+       ka_mco2d=>ka_mco2
+       ka_mcod=>ka_mco
+       kb_mo3d=>kb_mo3
+       selfrefd=>selfref
+       forrefd=>forref
+!$acc enter data copyin(kaod,absad)
+      end subroutine
+
+      subroutine reg13
+
+      
+      
+       !
+      
+      
+      
+      
+      
+
+      
+      
+       !
+      
+      
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg13_f
+
+      module rrlw_kg14_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 14
+! band 14: 2250-2380 cm-1 (low - co2; high - co2)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+!fracrefbo: real
+! kao : real
+! kbo : real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no14 = 16
+
+      real ,target, dimension(no14) :: fracrefao
+      real ,target, dimension(no14) :: fracrefbo
+
+      real ,target :: kao(5,13,no14)
+      real ,target :: kbo(5,13:59,no14)
+      real ,target :: selfrefo(10,no14)
+      real ,target :: forrefo(4,no14)
+
+      real ,pointer , dimension(:) :: fracrefaod
+      real ,pointer , dimension(:) :: fracrefbod
+
+      real :: kaod(5,13,no14)
+      real :: kbod(5,13:59,no14)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 14
+! band 14: 2250-2380 cm-1 (low - co2; high - co2)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+!fracrefb : real
+! ka : real
+! kb : real
+! selfref : real
+! forref : real
+!
+! absa : real
+! absb : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng14 = 2
+
+      real ,target, dimension(ng14) :: fracrefa
+      real ,target, dimension(ng14) :: fracrefb
+
+      real :: ka(5,13,ng14) ,absa(65,ng14)
+      real :: kb(5,13:59,ng14),absb(235,ng14)
+      real ,target :: selfref(10,ng14)
+      real ,target :: forref(4,ng14)
+
+      real ,pointer , dimension(:) :: fracrefad
+      real ,pointer , dimension(:) :: fracrefbd
+
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      equivalence (ka(1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU14
+
+       kaod = kao
+       kbod = kbo
+
+       fracrefaod=>fracrefao
+       fracrefbod=>fracrefbo
+
+       !kaod=>kao
+       !kbod=>kbo
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+
+       fracrefad=>fracrefa
+       fracrefbd=>fracrefb
+
+       !kad=>ka
+       !kbd=>kb
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 65, ng14)); absad=absa
+       if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 235, ng14)); absbd=absb
+
+       selfrefd=>selfref
+       forrefd=>forref
+!$acc enter data copyin(kaod,kbod,absad,absbd)
+      end subroutine
+
+      subroutine reg14
+
+      
+      
+
+       !
+       !
+      
+      
+
+      
+      
+
+       !
+       !
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg14_f
+
+      module rrlw_kg15_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 15
+! band 15: 2380-2600 cm-1 (low - n2o,co2; high - nothing)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+! kao : real
+! kao_mn2 : real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no15 = 16
+
+      real ,target :: fracrefao(no15,9)
+      real ,target :: kao(9,5,13,no15)
+      real ,target :: kao_mn2(9,19,no15)
+      real ,target :: selfrefo(10,no15)
+      real ,target :: forrefo(4,no15)
+
+      real ,pointer :: fracrefaod(:,:)
+      real :: kaod(9,5,13,no15)
+      real ,pointer :: kao_mn2d(:,:,:)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 15
+! band 15: 2380-2600 cm-1 (low - n2o,co2; high - nothing)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+! ka : real
+! ka_mn2 : real
+! selfref : real
+! forref : real
+!
+! absa : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng15 = 2
+
+      real ,target :: fracrefa(ng15,9)
+      real :: ka(9,5,13,ng15) ,absa(585,ng15)
+      real ,target :: ka_mn2(9,19,ng15)
+      real ,target :: selfref(10,ng15)
+      real ,target :: forref(4,ng15)
+
+      real ,pointer :: fracrefad(:,:)
+      real ,allocatable :: absad(:,:)
+      real ,pointer :: ka_mn2d(:,:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      equivalence (ka(1,1,1,1),absa(1,1))
+
+      contains
+
+      subroutine copyToGPU15
+
+       kaod = kao
+
+       fracrefaod=>fracrefao
+       !kaod=>kao
+       kao_mn2d=>kao_mn2
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+
+       fracrefad=>fracrefa
+       !kad=>ka
+
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 585, ng15)); absad=absa
+
+       ka_mn2d=>ka_mn2
+       selfrefd=>selfref
+       forrefd=>forref
+!$acc enter data copyin(kaod,absad,ka_mn2d)
+      end subroutine
+
+      subroutine reg15
+
+      
+       !
+      
+      
+      
+
+      
+       !
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg15_f
+
+      module rrlw_kg16_f
+
+! use parkind ,only : im => kind , rb => kind
+
+      use memory
+! implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_lw ORIGINAL abs. coefficients for interval 16
+! band 16: 2600-3000 cm-1 (low - h2o,ch4; high - nothing)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefao: real
+! kao : real
+! kbo : real
+! selfrefo: real
+! forrefo : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: no16 = 16
+
+      real ,target, dimension(no16) :: fracrefbo
+
+      real ,target :: fracrefao(no16,9)
+      real ,target :: kao(9,5,13,no16)
+      real ,target :: kbo(5,13:59,no16)
+      real ,target :: selfrefo(10,no16)
+      real ,target :: forrefo(4,no16)
+
+      real ,pointer , dimension(:) :: fracrefbod
+      real ,pointer :: fracrefaod(:,:)
+      real :: kaod(9,5,13,no16)
+      real :: kbod(5,13:59,no16)
+      real ,pointer :: selfrefod(:,:)
+      real ,pointer :: forrefod(:,:)
+
+!-----------------------------------------------------------------
+! rrtmg_lw COMBINED abs. coefficients for interval 16
+! band 16: 2600-3000 cm-1 (low - h2o,ch4; high - nothing)
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+! name type purpose
+! ---- : ---- : ---------------------------------------------
+!fracrefa : real
+! ka : real
+! kb : real
+! selfref : real
+! forref : real
+!
+! absa : real
+! absb : real
+!-----------------------------------------------------------------
+
+      integer , parameter :: ng16 = 2
+
+      real ,target, dimension(ng16) :: fracrefb
+
+      real ,target :: fracrefa(ng16,9)
+      real :: ka(9,5,13,ng16) ,absa(585,ng16)
+      real :: kb(5,13:59,ng16), absb(235,ng16)
+      real ,target :: selfref(10,ng16)
+      real ,target :: forref(4,ng16)
+
+      real ,pointer , dimension(:) :: fracrefbd
+
+      real ,pointer :: fracrefad(:,:)
+      real ,allocatable :: absad(:,:)
+      real ,allocatable :: absbd(:,:)
+      real ,pointer :: selfrefd(:,:)
+      real ,pointer :: forrefd(:,:)
+
+      equivalence (ka(1,1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      contains
+
+      subroutine copyToGPU16
+
+       kaod = kao
+       kbod = kbo
+
+       fracrefaod=>fracrefao
+
+       !kaod=>kao
+       !kbod=>kbo
+       selfrefod=>selfrefo
+       forrefod=>forrefo
+
+       fracrefad=>fracrefa
+       fracrefbd=>fracrefb
+
+       !kad=>ka
+       !kbd=>kb
+       if (allocated(absad).eqv..true.) deallocate(absad) ;allocate( absad( 585, ng16)); absad=absa
+       if (allocated(absbd).eqv..true.) deallocate(absbd) ;allocate( absbd( 235, ng16)); absbd=absb
+
+       selfrefd=>selfref
+       forrefd=>forref
+!$acc enter data copyin(kaod,kbod,absad,absbd)
+      end subroutine
+
+      subroutine reg16
+
+      
+
+       !
+       !
+      
+      
+
+      
+      
+
+       !
+       !
+      
+      
+      
+      
+
+      end subroutine
+
+      end module rrlw_kg16_f
+
+      module rrlw_ncpar
+
+! use parkind ,only : im => kind , rb => kind
+
+! implicit none
+      save
+
+      real , parameter :: cpdair = 1003.5 ! Specific heat capacity of dry air
+                                                         ! at constant pressure at 273 K
+                                                         ! (J kg-1 K-1)
+
+
+      integer , parameter :: maxAbsorberNameLength = 5, &
+                             Absorber = 12
+      character(len = maxAbsorberNameLength), dimension(Absorber), parameter :: &
+      AbsorberNames = (/ &
+                                'N2   ', &
+                                'CCL4 ', &
+                                'CFC11', &
+                                'CFC12', &
+                                'CFC22', &
+                                'H2O  ', &
+                                'CO2  ', &
+                                'O3   ', &
+                                'N2O  ', &
+                                'CO   ', &
+                                'CH4  ', &
+                                'O2   ' /)
+
+       integer , dimension(40) :: status
+       integer :: i
+       integer , parameter :: keylower = 9, &
+                               keyupper = 5, &
+                               Tdiff = 5, &
+                               ps = 59, &
+                               plower = 13, &
+                               pupper = 47, &
+                               Tself = 10, &
+                               Tforeign = 4, &
+                               pforeign = 4, &
+                               T = 19, &
+                               Tplanck = 181, &
+                               band = 16, &
+                               GPoint = 16, &
+                               GPointSet = 2
+
+      contains
+
+      subroutine getAbsorberIndex(AbsorberName,AbsorberIndex)
+                character(len = *), intent(in) :: AbsorberName
+                integer , intent(out) :: AbsorberIndex
+
+                integer :: m
+
+                AbsorberIndex = -1
+                do m = 1, Absorber
+                        if (trim(AbsorberNames(m)) == trim(AbsorberName)) then
+                                AbsorberIndex = m
+                        end if
+                end do
+
+                if (AbsorberIndex == -1) then
+                        print*, "Absorber name index lookup failed."
+                end if
+      end subroutine getAbsorberIndex
+
+      end module rrlw_ncpar
+
+      module rrlw_ref_f
+
+! use parkind, only : im => kind , rb => kind
+
+! implicit none
+
+!------------------------------------------------------------------
+! rrtmg_lw reference atmosphere
+! Based on standard mid-latitude summer profile
+!
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+! name type purpose
+! ----- : ---- : ----------------------------------------------
+! pref : real : Reference pressure levels
+! preflog: real : Reference pressure levels, ln(pref)
+! tref : real : Reference temperature levels for MLS profile
+! chi_mls: real :
+!------------------------------------------------------------------
+
+      real , dimension(59) :: pref
+      real , dimension(59) :: preflog
+      real , dimension(59) :: tref
+      real :: chi_mls(7,59)
+
+      ! (dmb 2012) These GPU arrays are defined as constant so that they are cached.
+      ! This is really needed because they accessed in quite a scattered pattern.
+      real :: chi_mlsd(7,59)
+      real :: preflogd(59)
+      real :: trefd(59)
+
+
+
+
+
+
+
+      contains
+
+      ! (dmb 2012) Copy the reference arrays over to the GPU
+      subroutine copyToGPUref()
+
+        chi_mls = chi_mls
+        preflog = preflog
+        tref = tref
+
+      end subroutine
+
+      end module rrlw_ref_f
+
+      module rrlw_tbl_f
+
+! use parkind, only : im => kind , rb => kind
+
+! implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_lw exponential lookup table arrays
+
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, Jun 2006
+! Revised: MJIacono, AER, Aug 2007
+! Revised: MJIacono, AER, Aug 2008
+!------------------------------------------------------------------
+
+! name type purpose
+! ----- : ---- : ----------------------------------------------
+! ntbl : integer: Lookup table dimension
+! tblint : real : Lookup table conversion factor
+! tau_tbl: real : Clear-sky optical depth (used in cloudy radiative
+! transfer)
+! exp_tbl: real : Transmittance lookup table
+! tfn_tbl: real : Tau transition function; i.e. the transition of
+! the Planck function from that for the mean layer
+! temperature to that for the layer boundary
+! temperature as a function of optical depth.
+! The "linear in tau" method is used to make
+! the table.
+! pade : real : Pade constant
+! bpade : real : Inverse of Pade constant
+!------------------------------------------------------------------
+
+      integer , parameter :: ntbl = 10000
+
+      real , parameter :: tblint = 10000.0
+
+      real , dimension(0:ntbl) :: tau_tbl
+      real , dimension(0:ntbl) :: exp_tbl
+      real , dimension(0:ntbl) :: tfn_tbl
+
+      real , parameter :: pade = 0.278
+      real :: bpade
+
+      end module rrlw_tbl_f
+
+      module rrlw_vsn_f
+
+! implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_lw version information
+
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+! name type purpose
+! ----- : ---- : ----------------------------------------------
+!hnamrtm :character:
+!hnamini :character:
+!hnamcld :character:
+!hnamclc :character:
+!hnamrtr :character:
+!hnamrtx :character:
+!hnamrtc :character:
+!hnamset :character:
+!hnamtau :character:
+!hnamatm :character:
+!hnamutl :character:
+!hnamext :character:
+!hnamkg :character:
+!
+! hvrrtm :character:
+! hvrini :character:
+! hvrcld :character:
+! hvrclc :character:
+! hvrrtr :character:
+! hvrrtx :character:
+! hvrrtc :character:
+! hvrset :character:
+! hvrtau :character:
+! hvratm :character:
+! hvrutl :character:
+! hvrext :character:
+! hvrkg :character:
+!------------------------------------------------------------------
+
+      character*18 hvrrtm,hvrini,hvrcld,hvrclc,hvrrtr,hvrrtx, &
+                   hvrrtc,hvrset,hvrtau,hvratm,hvrutl,hvrext
+      character*20 hnamrtm,hnamini,hnamcld,hnamclc,hnamrtr,hnamrtx, &
+                   hnamrtc,hnamset,hnamtau,hnamatm,hnamutl,hnamext
+
+      character*18 hvrkg
+      character*20 hnamkg
+
+      end module rrlw_vsn_f
+
+      module rrlw_wvn_f
+
+! use parkind, only : im => kind , rb => kind
+      use parrrtm_f, only : nbndlw, mg, ngptlw, maxinpx
+
+! implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_lw spectral information
+
+! Initial version: JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+! name type purpose
+! ----- : ---- : ----------------------------------------------
+! ng : integer: Number of original g-intervals in each spectral band
+! nspa : integer: For the lower atmosphere, the number of reference
+! atmospheres that are stored for each spectral band
+! per pressure level and temperature. Each of these
+! atmospheres has different relative amounts of the
+! key species for the band (i.e. different binary
+! species parameters).
+! nspb : integer: Same as nspa for the upper atmosphere
+!wavenum1: real : Spectral band lower boundary in wavenumbers
+!wavenum2: real : Spectral band upper boundary in wavenumbers
+! delwave: real : Spectral band width in wavenumbers
+! totplnk: real : Integrated Planck value for each band; (band 16
+! includes total from 2600 cm-1 to infinity)
+! Used for calculation across total spectrum
+!totplk16: real : Integrated Planck value for band 16 (2600-3250 cm-1)
+! Used for calculation in band 16 only if
+! individual band output requested
+!totplnkderiv: real: Integrated Planck function derivative with respect
+! to temperature for each band; (band 16
+! includes total from 2600 cm-1 to infinity)
+! Used for calculation across total spectrum
+!totplk16deriv:real: Integrated Planck function derivative with respect
+! to temperature for band 16 (2600-3250 cm-1)
+! Used for calculation in band 16 only if
+! individual band output requested
+!
+! ngc : integer: The number of new g-intervals in each band
+! ngs : integer: The cumulative sum of new g-intervals for each band
+! ngm : integer: The index of each new g-interval relative to the
+! original 16 g-intervals in each band
+! ngn : integer: The number of original g-intervals that are
+! combined to make each new g-intervals in each band
+! ngb : integer: The band index for each new g-interval
+! wt : real : RRTM weights for the original 16 g-intervals
+! rwgt : real : Weights for combining original 16 g-intervals
+! (256 total) into reduced set of g-intervals
+! (140 total)
+! nxmol : integer: Number of cross-section molecules
+! ixindx : integer: Flag for active cross-sections in calculation
+!------------------------------------------------------------------
+
+      integer :: ng(nbndlw)
+      integer :: nspa(nbndlw)
+      integer :: nspb(nbndlw)
+
+      real :: wavenum1(nbndlw)
+      real :: wavenum2(nbndlw)
+      real :: delwave(nbndlw)
+
+      real :: totplnk(181,nbndlw)
+      real :: totplk16(181)
+
+      real :: totplnkderiv(181,nbndlw)
+      real :: totplk16deriv(181)
+
+      integer :: ngc(nbndlw)
+      integer :: ngs(nbndlw)
+      integer :: ngn(ngptlw)
+      integer :: ngb(ngptlw)
+      integer :: ngm(nbndlw*mg)
+
+      real :: wt(mg)
+      real :: rwgt(nbndlw*mg)
+
+      integer :: nxmol
+      integer :: ixindx(maxinpx)
+
+      end module rrlw_wvn_f
+
+
+! Fortran-95 implementation of the Mersenne Twister 19937, following
+! the C implementation described below (code mt19937ar-cok.c, dated 2002/2/10),
+! adapted cosmetically by making the names more general.
+! Users must declare one or more variables of type randomNumberSequence in the calling
+! procedure which are then initialized using a required seed. If the
+! variable is not initialized the random numbers will all be 0.
+! For example:
+! program testRandoms
+! use RandomNumbers
+! type(randomNumberSequence) :: randomNumbers
+! integer :: i
+!
+! randomNumbers = new_RandomNumberSequence(seed = 100)
+! do i = 1, 10
+! print ('(f12.10, 2x)'), getRandomReal(randomNumbers)
+! end do
+! end program testRandoms
+!
+! Fortran-95 implementation by
+! Robert Pincus
+! NOAA-CIRES Climate Diagnostics Center
+! Boulder, CO 80305
+! email: Robert.Pincus@colorado.edu
+!
+! This documentation in the original C program reads:
+! -------------------------------------------------------------
+! A C-program for MT19937, with initialization improved 2002/2/10.
+! Coded by Takuji Nishimura and Makoto Matsumoto.
+! This is a faster version by taking Shawn Cokus's optimization,
+! Matthe Bellew's simplification, Isaku Wada's real version.
+!
+! Before using, initialize the state by using init_genrand(seed)
+! or init_by_array(init_key, key_length).
+!
+! Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions
+! are met:
+!
+! 1. Redistributions of source code must retain the above copyright
+! notice, this list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright
+! notice, this list of conditions and the following disclaimer in the
+! documentation and/or other materials provided with the distribution.
+!
+! 3. The names of its contributors may not be used to endorse or promote
+! products derived from this software without specific prior written
+! permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+! A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+! CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+! EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+! PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+! PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+! LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+! NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+! SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+!
+!
+! Any feedback is very welcome.
+! http:
+! email: matumoto@math.keio.ac.jp
+! -------------------------------------------------------------
+
+  module MersenneTwister_f
+! -------------------------------------------------------------
+
+   !use parkind, only : im => kind , rb => kind
+
+  implicit none
+  private
+
+  ! Algorithm parameters
+  ! -------
+  ! Period parameters
+  integer , parameter :: blockSize = 624, &
+                        M = 397, &
+                        MATRIX_A = -1727483681, & ! constant vector a (0x9908b0dfUL)
+! UMASK = -2147483648, & ! most significant w-r bits (0x80000000UL)
+                        UMASK = -2147483647, & ! most significant w-r bits (0x80000000UL)
+                        LMASK = 2147483647 ! least significant r bits (0x7fffffffUL)
+  ! Tempering parameters
+  integer , parameter :: TMASKB= -1658038656, & ! (0x9d2c5680UL)
+                        TMASKC= -272236544 ! (0xefc60000UL)
+  ! -------
+
+  ! The type containing the state variable
+  type randomNumberSequence
+    integer :: currentElement ! = blockSize
+    integer , dimension(0:blockSize -1) :: state ! = 0
+  end type randomNumberSequence
+
+  interface new_RandomNumberSequence
+    module procedure initialize_scalar, initialize_vector
+  end interface new_RandomNumberSequence
+
+  public :: randomNumberSequence
+  public :: new_RandomNumberSequence, finalize_RandomNumberSequence, &
+            getRandomInt, getRandomPositiveInt, getRandomReal
+! -------------------------------------------------------------
+contains
+  ! -------------------------------------------------------------
+  ! Private functions
+  ! ---------------------------
+  function mixbits(u, v)
+    integer , intent( in) :: u, v
+    integer :: mixbits
+
+    mixbits = ior(iand(u, UMASK), iand(v, LMASK))
+  end function mixbits
+  ! ---------------------------
+  function twist(u, v)
+    integer , intent( in) :: u, v
+    integer :: twist
+
+    ! Local variable
+    integer , parameter, dimension(0:1) :: t_matrix = (/ 0 , MATRIX_A /)
+
+    twist = ieor(ishft(mixbits(u, v), -1 ), t_matrix(iand(v, 1 )))
+    twist = ieor(ishft(mixbits(u, v), -1 ), t_matrix(iand(v, 1 )))
+  end function twist
+  ! ---------------------------
+  subroutine nextState(twister)
+    type(randomNumberSequence), intent(inout) :: twister
+
+    ! Local variables
+    integer :: k
+
+    do k = 0, blockSize - M - 1
+      twister%state(k) = ieor(twister%state(k + M), &
+                              twist(twister%state(k), twister%state(k + 1 )))
+    end do
+    do k = blockSize - M, blockSize - 2
+      twister%state(k) = ieor(twister%state(k + M - blockSize), &
+                              twist(twister%state(k), twister%state(k + 1 )))
+    end do
+    twister%state(blockSize - 1 ) = ieor(twister%state(M - 1 ), &
+                                        twist(twister%state(blockSize - 1 ), twister%state(0 )))
+    twister%currentElement = 0
+
+  end subroutine nextState
+  ! ---------------------------
+  elemental function temper(y)
+    integer , intent(in) :: y
+    integer :: temper
+
+    integer :: x
+
+    ! Tempering
+    x = ieor(y, ishft(y, -11))
+    x = ieor(x, iand(ishft(x, 7), TMASKB))
+    x = ieor(x, iand(ishft(x, 15), TMASKC))
+    temper = ieor(x, ishft(x, -18))
+  end function temper
+  ! -------------------------------------------------------------
+  ! Public (but hidden) functions
+  ! --------------------
+  function initialize_scalar(seed) result(twister)
+    integer , intent(in ) :: seed
+    type(randomNumberSequence) :: twister
+
+    integer :: i
+    ! See Knuth TAOCP Vol2. 3rd Ed. P.106 for multiplier. In the previous versions,
+    ! MSBs of the seed affect only MSBs of the array state[].
+    ! 2002/01/09 modified by Makoto Matsumoto
+
+    twister%state(0) = iand(seed, -1 )
+    do i = 1, blockSize - 1 ! ubound(twister%state)
+       twister%state(i) = 1812433253 * ieor(twister%state(i-1), &
+                                            ishft(twister%state(i-1), -30 )) + i
+       twister%state(i) = iand(twister%state(i), -1 ) ! for >32 bit machines
+    end do
+    twister%currentElement = blockSize
+  end function initialize_scalar
+  ! -------------------------------------------------------------
+  function initialize_vector(seed) result(twister)
+    integer , dimension(0:), intent(in) :: seed
+    type(randomNumberSequence) :: twister
+
+    integer :: i, j, k, nFirstLoop, nWraps
+
+    nWraps = 0
+    twister = initialize_scalar(19650218 )
+
+    nFirstLoop = max(blockSize, size(seed))
+    do k = 1, nFirstLoop
+       i = mod(k + nWraps, blockSize)
+       j = mod(k - 1, size(seed))
+       if(i == 0) then
+         twister%state(i) = twister%state(blockSize - 1)
+         twister%state(1) = ieor(twister%state(1), &
+                                 ieor(twister%state(1-1), &
+                                      ishft(twister%state(1-1), -30 )) * 1664525 ) + &
+                            seed(j) + j ! Non-linear
+         twister%state(i) = iand(twister%state(i), -1 ) ! for >32 bit machines
+         nWraps = nWraps + 1
+       else
+         twister%state(i) = ieor(twister%state(i), &
+                                 ieor(twister%state(i-1), &
+                                      ishft(twister%state(i-1), -30 )) * 1664525 ) + &
+                            seed(j) + j ! Non-linear
+         twister%state(i) = iand(twister%state(i), -1 ) ! for >32 bit machines
+      end if
+    end do
+
+    !
+    ! Walk through the state array, beginning where we left off in the block above
+    !
+    do i = mod(nFirstLoop, blockSize) + nWraps + 1, blockSize - 1
+      twister%state(i) = ieor(twister%state(i), &
+                              ieor(twister%state(i-1), &
+                                   ishft(twister%state(i-1), -30 )) * 1566083941 ) - i ! Non-linear
+      twister%state(i) = iand(twister%state(i), -1 ) ! for >32 bit machines
+    end do
+
+    twister%state(0) = twister%state(blockSize - 1)
+
+    do i = 1, mod(nFirstLoop, blockSize) + nWraps
+      twister%state(i) = ieor(twister%state(i), &
+                              ieor(twister%state(i-1), &
+                                   ishft(twister%state(i-1), -30 )) * 1566083941 ) - i ! Non-linear
+      twister%state(i) = iand(twister%state(i), -1 ) ! for >32 bit machines
+    end do
+
+    twister%state(0) = UMASK
+    twister%currentElement = blockSize
+
+  end function initialize_vector
+  ! -------------------------------------------------------------
+  ! Public functions
+  ! --------------------
+  function getRandomInt(twister)
+    type(randomNumberSequence), intent(inout) :: twister
+    integer :: getRandomInt
+    ! Generate a random integer on the interval [0,0xffffffff]
+    ! Equivalent to genrand_int32 in the C code.
+    ! Fortran doesn't have a type that's unsigned like C does,
+    ! so this is integers in the range -2**31 - 2**31
+    ! All functions for getting random numbers call this one,
+    ! then manipulate the result
+
+    if(twister%currentElement >= blockSize) call nextState(twister)
+
+    getRandomInt = temper(twister%state(twister%currentElement))
+    twister%currentElement = twister%currentElement + 1
+
+  end function getRandomInt
+  ! --------------------
+  function getRandomPositiveInt(twister)
+    type(randomNumberSequence), intent(inout) :: twister
+    integer :: getRandomPositiveInt
+    ! Generate a random integer on the interval [0,0x7fffffff]
+    ! or [0,2**31]
+    ! Equivalent to genrand_int31 in the C code.
+
+    ! Local integers
+    integer :: localInt
+
+    localInt = getRandomInt(twister)
+    getRandomPositiveInt = ishft(localInt, -1)
+
+  end function getRandomPositiveInt
+  ! --------------------
+!! mji - modified Jan 2007, double converted to rrtmg real kind type
+  function getRandomReal(twister)
+    type(randomNumberSequence), intent(inout) :: twister
+! double precision :: getRandomReal
+    real :: getRandomReal
+    ! Generate a random number on [0,1]
+    ! Equivalent to genrand_real1 in the C code
+    ! The result is stored as double precision but has 32 bit resolution
+
+    integer :: localInt
+
+    localInt = getRandomInt(twister)
+    if(localInt < 0) then
+! getRandomReal = dble(localInt + 2.0d0**32)/(2.0d0**32 - 1.0d0)
+      getRandomReal = (localInt + 2.0**32 )/(2.0**32 - 1.0 )
+    else
+! getRandomReal = dble(localInt )/(2.0d0**32 - 1.0d0)
+      getRandomReal = (localInt )/(2.0**32 - 1.0 )
+    end if
+
+  end function getRandomReal
+  ! --------------------
+  subroutine finalize_RandomNumberSequence(twister)
+    type(randomNumberSequence), intent(inout) :: twister
+
+      twister%currentElement = blockSize
+      twister%state(:) = 0
+  end subroutine finalize_RandomNumberSequence
+
+  ! --------------------
+
+  end module MersenneTwister_f
+
+
+  module mcica_random_numbers_f
+
+  ! Generic module to wrap random number generators.
+  ! The module defines a type that identifies the particular stream of random
+  ! numbers, and has procedures for initializing it and getting real numbers
+  ! in the range 0 to 1.
+  ! This version uses the Mersenne Twister to generate random numbers on [0, 1].
+  !
+  use MersenneTwister_f, only: randomNumberSequence, & ! The random number engine.
+                             new_RandomNumberSequence, getRandomReal
+!! mji
+!! use time_manager_mod, only: time_type, get_date
+
+   !use parkind, only : im => kind , rb => kind
+
+  implicit none
+  private
+
+  type randomNumberStream
+    type(randomNumberSequence) :: theNumbers
+  end type randomNumberStream
+
+  interface getRandomNumbers
+    module procedure getRandomNumber_Scalar, getRandomNumber_1D, getRandomNumber_2D
+  end interface getRandomNumbers
+
+  interface initializeRandomNumberStream
+    module procedure initializeRandomNumberStream_S, initializeRandomNumberStream_V
+  end interface initializeRandomNumberStream
+
+  public :: randomNumberStream, &
+            initializeRandomNumberStream, getRandomNumbers
+!! mji
+!! initializeRandomNumberStream, getRandomNumbers, &
+!! constructSeed
+contains
+  ! ---------------------------------------------------------
+  ! Initialization
+  ! ---------------------------------------------------------
+  function initializeRandomNumberStream_S(seed) result(new)
+    integer , intent( in) :: seed
+    type(randomNumberStream) :: new
+
+    new%theNumbers = new_RandomNumberSequence(seed)
+
+  end function initializeRandomNumberStream_S
+  ! ---------------------------------------------------------
+  function initializeRandomNumberStream_V(seed) result(new)
+    integer , dimension(:), intent( in) :: seed
+    type(randomNumberStream) :: new
+
+    new%theNumbers = new_RandomNumberSequence(seed)
+
+  end function initializeRandomNumberStream_V
+  ! ---------------------------------------------------------
+  ! Procedures for drawing random numbers
+  ! ---------------------------------------------------------
+  subroutine getRandomNumber_Scalar(stream, number)
+    type(randomNumberStream), intent(inout) :: stream
+    real , intent( out) :: number
+
+    number = getRandomReal(stream%theNumbers)
+  end subroutine getRandomNumber_Scalar
+  ! ---------------------------------------------------------
+  subroutine getRandomNumber_1D(stream, numbers)
+    type(randomNumberStream), intent(inout) :: stream
+    real , dimension(:), intent( out) :: numbers
+
+    ! Local variables
+    integer :: i
+
+    do i = 1, size(numbers)
+      numbers(i) = getRandomReal(stream%theNumbers)
+    end do
+  end subroutine getRandomNumber_1D
+  ! ---------------------------------------------------------
+  subroutine getRandomNumber_2D(stream, numbers)
+    type(randomNumberStream), intent(inout) :: stream
+    real , dimension(:, :), intent( out) :: numbers
+
+    ! Local variables
+    integer :: i
+
+    do i = 1, size(numbers, 2)
+      call getRandomNumber_1D(stream, numbers(:, i))
+    end do
+  end subroutine getRandomNumber_2D
+! mji
+! ! ---------------------------------------------------------
+! ! Constructing a unique seed from grid cell index and model date/time
+! ! Once we have the GFDL stuff we'll add the year, month, day, hour, minute
+! ! ---------------------------------------------------------
+! function constructSeed(i, j, time) result(seed)
+! integer , intent( in) :: i, j
+! type(time_type), intent( in) :: time
+! integer , dimension(8) :: seed
+!
+! ! Local variables
+! integer :: year, month, day, hour, minute, second
+!
+!
+! call get_date(time, year, month, day, hour, minute, second)
+! seed = (/ i, j, year, month, day, hour, minute, second /)
+! end function constructSeed
+
+  end module mcica_random_numbers_f
+
+      module gpu_mcica_subcol_gen_lw
+
+! --------------------------------------------------------------------------
+! | |
+! | Copyright 2006-2009, Atmospheric & Environmental Research, Inc. (AER). |
+! | This software may be used, copied, or redistributed as long as it is |
+! | not sold and this copyright notice is reproduced on each copy made. |
+! | This model is provided as is without any express or implied warranties. |
+! | (http:
+! | |
+! --------------------------------------------------------------------------
+
+! Purpose: Create McICA stochastic arrays for cloud physical or optical properties.
+! Two options are possible:
+! 1) Input cloud physical properties: cloud fraction, ice and liquid water
+! paths, ice fraction, and particle sizes. Output will be stochastic
+! arrays of these variables. (inflag = 1)
+! 2) Input cloud optical properties directly: cloud optical depth, single
+! scattering albedo and asymmetry parameter. Output will be stochastic
+! arrays of these variables. (inflag = 0; longwave scattering is not
+! yet available, ssac and asmc are for future expansion)
+
+! --------- Modules ----------
+
+       !use parkind, only : im => kind , rb => kind
+      use parrrtm_f, only : nbndlw, ngptlw, mxlay
+      use rrlw_con_f, only: grav
+      use rrlw_wvn_f, only: ngb
+      use rrlw_vsn_f
+
+
+
+
+
+
+      implicit none
+! public interfaces/functions/subroutines
+      !public :: mcica_subcol_lwg, generate_stochastic_cloudsg
+
+      contains
+
+!------------------------------------------------------------------
+! Public subroutines
+!------------------------------------------------------------------
+
+      subroutine mcica_subcol_lwg(colstart, ncol, nlay, icld, permuteseed, irng, &
+
+                       pmidd,clwpd,ciwpd,cswpd,taucd, &
+
+                       play, cldfrac, ciwp, clwp, cswp, tauc, ngbd, cldfmcl, &
+                       ciwpmcl, clwpmcl, cswpmcl, taucmcl)
+
+! ----- Input -----
+! Control
+      integer , intent(in) :: colstart ! column/longitude index
+      integer , intent(in) :: ncol ! number of columns
+      integer , intent(in) :: nlay ! number of model layers
+      integer , intent(in) :: icld ! clear/cloud, cloud overlap flag
+      integer , intent(in) :: permuteseed ! if the cloud generator is called multiple times,
+                                                      ! permute the seed between each call.
+                                                      ! between calls for LW and SW, recommended
+                                                      ! permuteseed differes by 'ngpt'
+      integer , intent(in) :: irng ! flag for random number generator
+                                                      ! 0 = kissvec
+                                                      ! 1 = Mersenne Twister
+! integer , intent(in) :: cloudMH, cloudHH
+
+! Atmosphere
+      real , intent(in) :: play(:,:) ! layer pressures (mb)
+                                                      ! Dimensions: (ncol,nlay)
+
+! Atmosphere/clouds - cldprop
+      real , intent(in) :: cldfrac(:,:) ! layer cloud fraction
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: tauc(:,:,:) ! in-cloud optical depth
+                                                      ! Dimensions: (ncol,nbndlw,nlay)
+      real , intent(in) :: ciwp(:,:) ! in-cloud ice water path
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: clwp(:,:) ! in-cloud liquid water path
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: cswp(:,:) ! in-cloud snow path
+                                                      ! Dimensions: (ncol,nlay)
+      integer , intent(in) :: ngbd(:)
+
+! ----- Output -----
+! Atmosphere/clouds - cldprmc [mcica]
+      real , intent(out) :: cldfmcl(:,:,:) ! cloud fraction [mcica]
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real , intent(out) :: ciwpmcl(:,:,:) ! in-cloud ice water path [mcica]
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real , intent(out) :: clwpmcl(:,:,:) ! in-cloud liquid water path [mcica]
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real , intent(out) :: cswpmcl(:,:,:) ! in-cloud snow water path [mcica]
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real , intent(out) :: taucmcl(:,:,:) ! in-cloud optical depth [mcica]
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+
+
+! were module data but changed to arguments because not thread-safe
+      real :: pmidd(:, :)
+      real :: clwpd(:,:), ciwpd(:,:), cswpd(:,:), taucd(:,:,:)
+
+
+! ----- Local -----
+
+! Stochastic cloud generator variables [mcica]
+      integer , parameter :: nsubclw = ngptlw ! number of sub-columns (g-point intervals)
+      integer :: ilev ! loop index
+
+      real :: pmid(ncol, nlay) ! layer pressures (Pa)
+
+
+
+      integer, save :: counter = 0
+      integer :: i,j,k,tk
+      real :: t1, t2
+
+! Return if clear sky; or stop if icld out of range
+      if (icld.eq.0) then
+!$acc data pcopy(cldfmcl,ciwpmcl,clwpmcl,cswpmcl,taucmcl,pmidd,play)
+!$acc kernels      
+        cldfmcl = 0.0
+        ciwpmcl = 0.0
+        clwpmcl = 0.0
+        cswpmcl = 0.0
+        taucmcl = 0.0
+! cloudFlag = 0.0
+!$acc end kernels
+!$acc end data
+        return
+      end if
+      if (icld.lt.0.or.icld.gt.4) then
+         stop 'MCICA_SUBCOL: INVALID ICLD'
+      endif
+
+! NOTE: For GCM mode, permuteseed must be offset between LW and SW by at least the number of subcolumns
+
+
+! Pass particle sizes to new arrays, no subcolumns for these properties yet
+! Convert pressures from mb to Pa
+
+!$acc data pcopy(cldfmcl,ciwpmcl,clwpmcl,cswpmcl,taucmcl,pmidd,play)
+
+
+!$acc kernels
+      pmidd(1:ncol,:nlay) = play(colstart:colstart+ncol-1,:nlay)*1.e2
+!$acc end kernels      
+!$acc end data      
+      end subroutine mcica_subcol_lwg
+
+!-------------------------------------------------------------------------------------------------
+       subroutine generate_stochastic_cloudsg(ncol, nlay, icld, ngbd, &
+
+                                 pmidd,cldfracd,clwpd,ciwpd,cswpd,taucd,changeSeed, &
+
+                                 cld_stoch, clwp_stoch, ciwp_stoch, cswp_stoch, &
+                                 tauc_stoch)
+!-------------------------------------------------------------------------------------------------
+
+  !----------------------------------------------------------------------------------------------------------------
+  ! ---------------------
+  ! Contact: Cecile Hannay (hannay@ucar.edu)
+  !
+  ! Original code: Based on Raisanen et al., QJRMS, 2004.
+  !
+  ! Modifications: Generalized for use with RRTMG and added Mersenne Twister as the default
+  ! random number generator, which can be changed to the optional kissvec random number generator
+  ! with flag 'irng'. Some extra functionality has been commented or removed.
+  ! Michael J. Iacono, AER, Inc., February 2007
+  !
+  ! Given a profile of cloud fraction, cloud water and cloud ice, we produce a set of subcolumns.
+  ! Each layer within each subcolumn is homogeneous, with cloud fraction equal to zero or one
+  ! and uniform cloud liquid and cloud ice concentration.
+  ! The ensemble as a whole reproduces the probability function of cloud liquid and ice within each layer
+  ! and obeys an overlap assumption in the vertical.
+  !
+  ! Overlap assumption:
+  ! The cloud are consistent with 4 overlap assumptions: random, maximum, maximum-random and exponential.
+  ! The default option is maximum-random (option 3)
+  ! The options are: 1=random overlap, 2=max/random, 3=maximum overlap, 4=exponential overlap
+  ! This is set with the variable "overlap"
+  !mji - Exponential overlap option (overlap=4) has been deactivated in this version
+  ! The exponential overlap uses also a length scale, Zo. (real, parameter :: Zo = 2500. )
+  !
+  ! Seed:
+  ! If the stochastic cloud generator is called several times during the same timestep,
+  ! one should change the seed between the call to insure that the subcolumns are different.
+  ! This is done by changing the argument 'changeSeed'
+  ! For example, if one wants to create a set of columns for the shortwave and another set for the longwave ,
+  ! use 'changeSeed = 1' for the first call and'changeSeed = 2' for the second call
+  !
+  ! PDF assumption:
+  ! We can use arbitrary complicated PDFS.
+  ! In the present version, we produce homogeneuous clouds (the simplest case).
+  ! Future developments include using the PDF scheme of Ben Johnson.
+  !
+  ! History file:
+  ! Option to add diagnostics variables in the history file. (using FINCL in the namelist)
+  ! nsubcol = number of subcolumns
+  ! overlap = overlap type (1-3)
+  ! Zo = length scale
+  ! CLOUD_S = mean of the subcolumn cloud fraction ('_S" means Stochastic)
+  ! CLDLIQ_S = mean of the subcolumn cloud water
+  ! CLDICE_S = mean of the subcolumn cloud ice
+  !
+  ! Note:
+  ! Here: we force that the cloud condensate to be consistent with the cloud fraction
+  ! i.e we only have cloud condensate when the cell is cloudy.
+  ! In CAM: The cloud condensate and the cloud fraction are obtained from 2 different equations
+  ! and the 2 quantities can be inconsistent (i.e. CAM can produce cloud fraction
+  ! without cloud condensate or the opposite).
+  !---------------------------------------------------------------------------------------------------------------
+
+
+! -- Arguments
+
+      integer , intent(in) :: ncol ! number of columns
+      integer , intent(in) :: nlay ! number of layers
+      integer , intent(in) :: icld ! clear/cloud, cloud overlap flag
+
+       integer , intent(in) :: ngbd(:)
+
+
+! were module data but changed to arguments because not thread-safe
+      real :: pmidd(:, :)
+      real :: cldfracd(:,:), clwpd(:,:), ciwpd(:,:), cswpd(:,:), taucd(:,:,:)
+      integer, intent(in) :: changeSeed
+
+
+! real , intent(in) :: ssac(:,:,:) ! in-cloud single scattering albedo
+                                                      ! Dimensions: (nbndlw,ncol,nlay)
+                                                      ! inactive - for future expansion
+! real , intent(in) :: asmc(:,:,:) ! in-cloud asymmetry parameter
+                                                      ! Dimensions: (nbndlw,ncol,nlay)
+                                                      ! inactive - for future expansion
+
+      real , intent(out) :: cld_stoch(:,:,:) ! subcolumn cloud fraction
+                                                      ! Dimensions: (ncol,ngptlw,nlay)
+      real , intent(out) :: clwp_stoch(:,:,:) ! subcolumn in-cloud liquid water path
+                                                      ! Dimensions: (ncol,ngptlw,nlay)
+      real , intent(out) :: ciwp_stoch(:,:,:) ! subcolumn in-cloud ice water path
+                                                      ! Dimensions: (ncol,ngptlw,nlay)
+      real , intent(out) :: cswp_stoch(:,:,:) ! subcolumn in-cloud snow water path
+                                                      ! Dimensions: (ncol,ngptlw,nlay)
+      real , intent(out) :: tauc_stoch(:,:,:) ! subcolumn in-cloud optical depth
+                                                      ! Dimensions: (ncol,ngptlw,nlay)
+! real , intent(out) :: ssac_stoch(:,:,:)! subcolumn in-cloud single scattering albedo
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+                                                      ! inactive - for future expansion
+! real , intent(out) :: asmc_stoch(:,:,:)! subcolumn in-cloud asymmetry parameter
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+                                                      ! inactive - for future expansion
+
+      !integer, value, intent(in) :: counter
+
+! Cloud condensate
+
+       real :: RIND1, RIND2, ZCW, SIGMA_QCW
+       integer :: IND1, IND2
+
+       real :: CDF3(mxlay) ! random numbers
+
+       real :: cfs
+       integer, parameter :: nsubcol = 140
+
+! Constants (min value for cloud fraction and cloud water and ice)
+     ! real , parameter :: cldmin = 1.0e-20 ! min cloud fraction
+! real , parameter :: qmin = 1.0e-10 ! min cloud water and cloud ice (not used)
+
+! Variables related to random number and seed
+
+
+
+
+
+      real :: CDF(mxlay), CDF2(mxlay) ! random numbers
+      integer,dimension(ncol) :: seed1, seed2, seed3, seed4 ! seed to create random number (kissvec)
+      integer :: seed1_, seed2_, seed3_, seed4_ ! seed to create random number (kissvec)
+      real ,dimension(ncol) :: rand_num ! random number (kissvec)
+
+      integer :: iseed ! seed to create random number (Mersenne Teister)
+      real :: rand_num_mt ! random number (Mersenne Twister)
+
+! Flag to identify cloud fraction in subcolumns
+   ! logical :: iscloudy(mxlay) ! flag that says whether a gridbox is cloudy
+
+! Indices
+      integer :: ilev, isubcol, i, n ! indices
+
+      integer :: iplon, gp
+      integer :: m, k, n1, kiss
+
+      m(k, n1) = ieor (k, ishft (k, n1) )
+! ----- Create seed --------
+
+! Advance randum number generator by changeseed values
+
+! For kissvec, create a seed that depends on the state of the columns. Maybe not the best way, but it works.
+! Must use pmid from bottom four layers.
+
+
+
+
+
+
+! Have it agree with the original _lw.F version, jm 20141222
+     if(icld.eq.1) CALL wrf_error_fatal("icld == 1 not supported: module_ra_rrtmg_lwf.F")
+     if(icld.eq.3) CALL wrf_error_fatal("icld == 3 doesn't adopted to GPU (OpenACC)")
+
+!$acc data pcopy(pmidd,cldfracd,cldfracd,clwpd,ciwpd,cswpd,taucd,&
+!$acc           cld_stoch,clwp_stoch,ciwp_stoch,cswp_stoch,tauc_stoch)
+!$acc kernels
+    do iplon = 1, ncol
+!$acc loop private(CDF)     
+     do gp = 1, nsubcol
+
+       seed1_ = (pmidd(iplon,1) - int(pmidd(iplon,1))) * 1000000000 + gp*11
+       seed3_ = (pmidd(iplon,2) - int(pmidd(iplon,2))) * 1000000000 + gp*13
+       seed2_ =  seed1_ + gp
+       seed4_ =  seed2_ - gp
+
+
+! ------ Apply overlap assumption --------
+
+! generate the random numbers
+
+       select case (icld)
+
+! Maximum-Random overlap
+       case(2)
+!$acc loop seq            
+            do ilev = 1,nlay
+             seed1_ = 69069 * seed1_ + 1327217885
+             seed2_ = m (m (m (seed2_, 13), - 17), 5)
+             seed3_ = 18000 * iand (seed3_, 65535) + ishft (seed3_, - 16)
+             seed4_ = 30903 * iand (seed4_, 65535) + ishft (seed4_, - 16)
+             kiss = seed1_ + seed2_ + ishft (seed3_, 16) + seed4_
+             CDF(ilev) = kiss*2.328306e-10 + 0.5
+            enddo
+!$acc loop seq            
+            do ilev = 2,nlay
+             if (CDF(ilev-1) > 1. - cldfracd(iplon, ilev-1)) then
+                CDF(ilev) = CDF(ilev-1)
+             else
+                 CDF(ilev) = CDF(ilev) * (1. - cldfracd(iplon, ilev-1))
+             end if
+            end do
+
+! Maximum overlap
+       case(3)
+#if 0            
+          print *, "icld == 3 doesn't adopted to GPU (OpenACC)"
+            do iplon = 1, ncol
+! call kissvec(seed1(iplon), seed2(iplon), seed3(iplon), seed4(iplon), rand_num(iplon))
+          seed1(iplon) = 69069 * seed1(iplon) + 1327217885
+          seed2(iplon) = m (m (m (seed2(iplon), 13), - 17), 5)
+          seed3(iplon) = 18000 * iand (seed3(iplon), 65535) + ishft (seed3(iplon), - 16)
+          seed4(iplon) = 30903 * iand (seed4(iplon), 65535) + ishft (seed4(iplon), - 16)
+          kiss = seed1(iplon) + seed2(iplon) + ishft (seed3(iplon), 16) + seed4(iplon)
+          rand_num(iplon) = kiss*2.328306e-10 + 0.5
+            enddo
+           do ilev = 1,nlay
+            do iplon = 1, ncol
+             CDF(ilev,iplon) = rand_num(iplon)
+            enddo
+           end do
+#endif
+       end select
+
+
+      n = ngbd(gp)
+      do ilev = 1,nlay
+        cfs = cldfracd(iplon, ilev)
+         ! do gp = 1, nsubcol
+
+
+
+               if (CDF(ilev) >=1. - cfs) then
+
+
+                  cld_stoch(iplon,gp,ilev) = 1.
+                  clwp_stoch(iplon,gp,ilev) = clwpd(iplon,ilev)
+                  ciwp_stoch(iplon,gp,ilev) = ciwpd(iplon,ilev)
+                  cswp_stoch(iplon,gp,ilev) = cswpd(iplon,ilev)
+
+                  tauc_stoch(iplon,gp,ilev) = taucd(iplon,n,ilev)
+
+               else
+                  cld_stoch(iplon,gp,ilev) = 0.
+                  clwp_stoch(iplon,gp,ilev) = 0.
+                  ciwp_stoch(iplon,gp,ilev) = 0.
+                  cswp_stoch(iplon,gp,ilev) = 0.
+                  tauc_stoch(iplon,gp,ilev) = 0.
+! ssac_stoch(isubcol,i,ilev) = 1.
+! asmc_stoch(isubcol,i,ilev) = 1.
+               endif
+
+       enddo
+
+      enddo  ! gp
+      enddo ! iplon
+!$acc end kernels      
+!$acc end data
+
+
+      end subroutine generate_stochastic_cloudsg
+
+      subroutine kissvec(seed1,seed2,seed3,seed4,ran_arr)
+!--------------------------------------------------------------------------------------------------
+
+! public domain code
+! made available from http:
+! downloaded by pjr on 03/16/04 for NCAR CAM
+! converted to vector form, functions inlined by pjr,mvr on 05/10/2004
+
+! The KISS (Keep It Simple Stupid) random number generator. Combines:
+! (1) The congruential generator x(n)=69069*x(n-1)+1327217885, period 2^32.
+! (2) A 3-shift shift-register generator, period 2^32-1,
+! (3) Two 16-bit multiply-with-carry generators, period 597273182964842497>2^59
+! Overall period>2^123;
+!
+      real , intent(inout) :: ran_arr
+      integer , intent(inout) :: seed1,seed2,seed3,seed4
+      integer :: i,sz,kiss
+      integer :: m, k, n
+
+! inline function
+      m(k, n) = ieor (k, ishft (k, n) )
+
+      seed1 = 69069 * seed1 + 1327217885
+      seed2 = m (m (m (seed2, 13), - 17), 5)
+      seed3 = 18000 * iand (seed3, 65535) + ishft (seed3, - 16)
+      seed4 = 30903 * iand (seed4, 65535) + ishft (seed4, - 16)
+      kiss = seed1 + seed2 + ishft (seed3, 16) + seed4
+      ran_arr = kiss*2.328306e-10 + 0.5
+
+      end subroutine kissvec
+
+      end module gpu_mcica_subcol_gen_lw
+
+! (dmb 2012) This is the GPU version of the cldprmc routine. I have parallelized across
+! all 3 dimensions (columns, g-points, and layers) to make this routine run very fast on the GPU.
+! The greatest speedup was obtained by switching the indices for the cloud variables so that
+! the columns were the least significant (leftmost) dimension
+
+      module gpu_rrtmg_lw_cldprmc
+
+! --------------------------------------------------------------------------
+! | |
+! | Copyright 2002-2009, Atmospheric & Environmental Research, Inc. (AER). |
+! | This software may be used, copied, or redistributed as long as it is |
+! | not sold and this copyright notice is reproduced on each copy made. |
+! | This model is provided as is without any express or implied warranties. |
+! | (http:
+! | |
+! --------------------------------------------------------------------------
+
+! --------- Modules ----------
+
+! use parkind, only : im => kind , rb => kind
+      use parrrtm_f, only : ngptlw, nbndlw
+      use rrlw_cld_f, only: abscld1, absliq0, absliq1, &
+                          absice0, absice1, absice2, absice3
+! use rrlw_wvn_f, only: ngb
+      use rrlw_vsn_f, only: hvrclc, hnamclc
+
+
+
+
+      implicit none
+      contains
+
+! ------------------------------------------------------------------------------
+      subroutine cldprmcg(ncol, nlayers, &
+
+                inflagd,iceflagd,liqflagd,ciwpmcd,clwpmcd,cswpmcd,relqmcd,reicmcd,resnmcd, &
+                absice0d,absice1d,absice2d,absice3d,absliq1d, &
+
+                                  cldfmc, taucmc, ngb, icb, ncbands, icldlyr)
+! ------------------------------------------------------------------------------
+
+! Purpose: Compute the cloud optical depth(s) for each cloudy layer.
+
+! ------- Input -------
+
+      integer, value, intent(in) :: ncol ! total number of columns
+      integer, value, intent(in) :: nlayers ! total number of layers
+
+
+
+
+
+      real , intent(in) :: cldfmc(CHNK, ngptlw, nlayers+1) ! cloud fraction [mcica]
+
+      integer , intent(out) :: icldlyr( CHNK, nlayers+1)
+      integer , dimension(140), intent(in) :: ngb
+      integer , intent(in) :: icb(16)
+      real , intent(inout) :: taucmc(:,:,:) ! cloud optical depth [mcica]
+
+      real , parameter :: absliq0 = 0.0903614
+
+! ------- Output -------
+
+      integer , intent(out) :: ncbands(:) ! number of cloud spectral bands
+
+
+!changed to arguments for thread safety on CPU
+      integer :: inflagd(:), iceflagd(:), liqflagd(:)
+
+      real :: ciwpmcd(:,:,:) ! in-cloud ice water path [mcica]
+      real :: clwpmcd(:,:,:) ! in-cloud liquid water path [mcica]
+      real :: cswpmcd(:,:,:) ! in-cloud snow water path [mcica]
+                                                      ! Dimensions: (CHNK,ngptlw,nlayers)
+      real :: relqmcd(:,:) ! liquid particle effective radius (microns)
+      real :: reicmcd(:,:) ! ice particle effective size (microns)
+      real :: resnmcd(:,:) ! snow particle effective size (microns)
+                                                      ! Dimensions: (CHNK,nlayers)
+                                                      ! specific definition of reicmc depends on setting of iceflag:
+                                                      ! iceflag = 0: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                                      ! r_ec must be >= 10.0 microns
+                                                      ! iceflag = 1: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                                      ! r_ec range is limited to 13.0 to 130.0 microns
+                                                      ! iceflag = 2: ice effective radius, r_k, (Key, Streamer Ref. Manual, 1996)
+                                                      ! r_k range is limited to 5.0 to 131.0 microns
+                                                      ! iceflag = 3: generalized effective size, dge, (Fu, 1996),
+                                                      ! dge range is limited to 5.0 to 140.0 microns
+                                                      ! [dge = 1.0315 * r_ec]
+
+      real, dimension(2) :: absice0d
+      real, dimension(2,5) :: absice1d
+      real, dimension(43,16) :: absice2d
+      real, dimension(46,16) :: absice3d
+      real, dimension(58,16) :: absliq1d
+
+
+! ------- Local -------
+
+      integer :: iplon
+      integer :: lay ! Layer index
+      integer :: ib ! spectral band index
+      integer :: ig ! g-point interval index
+      integer :: index
+
+
+      real :: abscoice ! ice absorption coefficients
+      real :: abscoliq ! liquid absorption coefficients
+      real :: abscosno ! snow absorption coefficients
+      real :: cwp ! cloud water path
+      real :: radice ! cloud ice effective size (microns)
+      real :: radliq ! cloud liquid droplet radius (microns)
+      real :: radsno ! cloud snow effective radius (microns)
+      real :: factor !
+      real :: fint !
+      real , parameter :: eps = 1.e-6 ! epsilon
+      real , parameter :: cldmin = 1.e-20 ! minimum value for cloud quantities
+
+      character*256 errmess
+! ------- Definitions -------
+
+! Explanation of the method for each value of INFLAG. Values of
+! 0 or 1 for INFLAG do not distingish being liquid and ice clouds.
+! INFLAG = 2 does distinguish between liquid and ice clouds, and
+! requires further user input to specify the method to be used to
+! compute the aborption due to each.
+! INFLAG = 0: For each cloudy layer, the cloud fraction and (gray)
+! optical depth are input.
+! INFLAG = 1: For each cloudy layer, the cloud fraction and cloud
+! water path (g/m2) are input. The (gray) cloud optical
+! depth is computed as in CCM2.
+! INFLAG = 2: For each cloudy layer, the cloud fraction, cloud
+! water path (g/m2), and cloud ice fraction are input.
+! ICEFLAG = 0: The ice effective radius (microns) is input and the
+! optical depths due to ice clouds are computed as in CCM3.
+! ICEFLAG = 1: The ice effective radius (microns) is input and the
+! optical depths due to ice clouds are computed as in
+! Ebert and Curry, JGR, 97, 3831-3836 (1992). The
+! spectral regions in this work have been matched with
+! the spectral bands in RRTM to as great an extent
+! as possible:
+! E&C 1 IB = 5 RRTM bands 9-16
+! E&C 2 IB = 4 RRTM bands 6-8
+! E&C 3 IB = 3 RRTM bands 3-5
+! E&C 4 IB = 2 RRTM band 2
+! E&C 5 IB = 1 RRTM band 1
+! ICEFLAG = 2: The ice effective radius (microns) is input and the
+! optical properties due to ice clouds are computed from
+! the optical properties stored in the RT code,
+! STREAMER v3.0 (Reference: Key. J., Streamer
+! User's Guide, Cooperative Institute for
+! Meteorological Satellite Studies, 2001, 96 pp.).
+! Valid range of values for re are between 5.0 and
+! 131.0 micron.
+! ICEFLAG = 3: The ice generalized effective size (dge) is input
+! and the optical properties, are calculated as in
+! Q. Fu, J. Climate, (1998). Q. Fu provided high resolution
+! tables which were appropriately averaged for the
+! bands in RRTM_LW. Linear interpolation is used to
+! get the coefficients from the stored tables.
+! Valid range of values for dge are between 5.0 and
+! 140.0 micron.
+! LIQFLAG = 0: The optical depths due to water clouds are computed as
+! in CCM3.
+! LIQFLAG = 1: The water droplet effective radius (microns) is input
+! and the optical depths due to water clouds are computed
+! as in Hu and Stamnes, J., Clim., 6, 728-742, (1993).
+! The values for absorption coefficients appropriate for
+! the spectral bands in RRTM have been obtained for a
+! range of effective radii by an averaging procedure
+! based on the work of J. Pinto (private communication).
+! Linear interpolation is used to get the absorption
+! coefficients for the input effective radius.
+
+! (dmb 2012) Here insead of looping over the column, layer, and band dimensions,
+! I compute the index for each dimension from the grid and block layout. This
+! function is called once per each thread, and each thread has a unique combination of
+! column, layer, and g-point.
+!$acc kernels
+!$acc loop independent
+    do iplon = 1, CHNK
+!$acc loop independent
+      do lay = 1, nlayers
+!$acc loop independent
+        do ig = 1, ngptlw
+
+
+          ncbands(iplon) = 1
+! (dmb 2012) all of the cloud variables have been modified so that the column dimensions
+! is least significant.
+          if (cldfmc(iplon,ig,lay) .eq. 1. ) then
+            icldlyr(iplon, lay)=1
+          endif
+          cwp = ciwpmcd(iplon,ig,lay) + clwpmcd(iplon,ig,lay) + cswpmcd(iplon,ig,lay)
+! (dmb 2012) the stop commands were removed because they aren't supported on the GPU
+          if (cldfmc(iplon,ig,lay) .ge. cldmin .and. &
+             (cwp .ge. cldmin .or. taucmc(iplon,ig,lay) .ge. cldmin)) then
+
+
+!jm top cldprmc inflagd 5
+!jm top cldprmc iceflagd 5
+!jm top cldprmc liqflagd 1
+
+
+!jm zap if(inflagd(iplon) .eq. 2) then
+            if(inflagd(iplon) .ge. 2) then
+               radice = reicmcd(iplon, lay)
+
+! Calculation of absorption coefficients due to ice clouds.
+               if (ciwpmcd(iplon,ig,lay)+cswpmcd(iplon,ig,lay) .eq. 0.0) then
+                  abscoice = 0.0
+                  abscosno = 0.0
+
+               elseif (iceflagd(iplon) .eq. 0) then
+                  abscoice= absice0d(1) + absice0d(2)/radice
+                  abscosno = 0.0
+
+               elseif (iceflagd(iplon) .eq. 1) then
+                  ncbands(iplon) = 5
+                  ib = icb(ngb(ig))
+                  abscoice = absice1d(1,ib) + absice1d(2,ib)/radice
+                  abscosno = 0.0
+
+! For iceflag=2 option, ice particle effective radius is limited to 5.0 to 131.0 microns
+
+               elseif (iceflagd(iplon) .eq. 2) then
+                  ncbands(iplon) = 16
+                  factor = (radice - 2.)/3.
+                  index = int(factor)
+! mji - temporary fix to prevent out of range subscripts
+                     if (index .le. 0) index = 1
+                     if (index .ge. 43) index = 42
+! if (index .eq. 43) index = 42
+                  fint = factor - float(index)
+                  ib = ngb(ig)
+                  abscoice = &
+                      absice2d(index,ib) + fint * &
+                      (absice2d(index+1,ib) - (absice2d(index,ib)))
+                  abscosno = 0.0
+
+! For iceflag=3 option, ice particle generalized effective size is limited to 5.0 to 140.0 microns
+
+!jm elseif (iceflagd(iplon) .eq. 3) then
+               elseif (iceflagd(iplon) .ge. 3) then
+                  ncbands(iplon) = 16
+                  factor = (radice - 2.)/3.
+                  index = int(factor)
+! mji - temporary fix to prevent out of range subscripts
+                  if (index .le. 0) index = 1
+                  if (index .ge. 46) index = 45
+! if (index .eq. 46) index = 45
+                  fint = factor - float(index)
+                  ib = ngb(ig)
+                  abscoice= &
+                      absice3d(index,ib) + fint * &
+                      (absice3d(index+1,ib) - (absice3d(index,ib)))
+                  abscosno = 0.0
+               endif
+
+!..Incorporate additional effects due to snow.
+               if (cswpmcd(iplon,ig,lay).gt.0.0 .and. iceflagd(iplon) .eq. 5) then
+                  radsno = resnmcd(iplon,lay)
+                  ncbands(iplon) = 16
+                  factor = (radsno - 2.)/3.
+                  index = int(factor)
+! mji - temporary fix to prevent out of range subscripts
+                  if (index .le. 0) index = 1
+                  if (index .ge. 46) index = 45
+! if (index .eq. 46) index = 45
+                  fint = factor - float(index)
+                  ib = ngb(ig)
+                  abscosno = &
+                      absice3d(index,ib) + fint * &
+                      (absice3d(index+1,ib) - (absice3d(index,ib)))
+               endif
+
+! Calculation of absorption coefficients due to water clouds.
+!jm if (liqflagd(iplon) .eq. 1) then
+               if (clwpmcd(iplon,ig,lay) .eq. 0.0) then
+                 abscoliq = 0.0
+               else if (liqflagd(iplon) .eq. 0) then
+                 abscoliq = absliq0
+               else if (liqflagd(iplon) .eq. 1) then
+                 radliq = relqmcd(iplon, lay)
+                 index = int(radliq - 1.5 )
+! mji - temporary fix to prevent out of range subscripts
+                     if (index .le. 0) index = 1
+                     if (index .ge. 58) index = 57
+! if (index .eq. 0) index = 1
+! if (index .eq. 58) index = 57
+                 fint = radliq - 1.5 - float(index)
+                 ib = ngb(ig)
+                 abscoliq = &
+                     absliq1d(index,ib) + fint * &
+                     (absliq1d(index+1,ib) - (absliq1d(index,ib)))
+               endif
+
+               taucmc(iplon,ig,lay) = ciwpmcd(iplon,ig,lay) * abscoice + &
+                                      clwpmcd(iplon,ig,lay) * abscoliq + &
+                                      cswpmcd(iplon,ig,lay) * abscosno
+
+
+            endif
+          endif
+
+
+
+
+        end do
+      end do
+    end do
+!$acc end kernels
+
+
+      end subroutine cldprmcg
+
+
+
+
+
+
+! (dmb 2012) This subroutine allocates the module level arrays on the GPU
+      subroutine allocateGPUcldprmcg(ncol, nlay, ngptlw)
+
+         integer , intent(in) :: nlay, ngptlw, ncol
+      end subroutine
+
+      ! (dmb 2012) This subroutine deallocates any GPU arrays.
+      subroutine deallocateGPUcldprmcg()
+      end subroutine
+
+      ! (dmb 2012) This subroutine copies input data from the CPU over to the GPU
+      ! for use in the cldprmcg subroutine.
+      subroutine copyGPUcldprmcg(inflag, iceflag, liqflag,&
+                                 absice0, absice1, absice2, absice3, absliq1)
+
+         integer :: inflag(:), iceflag(:), liqflag(:)
+
+         real , dimension(:) :: absice0
+         real , dimension(:,:) :: absice1
+         real , dimension(:,:) :: absice2
+         real , dimension(:,:) :: absice3
+         real , dimension(:,:) :: absliq1
+      end subroutine
+
+      end module gpu_rrtmg_lw_cldprmc
+
+! (dmb 2012) This is the GPU version of the rtrnmc subroutine. This has been greatly
+! modified to be efficiently run on the GPU. Originally, there was a g-point loop within
+! this subroutine to perform the summation of the fluxes over the g-points. This has been
+! modified so that this subroutine can be run in parallel across the g-points. This was
+! absolutely critical because of two reasons.
+! 1. For a relatively low number of profiles, there wouldn't be enough threads to keep
+! the GPU busy enough to run at full potential. As a result of this, this subroutine
+! would end up being a bottleneck.
+! 2. The memory access for the GPU arrays would be innefient because there would be very
+! little coalescing which is critical for obtaining optimal performance.
+
+      module gpu_rrtmg_lw_rtrnmc
+
+! --------------------------------------------------------------------------
+! | |
+! | Copyright 2002-2009, Atmospheric & Environmental Research, Inc. (AER). |
+! | This software may be used, copied, or redistributed as long as it is |
+! | not sold and this copyright notice is reproduced on each copy made. |
+! | This model is provided as is without any express or implied warranties. |
+! | (http:
+! | |
+! --------------------------------------------------------------------------
+
+! --------- Modules ----------
+
+! use parkind, only : im => kind , rb => kind
+      use parrrtm_f, only : mg, nbndlw, ngptlw, mxlay
+      use rrlw_con_f, only: fluxfac, heatfac
+! (jm 2014) not sure why the GPU version defines ntbl 2x instead of using it
+! from rrlw_tbl, but will leave it alone for now. However, it is an error when
+! compiling for CPU, at least with the Intel compiler. Says it's defined twice.
+
+
+
+      use rrlw_tbl_f, only: bpade, tblint, tau_tbl, exp_tbl, tfn_tbl, ntbl
+
+
+
+
+
+
+      implicit none
+      contains
+
+!-----------------------------------------------------------------------------
+      subroutine rtrnmcg(ncol, nlayers, istart, iend, iout &
+
+         ,ncol_,nlayers_,nbndlw_,ngptlw_ &
+         ,taucmcd,pzd,pwvcmd,semissd,planklayd,planklevd,plankbndd,gurad,gdrad,gclrurad,gclrdrad &
+         ,gdtotuflux_dtd,gdtotuclfl_dtd,idrvd,bpaded,heatfacd,fluxfacd,a0d,a1d,a2d &
+         ,delwaved,totufluxd,totdfluxd,fnetd,htrd,totuclfld,totdclfld,fnetcd,htrcd,dtotuflux_dtd &
+         ,dtotuclfl_dtd,dplankbnd_dtd &
+                                 ,ngb,icldlyr, taug, fracsd, cldfmcd)
+!-----------------------------------------------------------------------------
+!
+! Original version: E. J. Mlawer, et al. RRTM_V3.0
+! Revision for GCMs: Michael J. Iacono; October, 2002
+! Revision for F90: Michael J. Iacono; June, 2006
+! Revision for dFdT option: M. J. Iacono and E. J. Mlawer, November 2009
+!
+! This program calculates the upward fluxes, downward fluxes, and
+! heating rates for an arbitrary clear or cloudy atmosphere. The input
+! to this program is the atmospheric profile, all Planck function
+! information, and the cloud fraction by layer. A variable diffusivity
+! angle (SECDIFF) is used for the angle integration. Bands 2-3 and 5-9
+! use a value for SECDIFF that varies from 1.50 to 1.80 as a function of
+! the column water vapor, and other bands use a value of 1.66. The Gaussian
+! weight appropriate to this angle (WTDIFF=0.5) is applied here. Note that
+! use of the emissivity angle for the flux integration can cause errors of
+! 1 to 4 W/m2 within cloudy layers.
+! Clouds are treated with the McICA stochastic approach and maximum-random
+! cloud overlap.
+! This subroutine also provides the optional capability to calculate
+! the derivative of upward flux respect to surface temperature using
+! the pre-tabulated derivative of the Planck function with respect to
+! temperature integrated over each spectral band.
+!***************************************************************************
+
+! ------- Declarations -------
+
+! ----- Input -----
+      integer(kind=4), value, intent(in) :: nlayers ! total number of layers
+      integer(kind=4), value, intent(in) :: ncol ! total number of columns
+      integer(kind=4), value, intent(in) :: istart ! beginning band of calculation
+      integer(kind=4), value, intent(in) :: iend ! ending band of calculation
+      integer(kind=4), value, intent(in) :: iout ! output option flag
+      integer , intent(in) :: ngb(:) ! band index
+
+      integer , intent(in) :: icldlyr(:,:)
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+      real :: cldfmcd(:,:,:)
+
+
+      integer :: ncol_,nlayers_,nbndlw_,ngptlw_
+! changed to arguments for thread safety
+
+
+
+      integer :: ngsd(nbndlw)
+
+! Atmosphere
+      real :: taucmcd(CHNK, ngptlw_, nlayers_+1)
+
+      real , dimension(CHNK, 0:nlayers_+1) :: pzd ! level (interface) pressures (hPa, mb)
+                                                        ! Dimensions: (ncol,0:nlayers)
+      real , dimension(CHNK) :: pwvcmd ! precipitable water vapor (cm)
+                                                        ! Dimensions: (ncol)
+      real , dimension(CHNK,nbndlw_) :: semissd ! lw surface emissivity
+                                                        ! Dimensions: (ncol,nbndlw)
+      real , dimension(CHNK,nlayers_+1,nbndlw_) :: planklayd !
+                                                        ! Dimensions: (ncol,nlayers+1,nbndlw)
+      real , dimension(CHNK,0:nlayers_+1,nbndlw_) :: planklevd !
+                                                        ! Dimensions: (ncol,0:nlayers+1,nbndlw)
+      real, dimension(CHNK,nbndlw_) :: plankbndd !
+                                                        ! Dimensions: (ncol,nbndlw)
+
+      real :: gurad(CHNK,ngptlw_,0:nlayers_+1) ! upward longwave flux (w/m2)
+      real :: gdrad(CHNK,ngptlw_,0:nlayers_+1) ! downward longwave flux (w/m2)
+      real :: gclrurad(CHNK,ngptlw_,0:nlayers_+1) ! clear sky upward longwave flux (w/m2)
+      real :: gclrdrad(CHNK,ngptlw_,0:nlayers_+1) ! clear sky downward longwave flux (w/m2)
+
+      real :: gdtotuflux_dtd(CHNK, ngptlw_, 0:nlayers_+1) ! change in upward longwave flux (w/m1/k)
+                                     ! with respect to surface temperature
+
+      real :: gdtotuclfl_dtd(CHNK, ngptlw_, 0:nlayers_+1) ! change in clear sky upward longwave flux (w/m2/k)
+                                     ! with respect to surface temperature
+
+! Clouds
+      integer :: idrvd ! flag for calculation of dF/dt from
+                                                      ! Planck derivative [0=off, 1=on]
+      real :: bpaded
+      real :: heatfacd
+      real :: fluxfacd
+      real :: a0d(nbndlw_), a1d(nbndlw_), a2d(nbndlw_)
+      real :: delwaved(nbndlw_)
+      real :: totufluxd(CHNK, 0:nlayers_+1) ! upward longwave flux (w/m2)
+      real :: totdfluxd(CHNK, 0:nlayers_+1) ! downward longwave flux (w/m2)
+      real :: fnetd(CHNK, 0:nlayers_+1) ! net longwave flux (w/m2)
+      real :: htrd(CHNK, 0:nlayers_+1) ! longwave heating rate (k/day)
+      real :: totuclfld(CHNK, 0:nlayers_+1) ! clear sky upward longwave flux (w/m2)
+      real :: totdclfld(CHNK, 0:nlayers_+1) ! clear sky downward longwave flux (w/m2)
+      real :: fnetcd(CHNK, 0:nlayers_+1) ! clear sky net longwave flux (w/m2)
+      real :: htrcd(CHNK, 0:nlayers_+1) ! clear sky longwave heating rate (k/day)
+      real :: dtotuflux_dtd(CHNK, 0:nlayers_+1) ! change in upward longwave flux (w/m2/k)
+                                                       ! with respect to surface temperature
+      real :: dtotuclfl_dtd(CHNK, 0:nlayers_+1) ! change in clear sky upward longwave flux (w/m2/k)
+                                                       ! with respect to surface temperature
+      real :: dplankbnd_dtd(CHNK,nbndlw_)
+
+   ! ----- Local -----
+! Declarations for radiative transfer
+      real :: atot(  mxlay)
+      real :: atrans(  mxlay)
+      real :: bbugas(  mxlay)
+      real :: bbutot(  mxlay)
+
+      real :: uflux( ncol, 0:mxlay)
+      real :: dflux( ncol, 0:mxlay)
+      real :: uclfl( ncol, 0:mxlay)
+      real :: dclfl( ncol, 0:mxlay)
+      real :: odclds
+      real :: efclfracs
+      real :: absclds
+
+!      real :: secdiff (ncol) ! secant of diffusivity angle
+!      real :: transcld, radld (ncol), radclrd (ncol), plfrac, blay, dplankup, dplankdn
+!      real :: odepth, odtot, odepth_rec, odtot_rec, gassrc
+!      real :: tblind, tfactot, bbd, bbdtot, tfacgas, transc, tausfac
+!      real :: rad0, reflect, radlu (ncol) , radclru (ncol)
+!      real :: d_rad0_dt, d_radlu_dt (ncol) , d_radclru_dt (ncol)
+
+      integer :: ibnd, ib, lay, lev, l, ig ! loop indices
+      integer :: igc ! g-point interval counter
+      integer :: iclddn_ ! flag for cloud in down path
+      integer :: ittot, itgas, itr ! lookup table indices
+
+! ------- Definitions -------
+! input
+! nlayers ! number of model layers
+! ngptlw ! total number of g-point subintervals
+! nbndlw ! number of longwave spectral bands
+! ncbands ! number of spectral bands for clouds
+! secdiff ! diffusivity angle
+! wtdiff ! weight for radiance to flux conversion
+! pavel ! layer pressures (mb)
+! pz ! level (interface) pressures (mb)
+! tavel ! layer temperatures (k)
+! tz ! level (interface) temperatures(mb)
+! tbound ! surface temperature (k)
+! cldfrac ! layer cloud fraction
+! taucloud ! layer cloud optical depth
+! itr ! integer look-up table index
+! icldlyr ! flag for cloudy layers
+! iclddn ! flag for cloud in column at any layer
+! semiss ! surface emissivities for each band
+! reflect ! surface reflectance
+! bpade ! 1/(pade constant)
+! tau_tbl ! clear sky optical depth look-up table
+! exp_tbl ! exponential look-up table for transmittance
+! tfn_tbl ! tau transition function look-up table
+
+! local
+! atrans ! gaseous absorptivity
+! abscld ! cloud absorptivity
+! atot ! combined gaseous and cloud absorptivity
+! odclr ! clear sky (gaseous) optical depth
+! odcld ! cloud optical depth
+! odtot ! optical depth of gas and cloud
+! tfacgas ! gas-only pade factor, used for planck fn
+! tfactot ! gas and cloud pade factor, used for planck fn
+! bbdgas ! gas-only planck function for downward rt
+! bbugas ! gas-only planck function for upward rt
+! bbdtot ! gas and cloud planck function for downward rt
+! bbutot ! gas and cloud planck function for upward calc.
+! gassrc ! source radiance due to gas only
+! efclfrac ! effective cloud fraction
+! radlu ! spectrally summed upward radiance
+! radclru ! spectrally summed clear sky upward radiance
+! urad ! upward radiance by layer
+! clrurad ! clear sky upward radiance by layer
+! radld ! spectrally summed downward radiance
+! radclrd ! spectrally summed clear sky downward radiance
+! drad ! downward radiance by layer
+! clrdrad ! clear sky downward radiance by layer
+! d_radlu_dt ! spectrally summed upward radiance
+! d_radclru_dt ! spectrally summed clear sky upward radiance
+! d_urad_dt ! upward radiance by layer
+! d_clrurad_dt ! clear sky upward radiance by layer
+
+! output
+! totuflux ! upward longwave flux (w/m2)
+! totdflux ! downward longwave flux (w/m2)
+! fnet ! net longwave flux (w/m2)
+! htr ! longwave heating rate (k/day)
+! totuclfl ! clear sky upward longwave flux (w/m2)
+! totdclfl ! clear sky downward longwave flux (w/m2)
+! fnetc ! clear sky net longwave flux (w/m2)
+! htrc ! clear sky longwave heating rate (k/day)
+! dtotuflux_dt ! change in upward longwave flux (w/m2/k)
+! ! with respect to surface temperature
+! dtotuclfl_dt ! change in clear sky upward longwave flux (w/m2/k)
+!
+
+
+! This secant and weight corresponds to the standard diffusivity
+! angle. This initial value is redefined below for some bands.
+      real , parameter :: wtdiff = 0.5
+      real , parameter :: rec_6 = 0.166667
+
+! Reset diffusivity angle for Bands 2-3 and 5-9 to vary (between 1.50
+! and 1.80) as a function of total column water vapor. The function
+! has been defined to minimize flux and cooling rate errors in these bands
+! over a wide range of precipitable water values.
+
+      integer :: iplon
+      real :: bbb
+
+! (dmb 2012) Here we compute the index for the column and band dimensions
+      real :: secdiff_ ! secant of diffusivity angle
+      real :: transcld, radld_, radclrd_, plfrac, blay, dplankup, dplankdn
+      real :: odepth, odtot, odepth_rec, odtot_rec, gassrc
+      real :: tblind, tfactot, bbd, bbdtot, tfacgas, transc, tausfac
+      real :: rad0, reflect, radlu_ , radclru_
+      real :: d_rad0_dt, d_radlu_dt (ncol) , d_radclru_dt (ncol)
+!$acc data  &
+!$acc      present(pwvcmd,ngb,gdtotuclfl_dtd,gdrad,a0d,a1d,a2d,planklevd,&
+!$acc              gdtotuflux_dtd,gclrurad,gclrdrad,fracsd,icldlyr,gurad,&
+!$acc    taucmcd,planklayd,plankbndd,exp_tbl,tau_tbl,semissd,delwaved,tfn_tbl,taug,cldfmcd)
+
+!$acc kernels
+!$acc loop independent  
+      do igc = 1, 140
+!$acc loop private(bbutot,atot,atrans,bbugas)       
+       do iplon = 1, ncol
+
+
+         ibnd = ngb(igc)
+
+         if (ibnd.eq.1 .or. ibnd.eq.4 .or. ibnd.ge.10) then
+           SECDIFF_ = 1.66
+         else
+           SECDIFF_ = a0d(ibnd) + a1d(ibnd)*exp(a2d(ibnd)*pwvcmd(iplon))
+           if (SECDIFF_ .gt. 1.80 ) SECDIFF_ = 1.80
+           if (SECDIFF_ .lt. 1.50 ) SECDIFF_ = 1.50
+         endif
+         gurad(iplon, igc, 0) = 0.0
+         gdrad(iplon, igc, 0) = 0.0
+!totuflux(iplon,igc,0) = 0.0
+!totdflux(iplon,igc,0) = 0.0
+         gclrurad(iplon, igc, 0) = 0.0
+         gclrdrad(iplon, igc, 0) = 0.0
+!totuclfl(iplon,igc,0) = 0.0
+!totdclfl(iplon,igc,0) = 0.0
+         if (idrvd .eq. 1) then
+            gdtotuflux_dtd(iplon,igc,0) = 0.0
+            gdtotuclfl_dtd(iplon,igc,0) = 0.0
+         endif
+
+!$acc loop seq
+         do lay = 1, nlayers
+            gurad(iplon, igc, lay) = 0.0
+            gdrad(iplon, igc, lay) = 0.0
+            gclrurad(iplon, igc, lay) = 0.0
+            gclrdrad(iplon, igc, lay) = 0.0
+
+! (dmb 2012) I removed the band loop here because it was terribly inefficient
+! I now set the required variables outside of the kernel
+
+            if (idrvd .eq. 1) then
+               gdtotuflux_dtd(iplon,igc,lay) = 0.0
+               gdtotuclfl_dtd(iplon,igc,lay) = 0.0
+            endif
+         enddo
+
+! Radiative transfer starts here.
+         radld_ = 0.
+         radclrd_ = 0.
+         iclddn_ = 0
+
+! Downward radiative transfer loop.
+
+
+
+
+
+
+
+!$acc loop seq
+         do lev = nlayers, 1, -1
+               plfrac = fracsd(iplon,lev,igc)
+               blay = planklayd(iplon,lev,ibnd)
+               dplankup = planklevd(iplon,lev,ibnd) - blay
+               dplankdn = planklevd(iplon,lev-1,ibnd) - blay
+               odepth = SECDIFF_ * taug(iplon,lev,igc)
+               if (odepth .lt. 0.0 ) odepth = 0.0
+! Cloudy layer
+               if (icldlyr(iplon, lev).eq.1) then
+                  ICLDDN_ = 1
+! (dmb 2012) Here instead of using the lookup tables to compute
+! the optical depth and related quantities, I compute them on the
+! fly because this is actually much more efficient on the GPU.
+                  odclds = SECDIFF_ * taucmcd(iplon,igc,lev)
+                  absclds = 1. - exp(-odclds)
+                  efclfracs = absclds * cldfmcd(iplon, igc,lev)
+                  odtot = odepth + odclds
+                  tblind = odepth/(bpade+odepth)
+                  itgas = tblint*tblind+0.5
+                  odepth = tau_tbl(itgas)
+                  ATRANS(lev) = 1. - exp_tbl(itgas)
+                  tfacgas = tfn_tbl(itgas)
+                  gassrc = ATRANS(lev) * plfrac * (blay + tfacgas*dplankdn)
+
+                  odtot = odepth + odclds
+                  tblind = odtot/(bpade+odtot)
+                  ittot = tblint*tblind + 0.5
+                  tfactot = tfn_tbl(ittot)
+                  bbdtot = plfrac * (blay + tfactot*dplankdn)
+                  bbd = plfrac*(blay+tfacgas*dplankdn)
+                  ATOT(lev) = 1. - exp_tbl(ittot)
+
+
+                  RADLD_ = RADLD_ - RADLD_ * (ATRANS(lev) + &
+                  efclfracs * (1. - ATRANS(lev))) + &
+                  gassrc + cldfmcd(iplon, igc,lev) * &
+                  (bbdtot * ATOT(lev) - gassrc)
+                  gdrad(iplon, igc, lev-1) = gdrad(iplon, igc, lev-1) + RADLD_
+                  BBUGAS(lev) = plfrac * (blay + tfacgas * dplankup)
+                  BBUTOT(lev) = plfrac * (blay + tfactot * dplankup)
+
+! Clear layer
+               else
+  ! jm agree with the calculation in module_ra_rrtmg_lw.F ~line 3340
+                  if (odepth .le. 0.06) then
+                     ATRANS(lev) = odepth-0.5*odepth*odepth
+                     odepth = rec_6*odepth
+                     bbd = plfrac*(blay+dplankdn*odepth)
+                     BBUGAS(lev) = plfrac*(blay+dplankup*odepth)
+                  else
+                     tblind = odepth/(bpade+odepth)
+                     itr = tblint*tblind+0.5
+                     transc = exp_tbl(itr)
+                     ATRANS(lev) = 1.-transc
+                     tausfac = tfn_tbl(itr)
+                     bbd = plfrac*(blay+tausfac*dplankdn)
+                     BBUGAS(lev) = plfrac * (blay + tausfac * dplankup)
+                  endif
+
+
+                  RADLD_ = RADLD_ + (bbd-RADLD_ )*ATRANS(lev)
+                  gdrad(iplon, igc, lev-1) = gdrad(iplon, igc, lev-1) + RADLD_
+
+               endif
+
+! Set clear sky stream to total sky stream as long as layers
+! remain clear. Streams diverge when a cloud is reached (ICLDDN(iplon)=1),
+! and clear sky stream must be computed separately from that point.
+               if (ICLDDN_ .eq.1) then
+                  RADCLRD_ = RADCLRD_ + (bbd-RADCLRD_) * ATRANS(lev)
+! (dmb 2012) Rather than summing up the results and then computing the
+! total fluxes, I store the g-point specific values in GPU arrays to be
+! summed up later in a new kernel. This ensures that we can parallelize
+! across enough dimensions so that the GPU remains busy.
+                  gclrdrad(iplon, igc, lev-1) = gclrdrad(iplon, igc, lev-1) + RADCLRD_
+               else
+                  RADCLRD_ = RADLD_
+                  gclrdrad(iplon, igc, lev-1) = gdrad(iplon, igc, lev-1)
+               endif
+         enddo ! end of downward radiation loop
+
+! Spectral emissivity & reflectance
+! Include the contribution of spectrally varying longwave emissivity
+! and reflection from the surface to the upward radiative transfer.
+! Note: Spectral and Lambertian reflection are identical for the
+! diffusivity angle flux integration used here.
+! Note: The emissivity is applied to plankbnd and dplankbnd_dt when
+! they are defined in subroutine setcoef.
+
+         rad0 = fracsd(iplon,1,igc) * plankbndd(iplon,ibnd)
+! Add in specular reflection of surface downward radiance.
+         reflect = 1. - semissd(iplon,ibnd)
+         RADLU_ = rad0 + reflect * RADLD_
+         RADCLRU_ = rad0 + reflect * RADCLRD_
+
+! Upward radiative transfer loop.
+         gurad(iplon, igc, 0) = gurad(iplon, igc, 0) + RADLU_
+         gclrurad(iplon, igc, 0) = gclrurad(iplon, igc, 0) + RADCLRU_
+
+!$acc loop seq
+         do lev = 1, nlayers
+! Cloudy layer
+            if (icldlyr(iplon, lev) .eq. 1) then
+               gassrc = BBUGAS(lev) * ATRANS(lev)
+               odclds = SECDIFF_ * taucmcd(iplon,igc,lev)
+               absclds = 1. - exp(-odclds)
+               efclfracs = absclds * cldfmcd(iplon, igc,lev)
+               RADLU_ = RADLU_ - RADLU_ * (ATRANS(lev) + &
+                   efclfracs * (1. - ATRANS(lev))) + &
+                   gassrc + cldfmcd(iplon, igc,lev) * &
+                   (BBUTOT(lev) * ATOT(lev) - gassrc)
+               gurad(iplon, igc, lev) = gurad(iplon, igc, lev) + RADLU_
+! Clear layer
+            else
+               RADLU_ = RADLU_ + (BBUGAS(lev)-RADLU_)*ATRANS(lev)
+               gurad(iplon, igc, lev) = gurad(iplon, igc, lev) + RADLU_
+            endif
+
+
+
+! Set clear sky stream to total sky stream as long as all layers
+! are clear (ICLDDN(iplon)=0). Streams must be calculated separately at
+! all layers when a cloud is present (ICLDDN=1), because surface
+! reflectance is different for each stream.
+               if (ICLDDN_.eq.1) then
+                  RADCLRU_ = RADCLRU_ + (BBUGAS(lev)-RADCLRU_)*ATRANS(lev)
+                  gclrurad(iplon, igc, lev) = gclrurad(iplon, igc, lev) + RADCLRU_
+               else
+                  RADCLRU_ = RADLU_
+                  gclrurad(iplon, igc, lev) = gurad(iplon, igc, lev)
+               endif
+       enddo
+
+
+          tblind = wtdiff * delwaved(ibnd) * fluxfacd
+ ! (dmb 2012) Now that the g-points values were created, we modify them
+ ! so that later summation (integration) will be simpler.
+!$acc loop seq          
+          do lev = 0, nlayers
+           gurad(iplon, igc, lev) = gurad(iplon, igc, lev) * tblind
+           gdrad(iplon, igc, lev) = gdrad(iplon, igc, lev) * tblind
+           gclrurad(iplon, igc, lev) = gclrurad(iplon, igc, lev) * tblind
+           gclrdrad(iplon, igc, lev) = gclrdrad(iplon, igc, lev) * tblind
+          end do
+
+
+
+
+       enddo ! iplon
+      end do ! igc loop
+!$acc end kernels
+!$acc end data
+
+
+      end subroutine rtrnmcg
+
+! (dmb 2012) This subroutine adds up the indivial g-point fluxes to arrive at a
+! final upward and downward flux value for each column and layer. This subroutine
+! is parallelized across the column and layer dimensions. As long as we parallelize
+! across two of the three dimesnions, we should usually have enough GPU saturation.
+      subroutine rtrnadd(ncol, nlay, ngpt, drvf &
+
+         ,ncol_,nlayers_,nbndlw_,ngptlw_ &
+         ,taucmcd,pzd,pwvcmd,semissd,planklayd,planklevd,plankbndd,gurad,gdrad,gclrurad,gclrdrad &
+         ,gdtotuflux_dtd,gdtotuclfl_dtd,idrvd,bpaded,heatfacd,fluxfacd,a0d,a1d,a2d &
+         ,delwaved,totufluxd,totdfluxd,fnetd,htrd,totuclfld,totdclfld,fnetcd,htrcd,dtotuflux_dtd &
+         ,dtotuclfl_dtd,dplankbnd_dtd &
+                                )
+
+      integer, intent(in), value :: ncol
+      integer, intent(in), value :: nlay
+      integer, intent(in), value :: ngpt
+      integer, intent(in), value :: drvf
+
+      integer :: ncol_,nlayers_,nbndlw_,ngptlw_
+! changed to arguments for thread safety
+
+
+
+      integer :: ngsd(nbndlw)
+
+! Atmosphere
+      real :: taucmcd(CHNK, ngptlw_, nlayers_+1)
+
+      real , dimension(CHNK, 0:nlayers_+1) :: pzd ! level (interface) pressures (hPa, mb)
+                                                        ! Dimensions: (ncol,0:nlayers)
+      real , dimension(CHNK) :: pwvcmd ! precipitable water vapor (cm)
+                                                        ! Dimensions: (ncol)
+      real , dimension(CHNK,nbndlw_) :: semissd ! lw surface emissivity
+                                                        ! Dimensions: (ncol,nbndlw)
+      real , dimension(CHNK,nlayers_+1,nbndlw_) :: planklayd !
+                                                        ! Dimensions: (ncol,nlayers+1,nbndlw)
+      real , dimension(CHNK,0:nlayers_+1,nbndlw_) :: planklevd !
+                                                        ! Dimensions: (ncol,0:nlayers+1,nbndlw)
+      real, dimension(CHNK,nbndlw_) :: plankbndd !
+                                                        ! Dimensions: (ncol,nbndlw)
+
+      real :: gurad(CHNK,ngptlw_,0:nlayers_+1) ! upward longwave flux (w/m2)
+      real :: gdrad(CHNK,ngptlw_,0:nlayers_+1) ! downward longwave flux (w/m2)
+      real :: gclrurad(CHNK,ngptlw_,0:nlayers_+1) ! clear sky upward longwave flux (w/m2)
+      real :: gclrdrad(CHNK,ngptlw_,0:nlayers_+1) ! clear sky downward longwave flux (w/m2)
+
+      real :: gdtotuflux_dtd(CHNK, ngptlw_, 0:nlayers_+1) ! change in upward longwave flux (w/m1/k)
+                                     ! with respect to surface temperature
+
+      real :: gdtotuclfl_dtd(CHNK, ngptlw_, 0:nlayers_+1) ! change in clear sky upward longwave flux (w/m2/k)
+                                     ! with respect to surface temperature
+
+! Clouds
+      integer :: idrvd ! flag for calculation of dF/dt from
+                                                      ! Planck derivative [0=off, 1=on]
+      real :: bpaded
+      real :: heatfacd
+      real :: fluxfacd
+      real :: a0d(nbndlw_), a1d(nbndlw_), a2d(nbndlw_)
+      real :: delwaved(nbndlw_)
+      real :: totufluxd(CHNK, 0:nlayers_+1) ! upward longwave flux (w/m2)
+      real :: totdfluxd(CHNK, 0:nlayers_+1) ! downward longwave flux (w/m2)
+      real :: fnetd(CHNK, 0:nlayers_+1) ! net longwave flux (w/m2)
+      real :: htrd(CHNK, 0:nlayers_+1) ! longwave heating rate (k/day)
+      real :: totuclfld(CHNK, 0:nlayers_+1) ! clear sky upward longwave flux (w/m2)
+      real :: totdclfld(CHNK, 0:nlayers_+1) ! clear sky downward longwave flux (w/m2)
+      real :: fnetcd(CHNK, 0:nlayers_+1) ! clear sky net longwave flux (w/m2)
+      real :: htrcd(CHNK, 0:nlayers_+1) ! clear sky longwave heating rate (k/day)
+      real :: dtotuflux_dtd(CHNK, 0:nlayers_+1) ! change in upward longwave flux (w/m2/k)
+                                                       ! with respect to surface temperature
+      real :: dtotuclfl_dtd(CHNK, 0:nlayers_+1) ! change in clear sky upward longwave flux (w/m2/k)
+                                                       ! with respect to surface temperature
+      real :: dplankbnd_dtd(CHNK,nbndlw_)
+
+      integer :: iplon, ilay, igp
+! real :: d(140)
+
+! (dmb 2012) compute the column and layer indices from the grid and block
+! configurations.
+! zap should move this inside the igp loop
+!$acc kernels
+      do iplon = 1, ncol
+        do ilay = 0, nlay
+
+
+          do igp = 1, ngpt
+
+            totufluxd(iplon, ilay)=totufluxd(iplon, ilay)+gurad(iplon, igp, ilay)
+            totdfluxd(iplon, ilay)=totdfluxd(iplon, ilay)+gdrad(iplon, igp, ilay)
+            totuclfld(iplon, ilay)=totuclfld(iplon, ilay)+gclrurad(iplon, igp, ilay)
+            totdclfld(iplon, ilay)=totdclfld(iplon, ilay)+gclrdrad(iplon, igp, ilay)
+
+          end do
+
+          if (drvf .eq. 1) then
+
+            do igp = 1, ngpt
+
+              dtotuflux_dtd(iplon, ilay) = dtotuflux_dtd(iplon, ilay) + gdtotuflux_dtd( iplon, igp, ilay)
+              dtotuclfl_dtd(iplon, ilay) = dtotuclfl_dtd(iplon, ilay) + gdtotuclfl_dtd( iplon, igp, ilay)
+
+            end do
+
+          end if
+
+
+
+
+        end do
+      end do
+!$acc end kernels
+
+
+      end subroutine
+
+! (dmb 2012) This kernel computes the heating rates separately. It is parallelized across the
+! columnn and layer dimensions.
+      subroutine rtrnheatrates(ncol, nlay &
+
+         ,ncol_,nlayers_,nbndlw_,ngptlw_ &
+         ,taucmcd,pzd,pwvcmd,semissd,planklayd,planklevd,plankbndd,gurad,gdrad,gclrurad,gclrdrad &
+         ,gdtotuflux_dtd,gdtotuclfl_dtd,idrvd,bpaded,heatfacd,fluxfacd,a0d,a1d,a2d &
+         ,delwaved,totufluxd,totdfluxd,fnetd,htrd,totuclfld,totdclfld,fnetcd,htrcd,dtotuflux_dtd &
+         ,dtotuclfl_dtd,dplankbnd_dtd &
+
+                                      )
+
+      integer, intent(in), value :: ncol
+      integer, intent(in), value :: nlay
+
+      integer :: ncol_,nlayers_,nbndlw_,ngptlw_
+! changed to arguments for thread safety
+
+
+
+      integer :: ngsd(nbndlw)
+
+! Atmosphere
+      real :: taucmcd(CHNK, ngptlw_, nlayers_+1)
+
+      real , dimension(CHNK, 0:nlayers_+1) :: pzd ! level (interface) pressures (hPa, mb)
+                                                        ! Dimensions: (ncol,0:nlayers)
+      real , dimension(CHNK) :: pwvcmd ! precipitable water vapor (cm)
+                                                        ! Dimensions: (ncol)
+      real , dimension(CHNK,nbndlw_) :: semissd ! lw surface emissivity
+                                                        ! Dimensions: (ncol,nbndlw)
+      real , dimension(CHNK,nlayers_+1,nbndlw_) :: planklayd !
+                                                        ! Dimensions: (ncol,nlayers+1,nbndlw)
+      real , dimension(CHNK,0:nlayers_+1,nbndlw_) :: planklevd !
+                                                        ! Dimensions: (ncol,0:nlayers+1,nbndlw)
+      real, dimension(CHNK,nbndlw_) :: plankbndd !
+                                                        ! Dimensions: (ncol,nbndlw)
+
+      real :: gurad(CHNK,ngptlw_,0:nlayers_+1) ! upward longwave flux (w/m2)
+      real :: gdrad(CHNK,ngptlw_,0:nlayers_+1) ! downward longwave flux (w/m2)
+      real :: gclrurad(CHNK,ngptlw_,0:nlayers_+1) ! clear sky upward longwave flux (w/m2)
+      real :: gclrdrad(CHNK,ngptlw_,0:nlayers_+1) ! clear sky downward longwave flux (w/m2)
+
+      real :: gdtotuflux_dtd(CHNK, ngptlw_, 0:nlayers_+1) ! change in upward longwave flux (w/m1/k)
+                                     ! with respect to surface temperature
+
+      real :: gdtotuclfl_dtd(CHNK, ngptlw_, 0:nlayers_+1) ! change in clear sky upward longwave flux (w/m2/k)
+                                     ! with respect to surface temperature
+
+! Clouds
+      integer :: idrvd ! flag for calculation of dF/dt from
+                                                      ! Planck derivative [0=off, 1=on]
+      real :: bpaded
+      real :: heatfacd
+      real :: fluxfacd
+      real :: a0d(nbndlw_), a1d(nbndlw_), a2d(nbndlw_)
+      real :: delwaved(nbndlw_)
+      real :: totufluxd(CHNK, 0:nlayers_+1) ! upward longwave flux (w/m2)
+      real :: totdfluxd(CHNK, 0:nlayers_+1) ! downward longwave flux (w/m2)
+      real :: fnetd(CHNK, 0:nlayers_+1) ! net longwave flux (w/m2)
+      real :: htrd(CHNK, 0:nlayers_+1) ! longwave heating rate (k/day)
+      real :: totuclfld(CHNK, 0:nlayers_+1) ! clear sky upward longwave flux (w/m2)
+      real :: totdclfld(CHNK, 0:nlayers_+1) ! clear sky downward longwave flux (w/m2)
+      real :: fnetcd(CHNK, 0:nlayers_+1) ! clear sky net longwave flux (w/m2)
+      real :: htrcd(CHNK, 0:nlayers_+1) ! clear sky longwave heating rate (k/day)
+      real :: dtotuflux_dtd(CHNK, 0:nlayers_+1) ! change in upward longwave flux (w/m2/k)
+                                                       ! with respect to surface temperature
+      real :: dtotuclfl_dtd(CHNK, 0:nlayers_+1) ! change in clear sky upward longwave flux (w/m2/k)
+                                                       ! with respect to surface temperature
+      real :: dplankbnd_dtd(CHNK,nbndlw_)
+
+
+
+      real :: t2
+      integer :: iplon, ilay
+!$acc kernels
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+        do ilay = 0, nlay - 1
+
+          t2 = pzd(iplon, ilay ) - pzd(iplon, ilay + 1)
+          htrd(iplon, ilay) = heatfacd * ((totufluxd(iplon, ilay) - totdfluxd(iplon, ilay)) &
+                 - (totufluxd(iplon, ilay+1) - totdfluxd(iplon, ilay+1)))/t2
+          htrcd(iplon, ilay) = heatfacd * ((totuclfld(iplon, ilay) - totdclfld(iplon, ilay)) &
+                 - (totuclfld(iplon, ilay+1) - totdclfld(iplon, ilay+1)))/t2
+
+
+
+
+        end do
+      end do
+!$acc end kernels
+
+
+      end subroutine
+
+! (dmb 2012) Copy needed variables over to the GPU. These arrays are pretty small so simple
+! stream 0 assignment operators suffice.
+      subroutine copyGPUrtrnmcg(pz, pwvcm, idrv, taut)
+
+      real , intent(in) :: pz(:,:) ! level (interface) pressures (hPa, mb)
+      integer , intent(in) :: idrv ! flag for calculation of dF/dt from
+      real , intent(in) :: taut(:,:,:)
+      real , intent(in) :: pwvcm(:)
+      end subroutine
+
+! (dmb 2012) Allocate the arrays for the rtrnmc routine on the GPU. Some of these arrays are
+! quite large as they contain all 3 dimensions. Luckily, for the gurad arrays, no copying of data
+! from the CPU is needed because they are only stored on the GPU.
+      subroutine allocateGPUrtrnmcg(ncol, nlay, ngptlw, drvf)
+
+      integer , intent(in) :: ncol, nlay, ngptlw, drvf
+integer,external :: omp_get_thread_num
+      end subroutine
+
+! (dmb 2012) This subroutine deallocates rtrnmc related GPU arrays.
+      subroutine deallocateGPUrtrnmcg( drvf )
+
+      integer , intent(in) :: drvf
+      end subroutine
+
+      end module gpu_rrtmg_lw_rtrnmc
+
+
+! (dmb 2012) This is the GPU version of the taumol subroutines. At first I was going to
+! try and combine the taumol routines into a single subroutine, but it turns out that
+! all 16 can remain and run efficiently on the GPU.
+      module gpu_rrtmg_lw_taumol
+
+! --------------------------------------------------------------------------
+! | |
+! | Copyright 2002-2009, Atmospheric & Environmental Research, Inc. (AER). |
+! | This software may be used, copied, or redistributed as long as it is |
+! | not sold and this copyright notice is reproduced on each copy made. |
+! | This model is provided as is without any express or implied warranties. |
+! | (http:
+! | |
+! --------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parkind, only : im => kind , rb => kind
+      use parrrtm_f, only : mg, nbndlw, maxxsec, ngptlw
+      use rrlw_con_f, only: oneminus
+      use rrlw_wvn_f, only: nspa, nspb
+      use rrlw_vsn_f, only: hvrtau, hnamtau
+      use rrlw_wvn_f, only: ngb
+      use rrlw_ref_f
+      use memory
+
+
+
+
+
+      implicit none
+      contains
+
+
+!defines for taugb functions
+!----------------------------------------------------------------------------
+      subroutine taugb1g( ncol, nlayers, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                )
+
+!----------------------------------------------------------------------------
+
+! ------- Modifications -------
+! Written by Eli J. Mlawer, Atmospheric & Environmental Research.
+! Revised by Michael J. Iacono, Atmospheric & Environmental Research.
+!
+! band 1: 10-350 cm-1 (low key - h2o; low minor - n2)
+! (high key - h2o; high minor - n2)
+!
+! note: previous versions of rrtm band 1:
+! 10-250 cm-1 (low - h2o; high - h2o)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng1
+      use rrlw_kg01_f
+
+! ------- Declarations -------
+
+      integer :: lay, ind0, ind1, inds, indf, indm, ig
+      real :: pp, corradj, scalen2, tauself, taufor, taun2
+      integer , value, intent(in) :: ncol, nlayers
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: iplon
+      integer :: nspad_1, nspbd_1
+
+      nspad_1 = nspad(1)
+      nspbd_1 = nspbd(1)
+
+!$acc data present(fracrefa,absa,ka_mn2,selffrac,selffac,scaleminorn2,forfrac,forfac,&
+!$acc              fac11,jt1,laytrop,fac10,fac00,fac01,colh2o,colbrd,selfref,taug,forref,  &
+!$acc              fracrefb,indfor,fracsd,indminor,jt,indself,jp,minorfrac,kb_mn2,pavel,absb) async(1)
+
+!$acc kernels async(1)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+
+! Minor gas mapping levels:
+! lower - n2, p = 142.5490 mbar, t = 215.70 k
+! upper - n2, p = 142.5490 mbar, t = 215.70 k
+
+! Compute the optical depth by interpolating in ln(pressure) and
+! temperature. Below laytrop, the water vapor self-continuum and
+! foreign continuum is interpolated (in temperature) separately.
+
+! Lower atmosphere loop
+
+
+       if (lay <= laytrop(iplon)) then
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad_1 + 1
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad_1 + 1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+         pp = pavel(iplon, lay)
+         corradj = 1.
+         if (pp .lt. 250. ) then
+            corradj = 1. - 0.15 * (250. -pp) / 154.4
+         endif
+
+         scalen2 = colbrd(iplon,lay) * scaleminorn2(iplon,lay)
+         do ig = 1, ng1
+            tauself = selffac(iplon,lay) * (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            taun2 = scalen2*(ka_mn2(indm,ig) + &
+                 minorfrac(iplon,lay) * (ka_mn2(indm+1,ig) - ka_mn2(indm,ig)))
+            taug(iplon,lay,ig) = corradj * (colh2o(iplon,lay) * &
+                (fac00(iplon,lay) * absa(ind0,ig) + &
+                 fac10(iplon,lay) * absa(ind0+1,ig) + &
+                 fac01(iplon,lay) * absa(ind1,ig) + &
+                 fac11(iplon,lay) * absa(ind1+1,ig)) &
+                 + tauself + taufor + taun2)
+             fracsd(iplon,lay,ig) = fracrefa(ig)
+
+         enddo
+      else
+
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd_1 + 1
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd_1 + 1
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+         pp = pavel(iplon, lay)
+         corradj = 1. - 0.15 * (pp / 95.6 )
+
+         scalen2 = colbrd(iplon,lay) * scaleminorn2(iplon,lay)
+         do ig = 1, ng1
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + &
+                 forfrac(iplon,lay) * (forref(indf+1,ig) - forref(indf,ig)))
+            taun2 = scalen2*(kb_mn2(indm,ig) + &
+                 minorfrac(iplon,lay) * (kb_mn2(indm+1,ig) - kb_mn2(indm,ig)))
+            taug(iplon,lay,ig) = corradj * (colh2o(iplon,lay) * &
+                (fac00(iplon,lay) * absb(ind0,ig) + &
+                 fac10(iplon,lay) * absb(ind0+1,ig) + &
+                 fac01(iplon,lay) * absb(ind1,ig) + &
+                 fac11(iplon,lay) * absb(ind1+1,ig)) &
+                 + taufor + taun2)
+            fracsd(iplon,lay,ig) = fracrefb(ig)
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+!$acc end data
+
+      end subroutine taugb1g
+
+!----------------------------------------------------------------------------
+      subroutine taugb2g( ncol, nlayers , taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                )
+!----------------------------------------------------------------------------
+!
+! band 2: 350-500 cm-1 (low key - h2o; high key - h2o)
+!
+! note: previous version of rrtm band 2:
+! 250 - 500 cm-1 (low - h2o; high - h2o)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng2, ngs1
+      use parrrtm_f, only : ngs1
+      use rrlw_kg02_f
+
+! ------- Declarations -------
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: lay, ind0, ind1, inds, indf, ig
+      real :: pp, corradj, tauself, taufor
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+      integer :: nspad_2, nspbd_2
+
+      nspad_2 = nspad(2)
+      nspbd_2 = nspbd(2)
+
+
+!$acc data present(fracrefa,absa,selffrac,selffac,pavel,forfrac,forfac,fac11,fac10,&
+!$acc              fac00,fac01,colh2o,absb,taug,selfref,forref,fracrefb,jt1,laytrop,jp,  &
+!$acc              indself,jt,indfor,fracsd) async(2)
+!$acc kernels  async(2)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Compute the optical depth by interpolating in ln(pressure) and
+! temperature. Below laytrop, the water vapor self-continuum and
+! foreign continuum is interpolated (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad_2 + 1
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad_2 + 1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         pp = pavel(iplon, lay)
+         corradj = 1. - .05 * (pp - 100. ) / 900.
+         do ig = 1, ng2
+            tauself = selffac(iplon,lay) * (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            taug(iplon,lay,ngs1+ig) = corradj * (colh2o(iplon,lay) * &
+                (fac00(iplon,lay) * absa(ind0,ig) + &
+                 fac10(iplon,lay) * absa(ind0+1,ig) + &
+                 fac01(iplon,lay) * absa(ind1,ig) + &
+                 fac11(iplon,lay) * absa(ind1+1,ig)) &
+                 + tauself + taufor)
+            fracsd(iplon,lay,ngs1+ig) = fracrefa(ig)
+         enddo
+      else
+
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd_2 + 1
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd_2 + 1
+         indf = indfor(iplon,lay)
+         do ig = 1, ng2
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + &
+                 forfrac(iplon,lay) * (forref(indf+1,ig) - forref(indf,ig)))
+            taug(iplon,lay,ngs1+ig) = colh2o(iplon,lay) * &
+                (fac00(iplon,lay) * absb(ind0,ig) + &
+                 fac10(iplon,lay) * absb(ind0+1,ig) + &
+                 fac01(iplon,lay) * absb(ind1,ig) + &
+                 fac11(iplon,lay) * absb(ind1+1,ig)) &
+                 + taufor
+            fracsd(iplon,lay,ngs1+ig) = fracrefb(ig)
+         enddo
+      endif
+
+      end do
+      end do
+!$acc end kernels
+!$acc end data
+
+      end subroutine taugb2g
+
+!----------------------------------------------------------------------------
+      subroutine taugb3g( ncol, nlayers, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                )
+!----------------------------------------------------------------------------
+!
+! band 3: 500-630 cm-1 (low key - h2o,co2; low minor - n2o)
+! (high key - h2o,co2; high minor - n2o)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng3, ngs2
+      use parrrtm_f, only : ngs2
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg03_f
+
+! ------- Declarations -------
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: lay, ind0, ind1, inds, indf, indm, ig
+      integer :: js, js1, jmn2o, jpl
+      real :: speccomb, specparm, specmult, fs
+      real :: speccomb1, specparm1, specmult1, fs1
+      real :: speccomb_mn2o, specparm_mn2o, specmult_mn2o, &
+                       fmn2o, fmn2omf, chi_n2o, ratn2o, adjfac, adjcoln2o
+      real :: speccomb_planck, specparm_planck, specmult_planck, fpl
+      real :: p, p4, fk0, fk1, fk2
+      real :: fac000, fac100, fac200, fac010, fac110, fac210
+      real :: fac001, fac101, fac201, fac011, fac111, fac211
+      real :: tauself, taufor, n2om1, n2om2, absn2o
+      real :: refrat_planck_a, refrat_planck_b, refrat_m_a, refrat_m_b
+      real :: tau_major, tau_major1
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+      integer :: nspad_3, nspbd_3
+
+      nspad_3 = nspad(3)
+      nspbd_3 = nspbd(3)
+
+
+!$acc data present(indfor,fracsd,indminor,jt,jp,minorfrac,absb,indself,colco2,colh2o,rat_h2oco2,&
+!$acc              coldry,chi_mls,kb_mn2o,coln2o,fac01,fac00,fac10,fracrefb,forref,taug,  &
+!$acc              selfref,laytrop,jt1,fac11,forfac,forfrac,rat_h2oco2_1,selffac,selffrac,      &
+!$acc              ka_mn2o,absa,fracrefa) async(3)
+!$acc kernels async(3)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Minor gas mapping levels:
+! lower - n2o, p = 706.272 mbar, t = 278.94 k
+! upper - n2o, p = 95.58 mbar, t = 215.7 k
+
+! P = 212.725 mb
+      refrat_planck_a = chi_mls(1,9)/chi_mls(2,9)
+
+! P = 95.58 mb
+      refrat_planck_b = chi_mls(1,13)/chi_mls(2,13)
+
+! P = 706.270mb
+      refrat_m_a = chi_mls(1,3)/chi_mls(2,3)
+
+! P = 95.58 mb
+      refrat_m_b = chi_mls(1,13)/chi_mls(2,13)
+
+! Compute the optical depth by interpolating in ln(pressure) and
+! temperature, and appropriate species. Below laytrop, the water vapor
+! self-continuum and foreign continuum is interpolated (in temperature)
+! separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+
+         speccomb = colh2o(iplon,lay) + rat_h2oco2(iplon,lay)*colco2(iplon,lay)
+         specparm = colh2o(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colh2o(iplon,lay) + rat_h2oco2_1(iplon,lay)*colco2(iplon,lay)
+         specparm1 = colh2o(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 8. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         speccomb_mn2o = colh2o(iplon,lay) + refrat_m_a*colco2(iplon,lay)
+         specparm_mn2o = colh2o(iplon,lay)/speccomb_mn2o
+         if (specparm_mn2o .ge. oneminusd) specparm_mn2o = oneminusd
+         specmult_mn2o = 8. *specparm_mn2o
+         jmn2o = 1 + int(specmult_mn2o)
+         fmn2o = mod(specmult_mn2o,1.0 )
+         fmn2omf = minorfrac(iplon,lay)*fmn2o
+! In atmospheres where the amount of N2O is too great to be considered
+! a minor species, adjust the column amount of N2O by an empirical factor
+! to obtain the proper contribution.
+         chi_n2o = coln2o(iplon,lay)/coldry(iplon,lay)
+         ratn2o = 1.e20 *chi_n2o/chi_mls(4,jp(iplon,lay)+1)
+         if (ratn2o .gt. 1.5 ) then
+            adjfac = 0.5 +(ratn2o-0.5 )**0.65
+            adjcoln2o = adjfac*chi_mls(4,jp(iplon,lay)+1)*coldry(iplon,lay)*1.e-20
+         else
+            adjcoln2o = coln2o(iplon,lay)
+         endif
+
+         speccomb_planck = colh2o(iplon,lay)+refrat_planck_a*colco2(iplon,lay)
+         specparm_planck = colh2o(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 8. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad_3 + js
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad_3 + js1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+
+         if (specparm .lt. 0.125 ) then
+            p = fs - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else if (specparm .gt. 0.875 ) then
+            p = -fs
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else
+            fac000 = (1. - fs) * fac00(iplon,lay)
+            fac010 = (1. - fs) * fac10(iplon,lay)
+            fac100 = fs * fac00(iplon,lay)
+            fac110 = fs * fac10(iplon,lay)
+         endif
+         if (specparm1 .lt. 0.125 ) then
+            p = fs1 - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else if (specparm1 .gt. 0.875 ) then
+            p = -fs1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else
+            fac001 = (1. - fs1) * fac01(iplon,lay)
+            fac011 = (1. - fs1) * fac11(iplon,lay)
+            fac101 = fs1 * fac01(iplon,lay)
+            fac111 = fs1 * fac11(iplon,lay)
+         endif
+
+         do ig = 1, ng3
+            tauself = selffac(iplon,lay)* (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            n2om1 = ka_mn2o(jmn2o,indm,ig) + fmn2o * &
+                 (ka_mn2o(jmn2o+1,indm,ig) - ka_mn2o(jmn2o,indm,ig))
+            n2om2 = ka_mn2o(jmn2o,indm+1,ig) + fmn2o * &
+                 (ka_mn2o(jmn2o+1,indm+1,ig) - ka_mn2o(jmn2o,indm+1,ig))
+            absn2o = n2om1 + minorfrac(iplon,lay) * (n2om2 - n2om1)
+
+            if (specparm .lt. 0.125 ) then
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac200 * absa(ind0+2,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig) + &
+                    fac210 * absa(ind0+11,ig))
+            else if (specparm .gt. 0.875 ) then
+               tau_major = speccomb * &
+                    (fac200 * absa(ind0-1,ig) + &
+                    fac100 * absa(ind0,ig) + &
+                    fac000 * absa(ind0+1,ig) + &
+                    fac210 * absa(ind0+8,ig) + &
+                    fac110 * absa(ind0+9,ig) + &
+                    fac010 * absa(ind0+10,ig))
+            else
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig))
+            endif
+
+            if (specparm1 .lt. 0.125 ) then
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac201 * absa(ind1+2,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig) + &
+                    fac211 * absa(ind1+11,ig))
+            else if (specparm1 .gt. 0.875 ) then
+               tau_major1 = speccomb1 * &
+                    (fac201 * absa(ind1-1,ig) + &
+                    fac101 * absa(ind1,ig) + &
+                    fac001 * absa(ind1+1,ig) + &
+                    fac211 * absa(ind1+8,ig) + &
+                    fac111 * absa(ind1+9,ig) + &
+                    fac011 * absa(ind1+10,ig))
+            else
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig))
+            endif
+
+            taug(iplon,lay,ngs2+ig) = tau_major + tau_major1 &
+                 + tauself + taufor &
+                 + adjcoln2o*absn2o
+            fracsd(iplon,lay,ngs2+ig) = fracrefa(ig,jpl) + fpl * &
+                 (fracrefa(ig,jpl+1)-fracrefa(ig,jpl))
+         enddo
+
+
+! Upper atmosphere loop
+      else
+
+         speccomb = colh2o(iplon,lay) + rat_h2oco2(iplon,lay)*colco2(iplon,lay)
+         specparm = colh2o(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 4. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colh2o(iplon,lay) + rat_h2oco2_1(iplon,lay)*colco2(iplon,lay)
+         specparm1 = colh2o(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 4. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         fac000 = (1. - fs) * fac00(iplon,lay)
+         fac010 = (1. - fs) * fac10(iplon,lay)
+         fac100 = fs * fac00(iplon,lay)
+         fac110 = fs * fac10(iplon,lay)
+         fac001 = (1. - fs1) * fac01(iplon,lay)
+         fac011 = (1. - fs1) * fac11(iplon,lay)
+         fac101 = fs1 * fac01(iplon,lay)
+         fac111 = fs1 * fac11(iplon,lay)
+
+         speccomb_mn2o = colh2o(iplon,lay) + refrat_m_b*colco2(iplon,lay)
+         specparm_mn2o = colh2o(iplon,lay)/speccomb_mn2o
+         if (specparm_mn2o .ge. oneminusd) specparm_mn2o = oneminusd
+         specmult_mn2o = 4. *specparm_mn2o
+         jmn2o = 1 + int(specmult_mn2o)
+         fmn2o = mod(specmult_mn2o,1.0 )
+         fmn2omf = minorfrac(iplon,lay)*fmn2o
+! In atmospheres where the amount of N2O is too great to be considered
+! a minor species, adjust the column amount of N2O by an empirical factor
+! to obtain the proper contribution.
+         chi_n2o = coln2o(iplon,lay)/coldry(iplon,lay)
+         ratn2o = 1.e20*chi_n2o/chi_mls(4,jp(iplon,lay)+1)
+         if (ratn2o .gt. 1.5 ) then
+            adjfac = 0.5 +(ratn2o-0.5 )**0.65
+            adjcoln2o = adjfac*chi_mls(4,jp(iplon,lay)+1)*coldry(iplon,lay)*1.e-20
+         else
+            adjcoln2o = coln2o(iplon,lay)
+         endif
+
+         speccomb_planck = colh2o(iplon,lay)+refrat_planck_b*colco2(iplon,lay)
+         specparm_planck = colh2o(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 4. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd_3 + js
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd_3 + js1
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+
+         do ig = 1, ng3
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + &
+                 forfrac(iplon,lay) * (forref(indf+1,ig) - forref(indf,ig)))
+            n2om1 = kb_mn2o(jmn2o,indm,ig) + fmn2o * &
+                 (kb_mn2o(jmn2o+1,indm,ig)-kb_mn2o(jmn2o,indm,ig))
+            n2om2 = kb_mn2o(jmn2o,indm+1,ig) + fmn2o * &
+                 (kb_mn2o(jmn2o+1,indm+1,ig)-kb_mn2o(jmn2o,indm+1,ig))
+            absn2o = n2om1 + minorfrac(iplon,lay) * (n2om2 - n2om1)
+            taug(iplon,lay,ngs2+ig) = speccomb * &
+                (fac000 * absb(ind0,ig) + &
+                fac100 * absb(ind0+1,ig) + &
+                fac010 * absb(ind0+5,ig) + &
+                fac110 * absb(ind0+6,ig)) &
+                + speccomb1 * &
+                (fac001 * absb(ind1,ig) + &
+                fac101 * absb(ind1+1,ig) + &
+                fac011 * absb(ind1+5,ig) + &
+                fac111 * absb(ind1+6,ig)) &
+                + taufor &
+                + adjcoln2o*absn2o
+            fracsd(iplon,lay,ngs2+ig) = fracrefb(ig,jpl) + fpl * &
+                (fracrefb(ig,jpl+1)-fracrefb(ig,jpl))
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+!$acc end data
+
+      end subroutine taugb3g
+
+!----------------------------------------------------------------------------
+      subroutine taugb4g( ncol, nlayers, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                )
+!----------------------------------------------------------------------------
+!
+! band 4: 630-700 cm-1 (low key - h2o,co2; high key - o3,co2)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng4, ngs3
+      use parrrtm_f, only : ngs3
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg04_f
+
+! ------- Declarations -------
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+
+      integer :: lay, ind0, ind1, inds, indf, ig
+      integer :: js, js1, jpl
+      real :: speccomb, specparm, specmult, fs
+      real :: speccomb1, specparm1, specmult1, fs1
+      real :: speccomb_planck, specparm_planck, specmult_planck, fpl
+      real :: p, p4, fk0, fk1, fk2
+      real :: fac000, fac100, fac200, fac010, fac110, fac210
+      real :: fac001, fac101, fac201, fac011, fac111, fac211
+      real :: tauself, taufor
+      real :: refrat_planck_a, refrat_planck_b
+      real :: tau_major, tau_major1
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present) async(4)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! P = 142.5940 mb
+      refrat_planck_a = chi_mls(1,11)/chi_mls(2,11)
+
+! P = 95.58350 mb
+      refrat_planck_b = chi_mls(3,13)/chi_mls(2,13)
+
+! Compute the optical depth by interpolating in ln(pressure) and
+! temperature, and appropriate species. Below laytrop, the water
+! vapor self-continuum and foreign continuum is interpolated (in temperature)
+! separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+
+         speccomb = colh2o(iplon,lay) + rat_h2oco2(iplon,lay)*colco2(iplon,lay)
+         specparm = colh2o(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colh2o(iplon,lay) + rat_h2oco2_1(iplon,lay)*colco2(iplon,lay)
+         specparm1 = colh2o(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 8. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         speccomb_planck = colh2o(iplon,lay)+refrat_planck_a*colco2(iplon,lay)
+         specparm_planck = colh2o(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 8. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(4) + js
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(4) + js1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+
+         if (specparm .lt. 0.125 ) then
+            p = fs - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else if (specparm .gt. 0.875 ) then
+            p = -fs
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else
+            fac000 = (1. - fs) * fac00(iplon,lay)
+            fac010 = (1. - fs) * fac10(iplon,lay)
+            fac100 = fs * fac00(iplon,lay)
+            fac110 = fs * fac10(iplon,lay)
+         endif
+
+         if (specparm1 .lt. 0.125 ) then
+            p = fs1 - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else if (specparm1 .gt. 0.875 ) then
+            p = -fs1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else
+            fac001 = (1. - fs1) * fac01(iplon,lay)
+            fac011 = (1. - fs1) * fac11(iplon,lay)
+            fac101 = fs1 * fac01(iplon,lay)
+            fac111 = fs1 * fac11(iplon,lay)
+         endif
+
+         do ig = 1, ng4
+            tauself = selffac(iplon,lay)* (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+
+            if (specparm .lt. 0.125 ) then
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac200 * absa(ind0+2,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig) + &
+                    fac210 * absa(ind0+11,ig))
+            else if (specparm .gt. 0.875 ) then
+               tau_major = speccomb * &
+                    (fac200 * absa(ind0-1,ig) + &
+                    fac100 * absa(ind0,ig) + &
+                    fac000 * absa(ind0+1,ig) + &
+                    fac210 * absa(ind0+8,ig) + &
+                    fac110 * absa(ind0+9,ig) + &
+                    fac010 * absa(ind0+10,ig))
+            else
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig))
+            endif
+
+            if (specparm1 .lt. 0.125 ) then
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac201 * absa(ind1+2,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig) + &
+                    fac211 * absa(ind1+11,ig))
+            else if (specparm1 .gt. 0.875 ) then
+               tau_major1 = speccomb1 * &
+                    (fac201 * absa(ind1-1,ig) + &
+                    fac101 * absa(ind1,ig) + &
+                    fac001 * absa(ind1+1,ig) + &
+                    fac211 * absa(ind1+8,ig) + &
+                    fac111 * absa(ind1+9,ig) + &
+                    fac011 * absa(ind1+10,ig))
+            else
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig))
+            endif
+
+            taug(iplon,lay,ngs3+ig) = tau_major + tau_major1 &
+                 + tauself + taufor
+            fracsd(iplon,lay,ngs3+ig) = fracrefa(ig,jpl) + fpl * &
+                 (fracrefa(ig,jpl+1)-fracrefa(ig,jpl))
+         enddo
+
+
+! Upper atmosphere loop
+      else
+
+         speccomb = colo3(iplon,lay) + rat_o3co2(iplon,lay)*colco2(iplon,lay)
+         specparm = colo3(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 4. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colo3(iplon,lay) + rat_o3co2_1(iplon,lay)*colco2(iplon,lay)
+         specparm1 = colo3(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 4. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         fac000 = (1. - fs) * fac00(iplon,lay)
+         fac010 = (1. - fs) * fac10(iplon,lay)
+         fac100 = fs * fac00(iplon,lay)
+         fac110 = fs * fac10(iplon,lay)
+         fac001 = (1. - fs1) * fac01(iplon,lay)
+         fac011 = (1. - fs1) * fac11(iplon,lay)
+         fac101 = fs1 * fac01(iplon,lay)
+         fac111 = fs1 * fac11(iplon,lay)
+
+         speccomb_planck = colo3(iplon,lay)+refrat_planck_b*colco2(iplon,lay)
+         specparm_planck = colo3(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 4. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd(4) + js
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd(4) + js1
+
+         do ig = 1, ng4
+            taug(iplon,lay,ngs3+ig) = speccomb * &
+                (fac000 * absb(ind0,ig) + &
+                fac100 * absb(ind0+1,ig) + &
+                fac010 * absb(ind0+5,ig) + &
+                fac110 * absb(ind0+6,ig)) &
+                + speccomb1 * &
+                (fac001 * absb(ind1,ig) + &
+                fac101 * absb(ind1+1,ig) + &
+                fac011 * absb(ind1+5,ig) + &
+                fac111 * absb(ind1+6,ig))
+            fracsd(iplon,lay,ngs3+ig) = fracrefb(ig,jpl) + fpl * &
+                (fracrefb(ig,jpl+1)-fracrefb(ig,jpl))
+         enddo
+
+! Empirical modification to code to improve stratospheric cooling rates
+! for co2. Revised to apply weighting for g-point reduction in this band.
+
+         taug(iplon,lay,ngs3+8)=taug(iplon,lay,ngs3+8)*0.92
+         taug(iplon,lay,ngs3+9)=taug(iplon,lay,ngs3+9)*0.88
+         taug(iplon,lay,ngs3+10)=taug(iplon,lay,ngs3+10)*1.07
+         taug(iplon,lay,ngs3+11)=taug(iplon,lay,ngs3+11)*1.1
+         taug(iplon,lay,ngs3+12)=taug(iplon,lay,ngs3+12)*0.99
+         taug(iplon,lay,ngs3+13)=taug(iplon,lay,ngs3+13)*0.88
+         taug(iplon,lay,ngs3+14)=taug(iplon,lay,ngs3+14)*0.943
+
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb4g
+
+!----------------------------------------------------------------------------
+      subroutine taugb5g( ncol, nlayers , taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                )
+!----------------------------------------------------------------------------
+!
+! band 5: 700-820 cm-1 (low key - h2o,co2; low minor - o3, ccl4)
+! (high key - o3,co2)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng5, ngs4
+      use parrrtm_f, only : ngs4
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg05_f
+
+! ------- Declarations -------
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: lay, ind0, ind1, inds, indf, indm, ig
+      integer :: js, js1, jmo3, jpl
+      real :: speccomb, specparm, specmult, fs
+      real :: speccomb1, specparm1, specmult1, fs1
+      real :: speccomb_mo3, specparm_mo3, specmult_mo3, fmo3
+      real :: speccomb_planck, specparm_planck, specmult_planck, fpl
+      real :: p, p4, fk0, fk1, fk2
+      real :: fac000, fac100, fac200, fac010, fac110, fac210
+      real :: fac001, fac101, fac201, fac011, fac111, fac211
+      real :: tauself, taufor, o3m1, o3m2, abso3
+      real :: refrat_planck_a, refrat_planck_b, refrat_m_a
+      real :: tau_major, tau_major1
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present) async(5)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Minor gas mapping level :
+! lower - o3, p = 317.34 mbar, t = 240.77 k
+! lower - ccl4
+
+! Calculate reference ratio to be used in calculation of Planck
+! fraction in lower/upper atmosphere.
+
+! P = 473.420 mb
+      refrat_planck_a = chi_mls(1,5)/chi_mls(2,5)
+
+! P = 0.2369 mb
+      refrat_planck_b = chi_mls(3,43)/chi_mls(2,43)
+
+! P = 317.3480
+      refrat_m_a = chi_mls(1,7)/chi_mls(2,7)
+
+! Compute the optical depth by interpolating in ln(pressure) and
+! temperature, and appropriate species. Below laytrop, the
+! water vapor self-continuum and foreign continuum is
+! interpolated (in temperature) separately.
+
+! Lower atmosphere loop
+      !do lay = 1, laytrop(iplon)
+      if (lay <= laytrop(iplon)) then
+         speccomb = colh2o(iplon,lay) + rat_h2oco2(iplon,lay)*colco2(iplon,lay)
+         specparm = colh2o(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colh2o(iplon,lay) + rat_h2oco2_1(iplon,lay)*colco2(iplon,lay)
+         specparm1 = colh2o(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 8. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         speccomb_mo3 = colh2o(iplon,lay) + refrat_m_a*colco2(iplon,lay)
+         specparm_mo3 = colh2o(iplon,lay)/speccomb_mo3
+         if (specparm_mo3 .ge. oneminusd) specparm_mo3 = oneminusd
+         specmult_mo3 = 8. *specparm_mo3
+         jmo3 = 1 + int(specmult_mo3)
+         fmo3 = mod(specmult_mo3,1.0 )
+
+         speccomb_planck = colh2o(iplon,lay)+refrat_planck_a*colco2(iplon,lay)
+         specparm_planck = colh2o(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 8. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(5) + js
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(5) + js1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+
+         if (specparm .lt. 0.125 ) then
+            p = fs - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else if (specparm .gt. 0.875 ) then
+            p = -fs
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else
+            fac000 = (1. - fs) * fac00(iplon,lay)
+            fac010 = (1. - fs) * fac10(iplon,lay)
+            fac100 = fs * fac00(iplon,lay)
+            fac110 = fs * fac10(iplon,lay)
+         endif
+
+         if (specparm1 .lt. 0.125 ) then
+            p = fs1 - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else if (specparm1 .gt. 0.875 ) then
+            p = -fs1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else
+            fac001 = (1. - fs1) * fac01(iplon,lay)
+            fac011 = (1. - fs1) * fac11(iplon,lay)
+            fac101 = fs1 * fac01(iplon,lay)
+            fac111 = fs1 * fac11(iplon,lay)
+         endif
+
+         do ig = 1, ng5
+            tauself = selffac(iplon,lay) * (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            o3m1 = ka_mo3(jmo3,indm,ig) + fmo3 * &
+                 (ka_mo3(jmo3+1,indm,ig)-ka_mo3(jmo3,indm,ig))
+            o3m2 = ka_mo3(jmo3,indm+1,ig) + fmo3 * &
+                 (ka_mo3(jmo3+1,indm+1,ig)-ka_mo3(jmo3,indm+1,ig))
+            abso3 = o3m1 + minorfrac(iplon,lay)*(o3m2-o3m1)
+
+            if (specparm .lt. 0.125 ) then
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac200 * absa(ind0+2,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig) + &
+                    fac210 * absa(ind0+11,ig))
+            else if (specparm .gt. 0.875 ) then
+               tau_major = speccomb * &
+                    (fac200 * absa(ind0-1,ig) + &
+                    fac100 * absa(ind0,ig) + &
+                    fac000 * absa(ind0+1,ig) + &
+                    fac210 * absa(ind0+8,ig) + &
+                    fac110 * absa(ind0+9,ig) + &
+                    fac010 * absa(ind0+10,ig))
+            else
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig))
+            endif
+
+            if (specparm1 .lt. 0.125 ) then
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac201 * absa(ind1+2,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig) + &
+                    fac211 * absa(ind1+11,ig))
+            else if (specparm1 .gt. 0.875 ) then
+               tau_major1 = speccomb1 * &
+                    (fac201 * absa(ind1-1,ig) + &
+                    fac101 * absa(ind1,ig) + &
+                    fac001 * absa(ind1+1,ig) + &
+                    fac211 * absa(ind1+8,ig) + &
+                    fac111 * absa(ind1+9,ig) + &
+                    fac011 * absa(ind1+10,ig))
+            else
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig))
+            endif
+
+            taug(iplon,lay,ngs4+ig) = tau_major + tau_major1 &
+                 + tauself + taufor &
+                 + abso3*colo3(iplon,lay) &
+                 + wx1(iplon,lay) * coldry(iplon,lay) * 1.e-20 * ccl4(ig)
+            fracsd(iplon,lay,ngs4+ig) = fracrefa(ig,jpl) + fpl * &
+                 (fracrefa(ig,jpl+1)-fracrefa(ig,jpl))
+         enddo
+      else
+
+! Upper atmosphere loop
+      !do lay = laytrop(iplon)+1, nlayers
+
+         speccomb = colo3(iplon,lay) + rat_o3co2(iplon,lay)*colco2(iplon,lay)
+         specparm = colo3(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 4. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colo3(iplon,lay) + rat_o3co2_1(iplon,lay)*colco2(iplon,lay)
+         specparm1 = colo3(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 4. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         fac000 = (1. - fs) * fac00(iplon,lay)
+         fac010 = (1. - fs) * fac10(iplon,lay)
+         fac100 = fs * fac00(iplon,lay)
+         fac110 = fs * fac10(iplon,lay)
+         fac001 = (1. - fs1) * fac01(iplon,lay)
+         fac011 = (1. - fs1) * fac11(iplon,lay)
+         fac101 = fs1 * fac01(iplon,lay)
+         fac111 = fs1 * fac11(iplon,lay)
+
+         speccomb_planck = colo3(iplon,lay)+refrat_planck_b*colco2(iplon,lay)
+         specparm_planck = colo3(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 4. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd(5) + js
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd(5) + js1
+
+         do ig = 1, ng5
+            taug(iplon,lay,ngs4+ig) = speccomb * &
+                (fac000 * absb(ind0,ig) + &
+                fac100 * absb(ind0+1,ig) + &
+                fac010 * absb(ind0+5,ig) + &
+                fac110 * absb(ind0+6,ig)) &
+                + speccomb1 * &
+                (fac001 * absb(ind1,ig) + &
+                fac101 * absb(ind1+1,ig) + &
+                fac011 * absb(ind1+5,ig) + &
+                fac111 * absb(ind1+6,ig)) &
+                + wx1(iplon, lay) * coldry(iplon,lay) * 1.e-20 * ccl4(ig)
+            fracsd(iplon,lay,ngs4+ig) = fracrefb(ig,jpl) + fpl * &
+                (fracrefb(ig,jpl+1)-fracrefb(ig,jpl))
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb5g
+
+!----------------------------------------------------------------------------
+      subroutine taugb6g( ncol, nlayers, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                )
+!----------------------------------------------------------------------------
+!
+! band 6: 820-980 cm-1 (low key - h2o; low minor - co2)
+! (high key - nothing; high minor - cfc11, cfc12)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng6, ngs5
+      use parrrtm_f, only : ngs5
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg06_f
+
+! ------- Declarations -------
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: lay, ind0, ind1, inds, indf, indm, ig
+      real :: chi_co2, ratco2, adjfac, adjcolco2
+      real :: tauself, taufor, absco2
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+
+
+
+
+
+!$acc kernels default(present) async(6)
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Minor gas mapping level:
+! lower - co2, p = 706.2720 mb, t = 294.2 k
+! upper - cfc11, cfc12
+
+! Compute the optical depth by interpolating in ln(pressure) and
+! temperature. The water vapor self-continuum and foreign continuum
+! is interpolated (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+
+! In atmospheres where the amount of CO2 is too great to be considered
+! a minor species, adjust the column amount of CO2 by an empirical factor
+! to obtain the proper contribution.
+         chi_co2 = colco2(iplon,lay)/(coldry(iplon,lay))
+         ratco2 = 1.e20 *chi_co2/chi_mls(2,jp(iplon,lay)+1)
+         if (ratco2 .gt. 3.0 ) then
+            adjfac = 2.0 +(ratco2-2.0 )**0.77
+            adjcolco2 = adjfac*chi_mls(2,jp(iplon,lay)+1)*coldry(iplon,lay)*1.e-20
+         else
+            adjcolco2 = colco2(iplon,lay)
+         endif
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(6) + 1
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(6) + 1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+
+         do ig = 1, ng6
+            tauself = selffac(iplon,lay) * (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            absco2 = (ka_mco2(indm,ig) + minorfrac(iplon,lay) * &
+                 (ka_mco2(indm+1,ig) - ka_mco2(indm,ig)))
+            taug(iplon,lay,ngs5+ig) = colh2o(iplon,lay) * &
+                (fac00(iplon,lay) * absa(ind0,ig) + &
+                 fac10(iplon,lay) * absa(ind0+1,ig) + &
+                 fac01(iplon,lay) * absa(ind1,ig) + &
+                 fac11(iplon,lay) * absa(ind1+1,ig)) &
+                 + tauself + taufor &
+                 + adjcolco2 * absco2 &
+                 + wx2(iplon, lay) * coldry(iplon,lay) * 1.e-20 * cfc11adj(ig) &
+                 + wx3(iplon, lay) * coldry(iplon,lay) * 1.e-20 * cfc12(ig)
+            fracsd(iplon,lay,ngs5+ig) = fracrefa(ig)
+         enddo
+      else
+
+         do ig = 1, ng6
+            taug(iplon,lay,ngs5+ig) = 0.0 &
+                 + wx2(iplon, lay) * coldry(iplon,lay) * 1.e-20 * cfc11adj(ig) &
+                 + wx3(iplon, lay) * coldry(iplon,lay) * 1.e-20 * cfc12(ig)
+            fracsd(iplon,lay,ngs5+ig) = fracrefa(ig)
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb6g
+
+!----------------------------------------------------------------------------
+      subroutine taugb7g( ncol, nlayers , taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                )
+!----------------------------------------------------------------------------
+!
+! band 7: 980-1080 cm-1 (low key - h2o,o3; low minor - co2)
+! (high key - o3; high minor - co2)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng7, ngs6
+      use parrrtm_f, only : ngs6
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg07_f
+
+! ------- Declarations -------
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: lay, ind0, ind1, inds, indf, indm, ig
+      integer :: js, js1, jmco2, jpl
+      real :: speccomb, specparm, specmult, fs
+      real :: speccomb1, specparm1, specmult1, fs1
+      real :: speccomb_mco2, specparm_mco2, specmult_mco2, fmco2
+      real :: speccomb_planck, specparm_planck, specmult_planck, fpl
+      real :: p, p4, fk0, fk1, fk2
+      real :: fac000, fac100, fac200, fac010, fac110, fac210
+      real :: fac001, fac101, fac201, fac011, fac111, fac211
+      real :: tauself, taufor, co2m1, co2m2, absco2
+      real :: chi_co2, ratco2, adjfac, adjcolco2
+      real :: refrat_planck_a, refrat_m_a
+      real :: tau_major, tau_major1
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present)  async(7)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Minor gas mapping level :
+! lower - co2, p = 706.2620 mbar, t= 278.94 k
+! upper - co2, p = 12.9350 mbar, t = 234.01 k
+
+! Calculate reference ratio to be used in calculation of Planck
+! fraction in lower atmosphere.
+
+! P = 706.2620 mb
+      refrat_planck_a = chi_mls(1,3)/chi_mls(3,3)
+
+! P = 706.2720 mb
+      refrat_m_a = chi_mls(1,3)/chi_mls(3,3)
+
+! Compute the optical depth by interpolating in ln(pressure),
+! temperature, and appropriate species. Below laytrop, the water
+! vapor self-continuum and foreign continuum is interpolated
+! (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+
+         speccomb = colh2o(iplon,lay) + rat_h2oo3(iplon,lay)*colo3(iplon,lay)
+         specparm = colh2o(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colh2o(iplon,lay) + rat_h2oo3_1(iplon,lay)*colo3(iplon,lay)
+         specparm1 = colh2o(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 8. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         speccomb_mco2 = colh2o(iplon,lay) + refrat_m_a*colo3(iplon,lay)
+         specparm_mco2 = colh2o(iplon,lay)/speccomb_mco2
+         if (specparm_mco2 .ge. oneminusd) specparm_mco2 = oneminusd
+         specmult_mco2 = 8. *specparm_mco2
+
+         jmco2 = 1 + int(specmult_mco2)
+         fmco2 = mod(specmult_mco2,1.0 )
+
+! In atmospheres where the amount of CO2 is too great to be considered
+! a minor species, adjust the column amount of CO2 by an empirical factor
+! to obtain the proper contribution.
+         chi_co2 = colco2(iplon,lay)/(coldry(iplon,lay))
+         ratco2 = 1.e20*chi_co2/chi_mls(2,jp(iplon,lay)+1)
+         if (ratco2 .gt. 3.0 ) then
+            adjfac = 3.0 +(ratco2-3.0 )**0.79
+            adjcolco2 = adjfac*chi_mls(2,jp(iplon,lay)+1)*coldry(iplon,lay)*1.e-20
+         else
+            adjcolco2 = colco2(iplon,lay)
+         endif
+
+         speccomb_planck = colh2o(iplon,lay)+refrat_planck_a*colo3(iplon,lay)
+         specparm_planck = colh2o(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 8. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(7) + js
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(7) + js1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+
+         if (specparm .lt. 0.125 ) then
+            p = fs - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else if (specparm .gt. 0.875 ) then
+            p = -fs
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else
+            fac000 = (1. - fs) * fac00(iplon,lay)
+            fac010 = (1. - fs) * fac10(iplon,lay)
+            fac100 = fs * fac00(iplon,lay)
+            fac110 = fs * fac10(iplon,lay)
+         endif
+         if (specparm1 .lt. 0.125 ) then
+            p = fs1 - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else if (specparm1 .gt. 0.875 ) then
+            p = -fs1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else
+            fac001 = (1. - fs1) * fac01(iplon,lay)
+            fac011 = (1. - fs1) * fac11(iplon,lay)
+            fac101 = fs1 * fac01(iplon,lay)
+            fac111 = fs1 * fac11(iplon,lay)
+         endif
+
+         do ig = 1, ng7
+            tauself = selffac(iplon,lay)* (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            co2m1 = ka_mco2(jmco2,indm,ig) + fmco2 * &
+                 (ka_mco2(jmco2+1,indm,ig) - ka_mco2(jmco2,indm,ig))
+            co2m2 = ka_mco2(jmco2,indm+1,ig) + fmco2 * &
+                 (ka_mco2(jmco2+1,indm+1,ig) - ka_mco2(jmco2,indm+1,ig))
+            absco2 = co2m1 + minorfrac(iplon,lay) * (co2m2 - co2m1)
+
+            if (specparm .lt. 0.125 ) then
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac200 * absa(ind0+2,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig) + &
+                    fac210 * absa(ind0+11,ig))
+            else if (specparm .gt. 0.875 ) then
+               tau_major = speccomb * &
+                    (fac200 * absa(ind0-1,ig) + &
+                    fac100 * absa(ind0,ig) + &
+                    fac000 * absa(ind0+1,ig) + &
+                    fac210 * absa(ind0+8,ig) + &
+                    fac110 * absa(ind0+9,ig) + &
+                    fac010 * absa(ind0+10,ig))
+            else
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig))
+            endif
+
+            if (specparm1 .lt. 0.125 ) then
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac201 * absa(ind1+2,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig) + &
+                    fac211 * absa(ind1+11,ig))
+            else if (specparm1 .gt. 0.875 ) then
+               tau_major1 = speccomb1 * &
+                    (fac201 * absa(ind1-1,ig) + &
+                    fac101 * absa(ind1,ig) + &
+                    fac001 * absa(ind1+1,ig) + &
+                    fac211 * absa(ind1+8,ig) + &
+                    fac111 * absa(ind1+9,ig) + &
+                    fac011 * absa(ind1+10,ig))
+            else
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig))
+            endif
+
+            taug(iplon,lay,ngs6+ig) = tau_major + tau_major1 &
+                 + tauself + taufor &
+                 + adjcolco2*absco2
+            fracsd(iplon,lay,ngs6+ig) = fracrefa(ig,jpl) + fpl * &
+                 (fracrefa(ig,jpl+1)-fracrefa(ig,jpl))
+         enddo
+    else
+! In atmospheres where the amount of CO2 is too great to be considered
+! a minor species, adjust the column amount of CO2 by an empirical factor
+! to obtain the proper contribution.
+         chi_co2 = colco2(iplon,lay)/(coldry(iplon,lay))
+         ratco2 = 1.e20*chi_co2/chi_mls(2,jp(iplon,lay)+1)
+         if (ratco2 .gt. 3.0 ) then
+            adjfac = 2.0 +(ratco2-2.0 )**0.79
+            adjcolco2 = adjfac*chi_mls(2,jp(iplon,lay)+1)*coldry(iplon,lay)*1.e-20
+         else
+            adjcolco2 = colco2(iplon,lay)
+         endif
+
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd(7) + 1
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd(7) + 1
+         indm = indminor(iplon,lay)
+
+         do ig = 1, ng7
+            absco2 = kb_mco2(indm,ig) + minorfrac(iplon,lay) * &
+                 (kb_mco2(indm+1,ig) - kb_mco2(indm,ig))
+            taug(iplon,lay,ngs6+ig) = colo3(iplon,lay) * &
+                 (fac00(iplon,lay) * absb(ind0,ig) + &
+                 fac10(iplon,lay) * absb(ind0+1,ig) + &
+                 fac01(iplon,lay) * absb(ind1,ig) + &
+                 fac11(iplon,lay) * absb(ind1+1,ig)) &
+                 + adjcolco2 * absco2
+            fracsd(iplon,lay,ngs6+ig) = fracrefb(ig)
+         enddo
+
+! Empirical modification to code to improve stratospheric cooling rates
+! for o3. Revised to apply weighting for g-point reduction in this band.
+
+         taug(iplon,lay,ngs6+6)=taug(iplon,lay,ngs6+6)*0.92
+         taug(iplon,lay,ngs6+7)=taug(iplon,lay,ngs6+7)*0.88
+         taug(iplon,lay,ngs6+8)=taug(iplon,lay,ngs6+8)*1.07
+         taug(iplon,lay,ngs6+9)=taug(iplon,lay,ngs6+9)*1.1
+         taug(iplon,lay,ngs6+10)=taug(iplon,lay,ngs6+10)*0.99
+         taug(iplon,lay,ngs6+11)=taug(iplon,lay,ngs6+11)*0.855
+
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb7g
+
+!----------------------------------------------------------------------------
+      subroutine taugb8g( ncol, nlayers, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                )
+!----------------------------------------------------------------------------
+!
+! band 8: 1080-1180 cm-1 (low key - h2o; low minor - co2,o3,n2o)
+! (high key - o3; high minor - co2, n2o)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng8, ngs7
+      use parrrtm_f, only : ngs7
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg08_f
+
+! ------- Declarations -------
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: lay, ind0, ind1, inds, indf, indm, ig
+      real :: tauself, taufor, absco2, abso3, absn2o
+      real :: chi_co2, ratco2, adjfac, adjcolco2
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present)  async(8)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Minor gas mapping level:
+! lower - co2, p = 1053.63 mb, t = 294.2 k
+! lower - o3, p = 317.348 mb, t = 240.77 k
+! lower - n2o, p = 706.2720 mb, t= 278.94 k
+! lower - cfc12,cfc11
+! upper - co2, p = 35.1632 mb, t = 223.28 k
+! upper - n2o, p = 8.716e-2 mb, t = 226.03 k
+
+! Compute the optical depth by interpolating in ln(pressure) and
+! temperature, and appropriate species. Below laytrop, the water vapor
+! self-continuum and foreign continuum is interpolated (in temperature)
+! separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+
+! In atmospheres where the amount of CO2 is too great to be considered
+! a minor species, adjust the column amount of CO2 by an empirical factor
+! to obtain the proper contribution.
+         chi_co2 = colco2(iplon,lay)/(coldry(iplon,lay))
+         ratco2 = 1.e20 *chi_co2/chi_mls(2,jp(iplon,lay)+1)
+         if (ratco2 .gt. 3.0 ) then
+            adjfac = 2.0 +(ratco2-2.0 )**0.65
+            adjcolco2 = adjfac*chi_mls(2,jp(iplon,lay)+1)*coldry(iplon,lay)*1.e-20
+         else
+            adjcolco2 = colco2(iplon,lay)
+         endif
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(8) + 1
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(8) + 1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+
+         do ig = 1, ng8
+            tauself = selffac(iplon,lay) * (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            absco2 = (ka_mco2(indm,ig) + minorfrac(iplon,lay) * &
+                 (ka_mco2(indm+1,ig) - ka_mco2(indm,ig)))
+            abso3 = (ka_mo3(indm,ig) + minorfrac(iplon,lay) * &
+                 (ka_mo3(indm+1,ig) - ka_mo3(indm,ig)))
+            absn2o = (ka_mn2o(indm,ig) + minorfrac(iplon,lay) * &
+                 (ka_mn2o(indm+1,ig) - ka_mn2o(indm,ig)))
+            taug(iplon,lay,ngs7+ig) = colh2o(iplon,lay) * &
+                 (fac00(iplon,lay) * absa(ind0,ig) + &
+                 fac10(iplon,lay) * absa(ind0+1,ig) + &
+                 fac01(iplon,lay) * absa(ind1,ig) + &
+                 fac11(iplon,lay) * absa(ind1+1,ig)) &
+                 + tauself + taufor &
+                 + adjcolco2*absco2 &
+                 + colo3(iplon,lay) * abso3 &
+                 + coln2o(iplon,lay) * absn2o &
+                 + wx3(iplon, lay) * coldry(iplon,lay) * 1.e-20 * cfc12(ig) &
+                 + wx4(iplon, lay) * coldry(iplon,lay) * 1.e-20 * cfc22adj(ig)
+            fracsd(iplon,lay,ngs7+ig) = fracrefa(ig)
+         enddo
+      else
+! In atmospheres where the amount of CO2 is too great to be considered
+! a minor species, adjust the column amount of CO2 by an empirical factor
+! to obtain the proper contribution.
+         chi_co2 = colco2(iplon,lay)/coldry(iplon,lay)
+         ratco2 = 1.e20 *chi_co2/chi_mls(2,jp(iplon,lay)+1)
+         if (ratco2 .gt. 3.0 ) then
+            adjfac = 2.0 +(ratco2-2.0 )**0.65
+            adjcolco2 = adjfac*chi_mls(2,jp(iplon,lay)+1) * coldry(iplon,lay)*1.e-20
+         else
+            adjcolco2 = colco2(iplon,lay)
+         endif
+
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd(8) + 1
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd(8) + 1
+         indm = indminor(iplon,lay)
+
+         do ig = 1, ng8
+            absco2 = (kb_mco2(indm,ig) + minorfrac(iplon,lay) * &
+                 (kb_mco2(indm+1,ig) - kb_mco2(indm,ig)))
+            absn2o = (kb_mn2o(indm,ig) + minorfrac(iplon,lay) * &
+                 (kb_mn2o(indm+1,ig) - kb_mn2o(indm,ig)))
+            taug(iplon,lay,ngs7+ig) = colo3(iplon,lay) * &
+                 (fac00(iplon,lay) * absb(ind0,ig) + &
+                 fac10(iplon,lay) * absb(ind0+1,ig) + &
+                 fac01(iplon,lay) * absb(ind1,ig) + &
+                 fac11(iplon,lay) * absb(ind1+1,ig)) &
+                 + adjcolco2*absco2 &
+                 + coln2o(iplon,lay)*absn2o &
+                 + wx3(iplon,lay) * coldry(iplon,lay) * 1.e-20 * cfc12(ig) &
+                 + wx4(iplon,lay) * coldry(iplon,lay) * 1.e-20 * cfc22adj(ig)
+            fracsd(iplon,lay,ngs7+ig) = fracrefb(ig)
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb8g
+
+!----------------------------------------------------------------------------
+      subroutine taugb9g( ncol, nlayers, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                )
+!----------------------------------------------------------------------------
+!
+! band 9: 1180-1390 cm-1 (low key - h2o,ch4; low minor - n2o)
+! (high key - ch4; high minor - n2o)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng9, ngs8
+      use parrrtm_f, only : ngs8
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg09_f
+
+! ------- Declarations -------
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: lay, ind0, ind1, inds, indf, indm, ig
+      integer :: js, js1, jmn2o, jpl
+      real :: speccomb, specparm, specmult, fs
+      real :: speccomb1, specparm1, specmult1, fs1
+      real :: speccomb_mn2o, specparm_mn2o, specmult_mn2o, fmn2o
+      real :: speccomb_planck, specparm_planck, specmult_planck, fpl
+      real :: p, p4, fk0, fk1, fk2
+      real :: fac000, fac100, fac200, fac010, fac110, fac210
+      real :: fac001, fac101, fac201, fac011, fac111, fac211
+      real :: tauself, taufor, n2om1, n2om2, absn2o
+      real :: chi_n2o, ratn2o, adjfac, adjcoln2o
+      real :: refrat_planck_a, refrat_m_a
+      real :: tau_major, tau_major1
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present)  async(9)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Minor gas mapping level :
+! lower - n2o, p = 706.272 mbar, t = 278.94 k
+! upper - n2o, p = 95.58 mbar, t = 215.7 k
+
+! Calculate reference ratio to be used in calculation of Planck
+! fraction in lower/upper atmosphere.
+
+! P = 212 mb
+      refrat_planck_a = chi_mls(1,9)/chi_mls(6,9)
+
+! P = 706.272 mb
+      refrat_m_a = chi_mls(1,3)/chi_mls(6,3)
+
+! Compute the optical depth by interpolating in ln(pressure),
+! temperature, and appropriate species. Below laytrop, the water
+! vapor self-continuum and foreign continuum is interpolated
+! (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+
+         speccomb = colh2o(iplon,lay) + rat_h2och4(iplon,lay)*colch4(iplon,lay)
+         specparm = colh2o(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colh2o(iplon,lay) + rat_h2och4_1(iplon,lay)*colch4(iplon,lay)
+         specparm1 = colh2o(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 8. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         speccomb_mn2o = colh2o(iplon,lay) + refrat_m_a*colch4(iplon,lay)
+         specparm_mn2o = colh2o(iplon,lay)/speccomb_mn2o
+         if (specparm_mn2o .ge. oneminusd) specparm_mn2o = oneminusd
+         specmult_mn2o = 8. *specparm_mn2o
+         jmn2o = 1 + int(specmult_mn2o)
+         fmn2o = mod(specmult_mn2o,1.0 )
+
+! In atmospheres where the amount of N2O is too great to be considered
+! a minor species, adjust the column amount of N2O by an empirical factor
+! to obtain the proper contribution.
+         chi_n2o = coln2o(iplon,lay)/(coldry(iplon,lay))
+         ratn2o = 1.e20 *chi_n2o/chi_mls(4,jp(iplon,lay)+1)
+         if (ratn2o .gt. 1.5 ) then
+            adjfac = 0.5 +(ratn2o-0.5 )**0.65
+            adjcoln2o = adjfac*chi_mls(4,jp(iplon,lay)+1)*coldry(iplon,lay)*1.e-20
+         else
+            adjcoln2o = coln2o(iplon,lay)
+         endif
+
+         speccomb_planck = colh2o(iplon,lay)+refrat_planck_a*colch4(iplon,lay)
+         specparm_planck = colh2o(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 8. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(9) + js
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(9) + js1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+
+         if (specparm .lt. 0.125 ) then
+            p = fs - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else if (specparm .gt. 0.875 ) then
+            p = -fs
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else
+            fac000 = (1. - fs) * fac00(iplon,lay)
+            fac010 = (1. - fs) * fac10(iplon,lay)
+            fac100 = fs * fac00(iplon,lay)
+            fac110 = fs * fac10(iplon,lay)
+         endif
+
+         if (specparm1 .lt. 0.125 ) then
+            p = fs1 - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else if (specparm1 .gt. 0.875 ) then
+            p = -fs1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else
+            fac001 = (1. - fs1) * fac01(iplon,lay)
+            fac011 = (1. - fs1) * fac11(iplon,lay)
+            fac101 = fs1 * fac01(iplon,lay)
+            fac111 = fs1 * fac11(iplon,lay)
+         endif
+
+         do ig = 1, ng9
+            tauself = selffac(iplon,lay)* (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            n2om1 = ka_mn2o(jmn2o,indm,ig) + fmn2o * &
+                 (ka_mn2o(jmn2o+1,indm,ig) - ka_mn2o(jmn2o,indm,ig))
+            n2om2 = ka_mn2o(jmn2o,indm+1,ig) + fmn2o * &
+                 (ka_mn2o(jmn2o+1,indm+1,ig) - ka_mn2o(jmn2o,indm+1,ig))
+            absn2o = n2om1 + minorfrac(iplon,lay) * (n2om2 - n2om1)
+
+            if (specparm .lt. 0.125 ) then
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac200 * absa(ind0+2,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig) + &
+                    fac210 * absa(ind0+11,ig))
+            else if (specparm .gt. 0.875 ) then
+               tau_major = speccomb * &
+                    (fac200 * absa(ind0-1,ig) + &
+                    fac100 * absa(ind0,ig) + &
+                    fac000 * absa(ind0+1,ig) + &
+                    fac210 * absa(ind0+8,ig) + &
+                    fac110 * absa(ind0+9,ig) + &
+                    fac010 * absa(ind0+10,ig))
+            else
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig))
+            endif
+
+            if (specparm1 .lt. 0.125 ) then
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac201 * absa(ind1+2,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig) + &
+                    fac211 * absa(ind1+11,ig))
+            else if (specparm1 .gt. 0.875 ) then
+               tau_major1 = speccomb1 * &
+                    (fac201 * absa(ind1-1,ig) + &
+                    fac101 * absa(ind1,ig) + &
+                    fac001 * absa(ind1+1,ig) + &
+                    fac211 * absa(ind1+8,ig) + &
+                    fac111 * absa(ind1+9,ig) + &
+                    fac011 * absa(ind1+10,ig))
+            else
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig))
+            endif
+
+            taug(iplon,lay,ngs8+ig) = tau_major + tau_major1 &
+                 + tauself + taufor &
+                 + adjcoln2o*absn2o
+            fracsd(iplon,lay,ngs8+ig) = fracrefa(ig,jpl) + fpl * &
+                 (fracrefa(ig,jpl+1)-fracrefa(ig,jpl))
+         enddo
+      else
+! In atmospheres where the amount of N2O is too great to be considered
+! a minor species, adjust the column amount of N2O by an empirical factor
+! to obtain the proper contribution.
+         chi_n2o = coln2o(iplon,lay)/(coldry(iplon,lay))
+         ratn2o = 1.e20 *chi_n2o/chi_mls(4,jp(iplon,lay)+1)
+         if (ratn2o .gt. 1.5 ) then
+            adjfac = 0.5 +(ratn2o-0.5 )**0.65
+            adjcoln2o = adjfac*chi_mls(4,jp(iplon,lay)+1)*coldry(iplon,lay)*1.e-20
+         else
+            adjcoln2o = coln2o(iplon,lay)
+         endif
+
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd(9) + 1
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd(9) + 1
+         indm = indminor(iplon,lay)
+
+         do ig = 1, ng9
+            absn2o = kb_mn2o(indm,ig) + minorfrac(iplon,lay) * &
+                (kb_mn2o(indm+1,ig) - kb_mn2o(indm,ig))
+            taug(iplon,lay,ngs8+ig) = colch4(iplon,lay) * &
+                 (fac00(iplon,lay) * absb(ind0,ig) + &
+                 fac10(iplon,lay) * absb(ind0+1,ig) + &
+                 fac01(iplon,lay) * absb(ind1,ig) + &
+                 fac11(iplon,lay) * absb(ind1+1,ig)) &
+                 + adjcoln2o*absn2o
+            fracsd(iplon,lay,ngs8+ig) = fracrefb(ig)
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb9g
+
+!----------------------------------------------------------------------------
+      subroutine taugb10g( ncol, nlayers, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                 )
+!----------------------------------------------------------------------------
+!
+! band 10: 1390-1480 cm-1 (low key - h2o; high key - h2o)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng10, ngs9
+      use parrrtm_f, only : ngs9
+      use rrlw_kg10_f
+
+! ------- Declarations -------
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: lay, ind0, ind1, inds, indf, ig
+      real :: tauself, taufor
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present) async(10)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Compute the optical depth by interpolating in ln(pressure) and
+! temperature. Below laytrop, the water vapor self-continuum and
+! foreign continuum is interpolated (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(10) + 1
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(10) + 1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+
+         do ig = 1, ng10
+            tauself = selffac(iplon,lay) * (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            taug(iplon,lay,ngs9+ig) = colh2o(iplon,lay) * &
+                 (fac00(iplon,lay) * absa(ind0,ig) + &
+                 fac10(iplon,lay) * absa(ind0+1,ig) + &
+                 fac01(iplon,lay) * absa(ind1,ig) + &
+                 fac11(iplon,lay) * absa(ind1+1,ig)) &
+                 + tauself + taufor
+            fracsd(iplon,lay,ngs9+ig) = fracrefa(ig)
+         enddo
+      else
+
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd(10) + 1
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd(10) + 1
+         indf = indfor(iplon,lay)
+
+         do ig = 1, ng10
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            taug(iplon,lay,ngs9+ig) = colh2o(iplon,lay) * &
+                 (fac00(iplon,lay) * absb(ind0,ig) + &
+                 fac10(iplon,lay) * absb(ind0+1,ig) + &
+                 fac01(iplon,lay) * absb(ind1,ig) + &
+                 fac11(iplon,lay) * absb(ind1+1,ig)) &
+                 + taufor
+            fracsd(iplon,lay,ngs9+ig) = fracrefb(ig)
+         enddo
+      end if
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+      end subroutine taugb10g
+
+!----------------------------------------------------------------------------
+      subroutine taugb11g( ncol, nlayers, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                 )
+!----------------------------------------------------------------------------
+!
+! band 11: 1480-1800 cm-1 (low - h2o; low minor - o2)
+! (high key - h2o; high minor - o2)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng11, ngs10
+      use parrrtm_f, only : ngs10
+      use rrlw_kg11_f
+
+! ------- Declarations -------
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: lay, ind0, ind1, inds, indf, indm, ig
+      real :: scaleo2, tauself, taufor, tauo2
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present) async(11)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Minor gas mapping level :
+! lower - o2, p = 706.2720 mbar, t = 278.94 k
+! upper - o2, p = 4.758820 mbarm t = 250.85 k
+
+! Compute the optical depth by interpolating in ln(pressure) and
+! temperature. Below laytrop, the water vapor self-continuum and
+! foreign continuum is interpolated (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(11) + 1
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(11) + 1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+         scaleo2 = colo2(iplon,lay)*scaleminor(iplon,lay)
+         do ig = 1, ng11
+            tauself = selffac(iplon,lay) * (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            tauo2 = scaleo2 * (ka_mo2(indm,ig) + minorfrac(iplon,lay) * &
+                 (ka_mo2(indm+1,ig) - ka_mo2(indm,ig)))
+            taug(iplon,lay,ngs10+ig) = colh2o(iplon,lay) * &
+                 (fac00(iplon,lay) * absa(ind0,ig) + &
+                 fac10(iplon,lay) * absa(ind0+1,ig) + &
+                 fac01(iplon,lay) * absa(ind1,ig) + &
+                 fac11(iplon,lay) * absa(ind1+1,ig)) &
+                 + tauself + taufor &
+                 + tauo2
+            fracsd(iplon,lay,ngs10+ig) = fracrefa(ig)
+         enddo
+      else
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd(11) + 1
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd(11) + 1
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+         scaleo2 = colo2(iplon,lay)*scaleminor(iplon,lay)
+         do ig = 1, ng11
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            tauo2 = scaleo2 * (kb_mo2(indm,ig) + minorfrac(iplon,lay) * &
+                 (kb_mo2(indm+1,ig) - kb_mo2(indm,ig)))
+            taug(iplon,lay,ngs10+ig) = colh2o(iplon,lay) * &
+                 (fac00(iplon,lay) * absb(ind0,ig) + &
+                 fac10(iplon,lay) * absb(ind0+1,ig) + &
+                 fac01(iplon,lay) * absb(ind1,ig) + &
+                 fac11(iplon,lay) * absb(ind1+1,ig)) &
+                 + taufor &
+                 + tauo2
+            fracsd(iplon,lay,ngs10+ig) = fracrefb(ig)
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb11g
+
+!----------------------------------------------------------------------------
+      subroutine taugb12g( ncol, nlayers, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                 )
+!----------------------------------------------------------------------------
+!
+! band 12: 1800-2080 cm-1 (low - h2o,co2; high - nothing)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng12, ngs11
+      use parrrtm_f, only : ngs11
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg12_f
+
+! ------- Declarations -------
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: lay, ind0, ind1, inds, indf, ig
+      integer :: js, js1, jpl
+      real :: speccomb, specparm, specmult, fs
+      real :: speccomb1, specparm1, specmult1, fs1
+      real :: speccomb_planck, specparm_planck, specmult_planck, fpl
+      real :: p, p4, fk0, fk1, fk2
+      real :: fac000, fac100, fac200, fac010, fac110, fac210
+      real :: fac001, fac101, fac201, fac011, fac111, fac211
+      real :: tauself, taufor
+      real :: refrat_planck_a
+      real :: tau_major, tau_major1
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present) async(12)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Calculate reference ratio to be used in calculation of Planck
+! fraction in lower/upper atmosphere.
+
+! P = 174.164 mb
+      refrat_planck_a = chi_mls(1,10)/chi_mls(2,10)
+
+! Compute the optical depth by interpolating in ln(pressure),
+! temperature, and appropriate species. Below laytrop, the water
+! vapor self-continuum adn foreign continuum is interpolated
+! (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+
+         speccomb = colh2o(iplon,lay) + rat_h2oco2(iplon,lay)*colco2(iplon,lay)
+         specparm = colh2o(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colh2o(iplon,lay) + rat_h2oco2_1(iplon,lay)*colco2(iplon,lay)
+         specparm1 = colh2o(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 8. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         speccomb_planck = colh2o(iplon,lay)+refrat_planck_a*colco2(iplon,lay)
+         specparm_planck = colh2o(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 8. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(12) + js
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(12) + js1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+
+         if (specparm .lt. 0.125 ) then
+            p = fs - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else if (specparm .gt. 0.875 ) then
+            p = -fs
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else
+            fac000 = (1. - fs) * fac00(iplon,lay)
+            fac010 = (1. - fs) * fac10(iplon,lay)
+            fac100 = fs * fac00(iplon,lay)
+            fac110 = fs * fac10(iplon,lay)
+         endif
+
+         if (specparm1 .lt. 0.125 ) then
+            p = fs1 - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else if (specparm1 .gt. 0.875 ) then
+            p = -fs1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else
+            fac001 = (1. - fs1) * fac01(iplon,lay)
+            fac011 = (1. - fs1) * fac11(iplon,lay)
+            fac101 = fs1 * fac01(iplon,lay)
+            fac111 = fs1 * fac11(iplon,lay)
+         endif
+
+         do ig = 1, ng12
+            tauself = selffac(iplon,lay)* (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+
+            if (specparm .lt. 0.125 ) then
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac200 * absa(ind0+2,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig) + &
+                    fac210 * absa(ind0+11,ig))
+            else if (specparm .gt. 0.875 ) then
+               tau_major = speccomb * &
+                    (fac200 * absa(ind0-1,ig) + &
+                    fac100 * absa(ind0,ig) + &
+                    fac000 * absa(ind0+1,ig) + &
+                    fac210 * absa(ind0+8,ig) + &
+                    fac110 * absa(ind0+9,ig) + &
+                    fac010 * absa(ind0+10,ig))
+            else
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig))
+            endif
+
+            if (specparm1 .lt. 0.125 ) then
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac201 * absa(ind1+2,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig) + &
+                    fac211 * absa(ind1+11,ig))
+            else if (specparm1 .gt. 0.875 ) then
+               tau_major1 = speccomb1 * &
+                    (fac201 * absa(ind1-1,ig) + &
+                    fac101 * absa(ind1,ig) + &
+                    fac001 * absa(ind1+1,ig) + &
+                    fac211 * absa(ind1+8,ig) + &
+                    fac111 * absa(ind1+9,ig) + &
+                    fac011 * absa(ind1+10,ig))
+            else
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig))
+            endif
+
+            taug(iplon,lay,ngs11+ig) = tau_major + tau_major1 &
+                 + tauself + taufor
+            fracsd(iplon,lay,ngs11+ig) = fracrefa(ig,jpl) + fpl * &
+                 (fracrefa(ig,jpl+1)-fracrefa(ig,jpl))
+         enddo
+
+      else
+         do ig = 1, ng12
+            taug(iplon,lay,ngs11+ig) = 0.0
+            fracsd(iplon,lay,ngs11+ig) = 0.0
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb12g
+
+!----------------------------------------------------------------------------
+      subroutine taugb13g( ncol, nlayers, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                 )
+!----------------------------------------------------------------------------
+!
+! band 13: 2080-2250 cm-1 (low key - h2o,n2o; high minor - o3 minor)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng13, ngs12
+      use parrrtm_f, only : ngs12
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg13_f
+! ------- Declarations -------
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: lay, ind0, ind1, inds, indf, indm, ig
+      integer :: js, js1, jmco2, jmco, jpl
+      real :: speccomb, specparm, specmult, fs
+      real :: speccomb1, specparm1, specmult1, fs1
+      real :: speccomb_mco2, specparm_mco2, specmult_mco2, fmco2
+      real :: speccomb_mco, specparm_mco, specmult_mco, fmco
+      real :: speccomb_planck, specparm_planck, specmult_planck, fpl
+      real :: p, p4, fk0, fk1, fk2
+      real :: fac000, fac100, fac200, fac010, fac110, fac210
+      real :: fac001, fac101, fac201, fac011, fac111, fac211
+      real :: tauself, taufor, co2m1, co2m2, absco2
+      real :: com1, com2, absco, abso3
+      real :: chi_co2, ratco2, adjfac, adjcolco2
+      real :: refrat_planck_a, refrat_m_a, refrat_m_a3
+      real :: tau_major, tau_major1
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present) async(13)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Minor gas mapping levels :
+! lower - co2, p = 1053.63 mb, t = 294.2 k
+! lower - co, p = 706 mb, t = 278.94 k
+! upper - o3, p = 95.5835 mb, t = 215.7 k
+
+! Calculate reference ratio to be used in calculation of Planck
+! fraction in lower/upper atmosphere.
+
+! P = 473.420 mb (Level 5)
+      refrat_planck_a = chi_mls(1,5)/chi_mls(4,5)
+
+! P = 1053. (Level 1)
+      refrat_m_a = chi_mls(1,1)/chi_mls(4,1)
+
+! P = 706. (Level 3)
+      refrat_m_a3 = chi_mls(1,3)/chi_mls(4,3)
+
+! Compute the optical depth by interpolating in ln(pressure),
+! temperature, and appropriate species. Below laytrop, the water
+! vapor self-continuum and foreign continuum is interpolated
+! (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+
+         speccomb = colh2o(iplon,lay) + rat_h2on2o(iplon,lay)*coln2o(iplon,lay)
+         specparm = colh2o(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colh2o(iplon,lay) + rat_h2on2o_1(iplon,lay)*coln2o(iplon,lay)
+         specparm1 = colh2o(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 8. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         speccomb_mco2 = colh2o(iplon,lay) + refrat_m_a*coln2o(iplon,lay)
+         specparm_mco2 = colh2o(iplon,lay)/speccomb_mco2
+         if (specparm_mco2 .ge. oneminusd) specparm_mco2 = oneminusd
+         specmult_mco2 = 8. *specparm_mco2
+         jmco2 = 1 + int(specmult_mco2)
+         fmco2 = mod(specmult_mco2,1.0 )
+
+! In atmospheres where the amount of CO2 is too great to be considered
+! a minor species, adjust the column amount of CO2 by an empirical factor
+! to obtain the proper contribution.
+         chi_co2 = colco2(iplon,lay)/(coldry(iplon,lay))
+         ratco2 = 1.e20 *chi_co2/3.55e-4
+         if (ratco2 .gt. 3.0 ) then
+            adjfac = 2.0 +(ratco2-2.0 )**0.68
+            adjcolco2 = adjfac*3.55e-4*coldry(iplon,lay)*1.e-20
+         else
+            adjcolco2 = colco2(iplon,lay)
+         endif
+
+         speccomb_mco = colh2o(iplon,lay) + refrat_m_a3*coln2o(iplon,lay)
+         specparm_mco = colh2o(iplon,lay)/speccomb_mco
+         if (specparm_mco .ge. oneminusd) specparm_mco = oneminusd
+         specmult_mco = 8. *specparm_mco
+         jmco = 1 + int(specmult_mco)
+         fmco = mod(specmult_mco,1.0 )
+
+         speccomb_planck = colh2o(iplon,lay)+refrat_planck_a*coln2o(iplon,lay)
+         specparm_planck = colh2o(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 8. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(13) + js
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(13) + js1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+
+         if (specparm .lt. 0.125 ) then
+            p = fs - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else if (specparm .gt. 0.875 ) then
+            p = -fs
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else
+            fac000 = (1. - fs) * fac00(iplon,lay)
+            fac010 = (1. - fs) * fac10(iplon,lay)
+            fac100 = fs * fac00(iplon,lay)
+            fac110 = fs * fac10(iplon,lay)
+         endif
+
+         if (specparm1 .lt. 0.125 ) then
+            p = fs1 - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else if (specparm1 .gt. 0.875 ) then
+            p = -fs1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else
+            fac001 = (1. - fs1) * fac01(iplon,lay)
+            fac011 = (1. - fs1) * fac11(iplon,lay)
+            fac101 = fs1 * fac01(iplon,lay)
+            fac111 = fs1 * fac11(iplon,lay)
+         endif
+
+         do ig = 1, ng13
+            tauself = selffac(iplon,lay)* (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            co2m1 = ka_mco2(jmco2,indm,ig) + fmco2 * &
+                 (ka_mco2(jmco2+1,indm,ig) - ka_mco2(jmco2,indm,ig))
+            co2m2 = ka_mco2(jmco2,indm+1,ig) + fmco2 * &
+                 (ka_mco2(jmco2+1,indm+1,ig) - ka_mco2(jmco2,indm+1,ig))
+            absco2 = co2m1 + minorfrac(iplon,lay) * (co2m2 - co2m1)
+            com1 = ka_mco(jmco,indm,ig) + fmco * &
+                 (ka_mco(jmco+1,indm,ig) - ka_mco(jmco,indm,ig))
+            com2 = ka_mco(jmco,indm+1,ig) + fmco * &
+                 (ka_mco(jmco+1,indm+1,ig) - ka_mco(jmco,indm+1,ig))
+            absco = com1 + minorfrac(iplon,lay) * (com2 - com1)
+
+            if (specparm .lt. 0.125 ) then
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac200 * absa(ind0+2,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig) + &
+                    fac210 * absa(ind0+11,ig))
+            else if (specparm .gt. 0.875 ) then
+               tau_major = speccomb * &
+                    (fac200 * absa(ind0-1,ig) + &
+                    fac100 * absa(ind0,ig) + &
+                    fac000 * absa(ind0+1,ig) + &
+                    fac210 * absa(ind0+8,ig) + &
+                    fac110 * absa(ind0+9,ig) + &
+                    fac010 * absa(ind0+10,ig))
+            else
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig))
+            endif
+
+            if (specparm1 .lt. 0.125 ) then
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac201 * absa(ind1+2,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig) + &
+                    fac211 * absa(ind1+11,ig))
+            else if (specparm1 .gt. 0.875 ) then
+               tau_major1 = speccomb1 * &
+                    (fac201 * absa(ind1-1,ig) + &
+                    fac101 * absa(ind1,ig) + &
+                    fac001 * absa(ind1+1,ig) + &
+                    fac211 * absa(ind1+8,ig) + &
+                    fac111 * absa(ind1+9,ig) + &
+                    fac011 * absa(ind1+10,ig))
+            else
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig))
+            endif
+
+            taug(iplon,lay,ngs12+ig) = tau_major + tau_major1 &
+                 + tauself + taufor &
+                 + adjcolco2*absco2 &
+                 + colco(iplon,lay)*absco
+            fracsd(iplon,lay,ngs12+ig) = fracrefa(ig,jpl) + fpl * &
+                 (fracrefa(ig,jpl+1)-fracrefa(ig,jpl))
+         enddo
+      else
+         indm = indminor(iplon,lay)
+         do ig = 1, ng13
+            abso3 = kb_mo3(indm,ig) + minorfrac(iplon,lay) * &
+                 (kb_mo3(indm+1,ig) - kb_mo3(indm,ig))
+            taug(iplon,lay,ngs12+ig) = colo3(iplon,lay)*abso3
+            fracsd(iplon,lay,ngs12+ig) = fracrefb(ig)
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb13g
+
+!----------------------------------------------------------------------------
+      subroutine taugb14g( ncol, nlayers , taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                 )
+!----------------------------------------------------------------------------
+!
+! band 14: 2250-2380 cm-1 (low - co2; high - co2)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng14, ngs13
+      use parrrtm_f, only : ngs13
+      use rrlw_kg14_f
+
+! ------- Declarations -------
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: lay, ind0, ind1, inds, indf, ig
+      real :: tauself, taufor
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present)  async(14)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Compute the optical depth by interpolating in ln(pressure) and
+! temperature. Below laytrop, the water vapor self-continuum
+! and foreign continuum is interpolated (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(14) + 1
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(14) + 1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         do ig = 1, ng14
+            tauself = selffac(iplon,lay) * (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            taug(iplon,lay,ngs13+ig) = colco2(iplon,lay) * &
+                 (fac00(iplon,lay) * absa(ind0,ig) + &
+                 fac10(iplon,lay) * absa(ind0+1,ig) + &
+                 fac01(iplon,lay) * absa(ind1,ig) + &
+                 fac11(iplon,lay) * absa(ind1+1,ig)) &
+                 + tauself + taufor
+            fracsd(iplon,lay,ngs13+ig) = fracrefa(ig)
+         enddo
+      else
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd(14) + 1
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd(14) + 1
+         do ig = 1, ng14
+            taug(iplon,lay,ngs13+ig) = colco2(iplon,lay) * &
+                 (fac00(iplon,lay) * absb(ind0,ig) + &
+                 fac10(iplon,lay) * absb(ind0+1,ig) + &
+                 fac01(iplon,lay) * absb(ind1,ig) + &
+                 fac11(iplon,lay) * absb(ind1+1,ig))
+            fracsd(iplon,lay,ngs13+ig) = fracrefb(ig)
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb14g
+
+!----------------------------------------------------------------------------
+      subroutine taugb15g( ncol, nlayers , taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                 )
+!----------------------------------------------------------------------------
+!
+! band 15: 2380-2600 cm-1 (low - n2o,co2; low minor - n2)
+! (high - nothing)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng15, ngs14
+      use parrrtm_f, only : ngs14
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg15_f
+
+! ------- Declarations -------
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: lay, ind0, ind1, inds, indf, indm, ig
+      integer :: js, js1, jmn2, jpl
+      real :: speccomb, specparm, specmult, fs
+      real :: speccomb1, specparm1, specmult1, fs1
+      real :: speccomb_mn2, specparm_mn2, specmult_mn2, fmn2
+      real :: speccomb_planck, specparm_planck, specmult_planck, fpl
+      real :: p, p4, fk0, fk1, fk2
+      real :: fac000, fac100, fac200, fac010, fac110, fac210
+      real :: fac001, fac101, fac201, fac011, fac111, fac211
+      real :: scalen2, tauself, taufor, n2m1, n2m2, taun2
+      real :: refrat_planck_a, refrat_m_a
+      real :: tau_major, tau_major1
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present) async(15)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Minor gas mapping level :
+! Lower - Nitrogen Continuum, P = 1053., T = 294.
+
+! Calculate reference ratio to be used in calculation of Planck
+! fraction in lower atmosphere.
+! P = 1053. mb (Level 1)
+      refrat_planck_a = chi_mls(4,1)/chi_mls(2,1)
+
+! P = 1053.
+      refrat_m_a = chi_mls(4,1)/chi_mls(2,1)
+
+! Compute the optical depth by interpolating in ln(pressure),
+! temperature, and appropriate species. Below laytrop, the water
+! vapor self-continuum and foreign continuum is interpolated
+! (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+
+         speccomb = coln2o(iplon,lay) + rat_n2oco2(iplon,lay)*colco2(iplon,lay)
+         specparm = coln2o(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = coln2o(iplon,lay) + rat_n2oco2_1(iplon,lay)*colco2(iplon,lay)
+         specparm1 = coln2o(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 8. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         speccomb_mn2 = coln2o(iplon,lay) + refrat_m_a*colco2(iplon,lay)
+         specparm_mn2 = coln2o(iplon,lay)/speccomb_mn2
+         if (specparm_mn2 .ge. oneminusd) specparm_mn2 = oneminusd
+         specmult_mn2 = 8. *specparm_mn2
+         jmn2 = 1 + int(specmult_mn2)
+         fmn2 = mod(specmult_mn2,1.0 )
+
+         speccomb_planck = coln2o(iplon,lay)+refrat_planck_a*colco2(iplon,lay)
+         specparm_planck = coln2o(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 8. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(15) + js
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(15) + js1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         indm = indminor(iplon,lay)
+
+         scalen2 = colbrd(iplon,lay)*scaleminor(iplon,lay)
+
+         if (specparm .lt. 0.125 ) then
+            p = fs - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else if (specparm .gt. 0.875 ) then
+            p = -fs
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else
+            fac000 = (1. - fs) * fac00(iplon,lay)
+            fac010 = (1. - fs) * fac10(iplon,lay)
+            fac100 = fs * fac00(iplon,lay)
+            fac110 = fs * fac10(iplon,lay)
+         endif
+         if (specparm1 .lt. 0.125 ) then
+            p = fs1 - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else if (specparm1 .gt. 0.875 ) then
+            p = -fs1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else
+            fac001 = (1. - fs1) * fac01(iplon,lay)
+            fac011 = (1. - fs1) * fac11(iplon,lay)
+            fac101 = fs1 * fac01(iplon,lay)
+            fac111 = fs1 * fac11(iplon,lay)
+         endif
+
+         do ig = 1, ng15
+            tauself = selffac(iplon,lay)* (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+            n2m1 = ka_mn2(jmn2,indm,ig) + fmn2 * &
+                 (ka_mn2(jmn2+1,indm,ig) - ka_mn2(jmn2,indm,ig))
+            n2m2 = ka_mn2(jmn2,indm+1,ig) + fmn2 * &
+                 (ka_mn2(jmn2+1,indm+1,ig) - ka_mn2(jmn2,indm+1,ig))
+            taun2 = scalen2 * (n2m1 + minorfrac(iplon,lay) * (n2m2 - n2m1))
+
+            if (specparm .lt. 0.125 ) then
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac200 * absa(ind0+2,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig) + &
+                    fac210 * absa(ind0+11,ig))
+            else if (specparm .gt. 0.875 ) then
+               tau_major = speccomb * &
+                    (fac200 * absa(ind0-1,ig) + &
+                    fac100 * absa(ind0,ig) + &
+                    fac000 * absa(ind0+1,ig) + &
+                    fac210 * absa(ind0+8,ig) + &
+                    fac110 * absa(ind0+9,ig) + &
+                    fac010 * absa(ind0+10,ig))
+            else
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig))
+            endif
+
+            if (specparm1 .lt. 0.125 ) then
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac201 * absa(ind1+2,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig) + &
+                    fac211 * absa(ind1+11,ig))
+            else if (specparm1 .gt. 0.875 ) then
+               tau_major1 = speccomb1 * &
+                    (fac201 * absa(ind1-1,ig) + &
+                    fac101 * absa(ind1,ig) + &
+                    fac001 * absa(ind1+1,ig) + &
+                    fac211 * absa(ind1+8,ig) + &
+                    fac111 * absa(ind1+9,ig) + &
+                    fac011 * absa(ind1+10,ig))
+            else
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig))
+            endif
+
+            taug(iplon,lay,ngs14+ig) = tau_major + tau_major1 &
+                 + tauself + taufor &
+                 + taun2
+            fracsd(iplon,lay,ngs14+ig) = fracrefa(ig,jpl) + fpl * &
+                 (fracrefa(ig,jpl+1)-fracrefa(ig,jpl))
+         enddo
+
+      else
+         do ig = 1, ng15
+            taug(iplon,lay,ngs14+ig) = 0.0
+            fracsd(iplon,lay,ngs14+ig) = 0.0
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb15g
+
+!----------------------------------------------------------------------------
+      subroutine taugb16g( ncol, nlayers , taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                 )
+!----------------------------------------------------------------------------
+!
+! band 16: 2600-3250 cm-1 (low key- h2o,ch4; high key - ch4)
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parrrtm_f, only : ng16, ngs15
+      use parrrtm_f, only : ngs15
+      use rrlw_ref_f, only : chi_mls
+      use rrlw_kg16_f
+
+! ------- Declarations -------
+      real :: taug(:,:,:)
+      real :: fracsd(:,:,:)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! Local
+      integer :: lay, ind0, ind1, inds, indf, ig
+      integer :: js, js1, jpl
+      real :: speccomb, specparm, specmult, fs
+      real :: speccomb1, specparm1, specmult1, fs1
+      real :: speccomb_planck, specparm_planck, specmult_planck, fpl
+      real :: p, p4, fk0, fk1, fk2
+      real :: fac000, fac100, fac200, fac010, fac110, fac210
+      real :: fac001, fac101, fac201, fac011, fac111, fac211
+      real :: tauself, taufor
+      real :: refrat_planck_a
+      real :: tau_major, tau_major1
+      integer , value, intent(in) :: ncol, nlayers
+      integer :: iplon
+
+
+
+
+
+
+!$acc kernels default(present)  async(16)
+!$acc loop independent
+      do iplon = 1, ncol
+!$acc loop independent
+      do lay = 1, nlayers
+
+! Calculate reference ratio to be used in calculation of Planck
+! fraction in lower atmosphere.
+
+! P = 387. mb (Level 6)
+      refrat_planck_a = chi_mls(1,6)/chi_mls(6,6)
+
+! Compute the optical depth by interpolating in ln(pressure),
+! temperature,and appropriate species. Below laytrop, the water
+! vapor self-continuum and foreign continuum is interpolated
+! (in temperature) separately.
+
+! Lower atmosphere loop
+      if (lay <= laytrop(iplon)) then
+         speccomb = colh2o(iplon,lay) + rat_h2och4(iplon,lay)*colch4(iplon,lay)
+         specparm = colh2o(iplon,lay)/speccomb
+         if (specparm .ge. oneminusd) specparm = oneminusd
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult,1.0 )
+
+         speccomb1 = colh2o(iplon,lay) + rat_h2och4_1(iplon,lay)*colch4(iplon,lay)
+         specparm1 = colh2o(iplon,lay)/speccomb1
+         if (specparm1 .ge. oneminusd) specparm1 = oneminusd
+         specmult1 = 8. *(specparm1)
+         js1 = 1 + int(specmult1)
+         fs1 = mod(specmult1,1.0 )
+
+         speccomb_planck = colh2o(iplon,lay)+refrat_planck_a*colch4(iplon,lay)
+         specparm_planck = colh2o(iplon,lay)/speccomb_planck
+         if (specparm_planck .ge. oneminusd) specparm_planck=oneminusd
+         specmult_planck = 8. *specparm_planck
+         jpl= 1 + int(specmult_planck)
+         fpl = mod(specmult_planck,1.0 )
+
+         ind0 = ((jp(iplon,lay)-1)*5+(jt(iplon,lay)-1))*nspad(16) + js
+         ind1 = (jp(iplon,lay)*5+(jt1(iplon,lay)-1))*nspad(16) + js1
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+
+         if (specparm .lt. 0.125 ) then
+            p = fs - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else if (specparm .gt. 0.875 ) then
+            p = -fs
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac000 = fk0*fac00(iplon,lay)
+            fac100 = fk1*fac00(iplon,lay)
+            fac200 = fk2*fac00(iplon,lay)
+            fac010 = fk0*fac10(iplon,lay)
+            fac110 = fk1*fac10(iplon,lay)
+            fac210 = fk2*fac10(iplon,lay)
+         else
+            fac000 = (1. - fs) * fac00(iplon,lay)
+            fac010 = (1. - fs) * fac10(iplon,lay)
+            fac100 = fs * fac00(iplon,lay)
+            fac110 = fs * fac10(iplon,lay)
+         endif
+
+         if (specparm1 .lt. 0.125 ) then
+            p = fs1 - 1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else if (specparm1 .gt. 0.875 ) then
+            p = -fs1
+            p4 = p**4
+            fk0 = p4
+            fk1 = 1 - p - 2.0 *p4
+            fk2 = p + p4
+            fac001 = fk0*fac01(iplon,lay)
+            fac101 = fk1*fac01(iplon,lay)
+            fac201 = fk2*fac01(iplon,lay)
+            fac011 = fk0*fac11(iplon,lay)
+            fac111 = fk1*fac11(iplon,lay)
+            fac211 = fk2*fac11(iplon,lay)
+         else
+            fac001 = (1. - fs1) * fac01(iplon,lay)
+            fac011 = (1. - fs1) * fac11(iplon,lay)
+            fac101 = fs1 * fac01(iplon,lay)
+            fac111 = fs1 * fac11(iplon,lay)
+         endif
+
+         do ig = 1, ng16
+            tauself = selffac(iplon,lay)* (selfref(inds,ig) + selffrac(iplon,lay) * &
+                 (selfref(inds+1,ig) - selfref(inds,ig)))
+            taufor = forfac(iplon,lay) * (forref(indf,ig) + forfrac(iplon,lay) * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+
+            if (specparm .lt. 0.125 ) then
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac200 * absa(ind0+2,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig) + &
+                    fac210 * absa(ind0+11,ig))
+            else if (specparm .gt. 0.875 ) then
+               tau_major = speccomb * &
+                    (fac200 * absa(ind0-1,ig) + &
+                    fac100 * absa(ind0,ig) + &
+                    fac000 * absa(ind0+1,ig) + &
+                    fac210 * absa(ind0+8,ig) + &
+                    fac110 * absa(ind0+9,ig) + &
+                    fac010 * absa(ind0+10,ig))
+            else
+               tau_major = speccomb * &
+                    (fac000 * absa(ind0,ig) + &
+                    fac100 * absa(ind0+1,ig) + &
+                    fac010 * absa(ind0+9,ig) + &
+                    fac110 * absa(ind0+10,ig))
+            endif
+
+            if (specparm1 .lt. 0.125 ) then
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac201 * absa(ind1+2,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig) + &
+                    fac211 * absa(ind1+11,ig))
+            else if (specparm1 .gt. 0.875 ) then
+               tau_major1 = speccomb1 * &
+                    (fac201 * absa(ind1-1,ig) + &
+                    fac101 * absa(ind1,ig) + &
+                    fac001 * absa(ind1+1,ig) + &
+                    fac211 * absa(ind1+8,ig) + &
+                    fac111 * absa(ind1+9,ig) + &
+                    fac011 * absa(ind1+10,ig))
+            else
+               tau_major1 = speccomb1 * &
+                    (fac001 * absa(ind1,ig) + &
+                    fac101 * absa(ind1+1,ig) + &
+                    fac011 * absa(ind1+9,ig) + &
+                    fac111 * absa(ind1+10,ig))
+            endif
+
+            taug(iplon,lay,ngs15+ig) = tau_major + tau_major1 &
+                 + tauself + taufor
+            fracsd(iplon,lay,ngs15+ig) = fracrefa(ig,jpl) + fpl * &
+                 (fracrefa(ig,jpl+1)-fracrefa(ig,jpl))
+         enddo
+      else
+         ind0 = ((jp(iplon,lay)-13)*5+(jt(iplon,lay)-1))*nspbd(16) + 1
+         ind1 = ((jp(iplon,lay)-12)*5+(jt1(iplon,lay)-1))*nspbd(16) + 1
+         do ig = 1, ng16
+            taug(iplon,lay,ngs15+ig) = colch4(iplon,lay) * &
+                 (fac00(iplon,lay) * absb(ind0,ig) + &
+                 fac10(iplon,lay) * absb(ind0+1,ig) + &
+                 fac01(iplon,lay) * absb(ind1,ig) + &
+                 fac11(iplon,lay) * absb(ind1+1,ig))
+            fracsd(iplon,lay,ngs15+ig) = fracrefb(ig)
+         enddo
+      endif
+
+
+
+
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine taugb16g
+
+      subroutine addAerosols( ncol, nlayers, ngptlw, nbndlw, ngbd, taug &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                                    )
+
+      integer , intent(in), value :: ncol, nlayers, ngptlw, nbndlw
+      integer , intent(in) :: ngbd(:)
+
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+      integer :: iplon, lay, ig
+      real :: taug(:,:,:)
+
+
+
+
+
+
+
+!$acc kernels
+      do iplon = 1, ncol
+      do lay = 1, nlayers
+      do ig = 1, ngptlw
+
+
+        taug(iplon, lay, ig) = taug(iplon, lay, ig) + tauaa(iplon, lay, ngbd(ig))
+
+
+
+
+      end do
+      end do
+      end do
+!$acc end kernels
+
+
+      end subroutine
+
+!----------------------------------------------------------------------------
+      subroutine taumolg(iplon, ncol, nlayers, ngbd, taug, fracsd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+                        )
+!----------------------------------------------------------------------------
+
+! *******************************************************************************
+! * *
+! * Optical depths developed for the *
+! * *
+! * RAPID RADIATIVE TRANSFER MODEL (RRTM) *
+! * *
+! * *
+! * ATMOSPHERIC AND ENVIRONMENTAL RESEARCH, INC. *
+! * 131 HARTWELL AVENUE *
+! * LEXINGTON, MA 02421 *
+! * *
+! * *
+! * ELI J. MLAWER *
+! * JENNIFER DELAMERE *
+! * STEVEN J. TAUBMAN *
+! * SHEPARD A. CLOUGH *
+! * *
+! * *
+! * *
+! * *
+! * email: mlawer@aer.com *
+! * email: jdelamer@aer.com *
+! * *
+! * The authors wish to acknowledge the contributions of the *
+! * following people: Karen Cady-Pereira, Patrick D. Brown, *
+! * Michael J. Iacono, Ronald E. Farren, Luke Chen, Robert Bergstrom. *
+! * *
+! *******************************************************************************
+! * *
+! * Revision for g-point reduction: Michael J. Iacono, AER, Inc. *
+! * *
+! *******************************************************************************
+! * TAUMOL *
+! * *
+! * This file contains the subroutines TAUGBn (where n goes from *
+! * 1 to 16). TAUGBn calculates the optical depths and Planck fractions *
+! * per g-value and layer for band n. *
+! * *
+! * Output: optical depths (unitless) *
+! * fractions needed to compute Planck functions at every layer *
+! * and g-value *
+! * *
+! * COMMON /TAUGCOM/ TAUG(MXLAY,MG) *
+! * COMMON /PLANKG/ fracsd(MXLAY,MG) *
+! * *
+! * Input *
+! * *
+! * COMMON /FEATURES/ NG(NBANDS),NSPA(NBANDS),NSPB(NBANDS) *
+! * COMMON /PRECISE/ oneminusd *
+! * COMMON /PROFILE/ NLAYERS,PAVEL(MXLAY),TAVEL(MXLAY), *
+! * & PZ(0:MXLAY),TZ(0:MXLAY) *
+! * COMMON /PROFDATA/ LAYTROP, *
+! * & COLH2O(MXLAY),COLCO2(MXLAY),COLO3(MXLAY), *
+! * & COLN2O(MXLAY),colco(MXLAY),COLCH4(MXLAY), *
+! * & COLO2(MXLAY)
+! * COMMON /INTFAC/ fac00(iplon,MXLAY),fac01(iplon,MXLAY), *
+! * & FAC10(MXLAY),fac11(iplon,MXLAY) *
+! * COMMON /INTIND/ JP(MXLAY),JT(MXLAY),JT1(MXLAY) *
+! * COMMON /SELF/ SELFFAC(MXLAY), SELFFRAC(MXLAY), INDSELF(MXLAY) *
+! * *
+! * Description: *
+! * NG(IBAND) - number of g-values in band IBAND *
+! * NSPA(IBAND) - for the lower atmosphere, the number of reference *
+! * atmospheres that are stored for band IBAND per *
+! * pressure level and temperature. Each of these *
+! * atmospheres has different relative amounts of the *
+! * key species for the band (i.e. different binary *
+! * species parameters). *
+! * NSPB(IBAND) - same for upper atmosphere *
+! * oneminusd - since problems are caused in some cases by interpolation *
+! * parameters equal to or greater than 1, for these cases *
+! * these parameters are set to this value, slightly < 1. *
+! * PAVEL - layer pressures (mb) *
+! * TAVEL - layer temperatures (degrees K) *
+! * PZ - level pressures (mb) *
+! * TZ - level temperatures (degrees K) *
+! * LAYTROP - layer at which switch is made from one combination of *
+! * key species to another *
+! * COLH2O, COLCO2, COLO3, COLN2O, COLCH4 - column amounts of water *
+! * vapor,carbon dioxide, ozone, nitrous ozide, methane, *
+! * respectively (molecules/cm**2) *
+! * FACij(LAY) - for layer LAY, these are factors that are needed to *
+! * compute the interpolation factors that multiply the *
+! * appropriate reference k-values. A value of 0 (1) for *
+! * i,j indicates that the corresponding factor multiplies *
+! * reference k-value for the lower (higher) of the two *
+! * appropriate temperatures, and altitudes, respectively. *
+! * JP - the index of the lower (in altitude) of the two appropriate *
+! * reference pressure levels needed for interpolation *
+! * JT, JT1 - the indices of the lower of the two appropriate reference *
+! * temperatures needed for interpolation (for pressure *
+! * levels JP and JP+1, respectively) *
+! * SELFFAC - scale factor needed for water vapor self-continuum, equals *
+! * (water vapor density)/(atmospheric density at 296K and *
+! * 1013 mb) *
+! * SELFFRAC - factor needed for temperature interpolation of reference *
+! * water vapor self-continuum data *
+! * INDSELF - index of the lower of the two appropriate reference *
+! * temperatures needed for the self-continuum interpolation *
+! * FORFAC - scale factor needed for water vapor foreign-continuum. *
+! * FORFRAC - factor needed for temperature interpolation of reference *
+! * water vapor foreign-continuum data *
+! * INDFOR - index of the lower of the two appropriate reference *
+! * temperatures needed for the foreign-continuum interpolation *
+! * *
+! * Data input *
+! * COMMON /Kn/ KA(NSPA(n),5,13,MG), KB(NSPB(n),5,13:59,MG), SELFREF(10,MG),*
+! * FORREF(4,MG), KA_M'MGAS', KB_M'MGAS' *
+! * (note: n is the band number,'MGAS' is the species name of the minor *
+! * gas) *
+! * *
+! * Description: *
+! * KA - k-values for low reference atmospheres (key-species only) *
+! * (units: cm**2/molecule) *
+! * KB - k-values for high reference atmospheres (key-species only) *
+! * (units: cm**2/molecule) *
+! * KA_M'MGAS' - k-values for low reference atmosphere minor species *
+! * (units: cm**2/molecule) *
+! * KB_M'MGAS' - k-values for high reference atmosphere minor species *
+! * (units: cm**2/molecule) *
+! * SELFREF - k-values for water vapor self-continuum for reference *
+! * atmospheres (used below LAYTROP) *
+! * (units: cm**2/molecule) *
+! * FORREF - k-values for water vapor foreign-continuum for reference *
+! * atmospheres (used below/above LAYTROP) *
+! * (units: cm**2/molecule) *
+! * *
+! * DIMENSION ABSA(65*NSPA(n),MG), ABSB(235*NSPB(n),MG) *
+! * EQUIVALENCE (KA,ABSA),(KB,ABSB) *
+! * *
+!*******************************************************************************
+
+      use parrrtm_f, only : ng1
+
+! ------- Declarations -------
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+
+! ----- Input -----
+      integer , intent(in) :: iplon ! the column number (move to calculated in kernel)
+      integer , intent(in) :: ncol ! the total number of columns
+      integer , intent(in) :: nlayers ! total number of layers
+      integer , intent(in) :: ngbd(:)
+      real , intent(in) :: fracsd(:,:,:)
+      real , intent(in) :: taug(:,:,:)
+
+      !real :: taugcc(ncol, nlayers, 140)
+
+! ----- Output -----
+
+      integer :: i,j,err
+      real :: t1, t2
+!jm this can be made constant if the arrays are padded out, otherwise
+!jm will generate a seg fault computing garbage data on unused ends of vectors
+!jm zap # define ncol CHNK
+
+
+! Calculate gaseous optical depth and planck fractions for each spectral band.
+
+! (dmb 2012) Here we configure the grid and thread blocks. These subroutines are
+! only parallelized across the column dimension so the blocks are one dimensional.
+      call taugb1g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb2g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb3g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb4g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb5g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb6g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb7g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb8g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb9g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb10g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb11g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb12g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb13g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb14g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb15g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+      call taugb16g (ncol, nlayers, taug, fracsd &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                           )
+
+
+!$acc wait
+
+
+
+! (dmb 2012) This code used to be in the main rrtmg_lw_rad source file
+! We add the aerosol optical depths to the gas optical depths
+      call addAerosols (ncol, nlayers, ngptlw, nbndlw, ngbd, taug &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__                                             &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o  &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac   &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11         &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1      &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1      &
+                    ,tauaa,nspad,nspbd,oneminusd                                                &
+                               )
+      end subroutine taumolg
+
+
+! undefines for taug functions
+!#ifndef _ACCEL
+
+!#endif
+
+! (dmb 2012) Allocate all of the needed memory for the taumol subroutines
+      subroutine allocateGPUTaumol(ncol, nlayers, npart)
+
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers
+      integer , intent(in) :: npart
+      integer :: i
+      end subroutine
+
+! (dmb 2012) Perform the necessary cleanup of the GPU arrays
+      subroutine deallocateGPUTaumol()
+      end subroutine
+
+      subroutine copyGPUTaumolMol( colstart, pncol, nlayers, colh2oc, colco2c, colo3c, coln2oc, colch4c, colo2c,&
+                                   px1,px2,px3,px4, npart)
+
+      integer, value, intent(in) :: colstart, pncol, nlayers, npart
+      real , intent(in) :: colh2oc(:,:), colco2c(:,:), colo3c(:,:), coln2oc(:,:), &
+                                     colch4c(:,:), colo2c(:,:), px1(:,:), px2(:,:), px3(:,:), px4(:,:)
+      end subroutine
+
+! (dmb 2012) Copy the needed data from the CPU to the GPU. I had to separate this
+! out into 16 separate functions to correspond with the 16 taumol subroutines.
+      subroutine copyGPUTaumol(pavelc, wxc, coldryc, tauap, pncol, colstart, nlay, npart)
+
+      use rrlw_kg01_f, only : copyToGPU1, reg1
+      use rrlw_kg02_f, only : copyToGPU2, reg2
+      use rrlw_kg03_f, only : copyToGPU3, reg3
+      use rrlw_kg04_f, only : copyToGPU4, reg4
+      use rrlw_kg05_f, only : copyToGPU5, reg5
+      use rrlw_kg06_f, only : copyToGPU6, reg6
+      use rrlw_kg07_f, only : copyToGPU7, reg7
+      use rrlw_kg08_f, only : copyToGPU8, reg8
+      use rrlw_kg09_f, only : copyToGPU9, reg9
+      use rrlw_kg10_f, only : copyToGPU10, reg10
+      use rrlw_kg11_f, only : copyToGPU11, reg11
+      use rrlw_kg12_f, only : copyToGPU12, reg12
+      use rrlw_kg13_f, only : copyToGPU13, reg13
+      use rrlw_kg14_f, only : copyToGPU14, reg14
+      use rrlw_kg15_f, only : copyToGPU15, reg15
+      use rrlw_kg16_f, only : copyToGPU16, reg16
+      use rrlw_ref_f, only : copyToGPUref
+
+      real , intent(in) :: pavelc(:,:) ! layer pressures (mb)
+                                                      ! Dimensions: (ncol,nlayers)
+      real , intent(in) :: wxc(:,:,:) ! cross-section amounts (mol/cm2)
+                                                      ! Dimensions: (ncol,maxxsec,nlayers)
+      real , intent(in) :: coldryc(:,:) ! column amount (dry air)
+                                                      ! Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: tauap(:,:,:)
+                                                      ! Dimensions: (ncol,nlayers,ngptlw)
+      integer, intent(in) :: pncol, colstart, nlay, npart
+      end subroutine
+
+      end module gpu_rrtmg_lw_taumol
+
+! This is the gpu version of the setcoef routine.
+      module gpu_rrtmg_lw_setcoef
+
+      use gpu_rrtmg_lw_rtrnmc
+
+      use parrrtm_f, only : nbndlw, mg, maxxsec, mxmol
+      use rrlw_wvn_f, only: totplnk, totplk16, totplnkderiv, totplk16deriv
+      use rrlw_vsn_f, only: hvrset, hnamset
+      use rrlw_ref_f, only : chi_mls
+
+      use gpu_rrtmg_lw_taumol
+
+      implicit none
+      contains
+
+! (dmb 2012) This subroutine allocates the needed GPU arrays
+      subroutine allocateGPUSetCoef( ncol, nlayers )
+
+         integer, intent(in) :: ncol
+         integer, intent(in) :: nlayers
+
+
+
+
+
+
+
+      end subroutine
+
+! (dmb 2012) This subroutine deallocates the GPU arrays
+      subroutine deallocateGPUSetCoef( )
+      end subroutine
+
+! (dmb 2012) Copy the needed reference data from the CPU to the GPU
+      subroutine copyGPUSetCoef()
+      end subroutine
+
+!----------------------------------------------------------------------------
+      subroutine setcoefg(ncol, nlayers, istart &
+
+         ,ncol_,nlayers_,nbndlw_,ngptlw_ &
+         ,taucmcd,pzd,pwvcmd,semissd,planklayd,planklevd,plankbndd,gurad,gdrad,gclrurad,gclrdrad &
+         ,gdtotuflux_dtd,gdtotuclfl_dtd,idrvd,bpaded,heatfacd,fluxfacd,a0d,a1d,a2d &
+         ,delwaved,totufluxd,totdfluxd,fnetd,htrd,totuclfld,totdclfld,fnetcd,htrcd,dtotuflux_dtd &
+         ,dtotuclfl_dtd,dplankbnd_dtd &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspad,nspbd,oneminusd &
+
+   ,taveld,tzd,tboundd,wbroadd,totplnkd,totplk16d,totplnkderivd,totplk16derivd &
+
+                                 )
+!----------------------------------------------------------------------------
+!
+! Purpose: For a given atmosphere, calculate the indices and
+! fractions related to the pressure and temperature interpolations.
+! Also calculate the values of the integrated Planck functions
+! for each band at the level and layer temperatures.
+
+! ------- Declarations -------
+
+
+      integer :: ncol_,nlayers_,nbndlw_,ngptlw_
+! changed to arguments for thread safety
+
+
+
+      integer :: ngsd(nbndlw)
+
+! Atmosphere
+      real :: taucmcd(CHNK, ngptlw_, nlayers_+1)
+
+      real , dimension(CHNK, 0:nlayers_+1) :: pzd ! level (interface) pressures (hPa, mb)
+                                                        ! Dimensions: (ncol,0:nlayers)
+      real , dimension(CHNK) :: pwvcmd ! precipitable water vapor (cm)
+                                                        ! Dimensions: (ncol)
+      real , dimension(CHNK,nbndlw_) :: semissd ! lw surface emissivity
+                                                        ! Dimensions: (ncol,nbndlw)
+      real , dimension(CHNK,nlayers_+1,nbndlw_) :: planklayd !
+                                                        ! Dimensions: (ncol,nlayers+1,nbndlw)
+      real , dimension(CHNK,0:nlayers_+1,nbndlw_) :: planklevd !
+                                                        ! Dimensions: (ncol,0:nlayers+1,nbndlw)
+      real, dimension(CHNK,nbndlw_) :: plankbndd !
+                                                        ! Dimensions: (ncol,nbndlw)
+
+      real :: gurad(CHNK,ngptlw_,0:nlayers_+1) ! upward longwave flux (w/m2)
+      real :: gdrad(CHNK,ngptlw_,0:nlayers_+1) ! downward longwave flux (w/m2)
+      real :: gclrurad(CHNK,ngptlw_,0:nlayers_+1) ! clear sky upward longwave flux (w/m2)
+      real :: gclrdrad(CHNK,ngptlw_,0:nlayers_+1) ! clear sky downward longwave flux (w/m2)
+
+      real :: gdtotuflux_dtd(CHNK, ngptlw_, 0:nlayers_+1) ! change in upward longwave flux (w/m1/k)
+                                     ! with respect to surface temperature
+
+      real :: gdtotuclfl_dtd(CHNK, ngptlw_, 0:nlayers_+1) ! change in clear sky upward longwave flux (w/m2/k)
+                                     ! with respect to surface temperature
+
+! Clouds
+      integer :: idrvd ! flag for calculation of dF/dt from
+                                                      ! Planck derivative [0=off, 1=on]
+      real :: bpaded
+      real :: heatfacd
+      real :: fluxfacd
+      real :: a0d(nbndlw_), a1d(nbndlw_), a2d(nbndlw_)
+      real :: delwaved(nbndlw_)
+      real :: totufluxd(CHNK, 0:nlayers_+1) ! upward longwave flux (w/m2)
+      real :: totdfluxd(CHNK, 0:nlayers_+1) ! downward longwave flux (w/m2)
+      real :: fnetd(CHNK, 0:nlayers_+1) ! net longwave flux (w/m2)
+      real :: htrd(CHNK, 0:nlayers_+1) ! longwave heating rate (k/day)
+      real :: totuclfld(CHNK, 0:nlayers_+1) ! clear sky upward longwave flux (w/m2)
+      real :: totdclfld(CHNK, 0:nlayers_+1) ! clear sky downward longwave flux (w/m2)
+      real :: fnetcd(CHNK, 0:nlayers_+1) ! clear sky net longwave flux (w/m2)
+      real :: htrcd(CHNK, 0:nlayers_+1) ! clear sky longwave heating rate (k/day)
+      real :: dtotuflux_dtd(CHNK, 0:nlayers_+1) ! change in upward longwave flux (w/m2/k)
+                                                       ! with respect to surface temperature
+      real :: dtotuclfl_dtd(CHNK, 0:nlayers_+1) ! change in clear sky upward longwave flux (w/m2/k)
+                                                       ! with respect to surface temperature
+      real :: dplankbnd_dtd(CHNK,nbndlw_)
+
+      integer :: ncol__,nlayers__,nbndlw__,ngptlw__
+! changed to arguments for thread safety (could reduce this list a bit)
+
+
+
+      real :: pavel(CHNK, nlayers__)
+      real :: wx1(CHNK,nlayers__)
+      real :: wx2(CHNK,nlayers__)
+      real :: wx3(CHNK,nlayers__)
+      real :: wx4(CHNK,nlayers__)
+      real :: coldry(CHNK, nlayers__)
+      integer :: laytrop(CHNK)
+      integer :: jp(CHNK,nlayers__)
+      integer :: jt(CHNK,nlayers__)
+      integer :: jt1(CHNK,nlayers__)
+      real :: colh2o(CHNK,nlayers__)
+      real :: colco2(CHNK,nlayers__)
+      real :: colo3(CHNK,nlayers__)
+      real :: coln2o(CHNK,nlayers__)
+      real :: colco(CHNK,nlayers__)
+      real :: colch4(CHNK,nlayers__)
+      real :: colo2(CHNK,nlayers__)
+      real :: colbrd(CHNK,nlayers__)
+      integer :: indself(CHNK,nlayers__)
+      integer :: indfor(CHNK,nlayers__)
+      real :: selffac(CHNK,nlayers__)
+      real :: selffrac(CHNK,nlayers__)
+      real :: forfac(CHNK,nlayers__)
+      real :: forfrac(CHNK,nlayers__)
+      integer :: indminor(CHNK,nlayers__)
+      real :: minorfrac(CHNK,nlayers__)
+      real :: scaleminor(CHNK,nlayers__)
+      real :: scaleminorn2(CHNK,nlayers__)
+      real :: fac00(CHNK,nlayers__), fac01(CHNK,nlayers__), fac10(CHNK,nlayers__), fac11(CHNK,nlayers__)
+      real :: rat_h2oco2(CHNK,nlayers__),rat_h2oco2_1(CHNK,nlayers__), &
+               rat_h2oo3(CHNK,nlayers__),rat_h2oo3_1(CHNK,nlayers__), &
+               rat_h2on2o(CHNK,nlayers__),rat_h2on2o_1(CHNK,nlayers__), &
+               rat_h2och4(CHNK,nlayers__),rat_h2och4_1(CHNK,nlayers__), &
+               rat_n2oco2(CHNK,nlayers__),rat_n2oco2_1(CHNK,nlayers__), &
+               rat_o3co2(CHNK,nlayers__),rat_o3co2_1(CHNK,nlayers__)
+                                                      ! Dimensions: (CHNK,nlayers__)
+      real :: tauaa(CHNK, nlayers__, nbndlw__)
+                                                      ! Dimensions: (CHNK,nlayers__,ngptlw__)
+
+      integer :: nspad(nbndlw__)
+      integer :: nspbd(nbndlw__)
+      real :: oneminusd
+      real :: taveld(CHNK,nlayers+1) ! layer temperatures (K)
+                                            ! Dimensions: (ncol,nlayers)
+      real :: tzd(CHNK,0:nlayers+1) ! level (interface) temperatures (K)
+                                            ! Dimensions: (ncol,0:nlayers)
+      real :: tboundd(CHNK) ! surface temperature (K)
+                                            ! Dimensions: (ncol)
+      real :: wbroadd(CHNK,nlayers+1) ! broadening gas column density (mol/cm2)
+                                            ! Dimensions: (ncol,nlayers)
+
+      real :: totplnkd(181,nbndlw)
+      real :: totplk16d(181)
+
+      real :: totplnkderivd(181,nbndlw)
+      real :: totplk16derivd(181)
+
+
+! ----- Input -----
+      integer , value, intent(in) :: ncol
+      integer , value, intent(in) :: nlayers ! total number of layers
+      integer , value, intent(in) :: istart ! beginning band of calculation
+!jm integer , value, intent(in) :: idrv ! Planck derivative option flag
+
+! ----- Local -----
+      integer :: indbound, indlev0
+      integer :: lay, indlay, indlev, iband
+      integer :: jp1
+      real :: stpfac, tbndfrac, t0frac, tlayfrac, tlevfrac
+      real :: dbdtlev, dbdtlay
+      real :: plog, fp, ft, ft1, water, scalefac, factor, compfp
+      integer :: iplon
+      real :: wv, lcoldry,laytrop_i
+
+
+
+
+
+!$acc data pcopyin(totplnkd,totplk16d,totplnkderivd,totplk16derivd)
+!$acc kernels
+      do iplon = 1, ncol
+        laytrop(iplon) = 0
+        laytrop_i = 0;
+        do lay = 1, nlayers
+          plog = alog(pavel(iplon, lay))
+          if (plog .le. 4.56 ) cycle
+          laytrop_i = laytrop_i + 1
+        enddo
+        laytrop(iplon) = laytrop_i
+      enddo
+
+!$acc loop independent
+      do iplon = 1, ncol
+
+
+        stpfac = 296. /1013.
+
+        indbound = tboundd(iplon) - 159.
+        if (indbound .lt. 1) then
+           indbound = 1
+        elseif (indbound .gt. 180) then
+           indbound = 180
+        endif
+        tbndfrac = tboundd(iplon) - 159. - float(indbound)
+        indlev0 = tzd(iplon, 0) - 159.
+        if (indlev0 .lt. 1) then
+           indlev0 = 1
+        elseif (indlev0 .gt. 180) then
+           indlev0 = 180
+        endif
+        t0frac = tzd(iplon, 0) - 159. - float(indlev0)
+      !  laytrop(iplon) = 0
+
+! Begin layer loop
+! Calculate the integrated Planck functions for each band at the
+! surface, level, and layer temperatures.
+!$acc loop independent        
+        do lay = 1, nlayers
+          indlay = taveld(iplon, lay) - 159.
+          lcoldry = coldry( iplon, lay)
+          wv = colh2o(iplon, lay) * lcoldry
+          if (indlay .lt. 1) then
+             indlay = 1
+          elseif (indlay .gt. 180) then
+             indlay = 180
+          endif
+          tlayfrac = taveld(iplon, lay) - 159. - float(indlay)
+          indlev = tzd(iplon, lay) - 159.
+          if (indlev .lt. 1) then
+             indlev = 1
+          elseif (indlev .gt. 180) then
+             indlev = 180
+          endif
+          tlevfrac = tzd(iplon, lay) - 159. - float(indlev)
+
+! Begin spectral band loop
+!$acc loop seq
+          do iband = 1, 15
+            if (lay.eq.1) then
+               dbdtlev = totplnkd(indbound+1,iband) - totplnkd(indbound,iband)
+               plankbndd(iplon, iband) = semissd(iplon, iband) * &
+                   (totplnkd(indbound,iband) + tbndfrac * dbdtlev)
+               dbdtlev = totplnkd(indlev0+1,iband)-totplnkd(indlev0,iband)
+               planklevd(iplon, 0,iband) = totplnkd(indlev0,iband) + t0frac * dbdtlev
+               if (idrvd .eq. 1) then
+                  dbdtlev = totplnkderivd(indbound+1,iband) - totplnkderivd(indbound,iband)
+                  dplankbnd_dtd(iplon, iband) = semissd(iplon, iband) * &
+                        (totplnkderivd(indbound,iband) + tbndfrac * dbdtlev)
+               endif
+            endif
+            dbdtlev = totplnkd(indlev+1,iband) - totplnkd(indlev,iband)
+            dbdtlay = totplnkd(indlay+1,iband) - totplnkd(indlay,iband)
+            planklayd(iplon, lay,iband) = totplnkd(indlay,iband) + tlayfrac * dbdtlay
+
+            planklevd(iplon, lay,iband) = totplnkd(indlev,iband) + tlevfrac * dbdtlev
+          enddo
+
+! For band 16, if radiative transfer will be performed on just
+! this band, use integrated Planck values up to 3250 cm-1.
+! If radiative transfer will be performed across all 16 bands,
+! then include in the integrated Planck values for this band
+! contributions from 2600 cm-1 to infinity.
+          iband = 16
+          if (istart .eq. 16) then
+             if (lay.eq.1) then
+                dbdtlev = totplk16d( indbound+1) - totplk16d( indbound)
+                plankbndd(iplon, iband) = semissd(iplon, iband) * &
+                     (totplk16d( indbound) + tbndfrac * dbdtlev)
+                if (idrvd .eq. 1) then
+                   dbdtlev = totplk16derivd( indbound+1) - totplk16derivd( indbound)
+                   dplankbnd_dtd(iplon, iband) = semissd(iplon, iband) * &
+                        (totplk16derivd(indbound) + tbndfrac * dbdtlev)
+                endif
+                dbdtlev = totplnkd(indlev0+1,iband)-totplnkd(indlev0,iband)
+                planklevd(iplon, 0,iband) = totplk16d( indlev0) + &
+                     t0frac * dbdtlev
+             endif
+             dbdtlev = totplk16d( indlev+1) - totplk16d( indlev)
+             dbdtlay = totplk16d( indlay+1) - totplk16d( indlay)
+             planklayd(iplon, lay,iband) = totplk16d( indlay) + tlayfrac * dbdtlay
+             planklevd(iplon, lay,iband) = totplk16d( indlev) + tlevfrac * dbdtlev
+          else
+             if (lay.eq.1) then
+                dbdtlev = totplnkd(indbound+1,iband) - totplnkd(indbound,iband)
+                plankbndd(iplon, iband) = semissd(iplon, iband) * &
+                     (totplnkd(indbound,iband) + tbndfrac * dbdtlev)
+                if (idrvd .eq. 1) then
+                   dbdtlev = totplnkderivd( indbound+1,iband) - totplnkderivd( indbound,iband)
+                   dplankbnd_dtd(iplon, iband) = semissd(iplon, iband) * &
+                        (totplnkderivd( indbound,iband) + tbndfrac * dbdtlev)
+                endif
+                dbdtlev = totplnkd(indlev0+1,iband)-totplnkd(indlev0,iband)
+                planklevd(iplon, 0,iband) = totplnkd(indlev0,iband) + t0frac * dbdtlev
+             endif
+             dbdtlev = totplnkd(indlev+1,iband) - totplnkd(indlev,iband)
+             dbdtlay = totplnkd(indlay+1,iband) - totplnkd(indlay,iband)
+             planklayd(iplon, lay,iband) = totplnkd(indlay,iband) + tlayfrac * dbdtlay
+             planklevd(iplon, lay,iband) = totplnkd(indlev,iband) + tlevfrac * dbdtlev
+          endif
+
+
+! Find the two reference pressures on either side of the
+! layer pressure. Store them in JP and JP1. Store in FP the
+! fraction of the difference (in ln(pressure)) between these
+! two values that the layer pressure lies.
+! plog = alog(pavel(lay))
+          plog = alog(pavel(iplon, lay))
+          jp(iplon, lay) = int(36. - 5*(plog+0.04 ))
+          if (jp(iplon, lay) .lt. 1) then
+             jp(iplon, lay) = 1
+          elseif (jp(iplon, lay) .gt. 58) then
+             jp(iplon, lay) = 58
+          endif
+          jp1 = jp(iplon, lay) + 1
+          fp = 5. *(preflog(jp(iplon, lay)) - plog)
+
+! Determine, for each reference pressure (JP and JP1), which
+! reference temperature (these are different for each
+! reference pressure) is nearest the layer temperature but does
+! not exceed it. Store these indices in JT and JT1, resp.
+! Store in FT (resp. FT1) the fraction of the way between JT
+! (JT1) and the next highest reference temperature that the
+! layer temperature falls.
+          jt(iplon, lay) = int(3. + (taveld(iplon, lay)-tref(jp(iplon, lay)))/15. )
+          if (jt(iplon, lay) .lt. 1) then
+             jt(iplon, lay) = 1
+          elseif (jt(iplon, lay) .gt. 4) then
+             jt(iplon, lay) = 4
+          endif
+          ft = ((taveld(iplon, lay)-tref(jp(iplon, lay)))/15. ) - float(jt(iplon, lay)-3)
+          jt1(iplon, lay) = int(3. + (taveld(iplon, lay)-tref( jp1))/15. )
+          if (jt1(iplon, lay) .lt. 1) then
+             jt1(iplon, lay) = 1
+          elseif (jt1(iplon, lay) .gt. 4) then
+             jt1(iplon, lay) = 4
+          endif
+          ft1 = ((taveld(iplon, lay)-tref(jp1))/15. ) - float(jt1(iplon, lay)-3)
+          water = wv/lcoldry
+          scalefac = pavel(iplon, lay) * stpfac / taveld(iplon, lay)
+
+! If the pressure is less than ~100mb, perform a different
+! set of species interpolations.
+          if (plog .le. 4.56 ) go to 5300
+!          laytrop(iplon) = laytrop(iplon) + 1
+
+          forfac(iplon, lay) = scalefac / (1.+water)
+          factor = (332.0 -taveld(iplon, lay))/36.0
+          indfor(iplon, lay) = min(2, max(1, int(factor)))
+          forfrac(iplon, lay) = factor - float(indfor(iplon, lay))
+
+! Set up factors needed to separately include the water vapor
+! self-continuum in the calculation of absorption coefficient.
+          selffac(iplon, lay) = water * forfac(iplon, lay)
+          factor = (taveld(iplon, lay)-188.0 )/7.2
+          indself(iplon, lay) = min(9, max(1, int(factor)-7))
+          selffrac(iplon, lay) = factor - float(indself(iplon, lay) + 7)
+
+! Set up factors needed to separately include the minor gases
+! in the calculation of absorption coefficient
+          scaleminor(iplon, lay) = pavel(iplon, lay)/taveld(iplon, lay)
+          scaleminorn2(iplon, lay) = (pavel(iplon, lay)/taveld(iplon, lay)) &
+              *(wbroadd(iplon, lay)/(lcoldry+wv))
+          factor = (taveld(iplon, lay)-180.8 )/7.2
+          indminor(iplon, lay) = min(18, max(1, int(factor)))
+          minorfrac(iplon, lay) = factor - float(indminor(iplon, lay))
+
+! Setup reference ratio to be used in calculation of binary
+! species parameter in lower atmosphere.
+          rat_h2oco2(iplon, lay)=chi_mls( 1,jp(iplon, lay))/chi_mls( 2,jp(iplon, lay))
+          rat_h2oco2_1(iplon, lay)=chi_mls( 1,jp(iplon, lay)+1)/chi_mls( 2,jp(iplon, lay)+1)
+
+          rat_h2oo3(iplon, lay)=chi_mls( 1,jp(iplon, lay))/chi_mls( 3,jp(iplon, lay))
+          rat_h2oo3_1(iplon, lay)=chi_mls( 1,jp(iplon, lay)+1)/chi_mls( 3,jp(iplon, lay)+1)
+
+          rat_h2on2o(iplon, lay)=chi_mls( 1,jp(iplon, lay))/chi_mls( 4,jp(iplon, lay))
+          rat_h2on2o_1(iplon, lay)=chi_mls( 1,jp(iplon, lay)+1)/chi_mls( 4,jp(iplon, lay)+1)
+
+          rat_h2och4(iplon, lay)=chi_mls( 1,jp(iplon, lay))/chi_mls( 6,jp(iplon, lay))
+          rat_h2och4_1(iplon, lay)=chi_mls( 1,jp(iplon, lay)+1)/chi_mls( 6,jp(iplon, lay)+1)
+
+          rat_n2oco2(iplon, lay)=chi_mls( 4,jp(iplon, lay))/chi_mls( 2,jp(iplon, lay))
+          rat_n2oco2_1(iplon, lay)=chi_mls( 4,jp(iplon, lay)+1)/chi_mls( 2,jp(iplon, lay)+1)
+
+! Calculate needed column amounts.
+          colh2o(iplon, lay) = 1.e-20 * colh2o(iplon, lay) * lcoldry
+          colco2(iplon, lay) = 1.e-20 * colco2(iplon, lay) * lcoldry
+          colo3(iplon, lay) = 1.e-20 * colo3(iplon, lay) * lcoldry
+          coln2o(iplon, lay) = 1.e-20 * coln2o(iplon, lay) * lcoldry
+          colco(iplon, lay) = 1.e-20 * colco(iplon, lay) * lcoldry
+          colch4(iplon, lay) = 1.e-20 * colch4(iplon, lay) * lcoldry
+          colo2(iplon, lay) = 1.e-20 * colo2(iplon, lay) * lcoldry
+          if (colco2(iplon, lay) .eq. 0. ) colco2(iplon, lay) = 1.e-32 * lcoldry
+          if (colo3(iplon, lay) .eq. 0. ) colo3(iplon, lay) = 1.e-32 * lcoldry
+          if (coln2o(iplon, lay) .eq. 0. ) coln2o(iplon, lay) = 1.e-32 * lcoldry
+          if (colco(iplon, lay) .eq. 0. ) colco(iplon, lay) = 1.e-32 * lcoldry
+          if (colch4(iplon, lay) .eq. 0. ) colch4(iplon, lay) = 1.e-32 * lcoldry
+          colbrd(iplon, lay) = 1.e-20 * wbroadd(iplon, lay)
+          go to 5400
+
+! Above laytrop.
+ 5300 continue
+
+          forfac(iplon, lay) = scalefac / (1.+water)
+          factor = (taveld(iplon, lay)-188.0 )/36.0
+          indfor(iplon, lay) = 3
+          forfrac(iplon, lay) = factor - 1.0
+
+! Set up factors needed to separately include the water vapor
+! self-continuum in the calculation of absorption coefficient.
+          selffac(iplon, lay) = water * forfac(iplon, lay)
+
+! Set up factors needed to separately include the minor gases
+! in the calculation of absorption coefficient
+          scaleminor(iplon, lay) = pavel(iplon, lay)/taveld(iplon, lay)
+          scaleminorn2(iplon, lay) = (pavel(iplon, lay)/taveld(iplon, lay)) &
+              * (wbroadd(iplon, lay)/(coldry(iplon, lay)+wv))
+          factor = (taveld(iplon, lay)-180.8 )/7.2
+          indminor(iplon, lay) = min(18, max(1, int(factor)))
+          minorfrac(iplon, lay) = factor - float(indminor(iplon, lay))
+
+! Setup reference ratio to be used in calculation of binary
+! species parameter in upper atmosphere.
+          rat_h2oco2(iplon, lay)=chi_mls( 1,jp(iplon, lay))/chi_mls( 2,jp(iplon, lay))
+          rat_h2oco2_1(iplon, lay)=chi_mls( 1,jp(iplon, lay)+1)/chi_mls( 2,jp(iplon, lay)+1)
+
+          rat_o3co2(iplon, lay)=chi_mls( 3,jp(iplon, lay))/chi_mls( 2,jp(iplon, lay))
+          rat_o3co2_1(iplon, lay)=chi_mls( 3,jp(iplon, lay)+1)/chi_mls( 2,jp(iplon, lay)+1)
+
+! Calculate needed column amounts.
+          colh2o(iplon, lay) = 1.e-20 * colh2o(iplon, lay) * lcoldry
+          colco2(iplon, lay) = 1.e-20 * colco2(iplon, lay) * lcoldry
+          colo3(iplon, lay) = 1.e-20 * colo3(iplon, lay) * lcoldry
+          coln2o(iplon, lay) = 1.e-20 * coln2o(iplon, lay) * lcoldry
+          colco(iplon, lay) = 1.e-20 * colco(iplon, lay) * lcoldry
+          colch4(iplon, lay) = 1.e-20 * colch4(iplon, lay) * lcoldry
+          colo2(iplon, lay) = 1.e-20 * colo2(iplon, lay) * lcoldry
+          if (colco2(iplon, lay) .eq. 0. ) colco2(iplon, lay) = 1.e-32 * lcoldry
+          if (colo3(iplon, lay) .eq. 0. ) colo3(iplon, lay) = 1.e-32 * lcoldry
+          if (coln2o(iplon, lay) .eq. 0. ) coln2o(iplon, lay) = 1.e-32 * lcoldry
+          if (colco(iplon, lay) .eq. 0. ) colco(iplon, lay) = 1.e-32 * lcoldry
+          if (colch4(iplon, lay) .eq. 0. ) colch4(iplon, lay) = 1.e-32 * lcoldry
+          colbrd(iplon, lay) = 1.e-20 * wbroadd(iplon, lay)
+ 5400 continue
+
+! We have now isolated the layer ln pressure and temperature,
+! between two reference pressures and two reference temperatures
+! (for each reference pressure). We multiply the pressure
+! fraction FP with the appropriate temperature fractions to get
+! the factors that will be needed for the interpolation that yields
+! the optical depths (performed in routines TAUGBn for band n).`
+
+          compfp = 1. - fp
+          fac10(iplon, lay) = compfp * ft
+          fac00(iplon, lay) = compfp * (1. - ft)
+          fac11(iplon, lay) = fp * ft1
+          fac01(iplon, lay) = fp * (1. - ft1)
+
+! Rescale selffac and forfac for use in taumol
+          selffac(iplon, lay) = colh2o(iplon, lay)*selffac(iplon, lay)
+          forfac(iplon, lay) = colh2o(iplon, lay)*forfac(iplon, lay)
+! End layer loop
+        enddo
+
+
+
+
+      end do
+!$acc end kernels
+!$acc end data
+
+      end subroutine setcoefg
+
+      end module gpu_rrtmg_lw_setcoef
+
+      module rrtmg_lw_setcoef_f
+
+! --------------------------------------------------------------------------
+! | |
+! | Copyright 2002-2009, Atmospheric & Environmental Research, Inc. (AER). |
+! | This software may be used, copied, or redistributed as long as it is |
+! | not sold and this copyright notice is reproduced on each copy made. |
+! | This model is provided as is without any express or implied warranties. |
+! | (http:
+! | |
+! --------------------------------------------------------------------------
+
+! ------- Modules -------
+
+! use parkind, only : im => kind , rb => kind
+      use parrrtm_f, only : nbndlw, mg, maxxsec, mxmol
+      use rrlw_wvn_f, only: totplnk, totplk16, totplnkderiv, totplk16deriv
+      use rrlw_ref_f
+
+      implicit none
+
+      contains
+
+!***************************************************************************
+      subroutine lwatmref
+!***************************************************************************
+
+      save
+
+! These pressures are chosen such that the ln of the first pressure
+! has only a few non-zero digits (i.e. ln(PREF(1)) = 6.96000) and
+! each subsequent ln(pressure) differs from the previous one by 0.2.
+
+      pref(:) = (/ &
+          1.05363e+03 ,8.62642e+02 ,7.06272e+02 ,5.78246e+02 ,4.73428e+02 , &
+          3.87610e+02 ,3.17348e+02 ,2.59823e+02 ,2.12725e+02 ,1.74164e+02 , &
+          1.42594e+02 ,1.16746e+02 ,9.55835e+01 ,7.82571e+01 ,6.40715e+01 , &
+          5.24573e+01 ,4.29484e+01 ,3.51632e+01 ,2.87892e+01 ,2.35706e+01 , &
+          1.92980e+01 ,1.57998e+01 ,1.29358e+01 ,1.05910e+01 ,8.67114e+00 , &
+          7.09933e+00 ,5.81244e+00 ,4.75882e+00 ,3.89619e+00 ,3.18993e+00 , &
+          2.61170e+00 ,2.13828e+00 ,1.75067e+00 ,1.43333e+00 ,1.17351e+00 , &
+          9.60789e-01 ,7.86628e-01 ,6.44036e-01 ,5.27292e-01 ,4.31710e-01 , &
+          3.53455e-01 ,2.89384e-01 ,2.36928e-01 ,1.93980e-01 ,1.58817e-01 , &
+          1.30029e-01 ,1.06458e-01 ,8.71608e-02 ,7.13612e-02 ,5.84256e-02 , &
+          4.78349e-02 ,3.91639e-02 ,3.20647e-02 ,2.62523e-02 ,2.14936e-02 , &
+          1.75975e-02 ,1.44076e-02 ,1.17959e-02 ,9.65769e-03 /)
+
+      preflog(:) = (/ &
+           6.9600e+00 , 6.7600e+00 , 6.5600e+00 , 6.3600e+00 , 6.1600e+00 , &
+           5.9600e+00 , 5.7600e+00 , 5.5600e+00 , 5.3600e+00 , 5.1600e+00 , &
+           4.9600e+00 , 4.7600e+00 , 4.5600e+00 , 4.3600e+00 , 4.1600e+00 , &
+           3.9600e+00 , 3.7600e+00 , 3.5600e+00 , 3.3600e+00 , 3.1600e+00 , &
+           2.9600e+00 , 2.7600e+00 , 2.5600e+00 , 2.3600e+00 , 2.1600e+00 , &
+           1.9600e+00 , 1.7600e+00 , 1.5600e+00 , 1.3600e+00 , 1.1600e+00 , &
+           9.6000e-01 , 7.6000e-01 , 5.6000e-01 , 3.6000e-01 , 1.6000e-01 , &
+          -4.0000e-02 ,-2.4000e-01 ,-4.4000e-01 ,-6.4000e-01 ,-8.4000e-01 , &
+          -1.0400e+00 ,-1.2400e+00 ,-1.4400e+00 ,-1.6400e+00 ,-1.8400e+00 , &
+          -2.0400e+00 ,-2.2400e+00 ,-2.4400e+00 ,-2.6400e+00 ,-2.8400e+00 , &
+          -3.0400e+00 ,-3.2400e+00 ,-3.4400e+00 ,-3.6400e+00 ,-3.8400e+00 , &
+          -4.0400e+00 ,-4.2400e+00 ,-4.4400e+00 ,-4.6400e+00 /)
+
+! These are the temperatures associated with the respective
+! pressures for the mls standard atmosphere.
+
+      tref(:) = (/ &
+           2.9420e+02 , 2.8799e+02 , 2.7894e+02 , 2.6925e+02 , 2.5983e+02 , &
+           2.5017e+02 , 2.4077e+02 , 2.3179e+02 , 2.2306e+02 , 2.1578e+02 , &
+           2.1570e+02 , 2.1570e+02 , 2.1570e+02 , 2.1706e+02 , 2.1858e+02 , &
+           2.2018e+02 , 2.2174e+02 , 2.2328e+02 , 2.2479e+02 , 2.2655e+02 , &
+           2.2834e+02 , 2.3113e+02 , 2.3401e+02 , 2.3703e+02 , 2.4022e+02 , &
+           2.4371e+02 , 2.4726e+02 , 2.5085e+02 , 2.5457e+02 , 2.5832e+02 , &
+           2.6216e+02 , 2.6606e+02 , 2.6999e+02 , 2.7340e+02 , 2.7536e+02 , &
+           2.7568e+02 , 2.7372e+02 , 2.7163e+02 , 2.6955e+02 , 2.6593e+02 , &
+           2.6211e+02 , 2.5828e+02 , 2.5360e+02 , 2.4854e+02 , 2.4348e+02 , &
+           2.3809e+02 , 2.3206e+02 , 2.2603e+02 , 2.2000e+02 , 2.1435e+02 , &
+           2.0887e+02 , 2.0340e+02 , 1.9792e+02 , 1.9290e+02 , 1.8809e+02 , &
+           1.8329e+02 , 1.7849e+02 , 1.7394e+02 , 1.7212e+02 /)
+
+       chi_mls(1,1:12) = (/ &
+        1.8760e-02 , 1.2223e-02 , 5.8909e-03 , 2.7675e-03 , 1.4065e-03 , &
+        7.5970e-04 , 3.8876e-04 , 1.6542e-04 , 3.7190e-05 , 7.4765e-06 , &
+        4.3082e-06 , 3.3319e-06 /)
+       chi_mls(1,13:59) = (/ &
+        3.2039e-06 , 3.1619e-06 , 3.2524e-06 , 3.4226e-06 , 3.6288e-06 , &
+        3.9148e-06 , 4.1488e-06 , 4.3081e-06 , 4.4420e-06 , 4.5778e-06 , &
+        4.7087e-06 , 4.7943e-06 , 4.8697e-06 , 4.9260e-06 , 4.9669e-06 , &
+        4.9963e-06 , 5.0527e-06 , 5.1266e-06 , 5.2503e-06 , 5.3571e-06 , &
+        5.4509e-06 , 5.4830e-06 , 5.5000e-06 , 5.5000e-06 , 5.4536e-06 , &
+        5.4047e-06 , 5.3558e-06 , 5.2533e-06 , 5.1436e-06 , 5.0340e-06 , &
+        4.8766e-06 , 4.6979e-06 , 4.5191e-06 , 4.3360e-06 , 4.1442e-06 , &
+        3.9523e-06 , 3.7605e-06 , 3.5722e-06 , 3.3855e-06 , 3.1988e-06 , &
+        3.0121e-06 , 2.8262e-06 , 2.6407e-06 , 2.4552e-06 , 2.2696e-06 , &
+        4.3360e-06 , 4.1442e-06 /)
+       chi_mls(2,1:12) = (/ &
+        3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , &
+        3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , &
+        3.5500e-04 , 3.5500e-04 /)
+       chi_mls(2,13:59) = (/ &
+        3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , &
+        3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , &
+        3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , &
+        3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , &
+        3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , &
+        3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , &
+        3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , &
+        3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , 3.5500e-04 , &
+        3.5500e-04 , 3.5471e-04 , 3.5427e-04 , 3.5384e-04 , 3.5340e-04 , &
+        3.5500e-04 , 3.5500e-04 /)
+       chi_mls(3,1:12) = (/ &
+        3.0170e-08 , 3.4725e-08 , 4.2477e-08 , 5.2759e-08 , 6.6944e-08 , &
+        8.7130e-08 , 1.1391e-07 , 1.5677e-07 , 2.1788e-07 , 3.2443e-07 , &
+        4.6594e-07 , 5.6806e-07 /)
+       chi_mls(3,13:59) = (/ &
+        6.9607e-07 , 1.1186e-06 , 1.7618e-06 , 2.3269e-06 , 2.9577e-06 , &
+        3.6593e-06 , 4.5950e-06 , 5.3189e-06 , 5.9618e-06 , 6.5113e-06 , &
+        7.0635e-06 , 7.6917e-06 , 8.2577e-06 , 8.7082e-06 , 8.8325e-06 , &
+        8.7149e-06 , 8.0943e-06 , 7.3307e-06 , 6.3101e-06 , 5.3672e-06 , &
+        4.4829e-06 , 3.8391e-06 , 3.2827e-06 , 2.8235e-06 , 2.4906e-06 , &
+        2.1645e-06 , 1.8385e-06 , 1.6618e-06 , 1.5052e-06 , 1.3485e-06 , &
+        1.1972e-06 , 1.0482e-06 , 8.9926e-07 , 7.6343e-07 , 6.5381e-07 , &
+        5.4419e-07 , 4.3456e-07 , 3.6421e-07 , 3.1194e-07 , 2.5967e-07 , &
+        2.0740e-07 , 1.9146e-07 , 1.9364e-07 , 1.9582e-07 , 1.9800e-07 , &
+        7.6343e-07 , 6.5381e-07 /)
+       chi_mls(4,1:12) = (/ &
+        3.2000e-07 , 3.2000e-07 , 3.2000e-07 , 3.2000e-07 , 3.2000e-07 , &
+        3.1965e-07 , 3.1532e-07 , 3.0383e-07 , 2.9422e-07 , 2.8495e-07 , &
+        2.7671e-07 , 2.6471e-07 /)
+       chi_mls(4,13:59) = (/ &
+        2.4285e-07 , 2.0955e-07 , 1.7195e-07 , 1.3749e-07 , 1.1332e-07 , &
+        1.0035e-07 , 9.1281e-08 , 8.5463e-08 , 8.0363e-08 , 7.3372e-08 , &
+        6.5975e-08 , 5.6039e-08 , 4.7090e-08 , 3.9977e-08 , 3.2979e-08 , &
+        2.6064e-08 , 2.1066e-08 , 1.6592e-08 , 1.3017e-08 , 1.0090e-08 , &
+        7.6249e-09 , 6.1159e-09 , 4.6672e-09 , 3.2857e-09 , 2.8484e-09 , &
+        2.4620e-09 , 2.0756e-09 , 1.8551e-09 , 1.6568e-09 , 1.4584e-09 , &
+        1.3195e-09 , 1.2072e-09 , 1.0948e-09 , 9.9780e-10 , 9.3126e-10 , &
+        8.6472e-10 , 7.9818e-10 , 7.5138e-10 , 7.1367e-10 , 6.7596e-10 , &
+        6.3825e-10 , 6.0981e-10 , 5.8600e-10 , 5.6218e-10 , 5.3837e-10 , &
+        9.9780e-10 , 9.3126e-10 /)
+       chi_mls(5,1:12) = (/ &
+        1.5000e-07 , 1.4306e-07 , 1.3474e-07 , 1.3061e-07 , 1.2793e-07 , &
+        1.2038e-07 , 1.0798e-07 , 9.4238e-08 , 7.9488e-08 , 6.1386e-08 , &
+        4.5563e-08 , 3.3475e-08 /)
+       chi_mls(5,13:59) = (/ &
+        2.5118e-08 , 1.8671e-08 , 1.4349e-08 , 1.2501e-08 , 1.2407e-08 , &
+        1.3472e-08 , 1.4900e-08 , 1.6079e-08 , 1.7156e-08 , 1.8616e-08 , &
+        2.0106e-08 , 2.1654e-08 , 2.3096e-08 , 2.4340e-08 , 2.5643e-08 , &
+        2.6990e-08 , 2.8456e-08 , 2.9854e-08 , 3.0943e-08 , 3.2023e-08 , &
+        3.3101e-08 , 3.4260e-08 , 3.5360e-08 , 3.6397e-08 , 3.7310e-08 , &
+        3.8217e-08 , 3.9123e-08 , 4.1303e-08 , 4.3652e-08 , 4.6002e-08 , &
+        5.0289e-08 , 5.5446e-08 , 6.0603e-08 , 6.8946e-08 , 8.3652e-08 , &
+        9.8357e-08 , 1.1306e-07 , 1.4766e-07 , 1.9142e-07 , 2.3518e-07 , &
+        2.7894e-07 , 3.5001e-07 , 4.3469e-07 , 5.1938e-07 , 6.0407e-07 , &
+        6.8946e-08 , 8.3652e-08 /)
+       chi_mls(6,1:12) = (/ &
+        1.7000e-06 , 1.7000e-06 , 1.6999e-06 , 1.6904e-06 , 1.6671e-06 , &
+        1.6351e-06 , 1.6098e-06 , 1.5590e-06 , 1.5120e-06 , 1.4741e-06 , &
+        1.4385e-06 , 1.4002e-06 /)
+       chi_mls(6,13:59) = (/ &
+        1.3573e-06 , 1.3130e-06 , 1.2512e-06 , 1.1668e-06 , 1.0553e-06 , &
+        9.3281e-07 , 8.1217e-07 , 7.5239e-07 , 7.0728e-07 , 6.6722e-07 , &
+        6.2733e-07 , 5.8604e-07 , 5.4769e-07 , 5.1480e-07 , 4.8206e-07 , &
+        4.4943e-07 , 4.1702e-07 , 3.8460e-07 , 3.5200e-07 , 3.1926e-07 , &
+        2.8646e-07 , 2.5498e-07 , 2.2474e-07 , 1.9588e-07 , 1.8295e-07 , &
+        1.7089e-07 , 1.5882e-07 , 1.5536e-07 , 1.5304e-07 , 1.5072e-07 , &
+        1.5000e-07 , 1.5000e-07 , 1.5000e-07 , 1.5000e-07 , 1.5000e-07 , &
+        1.5000e-07 , 1.5000e-07 , 1.5000e-07 , 1.5000e-07 , 1.5000e-07 , &
+        1.5000e-07 , 1.5000e-07 , 1.5000e-07 , 1.5000e-07 , 1.5000e-07 , &
+        1.5000e-07 , 1.5000e-07 /)
+       chi_mls(7,1:12) = (/ &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 /)
+       chi_mls(7,13:59) = (/ &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 , 0.2090 , 0.2090 , 0.2090 , &
+        0.2090 , 0.2090 /)
+!$acc enter data copyin(pref,preflog,tref,chi_mls)
+      end subroutine lwatmref
+
+!***************************************************************************
+      subroutine lwavplank
+!***************************************************************************
+
+      save
+
+      totplnk(1:50, 1) = (/ &
+      0.14783e-05 ,0.15006e-05 ,0.15230e-05 ,0.15455e-05 ,0.15681e-05 , &
+      0.15908e-05 ,0.16136e-05 ,0.16365e-05 ,0.16595e-05 ,0.16826e-05 , &
+      0.17059e-05 ,0.17292e-05 ,0.17526e-05 ,0.17762e-05 ,0.17998e-05 , &
+      0.18235e-05 ,0.18473e-05 ,0.18712e-05 ,0.18953e-05 ,0.19194e-05 , &
+      0.19435e-05 ,0.19678e-05 ,0.19922e-05 ,0.20166e-05 ,0.20412e-05 , &
+      0.20658e-05 ,0.20905e-05 ,0.21153e-05 ,0.21402e-05 ,0.21652e-05 , &
+      0.21902e-05 ,0.22154e-05 ,0.22406e-05 ,0.22659e-05 ,0.22912e-05 , &
+      0.23167e-05 ,0.23422e-05 ,0.23678e-05 ,0.23934e-05 ,0.24192e-05 , &
+      0.24450e-05 ,0.24709e-05 ,0.24968e-05 ,0.25229e-05 ,0.25490e-05 , &
+      0.25751e-05 ,0.26014e-05 ,0.26277e-05 ,0.26540e-05 ,0.26805e-05 /)
+      totplnk(51:100, 1) = (/ &
+      0.27070e-05 ,0.27335e-05 ,0.27602e-05 ,0.27869e-05 ,0.28136e-05 , &
+      0.28404e-05 ,0.28673e-05 ,0.28943e-05 ,0.29213e-05 ,0.29483e-05 , &
+      0.29754e-05 ,0.30026e-05 ,0.30298e-05 ,0.30571e-05 ,0.30845e-05 , &
+      0.31119e-05 ,0.31393e-05 ,0.31669e-05 ,0.31944e-05 ,0.32220e-05 , &
+      0.32497e-05 ,0.32774e-05 ,0.33052e-05 ,0.33330e-05 ,0.33609e-05 , &
+      0.33888e-05 ,0.34168e-05 ,0.34448e-05 ,0.34729e-05 ,0.35010e-05 , &
+      0.35292e-05 ,0.35574e-05 ,0.35857e-05 ,0.36140e-05 ,0.36424e-05 , &
+      0.36708e-05 ,0.36992e-05 ,0.37277e-05 ,0.37563e-05 ,0.37848e-05 , &
+      0.38135e-05 ,0.38421e-05 ,0.38708e-05 ,0.38996e-05 ,0.39284e-05 , &
+      0.39572e-05 ,0.39861e-05 ,0.40150e-05 ,0.40440e-05 ,0.40730e-05 /)
+      totplnk(101:150, 1) = (/ &
+      0.41020e-05 ,0.41311e-05 ,0.41602e-05 ,0.41893e-05 ,0.42185e-05 , &
+      0.42477e-05 ,0.42770e-05 ,0.43063e-05 ,0.43356e-05 ,0.43650e-05 , &
+      0.43944e-05 ,0.44238e-05 ,0.44533e-05 ,0.44828e-05 ,0.45124e-05 , &
+      0.45419e-05 ,0.45715e-05 ,0.46012e-05 ,0.46309e-05 ,0.46606e-05 , &
+      0.46903e-05 ,0.47201e-05 ,0.47499e-05 ,0.47797e-05 ,0.48096e-05 , &
+      0.48395e-05 ,0.48695e-05 ,0.48994e-05 ,0.49294e-05 ,0.49594e-05 , &
+      0.49895e-05 ,0.50196e-05 ,0.50497e-05 ,0.50798e-05 ,0.51100e-05 , &
+      0.51402e-05 ,0.51704e-05 ,0.52007e-05 ,0.52309e-05 ,0.52612e-05 , &
+      0.52916e-05 ,0.53219e-05 ,0.53523e-05 ,0.53827e-05 ,0.54132e-05 , &
+      0.54436e-05 ,0.54741e-05 ,0.55047e-05 ,0.55352e-05 ,0.55658e-05 /)
+      totplnk(151:181, 1) = (/ &
+      0.55964e-05 ,0.56270e-05 ,0.56576e-05 ,0.56883e-05 ,0.57190e-05 , &
+      0.57497e-05 ,0.57804e-05 ,0.58112e-05 ,0.58420e-05 ,0.58728e-05 , &
+      0.59036e-05 ,0.59345e-05 ,0.59653e-05 ,0.59962e-05 ,0.60272e-05 , &
+      0.60581e-05 ,0.60891e-05 ,0.61201e-05 ,0.61511e-05 ,0.61821e-05 , &
+      0.62131e-05 ,0.62442e-05 ,0.62753e-05 ,0.63064e-05 ,0.63376e-05 , &
+      0.63687e-05 ,0.63998e-05 ,0.64310e-05 ,0.64622e-05 ,0.64935e-05 , &
+      0.65247e-05 /)
+      totplnk(1:50, 2) = (/ &
+      0.20262e-05 ,0.20757e-05 ,0.21257e-05 ,0.21763e-05 ,0.22276e-05 , &
+      0.22794e-05 ,0.23319e-05 ,0.23849e-05 ,0.24386e-05 ,0.24928e-05 , &
+      0.25477e-05 ,0.26031e-05 ,0.26591e-05 ,0.27157e-05 ,0.27728e-05 , &
+      0.28306e-05 ,0.28889e-05 ,0.29478e-05 ,0.30073e-05 ,0.30673e-05 , &
+      0.31279e-05 ,0.31890e-05 ,0.32507e-05 ,0.33129e-05 ,0.33757e-05 , &
+      0.34391e-05 ,0.35029e-05 ,0.35674e-05 ,0.36323e-05 ,0.36978e-05 , &
+      0.37638e-05 ,0.38304e-05 ,0.38974e-05 ,0.39650e-05 ,0.40331e-05 , &
+      0.41017e-05 ,0.41708e-05 ,0.42405e-05 ,0.43106e-05 ,0.43812e-05 , &
+      0.44524e-05 ,0.45240e-05 ,0.45961e-05 ,0.46687e-05 ,0.47418e-05 , &
+      0.48153e-05 ,0.48894e-05 ,0.49639e-05 ,0.50389e-05 ,0.51143e-05 /)
+      totplnk(51:100, 2) = (/ &
+      0.51902e-05 ,0.52666e-05 ,0.53434e-05 ,0.54207e-05 ,0.54985e-05 , &
+      0.55767e-05 ,0.56553e-05 ,0.57343e-05 ,0.58139e-05 ,0.58938e-05 , &
+      0.59742e-05 ,0.60550e-05 ,0.61362e-05 ,0.62179e-05 ,0.63000e-05 , &
+      0.63825e-05 ,0.64654e-05 ,0.65487e-05 ,0.66324e-05 ,0.67166e-05 , &
+      0.68011e-05 ,0.68860e-05 ,0.69714e-05 ,0.70571e-05 ,0.71432e-05 , &
+      0.72297e-05 ,0.73166e-05 ,0.74039e-05 ,0.74915e-05 ,0.75796e-05 , &
+      0.76680e-05 ,0.77567e-05 ,0.78459e-05 ,0.79354e-05 ,0.80252e-05 , &
+      0.81155e-05 ,0.82061e-05 ,0.82970e-05 ,0.83883e-05 ,0.84799e-05 , &
+      0.85719e-05 ,0.86643e-05 ,0.87569e-05 ,0.88499e-05 ,0.89433e-05 , &
+      0.90370e-05 ,0.91310e-05 ,0.92254e-05 ,0.93200e-05 ,0.94150e-05 /)
+      totplnk(101:150, 2) = (/ &
+      0.95104e-05 ,0.96060e-05 ,0.97020e-05 ,0.97982e-05 ,0.98948e-05 , &
+      0.99917e-05 ,0.10089e-04 ,0.10186e-04 ,0.10284e-04 ,0.10382e-04 , &
+      0.10481e-04 ,0.10580e-04 ,0.10679e-04 ,0.10778e-04 ,0.10877e-04 , &
+      0.10977e-04 ,0.11077e-04 ,0.11178e-04 ,0.11279e-04 ,0.11380e-04 , &
+      0.11481e-04 ,0.11583e-04 ,0.11684e-04 ,0.11786e-04 ,0.11889e-04 , &
+      0.11992e-04 ,0.12094e-04 ,0.12198e-04 ,0.12301e-04 ,0.12405e-04 , &
+      0.12509e-04 ,0.12613e-04 ,0.12717e-04 ,0.12822e-04 ,0.12927e-04 , &
+      0.13032e-04 ,0.13138e-04 ,0.13244e-04 ,0.13349e-04 ,0.13456e-04 , &
+      0.13562e-04 ,0.13669e-04 ,0.13776e-04 ,0.13883e-04 ,0.13990e-04 , &
+      0.14098e-04 ,0.14206e-04 ,0.14314e-04 ,0.14422e-04 ,0.14531e-04 /)
+      totplnk(151:181, 2) = (/ &
+      0.14639e-04 ,0.14748e-04 ,0.14857e-04 ,0.14967e-04 ,0.15076e-04 , &
+      0.15186e-04 ,0.15296e-04 ,0.15407e-04 ,0.15517e-04 ,0.15628e-04 , &
+      0.15739e-04 ,0.15850e-04 ,0.15961e-04 ,0.16072e-04 ,0.16184e-04 , &
+      0.16296e-04 ,0.16408e-04 ,0.16521e-04 ,0.16633e-04 ,0.16746e-04 , &
+      0.16859e-04 ,0.16972e-04 ,0.17085e-04 ,0.17198e-04 ,0.17312e-04 , &
+      0.17426e-04 ,0.17540e-04 ,0.17654e-04 ,0.17769e-04 ,0.17883e-04 , &
+      0.17998e-04 /)
+      totplnk(1:50, 3) = (/ &
+      1.34822e-06 ,1.39134e-06 ,1.43530e-06 ,1.48010e-06 ,1.52574e-06 , &
+      1.57222e-06 ,1.61956e-06 ,1.66774e-06 ,1.71678e-06 ,1.76666e-06 , &
+      1.81741e-06 ,1.86901e-06 ,1.92147e-06 ,1.97479e-06 ,2.02898e-06 , &
+      2.08402e-06 ,2.13993e-06 ,2.19671e-06 ,2.25435e-06 ,2.31285e-06 , &
+      2.37222e-06 ,2.43246e-06 ,2.49356e-06 ,2.55553e-06 ,2.61837e-06 , &
+      2.68207e-06 ,2.74664e-06 ,2.81207e-06 ,2.87837e-06 ,2.94554e-06 , &
+      3.01356e-06 ,3.08245e-06 ,3.15221e-06 ,3.22282e-06 ,3.29429e-06 , &
+      3.36662e-06 ,3.43982e-06 ,3.51386e-06 ,3.58876e-06 ,3.66451e-06 , &
+      3.74112e-06 ,3.81857e-06 ,3.89688e-06 ,3.97602e-06 ,4.05601e-06 , &
+      4.13685e-06 ,4.21852e-06 ,4.30104e-06 ,4.38438e-06 ,4.46857e-06 /)
+      totplnk(51:100, 3) = (/ &
+      4.55358e-06 ,4.63943e-06 ,4.72610e-06 ,4.81359e-06 ,4.90191e-06 , &
+      4.99105e-06 ,5.08100e-06 ,5.17176e-06 ,5.26335e-06 ,5.35573e-06 , &
+      5.44892e-06 ,5.54292e-06 ,5.63772e-06 ,5.73331e-06 ,5.82970e-06 , &
+      5.92688e-06 ,6.02485e-06 ,6.12360e-06 ,6.22314e-06 ,6.32346e-06 , &
+      6.42455e-06 ,6.52641e-06 ,6.62906e-06 ,6.73247e-06 ,6.83664e-06 , &
+      6.94156e-06 ,7.04725e-06 ,7.15370e-06 ,7.26089e-06 ,7.36883e-06 , &
+      7.47752e-06 ,7.58695e-06 ,7.69712e-06 ,7.80801e-06 ,7.91965e-06 , &
+      8.03201e-06 ,8.14510e-06 ,8.25891e-06 ,8.37343e-06 ,8.48867e-06 , &
+      8.60463e-06 ,8.72128e-06 ,8.83865e-06 ,8.95672e-06 ,9.07548e-06 , &
+      9.19495e-06 ,9.31510e-06 ,9.43594e-06 ,9.55745e-06 ,9.67966e-06 /)
+      totplnk(101:150, 3) = (/ &
+      9.80254e-06 ,9.92609e-06 ,1.00503e-05 ,1.01752e-05 ,1.03008e-05 , &
+      1.04270e-05 ,1.05539e-05 ,1.06814e-05 ,1.08096e-05 ,1.09384e-05 , &
+      1.10679e-05 ,1.11980e-05 ,1.13288e-05 ,1.14601e-05 ,1.15922e-05 , &
+      1.17248e-05 ,1.18581e-05 ,1.19920e-05 ,1.21265e-05 ,1.22616e-05 , &
+      1.23973e-05 ,1.25337e-05 ,1.26706e-05 ,1.28081e-05 ,1.29463e-05 , &
+      1.30850e-05 ,1.32243e-05 ,1.33642e-05 ,1.35047e-05 ,1.36458e-05 , &
+      1.37875e-05 ,1.39297e-05 ,1.40725e-05 ,1.42159e-05 ,1.43598e-05 , &
+      1.45044e-05 ,1.46494e-05 ,1.47950e-05 ,1.49412e-05 ,1.50879e-05 , &
+      1.52352e-05 ,1.53830e-05 ,1.55314e-05 ,1.56803e-05 ,1.58297e-05 , &
+      1.59797e-05 ,1.61302e-05 ,1.62812e-05 ,1.64327e-05 ,1.65848e-05 /)
+      totplnk(151:181, 3) = (/ &
+      1.67374e-05 ,1.68904e-05 ,1.70441e-05 ,1.71982e-05 ,1.73528e-05 , &
+      1.75079e-05 ,1.76635e-05 ,1.78197e-05 ,1.79763e-05 ,1.81334e-05 , &
+      1.82910e-05 ,1.84491e-05 ,1.86076e-05 ,1.87667e-05 ,1.89262e-05 , &
+      1.90862e-05 ,1.92467e-05 ,1.94076e-05 ,1.95690e-05 ,1.97309e-05 , &
+      1.98932e-05 ,2.00560e-05 ,2.02193e-05 ,2.03830e-05 ,2.05472e-05 , &
+      2.07118e-05 ,2.08768e-05 ,2.10423e-05 ,2.12083e-05 ,2.13747e-05 , &
+      2.15414e-05 /)
+      totplnk(1:50, 4) = (/ &
+      8.90528e-07 ,9.24222e-07 ,9.58757e-07 ,9.94141e-07 ,1.03038e-06 , &
+      1.06748e-06 ,1.10545e-06 ,1.14430e-06 ,1.18403e-06 ,1.22465e-06 , &
+      1.26618e-06 ,1.30860e-06 ,1.35193e-06 ,1.39619e-06 ,1.44136e-06 , &
+      1.48746e-06 ,1.53449e-06 ,1.58246e-06 ,1.63138e-06 ,1.68124e-06 , &
+      1.73206e-06 ,1.78383e-06 ,1.83657e-06 ,1.89028e-06 ,1.94495e-06 , &
+      2.00060e-06 ,2.05724e-06 ,2.11485e-06 ,2.17344e-06 ,2.23303e-06 , &
+      2.29361e-06 ,2.35519e-06 ,2.41777e-06 ,2.48134e-06 ,2.54592e-06 , &
+      2.61151e-06 ,2.67810e-06 ,2.74571e-06 ,2.81433e-06 ,2.88396e-06 , &
+      2.95461e-06 ,3.02628e-06 ,3.09896e-06 ,3.17267e-06 ,3.24741e-06 , &
+      3.32316e-06 ,3.39994e-06 ,3.47774e-06 ,3.55657e-06 ,3.63642e-06 /)
+      totplnk(51:100, 4) = (/ &
+      3.71731e-06 ,3.79922e-06 ,3.88216e-06 ,3.96612e-06 ,4.05112e-06 , &
+      4.13714e-06 ,4.22419e-06 ,4.31227e-06 ,4.40137e-06 ,4.49151e-06 , &
+      4.58266e-06 ,4.67485e-06 ,4.76806e-06 ,4.86229e-06 ,4.95754e-06 , &
+      5.05383e-06 ,5.15113e-06 ,5.24946e-06 ,5.34879e-06 ,5.44916e-06 , &
+      5.55053e-06 ,5.65292e-06 ,5.75632e-06 ,5.86073e-06 ,5.96616e-06 , &
+      6.07260e-06 ,6.18003e-06 ,6.28848e-06 ,6.39794e-06 ,6.50838e-06 , &
+      6.61983e-06 ,6.73229e-06 ,6.84573e-06 ,6.96016e-06 ,7.07559e-06 , &
+      7.19200e-06 ,7.30940e-06 ,7.42779e-06 ,7.54715e-06 ,7.66749e-06 , &
+      7.78882e-06 ,7.91110e-06 ,8.03436e-06 ,8.15859e-06 ,8.28379e-06 , &
+      8.40994e-06 ,8.53706e-06 ,8.66515e-06 ,8.79418e-06 ,8.92416e-06 /)
+      totplnk(101:150, 4) = (/ &
+      9.05510e-06 ,9.18697e-06 ,9.31979e-06 ,9.45356e-06 ,9.58826e-06 , &
+      9.72389e-06 ,9.86046e-06 ,9.99793e-06 ,1.01364e-05 ,1.02757e-05 , &
+      1.04159e-05 ,1.05571e-05 ,1.06992e-05 ,1.08422e-05 ,1.09861e-05 , &
+      1.11309e-05 ,1.12766e-05 ,1.14232e-05 ,1.15707e-05 ,1.17190e-05 , &
+      1.18683e-05 ,1.20184e-05 ,1.21695e-05 ,1.23214e-05 ,1.24741e-05 , &
+      1.26277e-05 ,1.27822e-05 ,1.29376e-05 ,1.30939e-05 ,1.32509e-05 , &
+      1.34088e-05 ,1.35676e-05 ,1.37273e-05 ,1.38877e-05 ,1.40490e-05 , &
+      1.42112e-05 ,1.43742e-05 ,1.45380e-05 ,1.47026e-05 ,1.48680e-05 , &
+      1.50343e-05 ,1.52014e-05 ,1.53692e-05 ,1.55379e-05 ,1.57074e-05 , &
+      1.58778e-05 ,1.60488e-05 ,1.62207e-05 ,1.63934e-05 ,1.65669e-05 /)
+      totplnk(151:181, 4) = (/ &
+      1.67411e-05 ,1.69162e-05 ,1.70920e-05 ,1.72685e-05 ,1.74459e-05 , &
+      1.76240e-05 ,1.78029e-05 ,1.79825e-05 ,1.81629e-05 ,1.83440e-05 , &
+      1.85259e-05 ,1.87086e-05 ,1.88919e-05 ,1.90760e-05 ,1.92609e-05 , &
+      1.94465e-05 ,1.96327e-05 ,1.98199e-05 ,2.00076e-05 ,2.01961e-05 , &
+      2.03853e-05 ,2.05752e-05 ,2.07658e-05 ,2.09571e-05 ,2.11491e-05 , &
+      2.13418e-05 ,2.15352e-05 ,2.17294e-05 ,2.19241e-05 ,2.21196e-05 , &
+      2.23158e-05 /)
+      totplnk(1:50, 5) = (/ &
+      5.70230e-07 ,5.94788e-07 ,6.20085e-07 ,6.46130e-07 ,6.72936e-07 , &
+      7.00512e-07 ,7.28869e-07 ,7.58019e-07 ,7.87971e-07 ,8.18734e-07 , &
+      8.50320e-07 ,8.82738e-07 ,9.15999e-07 ,9.50110e-07 ,9.85084e-07 , &
+      1.02093e-06 ,1.05765e-06 ,1.09527e-06 ,1.13378e-06 ,1.17320e-06 , &
+      1.21353e-06 ,1.25479e-06 ,1.29698e-06 ,1.34011e-06 ,1.38419e-06 , &
+      1.42923e-06 ,1.47523e-06 ,1.52221e-06 ,1.57016e-06 ,1.61910e-06 , &
+      1.66904e-06 ,1.71997e-06 ,1.77192e-06 ,1.82488e-06 ,1.87886e-06 , &
+      1.93387e-06 ,1.98991e-06 ,2.04699e-06 ,2.10512e-06 ,2.16430e-06 , &
+      2.22454e-06 ,2.28584e-06 ,2.34821e-06 ,2.41166e-06 ,2.47618e-06 , &
+      2.54178e-06 ,2.60847e-06 ,2.67626e-06 ,2.74514e-06 ,2.81512e-06 /)
+      totplnk(51:100, 5) = (/ &
+      2.88621e-06 ,2.95841e-06 ,3.03172e-06 ,3.10615e-06 ,3.18170e-06 , &
+      3.25838e-06 ,3.33618e-06 ,3.41511e-06 ,3.49518e-06 ,3.57639e-06 , &
+      3.65873e-06 ,3.74221e-06 ,3.82684e-06 ,3.91262e-06 ,3.99955e-06 , &
+      4.08763e-06 ,4.17686e-06 ,4.26725e-06 ,4.35880e-06 ,4.45150e-06 , &
+      4.54537e-06 ,4.64039e-06 ,4.73659e-06 ,4.83394e-06 ,4.93246e-06 , &
+      5.03215e-06 ,5.13301e-06 ,5.23504e-06 ,5.33823e-06 ,5.44260e-06 , &
+      5.54814e-06 ,5.65484e-06 ,5.76272e-06 ,5.87177e-06 ,5.98199e-06 , &
+      6.09339e-06 ,6.20596e-06 ,6.31969e-06 ,6.43460e-06 ,6.55068e-06 , &
+      6.66793e-06 ,6.78636e-06 ,6.90595e-06 ,7.02670e-06 ,7.14863e-06 , &
+      7.27173e-06 ,7.39599e-06 ,7.52142e-06 ,7.64802e-06 ,7.77577e-06 /)
+      totplnk(101:150, 5) = (/ &
+      7.90469e-06 ,8.03477e-06 ,8.16601e-06 ,8.29841e-06 ,8.43198e-06 , &
+      8.56669e-06 ,8.70256e-06 ,8.83957e-06 ,8.97775e-06 ,9.11706e-06 , &
+      9.25753e-06 ,9.39915e-06 ,9.54190e-06 ,9.68580e-06 ,9.83085e-06 , &
+      9.97704e-06 ,1.01243e-05 ,1.02728e-05 ,1.04224e-05 ,1.05731e-05 , &
+      1.07249e-05 ,1.08779e-05 ,1.10320e-05 ,1.11872e-05 ,1.13435e-05 , &
+      1.15009e-05 ,1.16595e-05 ,1.18191e-05 ,1.19799e-05 ,1.21418e-05 , &
+      1.23048e-05 ,1.24688e-05 ,1.26340e-05 ,1.28003e-05 ,1.29676e-05 , &
+      1.31361e-05 ,1.33056e-05 ,1.34762e-05 ,1.36479e-05 ,1.38207e-05 , &
+      1.39945e-05 ,1.41694e-05 ,1.43454e-05 ,1.45225e-05 ,1.47006e-05 , &
+      1.48797e-05 ,1.50600e-05 ,1.52413e-05 ,1.54236e-05 ,1.56070e-05 /)
+      totplnk(151:181, 5) = (/ &
+      1.57914e-05 ,1.59768e-05 ,1.61633e-05 ,1.63509e-05 ,1.65394e-05 , &
+      1.67290e-05 ,1.69197e-05 ,1.71113e-05 ,1.73040e-05 ,1.74976e-05 , &
+      1.76923e-05 ,1.78880e-05 ,1.80847e-05 ,1.82824e-05 ,1.84811e-05 , &
+      1.86808e-05 ,1.88814e-05 ,1.90831e-05 ,1.92857e-05 ,1.94894e-05 , &
+      1.96940e-05 ,1.98996e-05 ,2.01061e-05 ,2.03136e-05 ,2.05221e-05 , &
+      2.07316e-05 ,2.09420e-05 ,2.11533e-05 ,2.13657e-05 ,2.15789e-05 , &
+      2.17931e-05 /)
+      totplnk(1:50, 6) = (/ &
+      2.73493e-07 ,2.87408e-07 ,3.01848e-07 ,3.16825e-07 ,3.32352e-07 , &
+      3.48439e-07 ,3.65100e-07 ,3.82346e-07 ,4.00189e-07 ,4.18641e-07 , &
+      4.37715e-07 ,4.57422e-07 ,4.77774e-07 ,4.98784e-07 ,5.20464e-07 , &
+      5.42824e-07 ,5.65879e-07 ,5.89638e-07 ,6.14115e-07 ,6.39320e-07 , &
+      6.65266e-07 ,6.91965e-07 ,7.19427e-07 ,7.47666e-07 ,7.76691e-07 , &
+      8.06516e-07 ,8.37151e-07 ,8.68607e-07 ,9.00896e-07 ,9.34029e-07 , &
+      9.68018e-07 ,1.00287e-06 ,1.03860e-06 ,1.07522e-06 ,1.11274e-06 , &
+      1.15117e-06 ,1.19052e-06 ,1.23079e-06 ,1.27201e-06 ,1.31418e-06 , &
+      1.35731e-06 ,1.40141e-06 ,1.44650e-06 ,1.49257e-06 ,1.53965e-06 , &
+      1.58773e-06 ,1.63684e-06 ,1.68697e-06 ,1.73815e-06 ,1.79037e-06 /)
+      totplnk(51:100, 6) = (/ &
+      1.84365e-06 ,1.89799e-06 ,1.95341e-06 ,2.00991e-06 ,2.06750e-06 , &
+      2.12619e-06 ,2.18599e-06 ,2.24691e-06 ,2.30895e-06 ,2.37212e-06 , &
+      2.43643e-06 ,2.50189e-06 ,2.56851e-06 ,2.63628e-06 ,2.70523e-06 , &
+      2.77536e-06 ,2.84666e-06 ,2.91916e-06 ,2.99286e-06 ,3.06776e-06 , &
+      3.14387e-06 ,3.22120e-06 ,3.29975e-06 ,3.37953e-06 ,3.46054e-06 , &
+      3.54280e-06 ,3.62630e-06 ,3.71105e-06 ,3.79707e-06 ,3.88434e-06 , &
+      3.97288e-06 ,4.06270e-06 ,4.15380e-06 ,4.24617e-06 ,4.33984e-06 , &
+      4.43479e-06 ,4.53104e-06 ,4.62860e-06 ,4.72746e-06 ,4.82763e-06 , &
+      4.92911e-06 ,5.03191e-06 ,5.13603e-06 ,5.24147e-06 ,5.34824e-06 , &
+      5.45634e-06 ,5.56578e-06 ,5.67656e-06 ,5.78867e-06 ,5.90213e-06 /)
+      totplnk(101:150, 6) = (/ &
+      6.01694e-06 ,6.13309e-06 ,6.25060e-06 ,6.36947e-06 ,6.48968e-06 , &
+      6.61126e-06 ,6.73420e-06 ,6.85850e-06 ,6.98417e-06 ,7.11120e-06 , &
+      7.23961e-06 ,7.36938e-06 ,7.50053e-06 ,7.63305e-06 ,7.76694e-06 , &
+      7.90221e-06 ,8.03887e-06 ,8.17690e-06 ,8.31632e-06 ,8.45710e-06 , &
+      8.59928e-06 ,8.74282e-06 ,8.88776e-06 ,9.03409e-06 ,9.18179e-06 , &
+      9.33088e-06 ,9.48136e-06 ,9.63323e-06 ,9.78648e-06 ,9.94111e-06 , &
+      1.00971e-05 ,1.02545e-05 ,1.04133e-05 ,1.05735e-05 ,1.07351e-05 , &
+      1.08980e-05 ,1.10624e-05 ,1.12281e-05 ,1.13952e-05 ,1.15637e-05 , &
+      1.17335e-05 ,1.19048e-05 ,1.20774e-05 ,1.22514e-05 ,1.24268e-05 , &
+      1.26036e-05 ,1.27817e-05 ,1.29612e-05 ,1.31421e-05 ,1.33244e-05 /)
+      totplnk(151:181, 6) = (/ &
+      1.35080e-05 ,1.36930e-05 ,1.38794e-05 ,1.40672e-05 ,1.42563e-05 , &
+      1.44468e-05 ,1.46386e-05 ,1.48318e-05 ,1.50264e-05 ,1.52223e-05 , &
+      1.54196e-05 ,1.56182e-05 ,1.58182e-05 ,1.60196e-05 ,1.62223e-05 , &
+      1.64263e-05 ,1.66317e-05 ,1.68384e-05 ,1.70465e-05 ,1.72559e-05 , &
+      1.74666e-05 ,1.76787e-05 ,1.78921e-05 ,1.81069e-05 ,1.83230e-05 , &
+      1.85404e-05 ,1.87591e-05 ,1.89791e-05 ,1.92005e-05 ,1.94232e-05 , &
+      1.96471e-05 /)
+      totplnk(1:50, 7) = (/ &
+      1.25349e-07 ,1.32735e-07 ,1.40458e-07 ,1.48527e-07 ,1.56954e-07 , &
+      1.65748e-07 ,1.74920e-07 ,1.84481e-07 ,1.94443e-07 ,2.04814e-07 , &
+      2.15608e-07 ,2.26835e-07 ,2.38507e-07 ,2.50634e-07 ,2.63229e-07 , &
+      2.76301e-07 ,2.89864e-07 ,3.03930e-07 ,3.18508e-07 ,3.33612e-07 , &
+      3.49253e-07 ,3.65443e-07 ,3.82195e-07 ,3.99519e-07 ,4.17428e-07 , &
+      4.35934e-07 ,4.55050e-07 ,4.74785e-07 ,4.95155e-07 ,5.16170e-07 , &
+      5.37844e-07 ,5.60186e-07 ,5.83211e-07 ,6.06929e-07 ,6.31355e-07 , &
+      6.56498e-07 ,6.82373e-07 ,7.08990e-07 ,7.36362e-07 ,7.64501e-07 , &
+      7.93420e-07 ,8.23130e-07 ,8.53643e-07 ,8.84971e-07 ,9.17128e-07 , &
+      9.50123e-07 ,9.83969e-07 ,1.01868e-06 ,1.05426e-06 ,1.09073e-06 /)
+      totplnk(51:100, 7) = (/ &
+      1.12810e-06 ,1.16638e-06 ,1.20558e-06 ,1.24572e-06 ,1.28680e-06 , &
+      1.32883e-06 ,1.37183e-06 ,1.41581e-06 ,1.46078e-06 ,1.50675e-06 , &
+      1.55374e-06 ,1.60174e-06 ,1.65078e-06 ,1.70087e-06 ,1.75200e-06 , &
+      1.80421e-06 ,1.85749e-06 ,1.91186e-06 ,1.96732e-06 ,2.02389e-06 , &
+      2.08159e-06 ,2.14040e-06 ,2.20035e-06 ,2.26146e-06 ,2.32372e-06 , &
+      2.38714e-06 ,2.45174e-06 ,2.51753e-06 ,2.58451e-06 ,2.65270e-06 , &
+      2.72210e-06 ,2.79272e-06 ,2.86457e-06 ,2.93767e-06 ,3.01201e-06 , &
+      3.08761e-06 ,3.16448e-06 ,3.24261e-06 ,3.32204e-06 ,3.40275e-06 , &
+      3.48476e-06 ,3.56808e-06 ,3.65271e-06 ,3.73866e-06 ,3.82595e-06 , &
+      3.91456e-06 ,4.00453e-06 ,4.09584e-06 ,4.18851e-06 ,4.28254e-06 /)
+      totplnk(101:150, 7) = (/ &
+      4.37796e-06 ,4.47475e-06 ,4.57293e-06 ,4.67249e-06 ,4.77346e-06 , &
+      4.87583e-06 ,4.97961e-06 ,5.08481e-06 ,5.19143e-06 ,5.29948e-06 , &
+      5.40896e-06 ,5.51989e-06 ,5.63226e-06 ,5.74608e-06 ,5.86136e-06 , &
+      5.97810e-06 ,6.09631e-06 ,6.21597e-06 ,6.33713e-06 ,6.45976e-06 , &
+      6.58388e-06 ,6.70950e-06 ,6.83661e-06 ,6.96521e-06 ,7.09531e-06 , &
+      7.22692e-06 ,7.36005e-06 ,7.49468e-06 ,7.63084e-06 ,7.76851e-06 , &
+      7.90773e-06 ,8.04846e-06 ,8.19072e-06 ,8.33452e-06 ,8.47985e-06 , &
+      8.62674e-06 ,8.77517e-06 ,8.92514e-06 ,9.07666e-06 ,9.22975e-06 , &
+      9.38437e-06 ,9.54057e-06 ,9.69832e-06 ,9.85762e-06 ,1.00185e-05 , &
+      1.01810e-05 ,1.03450e-05 ,1.05106e-05 ,1.06777e-05 ,1.08465e-05 /)
+      totplnk(151:181, 7) = (/ &
+      1.10168e-05 ,1.11887e-05 ,1.13621e-05 ,1.15372e-05 ,1.17138e-05 , &
+      1.18920e-05 ,1.20718e-05 ,1.22532e-05 ,1.24362e-05 ,1.26207e-05 , &
+      1.28069e-05 ,1.29946e-05 ,1.31839e-05 ,1.33749e-05 ,1.35674e-05 , &
+      1.37615e-05 ,1.39572e-05 ,1.41544e-05 ,1.43533e-05 ,1.45538e-05 , &
+      1.47558e-05 ,1.49595e-05 ,1.51647e-05 ,1.53716e-05 ,1.55800e-05 , &
+      1.57900e-05 ,1.60017e-05 ,1.62149e-05 ,1.64296e-05 ,1.66460e-05 , &
+      1.68640e-05 /)
+      totplnk(1:50, 8) = (/ &
+      6.74445e-08 ,7.18176e-08 ,7.64153e-08 ,8.12456e-08 ,8.63170e-08 , &
+      9.16378e-08 ,9.72168e-08 ,1.03063e-07 ,1.09184e-07 ,1.15591e-07 , &
+      1.22292e-07 ,1.29296e-07 ,1.36613e-07 ,1.44253e-07 ,1.52226e-07 , &
+      1.60540e-07 ,1.69207e-07 ,1.78236e-07 ,1.87637e-07 ,1.97421e-07 , &
+      2.07599e-07 ,2.18181e-07 ,2.29177e-07 ,2.40598e-07 ,2.52456e-07 , &
+      2.64761e-07 ,2.77523e-07 ,2.90755e-07 ,3.04468e-07 ,3.18673e-07 , &
+      3.33381e-07 ,3.48603e-07 ,3.64352e-07 ,3.80638e-07 ,3.97474e-07 , &
+      4.14871e-07 ,4.32841e-07 ,4.51395e-07 ,4.70547e-07 ,4.90306e-07 , &
+      5.10687e-07 ,5.31699e-07 ,5.53357e-07 ,5.75670e-07 ,5.98652e-07 , &
+      6.22315e-07 ,6.46672e-07 ,6.71731e-07 ,6.97511e-07 ,7.24018e-07 /)
+      totplnk(51:100, 8) = (/ &
+      7.51266e-07 ,7.79269e-07 ,8.08038e-07 ,8.37584e-07 ,8.67922e-07 , &
+      8.99061e-07 ,9.31016e-07 ,9.63797e-07 ,9.97417e-07 ,1.03189e-06 , &
+      1.06722e-06 ,1.10343e-06 ,1.14053e-06 ,1.17853e-06 ,1.21743e-06 , &
+      1.25726e-06 ,1.29803e-06 ,1.33974e-06 ,1.38241e-06 ,1.42606e-06 , &
+      1.47068e-06 ,1.51630e-06 ,1.56293e-06 ,1.61056e-06 ,1.65924e-06 , &
+      1.70894e-06 ,1.75971e-06 ,1.81153e-06 ,1.86443e-06 ,1.91841e-06 , &
+      1.97350e-06 ,2.02968e-06 ,2.08699e-06 ,2.14543e-06 ,2.20500e-06 , &
+      2.26573e-06 ,2.32762e-06 ,2.39068e-06 ,2.45492e-06 ,2.52036e-06 , &
+      2.58700e-06 ,2.65485e-06 ,2.72393e-06 ,2.79424e-06 ,2.86580e-06 , &
+      2.93861e-06 ,3.01269e-06 ,3.08803e-06 ,3.16467e-06 ,3.24259e-06 /)
+      totplnk(101:150, 8) = (/ &
+      3.32181e-06 ,3.40235e-06 ,3.48420e-06 ,3.56739e-06 ,3.65192e-06 , &
+      3.73779e-06 ,3.82502e-06 ,3.91362e-06 ,4.00359e-06 ,4.09494e-06 , &
+      4.18768e-06 ,4.28182e-06 ,4.37737e-06 ,4.47434e-06 ,4.57273e-06 , &
+      4.67254e-06 ,4.77380e-06 ,4.87651e-06 ,4.98067e-06 ,5.08630e-06 , &
+      5.19339e-06 ,5.30196e-06 ,5.41201e-06 ,5.52356e-06 ,5.63660e-06 , &
+      5.75116e-06 ,5.86722e-06 ,5.98479e-06 ,6.10390e-06 ,6.22453e-06 , &
+      6.34669e-06 ,6.47042e-06 ,6.59569e-06 ,6.72252e-06 ,6.85090e-06 , &
+      6.98085e-06 ,7.11238e-06 ,7.24549e-06 ,7.38019e-06 ,7.51646e-06 , &
+      7.65434e-06 ,7.79382e-06 ,7.93490e-06 ,8.07760e-06 ,8.22192e-06 , &
+      8.36784e-06 ,8.51540e-06 ,8.66459e-06 ,8.81542e-06 ,8.96786e-06 /)
+      totplnk(151:181, 8) = (/ &
+      9.12197e-06 ,9.27772e-06 ,9.43513e-06 ,9.59419e-06 ,9.75490e-06 , &
+      9.91728e-06 ,1.00813e-05 ,1.02471e-05 ,1.04144e-05 ,1.05835e-05 , &
+      1.07543e-05 ,1.09267e-05 ,1.11008e-05 ,1.12766e-05 ,1.14541e-05 , &
+      1.16333e-05 ,1.18142e-05 ,1.19969e-05 ,1.21812e-05 ,1.23672e-05 , &
+      1.25549e-05 ,1.27443e-05 ,1.29355e-05 ,1.31284e-05 ,1.33229e-05 , &
+      1.35193e-05 ,1.37173e-05 ,1.39170e-05 ,1.41185e-05 ,1.43217e-05 , &
+      1.45267e-05 /)
+      totplnk(1:50, 9) = (/ &
+      2.61522e-08 ,2.80613e-08 ,3.00838e-08 ,3.22250e-08 ,3.44899e-08 , &
+      3.68841e-08 ,3.94129e-08 ,4.20820e-08 ,4.48973e-08 ,4.78646e-08 , &
+      5.09901e-08 ,5.42799e-08 ,5.77405e-08 ,6.13784e-08 ,6.52001e-08 , &
+      6.92126e-08 ,7.34227e-08 ,7.78375e-08 ,8.24643e-08 ,8.73103e-08 , &
+      9.23832e-08 ,9.76905e-08 ,1.03240e-07 ,1.09039e-07 ,1.15097e-07 , &
+      1.21421e-07 ,1.28020e-07 ,1.34902e-07 ,1.42075e-07 ,1.49548e-07 , &
+      1.57331e-07 ,1.65432e-07 ,1.73860e-07 ,1.82624e-07 ,1.91734e-07 , &
+      2.01198e-07 ,2.11028e-07 ,2.21231e-07 ,2.31818e-07 ,2.42799e-07 , &
+      2.54184e-07 ,2.65983e-07 ,2.78205e-07 ,2.90862e-07 ,3.03963e-07 , &
+      3.17519e-07 ,3.31541e-07 ,3.46039e-07 ,3.61024e-07 ,3.76507e-07 /)
+      totplnk(51:100, 9) = (/ &
+      3.92498e-07 ,4.09008e-07 ,4.26050e-07 ,4.43633e-07 ,4.61769e-07 , &
+      4.80469e-07 ,4.99744e-07 ,5.19606e-07 ,5.40067e-07 ,5.61136e-07 , &
+      5.82828e-07 ,6.05152e-07 ,6.28120e-07 ,6.51745e-07 ,6.76038e-07 , &
+      7.01010e-07 ,7.26674e-07 ,7.53041e-07 ,7.80124e-07 ,8.07933e-07 , &
+      8.36482e-07 ,8.65781e-07 ,8.95845e-07 ,9.26683e-07 ,9.58308e-07 , &
+      9.90732e-07 ,1.02397e-06 ,1.05803e-06 ,1.09292e-06 ,1.12866e-06 , &
+      1.16526e-06 ,1.20274e-06 ,1.24109e-06 ,1.28034e-06 ,1.32050e-06 , &
+      1.36158e-06 ,1.40359e-06 ,1.44655e-06 ,1.49046e-06 ,1.53534e-06 , &
+      1.58120e-06 ,1.62805e-06 ,1.67591e-06 ,1.72478e-06 ,1.77468e-06 , &
+      1.82561e-06 ,1.87760e-06 ,1.93066e-06 ,1.98479e-06 ,2.04000e-06 /)
+      totplnk(101:150, 9) = (/ &
+      2.09631e-06 ,2.15373e-06 ,2.21228e-06 ,2.27196e-06 ,2.33278e-06 , &
+      2.39475e-06 ,2.45790e-06 ,2.52222e-06 ,2.58773e-06 ,2.65445e-06 , &
+      2.72238e-06 ,2.79152e-06 ,2.86191e-06 ,2.93354e-06 ,3.00643e-06 , &
+      3.08058e-06 ,3.15601e-06 ,3.23273e-06 ,3.31075e-06 ,3.39009e-06 , &
+      3.47074e-06 ,3.55272e-06 ,3.63605e-06 ,3.72072e-06 ,3.80676e-06 , &
+      3.89417e-06 ,3.98297e-06 ,4.07315e-06 ,4.16474e-06 ,4.25774e-06 , &
+      4.35217e-06 ,4.44802e-06 ,4.54532e-06 ,4.64406e-06 ,4.74428e-06 , &
+      4.84595e-06 ,4.94911e-06 ,5.05376e-06 ,5.15990e-06 ,5.26755e-06 , &
+      5.37671e-06 ,5.48741e-06 ,5.59963e-06 ,5.71340e-06 ,5.82871e-06 , &
+      5.94559e-06 ,6.06403e-06 ,6.18404e-06 ,6.30565e-06 ,6.42885e-06 /)
+      totplnk(151:181, 9) = (/ &
+      6.55364e-06 ,6.68004e-06 ,6.80806e-06 ,6.93771e-06 ,7.06898e-06 , &
+      7.20190e-06 ,7.33646e-06 ,7.47267e-06 ,7.61056e-06 ,7.75010e-06 , &
+      7.89133e-06 ,8.03423e-06 ,8.17884e-06 ,8.32514e-06 ,8.47314e-06 , &
+      8.62284e-06 ,8.77427e-06 ,8.92743e-06 ,9.08231e-06 ,9.23893e-06 , &
+      9.39729e-06 ,9.55741e-06 ,9.71927e-06 ,9.88291e-06 ,1.00483e-05 , &
+      1.02155e-05 ,1.03844e-05 ,1.05552e-05 ,1.07277e-05 ,1.09020e-05 , &
+      1.10781e-05 /)
+      totplnk(1:50,10) = (/ &
+      8.89300e-09 ,9.63263e-09 ,1.04235e-08 ,1.12685e-08 ,1.21703e-08 , &
+      1.31321e-08 ,1.41570e-08 ,1.52482e-08 ,1.64090e-08 ,1.76428e-08 , &
+      1.89533e-08 ,2.03441e-08 ,2.18190e-08 ,2.33820e-08 ,2.50370e-08 , &
+      2.67884e-08 ,2.86402e-08 ,3.05969e-08 ,3.26632e-08 ,3.48436e-08 , &
+      3.71429e-08 ,3.95660e-08 ,4.21179e-08 ,4.48040e-08 ,4.76294e-08 , &
+      5.05996e-08 ,5.37201e-08 ,5.69966e-08 ,6.04349e-08 ,6.40411e-08 , &
+      6.78211e-08 ,7.17812e-08 ,7.59276e-08 ,8.02670e-08 ,8.48059e-08 , &
+      8.95508e-08 ,9.45090e-08 ,9.96873e-08 ,1.05093e-07 ,1.10733e-07 , &
+      1.16614e-07 ,1.22745e-07 ,1.29133e-07 ,1.35786e-07 ,1.42711e-07 , &
+      1.49916e-07 ,1.57410e-07 ,1.65202e-07 ,1.73298e-07 ,1.81709e-07 /)
+      totplnk(51:100,10) = (/ &
+      1.90441e-07 ,1.99505e-07 ,2.08908e-07 ,2.18660e-07 ,2.28770e-07 , &
+      2.39247e-07 ,2.50101e-07 ,2.61340e-07 ,2.72974e-07 ,2.85013e-07 , &
+      2.97467e-07 ,3.10345e-07 ,3.23657e-07 ,3.37413e-07 ,3.51623e-07 , &
+      3.66298e-07 ,3.81448e-07 ,3.97082e-07 ,4.13212e-07 ,4.29848e-07 , &
+      4.47000e-07 ,4.64680e-07 ,4.82898e-07 ,5.01664e-07 ,5.20991e-07 , &
+      5.40888e-07 ,5.61369e-07 ,5.82440e-07 ,6.04118e-07 ,6.26410e-07 , &
+      6.49329e-07 ,6.72887e-07 ,6.97095e-07 ,7.21964e-07 ,7.47506e-07 , &
+      7.73732e-07 ,8.00655e-07 ,8.28287e-07 ,8.56635e-07 ,8.85717e-07 , &
+      9.15542e-07 ,9.46122e-07 ,9.77469e-07 ,1.00960e-06 ,1.04251e-06 , &
+      1.07623e-06 ,1.11077e-06 ,1.14613e-06 ,1.18233e-06 ,1.21939e-06 /)
+      totplnk(101:150,10) = (/ &
+      1.25730e-06 ,1.29610e-06 ,1.33578e-06 ,1.37636e-06 ,1.41785e-06 , &
+      1.46027e-06 ,1.50362e-06 ,1.54792e-06 ,1.59319e-06 ,1.63942e-06 , &
+      1.68665e-06 ,1.73487e-06 ,1.78410e-06 ,1.83435e-06 ,1.88564e-06 , &
+      1.93797e-06 ,1.99136e-06 ,2.04582e-06 ,2.10137e-06 ,2.15801e-06 , &
+      2.21576e-06 ,2.27463e-06 ,2.33462e-06 ,2.39577e-06 ,2.45806e-06 , &
+      2.52153e-06 ,2.58617e-06 ,2.65201e-06 ,2.71905e-06 ,2.78730e-06 , &
+      2.85678e-06 ,2.92749e-06 ,2.99946e-06 ,3.07269e-06 ,3.14720e-06 , &
+      3.22299e-06 ,3.30007e-06 ,3.37847e-06 ,3.45818e-06 ,3.53923e-06 , &
+      3.62161e-06 ,3.70535e-06 ,3.79046e-06 ,3.87695e-06 ,3.96481e-06 , &
+      4.05409e-06 ,4.14477e-06 ,4.23687e-06 ,4.33040e-06 ,4.42538e-06 /)
+      totplnk(151:181,10) = (/ &
+      4.52180e-06 ,4.61969e-06 ,4.71905e-06 ,4.81991e-06 ,4.92226e-06 , &
+      5.02611e-06 ,5.13148e-06 ,5.23839e-06 ,5.34681e-06 ,5.45681e-06 , &
+      5.56835e-06 ,5.68146e-06 ,5.79614e-06 ,5.91242e-06 ,6.03030e-06 , &
+      6.14978e-06 ,6.27088e-06 ,6.39360e-06 ,6.51798e-06 ,6.64398e-06 , &
+      6.77165e-06 ,6.90099e-06 ,7.03198e-06 ,7.16468e-06 ,7.29906e-06 , &
+      7.43514e-06 ,7.57294e-06 ,7.71244e-06 ,7.85369e-06 ,7.99666e-06 , &
+      8.14138e-06 /)
+      totplnk(1:50,11) = (/ &
+      2.53767e-09 ,2.77242e-09 ,3.02564e-09 ,3.29851e-09 ,3.59228e-09 , &
+      3.90825e-09 ,4.24777e-09 ,4.61227e-09 ,5.00322e-09 ,5.42219e-09 , &
+      5.87080e-09 ,6.35072e-09 ,6.86370e-09 ,7.41159e-09 ,7.99628e-09 , &
+      8.61974e-09 ,9.28404e-09 ,9.99130e-09 ,1.07437e-08 ,1.15436e-08 , &
+      1.23933e-08 ,1.32953e-08 ,1.42522e-08 ,1.52665e-08 ,1.63410e-08 , &
+      1.74786e-08 ,1.86820e-08 ,1.99542e-08 ,2.12985e-08 ,2.27179e-08 , &
+      2.42158e-08 ,2.57954e-08 ,2.74604e-08 ,2.92141e-08 ,3.10604e-08 , &
+      3.30029e-08 ,3.50457e-08 ,3.71925e-08 ,3.94476e-08 ,4.18149e-08 , &
+      4.42991e-08 ,4.69043e-08 ,4.96352e-08 ,5.24961e-08 ,5.54921e-08 , &
+      5.86277e-08 ,6.19081e-08 ,6.53381e-08 ,6.89231e-08 ,7.26681e-08 /)
+      totplnk(51:100,11) = (/ &
+      7.65788e-08 ,8.06604e-08 ,8.49187e-08 ,8.93591e-08 ,9.39879e-08 , &
+      9.88106e-08 ,1.03834e-07 ,1.09063e-07 ,1.14504e-07 ,1.20165e-07 , &
+      1.26051e-07 ,1.32169e-07 ,1.38525e-07 ,1.45128e-07 ,1.51982e-07 , &
+      1.59096e-07 ,1.66477e-07 ,1.74132e-07 ,1.82068e-07 ,1.90292e-07 , &
+      1.98813e-07 ,2.07638e-07 ,2.16775e-07 ,2.26231e-07 ,2.36015e-07 , &
+      2.46135e-07 ,2.56599e-07 ,2.67415e-07 ,2.78592e-07 ,2.90137e-07 , &
+      3.02061e-07 ,3.14371e-07 ,3.27077e-07 ,3.40186e-07 ,3.53710e-07 , &
+      3.67655e-07 ,3.82031e-07 ,3.96848e-07 ,4.12116e-07 ,4.27842e-07 , &
+      4.44039e-07 ,4.60713e-07 ,4.77876e-07 ,4.95537e-07 ,5.13706e-07 , &
+      5.32392e-07 ,5.51608e-07 ,5.71360e-07 ,5.91662e-07 ,6.12521e-07 /)
+      totplnk(101:150,11) = (/ &
+      6.33950e-07 ,6.55958e-07 ,6.78556e-07 ,7.01753e-07 ,7.25562e-07 , &
+      7.49992e-07 ,7.75055e-07 ,8.00760e-07 ,8.27120e-07 ,8.54145e-07 , &
+      8.81845e-07 ,9.10233e-07 ,9.39318e-07 ,9.69113e-07 ,9.99627e-07 , &
+      1.03087e-06 ,1.06286e-06 ,1.09561e-06 ,1.12912e-06 ,1.16340e-06 , &
+      1.19848e-06 ,1.23435e-06 ,1.27104e-06 ,1.30855e-06 ,1.34690e-06 , &
+      1.38609e-06 ,1.42614e-06 ,1.46706e-06 ,1.50886e-06 ,1.55155e-06 , &
+      1.59515e-06 ,1.63967e-06 ,1.68512e-06 ,1.73150e-06 ,1.77884e-06 , &
+      1.82715e-06 ,1.87643e-06 ,1.92670e-06 ,1.97797e-06 ,2.03026e-06 , &
+      2.08356e-06 ,2.13791e-06 ,2.19330e-06 ,2.24975e-06 ,2.30728e-06 , &
+      2.36589e-06 ,2.42560e-06 ,2.48641e-06 ,2.54835e-06 ,2.61142e-06 /)
+      totplnk(151:181,11) = (/ &
+      2.67563e-06 ,2.74100e-06 ,2.80754e-06 ,2.87526e-06 ,2.94417e-06 , &
+      3.01429e-06 ,3.08562e-06 ,3.15819e-06 ,3.23199e-06 ,3.30704e-06 , &
+      3.38336e-06 ,3.46096e-06 ,3.53984e-06 ,3.62002e-06 ,3.70151e-06 , &
+      3.78433e-06 ,3.86848e-06 ,3.95399e-06 ,4.04084e-06 ,4.12907e-06 , &
+      4.21868e-06 ,4.30968e-06 ,4.40209e-06 ,4.49592e-06 ,4.59117e-06 , &
+      4.68786e-06 ,4.78600e-06 ,4.88561e-06 ,4.98669e-06 ,5.08926e-06 , &
+      5.19332e-06 /)
+      totplnk(1:50,12) = (/ &
+      2.73921e-10 ,3.04500e-10 ,3.38056e-10 ,3.74835e-10 ,4.15099e-10 , &
+      4.59126e-10 ,5.07214e-10 ,5.59679e-10 ,6.16857e-10 ,6.79103e-10 , &
+      7.46796e-10 ,8.20335e-10 ,9.00144e-10 ,9.86671e-10 ,1.08039e-09 , &
+      1.18180e-09 ,1.29142e-09 ,1.40982e-09 ,1.53757e-09 ,1.67529e-09 , &
+      1.82363e-09 ,1.98327e-09 ,2.15492e-09 ,2.33932e-09 ,2.53726e-09 , &
+      2.74957e-09 ,2.97710e-09 ,3.22075e-09 ,3.48145e-09 ,3.76020e-09 , &
+      4.05801e-09 ,4.37595e-09 ,4.71513e-09 ,5.07672e-09 ,5.46193e-09 , &
+      5.87201e-09 ,6.30827e-09 ,6.77205e-09 ,7.26480e-09 ,7.78794e-09 , &
+      8.34304e-09 ,8.93163e-09 ,9.55537e-09 ,1.02159e-08 ,1.09151e-08 , &
+      1.16547e-08 ,1.24365e-08 ,1.32625e-08 ,1.41348e-08 ,1.50554e-08 /)
+      totplnk(51:100,12) = (/ &
+      1.60264e-08 ,1.70500e-08 ,1.81285e-08 ,1.92642e-08 ,2.04596e-08 , &
+      2.17171e-08 ,2.30394e-08 ,2.44289e-08 ,2.58885e-08 ,2.74209e-08 , &
+      2.90290e-08 ,3.07157e-08 ,3.24841e-08 ,3.43371e-08 ,3.62782e-08 , &
+      3.83103e-08 ,4.04371e-08 ,4.26617e-08 ,4.49878e-08 ,4.74190e-08 , &
+      4.99589e-08 ,5.26113e-08 ,5.53801e-08 ,5.82692e-08 ,6.12826e-08 , &
+      6.44245e-08 ,6.76991e-08 ,7.11105e-08 ,7.46634e-08 ,7.83621e-08 , &
+      8.22112e-08 ,8.62154e-08 ,9.03795e-08 ,9.47081e-08 ,9.92066e-08 , &
+      1.03879e-07 ,1.08732e-07 ,1.13770e-07 ,1.18998e-07 ,1.24422e-07 , &
+      1.30048e-07 ,1.35880e-07 ,1.41924e-07 ,1.48187e-07 ,1.54675e-07 , &
+      1.61392e-07 ,1.68346e-07 ,1.75543e-07 ,1.82988e-07 ,1.90688e-07 /)
+      totplnk(101:150,12) = (/ &
+      1.98650e-07 ,2.06880e-07 ,2.15385e-07 ,2.24172e-07 ,2.33247e-07 , &
+      2.42617e-07 ,2.52289e-07 ,2.62272e-07 ,2.72571e-07 ,2.83193e-07 , &
+      2.94147e-07 ,3.05440e-07 ,3.17080e-07 ,3.29074e-07 ,3.41430e-07 , &
+      3.54155e-07 ,3.67259e-07 ,3.80747e-07 ,3.94631e-07 ,4.08916e-07 , &
+      4.23611e-07 ,4.38725e-07 ,4.54267e-07 ,4.70245e-07 ,4.86666e-07 , &
+      5.03541e-07 ,5.20879e-07 ,5.38687e-07 ,5.56975e-07 ,5.75751e-07 , &
+      5.95026e-07 ,6.14808e-07 ,6.35107e-07 ,6.55932e-07 ,6.77293e-07 , &
+      6.99197e-07 ,7.21656e-07 ,7.44681e-07 ,7.68278e-07 ,7.92460e-07 , &
+      8.17235e-07 ,8.42614e-07 ,8.68606e-07 ,8.95223e-07 ,9.22473e-07 , &
+      9.50366e-07 ,9.78915e-07 ,1.00813e-06 ,1.03802e-06 ,1.06859e-06 /)
+      totplnk(151:181,12) = (/ &
+      1.09986e-06 ,1.13184e-06 ,1.16453e-06 ,1.19796e-06 ,1.23212e-06 , &
+      1.26703e-06 ,1.30270e-06 ,1.33915e-06 ,1.37637e-06 ,1.41440e-06 , &
+      1.45322e-06 ,1.49286e-06 ,1.53333e-06 ,1.57464e-06 ,1.61679e-06 , &
+      1.65981e-06 ,1.70370e-06 ,1.74847e-06 ,1.79414e-06 ,1.84071e-06 , &
+      1.88821e-06 ,1.93663e-06 ,1.98599e-06 ,2.03631e-06 ,2.08759e-06 , &
+      2.13985e-06 ,2.19310e-06 ,2.24734e-06 ,2.30260e-06 ,2.35888e-06 , &
+      2.41619e-06 /)
+      totplnk(1:50,13) = (/ &
+      4.53634e-11 ,5.11435e-11 ,5.75754e-11 ,6.47222e-11 ,7.26531e-11 , &
+      8.14420e-11 ,9.11690e-11 ,1.01921e-10 ,1.13790e-10 ,1.26877e-10 , &
+      1.41288e-10 ,1.57140e-10 ,1.74555e-10 ,1.93665e-10 ,2.14613e-10 , &
+      2.37548e-10 ,2.62633e-10 ,2.90039e-10 ,3.19948e-10 ,3.52558e-10 , &
+      3.88073e-10 ,4.26716e-10 ,4.68719e-10 ,5.14331e-10 ,5.63815e-10 , &
+      6.17448e-10 ,6.75526e-10 ,7.38358e-10 ,8.06277e-10 ,8.79625e-10 , &
+      9.58770e-10 ,1.04410e-09 ,1.13602e-09 ,1.23495e-09 ,1.34135e-09 , &
+      1.45568e-09 ,1.57845e-09 ,1.71017e-09 ,1.85139e-09 ,2.00268e-09 , &
+      2.16464e-09 ,2.33789e-09 ,2.52309e-09 ,2.72093e-09 ,2.93212e-09 , &
+      3.15740e-09 ,3.39757e-09 ,3.65341e-09 ,3.92579e-09 ,4.21559e-09 /)
+      totplnk(51:100,13) = (/ &
+      4.52372e-09 ,4.85115e-09 ,5.19886e-09 ,5.56788e-09 ,5.95928e-09 , &
+      6.37419e-09 ,6.81375e-09 ,7.27917e-09 ,7.77168e-09 ,8.29256e-09 , &
+      8.84317e-09 ,9.42487e-09 ,1.00391e-08 ,1.06873e-08 ,1.13710e-08 , &
+      1.20919e-08 ,1.28515e-08 ,1.36514e-08 ,1.44935e-08 ,1.53796e-08 , &
+      1.63114e-08 ,1.72909e-08 ,1.83201e-08 ,1.94008e-08 ,2.05354e-08 , &
+      2.17258e-08 ,2.29742e-08 ,2.42830e-08 ,2.56545e-08 ,2.70910e-08 , &
+      2.85950e-08 ,3.01689e-08 ,3.18155e-08 ,3.35373e-08 ,3.53372e-08 , &
+      3.72177e-08 ,3.91818e-08 ,4.12325e-08 ,4.33727e-08 ,4.56056e-08 , &
+      4.79342e-08 ,5.03617e-08 ,5.28915e-08 ,5.55270e-08 ,5.82715e-08 , &
+      6.11286e-08 ,6.41019e-08 ,6.71951e-08 ,7.04119e-08 ,7.37560e-08 /)
+      totplnk(101:150,13) = (/ &
+      7.72315e-08 ,8.08424e-08 ,8.45927e-08 ,8.84866e-08 ,9.25281e-08 , &
+      9.67218e-08 ,1.01072e-07 ,1.05583e-07 ,1.10260e-07 ,1.15107e-07 , &
+      1.20128e-07 ,1.25330e-07 ,1.30716e-07 ,1.36291e-07 ,1.42061e-07 , &
+      1.48031e-07 ,1.54206e-07 ,1.60592e-07 ,1.67192e-07 ,1.74015e-07 , &
+      1.81064e-07 ,1.88345e-07 ,1.95865e-07 ,2.03628e-07 ,2.11643e-07 , &
+      2.19912e-07 ,2.28443e-07 ,2.37244e-07 ,2.46318e-07 ,2.55673e-07 , &
+      2.65316e-07 ,2.75252e-07 ,2.85489e-07 ,2.96033e-07 ,3.06891e-07 , &
+      3.18070e-07 ,3.29576e-07 ,3.41417e-07 ,3.53600e-07 ,3.66133e-07 , &
+      3.79021e-07 ,3.92274e-07 ,4.05897e-07 ,4.19899e-07 ,4.34288e-07 , &
+      4.49071e-07 ,4.64255e-07 ,4.79850e-07 ,4.95863e-07 ,5.12300e-07 /)
+      totplnk(151:181,13) = (/ &
+      5.29172e-07 ,5.46486e-07 ,5.64250e-07 ,5.82473e-07 ,6.01164e-07 , &
+      6.20329e-07 ,6.39979e-07 ,6.60122e-07 ,6.80767e-07 ,7.01922e-07 , &
+      7.23596e-07 ,7.45800e-07 ,7.68539e-07 ,7.91826e-07 ,8.15669e-07 , &
+      8.40076e-07 ,8.65058e-07 ,8.90623e-07 ,9.16783e-07 ,9.43544e-07 , &
+      9.70917e-07 ,9.98912e-07 ,1.02754e-06 ,1.05681e-06 ,1.08673e-06 , &
+      1.11731e-06 ,1.14856e-06 ,1.18050e-06 ,1.21312e-06 ,1.24645e-06 , &
+      1.28049e-06 /)
+      totplnk(1:50,14) = (/ &
+      1.40113e-11 ,1.59358e-11 ,1.80960e-11 ,2.05171e-11 ,2.32266e-11 , &
+      2.62546e-11 ,2.96335e-11 ,3.33990e-11 ,3.75896e-11 ,4.22469e-11 , &
+      4.74164e-11 ,5.31466e-11 ,5.94905e-11 ,6.65054e-11 ,7.42522e-11 , &
+      8.27975e-11 ,9.22122e-11 ,1.02573e-10 ,1.13961e-10 ,1.26466e-10 , &
+      1.40181e-10 ,1.55206e-10 ,1.71651e-10 ,1.89630e-10 ,2.09265e-10 , &
+      2.30689e-10 ,2.54040e-10 ,2.79467e-10 ,3.07128e-10 ,3.37190e-10 , &
+      3.69833e-10 ,4.05243e-10 ,4.43623e-10 ,4.85183e-10 ,5.30149e-10 , &
+      5.78755e-10 ,6.31255e-10 ,6.87910e-10 ,7.49002e-10 ,8.14824e-10 , &
+      8.85687e-10 ,9.61914e-10 ,1.04385e-09 ,1.13186e-09 ,1.22631e-09 , &
+      1.32761e-09 ,1.43617e-09 ,1.55243e-09 ,1.67686e-09 ,1.80992e-09 /)
+      totplnk(51:100,14) = (/ &
+      1.95212e-09 ,2.10399e-09 ,2.26607e-09 ,2.43895e-09 ,2.62321e-09 , &
+      2.81949e-09 ,3.02844e-09 ,3.25073e-09 ,3.48707e-09 ,3.73820e-09 , &
+      4.00490e-09 ,4.28794e-09 ,4.58819e-09 ,4.90647e-09 ,5.24371e-09 , &
+      5.60081e-09 ,5.97875e-09 ,6.37854e-09 ,6.80120e-09 ,7.24782e-09 , &
+      7.71950e-09 ,8.21740e-09 ,8.74271e-09 ,9.29666e-09 ,9.88054e-09 , &
+      1.04956e-08 ,1.11434e-08 ,1.18251e-08 ,1.25422e-08 ,1.32964e-08 , &
+      1.40890e-08 ,1.49217e-08 ,1.57961e-08 ,1.67140e-08 ,1.76771e-08 , &
+      1.86870e-08 ,1.97458e-08 ,2.08553e-08 ,2.20175e-08 ,2.32342e-08 , &
+      2.45077e-08 ,2.58401e-08 ,2.72334e-08 ,2.86900e-08 ,3.02122e-08 , &
+      3.18021e-08 ,3.34624e-08 ,3.51954e-08 ,3.70037e-08 ,3.88899e-08 /)
+      totplnk(101:150,14) = (/ &
+      4.08568e-08 ,4.29068e-08 ,4.50429e-08 ,4.72678e-08 ,4.95847e-08 , &
+      5.19963e-08 ,5.45058e-08 ,5.71161e-08 ,5.98309e-08 ,6.26529e-08 , &
+      6.55857e-08 ,6.86327e-08 ,7.17971e-08 ,7.50829e-08 ,7.84933e-08 , &
+      8.20323e-08 ,8.57035e-08 ,8.95105e-08 ,9.34579e-08 ,9.75488e-08 , &
+      1.01788e-07 ,1.06179e-07 ,1.10727e-07 ,1.15434e-07 ,1.20307e-07 , &
+      1.25350e-07 ,1.30566e-07 ,1.35961e-07 ,1.41539e-07 ,1.47304e-07 , &
+      1.53263e-07 ,1.59419e-07 ,1.65778e-07 ,1.72345e-07 ,1.79124e-07 , &
+      1.86122e-07 ,1.93343e-07 ,2.00792e-07 ,2.08476e-07 ,2.16400e-07 , &
+      2.24568e-07 ,2.32988e-07 ,2.41666e-07 ,2.50605e-07 ,2.59813e-07 , &
+      2.69297e-07 ,2.79060e-07 ,2.89111e-07 ,2.99455e-07 ,3.10099e-07 /)
+      totplnk(151:181,14) = (/ &
+      3.21049e-07 ,3.32311e-07 ,3.43893e-07 ,3.55801e-07 ,3.68041e-07 , &
+      3.80621e-07 ,3.93547e-07 ,4.06826e-07 ,4.20465e-07 ,4.34473e-07 , &
+      4.48856e-07 ,4.63620e-07 ,4.78774e-07 ,4.94325e-07 ,5.10280e-07 , &
+      5.26648e-07 ,5.43436e-07 ,5.60652e-07 ,5.78302e-07 ,5.96397e-07 , &
+      6.14943e-07 ,6.33949e-07 ,6.53421e-07 ,6.73370e-07 ,6.93803e-07 , &
+      7.14731e-07 ,7.36157e-07 ,7.58095e-07 ,7.80549e-07 ,8.03533e-07 , &
+      8.27050e-07 /)
+      totplnk(1:50,15) = (/ &
+      3.90483e-12 ,4.47999e-12 ,5.13122e-12 ,5.86739e-12 ,6.69829e-12 , &
+      7.63467e-12 ,8.68833e-12 ,9.87221e-12 ,1.12005e-11 ,1.26885e-11 , &
+      1.43534e-11 ,1.62134e-11 ,1.82888e-11 ,2.06012e-11 ,2.31745e-11 , &
+      2.60343e-11 ,2.92087e-11 ,3.27277e-11 ,3.66242e-11 ,4.09334e-11 , &
+      4.56935e-11 ,5.09455e-11 ,5.67338e-11 ,6.31057e-11 ,7.01127e-11 , &
+      7.78096e-11 ,8.62554e-11 ,9.55130e-11 ,1.05651e-10 ,1.16740e-10 , &
+      1.28858e-10 ,1.42089e-10 ,1.56519e-10 ,1.72243e-10 ,1.89361e-10 , &
+      2.07978e-10 ,2.28209e-10 ,2.50173e-10 ,2.73999e-10 ,2.99820e-10 , &
+      3.27782e-10 ,3.58034e-10 ,3.90739e-10 ,4.26067e-10 ,4.64196e-10 , &
+      5.05317e-10 ,5.49631e-10 ,5.97347e-10 ,6.48689e-10 ,7.03891e-10 /)
+      totplnk(51:100,15) = (/ &
+      7.63201e-10 ,8.26876e-10 ,8.95192e-10 ,9.68430e-10 ,1.04690e-09 , &
+      1.13091e-09 ,1.22079e-09 ,1.31689e-09 ,1.41957e-09 ,1.52922e-09 , &
+      1.64623e-09 ,1.77101e-09 ,1.90401e-09 ,2.04567e-09 ,2.19647e-09 , &
+      2.35690e-09 ,2.52749e-09 ,2.70875e-09 ,2.90127e-09 ,3.10560e-09 , &
+      3.32238e-09 ,3.55222e-09 ,3.79578e-09 ,4.05375e-09 ,4.32682e-09 , &
+      4.61574e-09 ,4.92128e-09 ,5.24420e-09 ,5.58536e-09 ,5.94558e-09 , &
+      6.32575e-09 ,6.72678e-09 ,7.14964e-09 ,7.59526e-09 ,8.06470e-09 , &
+      8.55897e-09 ,9.07916e-09 ,9.62638e-09 ,1.02018e-08 ,1.08066e-08 , &
+      1.14420e-08 ,1.21092e-08 ,1.28097e-08 ,1.35446e-08 ,1.43155e-08 , &
+      1.51237e-08 ,1.59708e-08 ,1.68581e-08 ,1.77873e-08 ,1.87599e-08 /)
+      totplnk(101:150,15) = (/ &
+      1.97777e-08 ,2.08423e-08 ,2.19555e-08 ,2.31190e-08 ,2.43348e-08 , &
+      2.56045e-08 ,2.69302e-08 ,2.83140e-08 ,2.97578e-08 ,3.12636e-08 , &
+      3.28337e-08 ,3.44702e-08 ,3.61755e-08 ,3.79516e-08 ,3.98012e-08 , &
+      4.17265e-08 ,4.37300e-08 ,4.58143e-08 ,4.79819e-08 ,5.02355e-08 , &
+      5.25777e-08 ,5.50114e-08 ,5.75393e-08 ,6.01644e-08 ,6.28896e-08 , &
+      6.57177e-08 ,6.86521e-08 ,7.16959e-08 ,7.48520e-08 ,7.81239e-08 , &
+      8.15148e-08 ,8.50282e-08 ,8.86675e-08 ,9.24362e-08 ,9.63380e-08 , &
+      1.00376e-07 ,1.04555e-07 ,1.08878e-07 ,1.13349e-07 ,1.17972e-07 , &
+      1.22751e-07 ,1.27690e-07 ,1.32793e-07 ,1.38064e-07 ,1.43508e-07 , &
+      1.49129e-07 ,1.54931e-07 ,1.60920e-07 ,1.67099e-07 ,1.73473e-07 /)
+      totplnk(151:181,15) = (/ &
+      1.80046e-07 ,1.86825e-07 ,1.93812e-07 ,2.01014e-07 ,2.08436e-07 , &
+      2.16082e-07 ,2.23957e-07 ,2.32067e-07 ,2.40418e-07 ,2.49013e-07 , &
+      2.57860e-07 ,2.66963e-07 ,2.76328e-07 ,2.85961e-07 ,2.95868e-07 , &
+      3.06053e-07 ,3.16524e-07 ,3.27286e-07 ,3.38345e-07 ,3.49707e-07 , &
+      3.61379e-07 ,3.73367e-07 ,3.85676e-07 ,3.98315e-07 ,4.11287e-07 , &
+      4.24602e-07 ,4.38265e-07 ,4.52283e-07 ,4.66662e-07 ,4.81410e-07 , &
+      4.96535e-07 /)
+      totplnk(1:50,16) = (/ &
+      0.28639e-12 ,0.33349e-12 ,0.38764e-12 ,0.44977e-12 ,0.52093e-12 , &
+      0.60231e-12 ,0.69522e-12 ,0.80111e-12 ,0.92163e-12 ,0.10586e-11 , &
+      0.12139e-11 ,0.13899e-11 ,0.15890e-11 ,0.18138e-11 ,0.20674e-11 , &
+      0.23531e-11 ,0.26744e-11 ,0.30352e-11 ,0.34401e-11 ,0.38936e-11 , &
+      0.44011e-11 ,0.49681e-11 ,0.56010e-11 ,0.63065e-11 ,0.70919e-11 , &
+      0.79654e-11 ,0.89357e-11 ,0.10012e-10 ,0.11205e-10 ,0.12526e-10 , &
+      0.13986e-10 ,0.15600e-10 ,0.17380e-10 ,0.19342e-10 ,0.21503e-10 , &
+      0.23881e-10 ,0.26494e-10 ,0.29362e-10 ,0.32509e-10 ,0.35958e-10 , &
+      0.39733e-10 ,0.43863e-10 ,0.48376e-10 ,0.53303e-10 ,0.58679e-10 , &
+      0.64539e-10 ,0.70920e-10 ,0.77864e-10 ,0.85413e-10 ,0.93615e-10 /)
+      totplnk(51:100,16) = (/ &
+      0.10252e-09 ,0.11217e-09 ,0.12264e-09 ,0.13397e-09 ,0.14624e-09 , &
+      0.15950e-09 ,0.17383e-09 ,0.18930e-09 ,0.20599e-09 ,0.22399e-09 , &
+      0.24339e-09 ,0.26427e-09 ,0.28674e-09 ,0.31090e-09 ,0.33686e-09 , &
+      0.36474e-09 ,0.39466e-09 ,0.42676e-09 ,0.46115e-09 ,0.49800e-09 , &
+      0.53744e-09 ,0.57964e-09 ,0.62476e-09 ,0.67298e-09 ,0.72448e-09 , &
+      0.77945e-09 ,0.83809e-09 ,0.90062e-09 ,0.96725e-09 ,0.10382e-08 , &
+      0.11138e-08 ,0.11941e-08 ,0.12796e-08 ,0.13704e-08 ,0.14669e-08 , &
+      0.15694e-08 ,0.16781e-08 ,0.17934e-08 ,0.19157e-08 ,0.20453e-08 , &
+      0.21825e-08 ,0.23278e-08 ,0.24815e-08 ,0.26442e-08 ,0.28161e-08 , &
+      0.29978e-08 ,0.31898e-08 ,0.33925e-08 ,0.36064e-08 ,0.38321e-08 /)
+      totplnk(101:150,16) = (/ &
+      0.40700e-08 ,0.43209e-08 ,0.45852e-08 ,0.48636e-08 ,0.51567e-08 , &
+      0.54652e-08 ,0.57897e-08 ,0.61310e-08 ,0.64897e-08 ,0.68667e-08 , &
+      0.72626e-08 ,0.76784e-08 ,0.81148e-08 ,0.85727e-08 ,0.90530e-08 , &
+      0.95566e-08 ,0.10084e-07 ,0.10638e-07 ,0.11217e-07 ,0.11824e-07 , &
+      0.12458e-07 ,0.13123e-07 ,0.13818e-07 ,0.14545e-07 ,0.15305e-07 , &
+      0.16099e-07 ,0.16928e-07 ,0.17795e-07 ,0.18699e-07 ,0.19643e-07 , &
+      0.20629e-07 ,0.21656e-07 ,0.22728e-07 ,0.23845e-07 ,0.25010e-07 , &
+      0.26223e-07 ,0.27487e-07 ,0.28804e-07 ,0.30174e-07 ,0.31600e-07 , &
+      0.33084e-07 ,0.34628e-07 ,0.36233e-07 ,0.37902e-07 ,0.39637e-07 , &
+      0.41440e-07 ,0.43313e-07 ,0.45259e-07 ,0.47279e-07 ,0.49376e-07 /)
+      totplnk(151:181,16) = (/ &
+      0.51552e-07 ,0.53810e-07 ,0.56153e-07 ,0.58583e-07 ,0.61102e-07 , &
+      0.63713e-07 ,0.66420e-07 ,0.69224e-07 ,0.72129e-07 ,0.75138e-07 , &
+      0.78254e-07 ,0.81479e-07 ,0.84818e-07 ,0.88272e-07 ,0.91846e-07 , &
+      0.95543e-07 ,0.99366e-07 ,0.10332e-06 ,0.10740e-06 ,0.11163e-06 , &
+      0.11599e-06 ,0.12050e-06 ,0.12515e-06 ,0.12996e-06 ,0.13493e-06 , &
+      0.14005e-06 ,0.14534e-06 ,0.15080e-06 ,0.15643e-06 ,0.16224e-06 , &
+      0.16823e-06 /)
+      totplk16(1:50) = (/ &
+      0.28481e-12 ,0.33159e-12 ,0.38535e-12 ,0.44701e-12 ,0.51763e-12 , &
+      0.59836e-12 ,0.69049e-12 ,0.79549e-12 ,0.91493e-12 ,0.10506e-11 , &
+      0.12045e-11 ,0.13788e-11 ,0.15758e-11 ,0.17984e-11 ,0.20493e-11 , &
+      0.23317e-11 ,0.26494e-11 ,0.30060e-11 ,0.34060e-11 ,0.38539e-11 , &
+      0.43548e-11 ,0.49144e-11 ,0.55387e-11 ,0.62344e-11 ,0.70086e-11 , &
+      0.78692e-11 ,0.88248e-11 ,0.98846e-11 ,0.11059e-10 ,0.12358e-10 , &
+      0.13794e-10 ,0.15379e-10 ,0.17128e-10 ,0.19055e-10 ,0.21176e-10 , &
+      0.23508e-10 ,0.26070e-10 ,0.28881e-10 ,0.31963e-10 ,0.35339e-10 , &
+      0.39034e-10 ,0.43073e-10 ,0.47484e-10 ,0.52299e-10 ,0.57548e-10 , &
+      0.63267e-10 ,0.69491e-10 ,0.76261e-10 ,0.83616e-10 ,0.91603e-10 /)
+      totplk16(51:100) = (/ &
+      0.10027e-09 ,0.10966e-09 ,0.11983e-09 ,0.13084e-09 ,0.14275e-09 , &
+      0.15562e-09 ,0.16951e-09 ,0.18451e-09 ,0.20068e-09 ,0.21810e-09 , &
+      0.23686e-09 ,0.25704e-09 ,0.27875e-09 ,0.30207e-09 ,0.32712e-09 , &
+      0.35400e-09 ,0.38282e-09 ,0.41372e-09 ,0.44681e-09 ,0.48223e-09 , &
+      0.52013e-09 ,0.56064e-09 ,0.60392e-09 ,0.65015e-09 ,0.69948e-09 , &
+      0.75209e-09 ,0.80818e-09 ,0.86794e-09 ,0.93157e-09 ,0.99929e-09 , &
+      0.10713e-08 ,0.11479e-08 ,0.12293e-08 ,0.13157e-08 ,0.14074e-08 , &
+      0.15047e-08 ,0.16079e-08 ,0.17172e-08 ,0.18330e-08 ,0.19557e-08 , &
+      0.20855e-08 ,0.22228e-08 ,0.23680e-08 ,0.25214e-08 ,0.26835e-08 , &
+      0.28546e-08 ,0.30352e-08 ,0.32257e-08 ,0.34266e-08 ,0.36384e-08 /)
+      totplk16(101:150) = (/ &
+      0.38615e-08 ,0.40965e-08 ,0.43438e-08 ,0.46041e-08 ,0.48779e-08 , &
+      0.51658e-08 ,0.54683e-08 ,0.57862e-08 ,0.61200e-08 ,0.64705e-08 , &
+      0.68382e-08 ,0.72240e-08 ,0.76285e-08 ,0.80526e-08 ,0.84969e-08 , &
+      0.89624e-08 ,0.94498e-08 ,0.99599e-08 ,0.10494e-07 ,0.11052e-07 , &
+      0.11636e-07 ,0.12246e-07 ,0.12884e-07 ,0.13551e-07 ,0.14246e-07 , &
+      0.14973e-07 ,0.15731e-07 ,0.16522e-07 ,0.17347e-07 ,0.18207e-07 , &
+      0.19103e-07 ,0.20037e-07 ,0.21011e-07 ,0.22024e-07 ,0.23079e-07 , &
+      0.24177e-07 ,0.25320e-07 ,0.26508e-07 ,0.27744e-07 ,0.29029e-07 , &
+      0.30365e-07 ,0.31753e-07 ,0.33194e-07 ,0.34691e-07 ,0.36246e-07 , &
+      0.37859e-07 ,0.39533e-07 ,0.41270e-07 ,0.43071e-07 ,0.44939e-07 /)
+      totplk16(151:181) = (/ &
+      0.46875e-07 ,0.48882e-07 ,0.50961e-07 ,0.53115e-07 ,0.55345e-07 , &
+      0.57655e-07 ,0.60046e-07 ,0.62520e-07 ,0.65080e-07 ,0.67728e-07 , &
+      0.70466e-07 ,0.73298e-07 ,0.76225e-07 ,0.79251e-07 ,0.82377e-07 , &
+      0.85606e-07 ,0.88942e-07 ,0.92386e-07 ,0.95942e-07 ,0.99612e-07 , &
+      0.10340e-06 ,0.10731e-06 ,0.11134e-06 ,0.11550e-06 ,0.11979e-06 , &
+      0.12421e-06 ,0.12876e-06 ,0.13346e-06 ,0.13830e-06 ,0.14328e-06 , &
+      0.14841e-06 /)
+!$acc enter data copyin(totplnk,totplk16)
+      end subroutine lwavplank
+
+!***************************************************************************
+      subroutine lwavplankderiv
+!***************************************************************************
+
+      save
+
+      totplnkderiv(1:50, 1) = (/ &
+      2.22125e-08 ,2.23245e-08 ,2.24355e-08 ,2.25435e-08 ,2.26560e-08 , &
+      2.27620e-08 ,2.28690e-08 ,2.29760e-08 ,2.30775e-08 ,2.31800e-08 , &
+      2.32825e-08 ,2.33825e-08 ,2.34820e-08 ,2.35795e-08 ,2.36760e-08 , &
+      2.37710e-08 ,2.38655e-08 ,2.39595e-08 ,2.40530e-08 ,2.41485e-08 , &
+      2.42395e-08 ,2.43300e-08 ,2.44155e-08 ,2.45085e-08 ,2.45905e-08 , &
+      2.46735e-08 ,2.47565e-08 ,2.48465e-08 ,2.49315e-08 ,2.50100e-08 , &
+      2.50905e-08 ,2.51705e-08 ,2.52490e-08 ,2.53260e-08 ,2.54075e-08 , &
+      2.54785e-08 ,2.55555e-08 ,2.56340e-08 ,2.57050e-08 ,2.57820e-08 , &
+      2.58525e-08 ,2.59205e-08 ,2.59945e-08 ,2.60680e-08 ,2.61375e-08 , &
+      2.61980e-08 ,2.62745e-08 ,2.63335e-08 ,2.63995e-08 ,2.64710e-08 /)
+      totplnkderiv(51:100, 1) = (/ &
+      2.65300e-08 ,2.66005e-08 ,2.66685e-08 ,2.67310e-08 ,2.67915e-08 , &
+      2.68540e-08 ,2.69065e-08 ,2.69730e-08 ,2.70270e-08 ,2.70690e-08 , &
+      2.71420e-08 ,2.71985e-08 ,2.72560e-08 ,2.73180e-08 ,2.73760e-08 , &
+      2.74285e-08 ,2.74840e-08 ,2.75290e-08 ,2.75950e-08 ,2.76360e-08 , &
+      2.76975e-08 ,2.77475e-08 ,2.78080e-08 ,2.78375e-08 ,2.79120e-08 , &
+      2.79510e-08 ,2.79955e-08 ,2.80625e-08 ,2.80920e-08 ,2.81570e-08 , &
+      2.81990e-08 ,2.82330e-08 ,2.82830e-08 ,2.83365e-08 ,2.83740e-08 , &
+      2.84295e-08 ,2.84910e-08 ,2.85275e-08 ,2.85525e-08 ,2.86085e-08 , &
+      2.86535e-08 ,2.86945e-08 ,2.87355e-08 ,2.87695e-08 ,2.88105e-08 , &
+      2.88585e-08 ,2.88945e-08 ,2.89425e-08 ,2.89580e-08 ,2.90265e-08 /)
+      totplnkderiv(101:150, 1) = (/ &
+      2.90445e-08 ,2.90905e-08 ,2.91425e-08 ,2.91560e-08 ,2.91970e-08 , &
+      2.91905e-08 ,2.92880e-08 ,2.92950e-08 ,2.93630e-08 ,2.93995e-08 , &
+      2.94425e-08 ,2.94635e-08 ,2.94770e-08 ,2.95290e-08 ,2.95585e-08 , &
+      2.95815e-08 ,2.95995e-08 ,2.96745e-08 ,2.96725e-08 ,2.97040e-08 , &
+      2.97750e-08 ,2.97905e-08 ,2.98175e-08 ,2.98355e-08 ,2.98705e-08 , &
+      2.99040e-08 ,2.99680e-08 ,2.99860e-08 ,3.00270e-08 ,3.00200e-08 , &
+      3.00770e-08 ,3.00795e-08 ,3.01065e-08 ,3.01795e-08 ,3.01815e-08 , &
+      3.02025e-08 ,3.02360e-08 ,3.02360e-08 ,3.03090e-08 ,3.03155e-08 , &
+      3.03725e-08 ,3.03635e-08 ,3.04270e-08 ,3.04610e-08 ,3.04635e-08 , &
+      3.04610e-08 ,3.05180e-08 ,3.05430e-08 ,3.05290e-08 ,3.05885e-08 /)
+      totplnkderiv(151:181, 1) = (/ &
+      3.05750e-08 ,3.05775e-08 ,3.06795e-08 ,3.07025e-08 ,3.07365e-08 , &
+      3.07435e-08 ,3.07525e-08 ,3.07680e-08 ,3.08115e-08 ,3.07930e-08 , &
+      3.08155e-08 ,3.08660e-08 ,3.08865e-08 ,3.08390e-08 ,3.09340e-08 , &
+      3.09685e-08 ,3.09340e-08 ,3.09820e-08 ,3.10365e-08 ,3.10705e-08 , &
+      3.10750e-08 ,3.10475e-08 ,3.11685e-08 ,3.11455e-08 ,3.11500e-08 , &
+      3.11775e-08 ,3.11890e-08 ,3.12045e-08 ,3.12185e-08 ,3.12415e-08 , &
+      3.12590e-08 /)
+      totplnkderiv(1:50, 2) = (/ &
+      4.91150e-08 ,4.97290e-08 ,5.03415e-08 ,5.09460e-08 ,5.15550e-08 , &
+      5.21540e-08 ,5.27575e-08 ,5.33500e-08 ,5.39500e-08 ,5.45445e-08 , &
+      5.51290e-08 ,5.57235e-08 ,5.62955e-08 ,5.68800e-08 ,5.74620e-08 , &
+      5.80425e-08 ,5.86145e-08 ,5.91810e-08 ,5.97435e-08 ,6.03075e-08 , &
+      6.08625e-08 ,6.14135e-08 ,6.19775e-08 ,6.25185e-08 ,6.30675e-08 , &
+      6.36145e-08 ,6.41535e-08 ,6.46920e-08 ,6.52265e-08 ,6.57470e-08 , &
+      6.62815e-08 ,6.68000e-08 ,6.73320e-08 ,6.78550e-08 ,6.83530e-08 , &
+      6.88760e-08 ,6.93735e-08 ,6.98790e-08 ,7.03950e-08 ,7.08810e-08 , &
+      7.13815e-08 ,7.18795e-08 ,7.23415e-08 ,7.28505e-08 ,7.33285e-08 , &
+      7.38075e-08 ,7.42675e-08 ,7.47605e-08 ,7.52380e-08 ,7.57020e-08 /)
+      totplnkderiv(51:100, 2) = (/ &
+      7.61495e-08 ,7.65955e-08 ,7.70565e-08 ,7.75185e-08 ,7.79735e-08 , &
+      7.83915e-08 ,7.88625e-08 ,7.93215e-08 ,7.97425e-08 ,8.02195e-08 , &
+      8.05905e-08 ,8.10335e-08 ,8.14770e-08 ,8.19025e-08 ,8.22955e-08 , &
+      8.27115e-08 ,8.31165e-08 ,8.35645e-08 ,8.39440e-08 ,8.43785e-08 , &
+      8.47380e-08 ,8.51495e-08 ,8.55405e-08 ,8.59720e-08 ,8.63135e-08 , &
+      8.67065e-08 ,8.70930e-08 ,8.74545e-08 ,8.78780e-08 ,8.82160e-08 , &
+      8.85625e-08 ,8.89850e-08 ,8.93395e-08 ,8.97080e-08 ,9.00675e-08 , &
+      9.04085e-08 ,9.07360e-08 ,9.11315e-08 ,9.13815e-08 ,9.18320e-08 , &
+      9.21500e-08 ,9.24725e-08 ,9.28640e-08 ,9.31955e-08 ,9.35185e-08 , &
+      9.38645e-08 ,9.41780e-08 ,9.45465e-08 ,9.48470e-08 ,9.51375e-08 /)
+      totplnkderiv(101:150, 2) = (/ &
+      9.55245e-08 ,9.57925e-08 ,9.61195e-08 ,9.64750e-08 ,9.68110e-08 , &
+      9.71715e-08 ,9.74150e-08 ,9.77250e-08 ,9.79600e-08 ,9.82600e-08 , &
+      9.85300e-08 ,9.88400e-08 ,9.91600e-08 ,9.95350e-08 ,9.97500e-08 , &
+      1.00090e-07 ,1.00370e-07 ,1.00555e-07 ,1.00935e-07 ,1.01275e-07 , &
+      1.01400e-07 ,1.01790e-07 ,1.01945e-07 ,1.02225e-07 ,1.02585e-07 , &
+      1.02895e-07 ,1.03010e-07 ,1.03285e-07 ,1.03540e-07 ,1.03890e-07 , &
+      1.04015e-07 ,1.04420e-07 ,1.04640e-07 ,1.04810e-07 ,1.05090e-07 , &
+      1.05385e-07 ,1.05600e-07 ,1.05965e-07 ,1.06050e-07 ,1.06385e-07 , &
+      1.06390e-07 ,1.06795e-07 ,1.06975e-07 ,1.07240e-07 ,1.07435e-07 , &
+      1.07815e-07 ,1.07960e-07 ,1.08010e-07 ,1.08535e-07 ,1.08670e-07 /)
+      totplnkderiv(151:181, 2) = (/ &
+      1.08855e-07 ,1.09210e-07 ,1.09195e-07 ,1.09510e-07 ,1.09665e-07 , &
+      1.09885e-07 ,1.10130e-07 ,1.10440e-07 ,1.10640e-07 ,1.10760e-07 , &
+      1.11125e-07 ,1.11195e-07 ,1.11345e-07 ,1.11710e-07 ,1.11765e-07 , &
+      1.11960e-07 ,1.12225e-07 ,1.12460e-07 ,1.12595e-07 ,1.12730e-07 , &
+      1.12880e-07 ,1.13295e-07 ,1.13215e-07 ,1.13505e-07 ,1.13665e-07 , &
+      1.13870e-07 ,1.14025e-07 ,1.14325e-07 ,1.14495e-07 ,1.14605e-07 , &
+      1.14905e-07 /)
+      totplnkderiv(1:50, 3) = (/ &
+      4.27040e-08 ,4.35430e-08 ,4.43810e-08 ,4.52210e-08 ,4.60630e-08 , &
+      4.69135e-08 ,4.77585e-08 ,4.86135e-08 ,4.94585e-08 ,5.03230e-08 , &
+      5.11740e-08 ,5.20250e-08 ,5.28940e-08 ,5.37465e-08 ,5.46175e-08 , &
+      5.54700e-08 ,5.63430e-08 ,5.72085e-08 ,5.80735e-08 ,5.89430e-08 , &
+      5.98015e-08 ,6.06680e-08 ,6.15380e-08 ,6.24130e-08 ,6.32755e-08 , &
+      6.41340e-08 ,6.50060e-08 ,6.58690e-08 ,6.67315e-08 ,6.76025e-08 , &
+      6.84585e-08 ,6.93205e-08 ,7.01845e-08 ,7.10485e-08 ,7.19160e-08 , &
+      7.27695e-08 ,7.36145e-08 ,7.44840e-08 ,7.53405e-08 ,7.61770e-08 , &
+      7.70295e-08 ,7.78745e-08 ,7.87350e-08 ,7.95740e-08 ,8.04150e-08 , &
+      8.12565e-08 ,8.20885e-08 ,8.29455e-08 ,8.37830e-08 ,8.46035e-08 /)
+      totplnkderiv(51:100, 3) = (/ &
+      8.54315e-08 ,8.62770e-08 ,8.70975e-08 ,8.79140e-08 ,8.87190e-08 , &
+      8.95625e-08 ,9.03625e-08 ,9.11795e-08 ,9.19930e-08 ,9.27685e-08 , &
+      9.36095e-08 ,9.43785e-08 ,9.52375e-08 ,9.59905e-08 ,9.67680e-08 , &
+      9.75840e-08 ,9.83755e-08 ,9.91710e-08 ,9.99445e-08 ,1.00706e-07 , &
+      1.01477e-07 ,1.02255e-07 ,1.03021e-07 ,1.03776e-07 ,1.04544e-07 , &
+      1.05338e-07 ,1.06082e-07 ,1.06843e-07 ,1.07543e-07 ,1.08298e-07 , &
+      1.09103e-07 ,1.09812e-07 ,1.10536e-07 ,1.11268e-07 ,1.12027e-07 , &
+      1.12727e-07 ,1.13464e-07 ,1.14183e-07 ,1.15037e-07 ,1.15615e-07 , &
+      1.16329e-07 ,1.17057e-07 ,1.17734e-07 ,1.18448e-07 ,1.19149e-07 , &
+      1.19835e-07 ,1.20512e-07 ,1.21127e-07 ,1.21895e-07 ,1.22581e-07 /)
+      totplnkderiv(101:150, 3) = (/ &
+      1.23227e-07 ,1.23928e-07 ,1.24560e-07 ,1.25220e-07 ,1.25895e-07 , &
+      1.26565e-07 ,1.27125e-07 ,1.27855e-07 ,1.28490e-07 ,1.29195e-07 , &
+      1.29790e-07 ,1.30470e-07 ,1.31070e-07 ,1.31690e-07 ,1.32375e-07 , &
+      1.32960e-07 ,1.33570e-07 ,1.34230e-07 ,1.34840e-07 ,1.35315e-07 , &
+      1.35990e-07 ,1.36555e-07 ,1.37265e-07 ,1.37945e-07 ,1.38425e-07 , &
+      1.38950e-07 ,1.39640e-07 ,1.40220e-07 ,1.40775e-07 ,1.41400e-07 , &
+      1.42020e-07 ,1.42500e-07 ,1.43085e-07 ,1.43680e-07 ,1.44255e-07 , &
+      1.44855e-07 ,1.45385e-07 ,1.45890e-07 ,1.46430e-07 ,1.46920e-07 , &
+      1.47715e-07 ,1.48090e-07 ,1.48695e-07 ,1.49165e-07 ,1.49715e-07 , &
+      1.50130e-07 ,1.50720e-07 ,1.51330e-07 ,1.51725e-07 ,1.52350e-07 /)
+      totplnkderiv(151:181, 3) = (/ &
+      1.52965e-07 ,1.53305e-07 ,1.53915e-07 ,1.54280e-07 ,1.54950e-07 , &
+      1.55370e-07 ,1.55850e-07 ,1.56260e-07 ,1.56825e-07 ,1.57470e-07 , &
+      1.57760e-07 ,1.58295e-07 ,1.58780e-07 ,1.59470e-07 ,1.59940e-07 , &
+      1.60325e-07 ,1.60825e-07 ,1.61100e-07 ,1.61605e-07 ,1.62045e-07 , &
+      1.62670e-07 ,1.63020e-07 ,1.63625e-07 ,1.63900e-07 ,1.64420e-07 , &
+      1.64705e-07 ,1.65430e-07 ,1.65610e-07 ,1.66220e-07 ,1.66585e-07 , &
+      1.66965e-07 /)
+      totplnkderiv(1:50, 4) = (/ &
+      3.32829e-08 ,3.41160e-08 ,3.49626e-08 ,3.58068e-08 ,3.66765e-08 , &
+      3.75320e-08 ,3.84095e-08 ,3.92920e-08 ,4.01830e-08 ,4.10715e-08 , &
+      4.19735e-08 ,4.28835e-08 ,4.37915e-08 ,4.47205e-08 ,4.56410e-08 , &
+      4.65770e-08 ,4.75090e-08 ,4.84530e-08 ,4.93975e-08 ,5.03470e-08 , &
+      5.13000e-08 ,5.22560e-08 ,5.32310e-08 ,5.41865e-08 ,5.51655e-08 , &
+      5.61590e-08 ,5.71120e-08 ,5.81075e-08 ,5.91060e-08 ,6.00895e-08 , &
+      6.10750e-08 ,6.20740e-08 ,6.30790e-08 ,6.40765e-08 ,6.50940e-08 , &
+      6.60895e-08 ,6.71230e-08 ,6.81200e-08 ,6.91260e-08 ,7.01485e-08 , &
+      7.11625e-08 ,7.21870e-08 ,7.32010e-08 ,7.42080e-08 ,7.52285e-08 , &
+      7.62930e-08 ,7.73040e-08 ,7.83185e-08 ,7.93410e-08 ,8.03560e-08 /)
+      totplnkderiv(51:100, 4) = (/ &
+      8.14115e-08 ,8.24200e-08 ,8.34555e-08 ,8.45100e-08 ,8.55265e-08 , &
+      8.65205e-08 ,8.75615e-08 ,8.85870e-08 ,8.96175e-08 ,9.07015e-08 , &
+      9.16475e-08 ,9.27525e-08 ,9.37055e-08 ,9.47375e-08 ,9.57995e-08 , &
+      9.67635e-08 ,9.77980e-08 ,9.87735e-08 ,9.98485e-08 ,1.00904e-07 , &
+      1.01900e-07 ,1.02876e-07 ,1.03905e-07 ,1.04964e-07 ,1.05956e-07 , &
+      1.06870e-07 ,1.07952e-07 ,1.08944e-07 ,1.10003e-07 ,1.10965e-07 , &
+      1.11952e-07 ,1.12927e-07 ,1.13951e-07 ,1.14942e-07 ,1.15920e-07 , &
+      1.16968e-07 ,1.17877e-07 ,1.18930e-07 ,1.19862e-07 ,1.20817e-07 , &
+      1.21817e-07 ,1.22791e-07 ,1.23727e-07 ,1.24751e-07 ,1.25697e-07 , &
+      1.26634e-07 ,1.27593e-07 ,1.28585e-07 ,1.29484e-07 ,1.30485e-07 /)
+      totplnkderiv(101:150, 4) = (/ &
+      1.31363e-07 ,1.32391e-07 ,1.33228e-07 ,1.34155e-07 ,1.35160e-07 , &
+      1.36092e-07 ,1.37070e-07 ,1.37966e-07 ,1.38865e-07 ,1.39740e-07 , &
+      1.40770e-07 ,1.41620e-07 ,1.42605e-07 ,1.43465e-07 ,1.44240e-07 , &
+      1.45305e-07 ,1.46220e-07 ,1.47070e-07 ,1.47935e-07 ,1.48890e-07 , &
+      1.49905e-07 ,1.50640e-07 ,1.51435e-07 ,1.52335e-07 ,1.53235e-07 , &
+      1.54045e-07 ,1.54895e-07 ,1.55785e-07 ,1.56870e-07 ,1.57360e-07 , &
+      1.58395e-07 ,1.59185e-07 ,1.60060e-07 ,1.60955e-07 ,1.61770e-07 , &
+      1.62445e-07 ,1.63415e-07 ,1.64170e-07 ,1.65125e-07 ,1.65995e-07 , &
+      1.66545e-07 ,1.67580e-07 ,1.68295e-07 ,1.69130e-07 ,1.69935e-07 , &
+      1.70800e-07 ,1.71610e-07 ,1.72365e-07 ,1.73215e-07 ,1.73770e-07 /)
+      totplnkderiv(151:181, 4) = (/ &
+      1.74590e-07 ,1.75525e-07 ,1.76095e-07 ,1.77125e-07 ,1.77745e-07 , &
+      1.78580e-07 ,1.79315e-07 ,1.80045e-07 ,1.80695e-07 ,1.81580e-07 , &
+      1.82360e-07 ,1.83205e-07 ,1.84055e-07 ,1.84315e-07 ,1.85225e-07 , &
+      1.85865e-07 ,1.86660e-07 ,1.87445e-07 ,1.88350e-07 ,1.88930e-07 , &
+      1.89420e-07 ,1.90275e-07 ,1.90630e-07 ,1.91650e-07 ,1.92485e-07 , &
+      1.93285e-07 ,1.93695e-07 ,1.94595e-07 ,1.94895e-07 ,1.95960e-07 , &
+      1.96525e-07 /)
+      totplnkderiv(1:50, 5) = (/ &
+      2.41948e-08 ,2.49273e-08 ,2.56705e-08 ,2.64263e-08 ,2.71899e-08 , &
+      2.79687e-08 ,2.87531e-08 ,2.95520e-08 ,3.03567e-08 ,3.11763e-08 , &
+      3.20014e-08 ,3.28390e-08 ,3.36865e-08 ,3.45395e-08 ,3.54083e-08 , &
+      3.62810e-08 ,3.71705e-08 ,3.80585e-08 ,3.89650e-08 ,3.98750e-08 , &
+      4.07955e-08 ,4.17255e-08 ,4.26635e-08 ,4.36095e-08 ,4.45605e-08 , &
+      4.55190e-08 ,4.64910e-08 ,4.74670e-08 ,4.84480e-08 ,4.94430e-08 , &
+      5.04460e-08 ,5.14440e-08 ,5.24500e-08 ,5.34835e-08 ,5.44965e-08 , &
+      5.55325e-08 ,5.65650e-08 ,5.76050e-08 ,5.86615e-08 ,5.97175e-08 , &
+      6.07750e-08 ,6.18400e-08 ,6.29095e-08 ,6.39950e-08 ,6.50665e-08 , &
+      6.61405e-08 ,6.72290e-08 ,6.82800e-08 ,6.94445e-08 ,7.05460e-08 /)
+      totplnkderiv(51:100, 5) = (/ &
+      7.16400e-08 ,7.27475e-08 ,7.38790e-08 ,7.49845e-08 ,7.61270e-08 , &
+      7.72375e-08 ,7.83770e-08 ,7.95045e-08 ,8.06315e-08 ,8.17715e-08 , &
+      8.29275e-08 ,8.40555e-08 ,8.52110e-08 ,8.63565e-08 ,8.75045e-08 , &
+      8.86735e-08 ,8.98150e-08 ,9.09970e-08 ,9.21295e-08 ,9.32730e-08 , &
+      9.44605e-08 ,9.56170e-08 ,9.67885e-08 ,9.79275e-08 ,9.91190e-08 , &
+      1.00278e-07 ,1.01436e-07 ,1.02625e-07 ,1.03792e-07 ,1.04989e-07 , &
+      1.06111e-07 ,1.07320e-07 ,1.08505e-07 ,1.09626e-07 ,1.10812e-07 , &
+      1.11948e-07 ,1.13162e-07 ,1.14289e-07 ,1.15474e-07 ,1.16661e-07 , &
+      1.17827e-07 ,1.19023e-07 ,1.20167e-07 ,1.21356e-07 ,1.22499e-07 , &
+      1.23653e-07 ,1.24876e-07 ,1.25983e-07 ,1.27175e-07 ,1.28325e-07 /)
+      totplnkderiv(101:150, 5) = (/ &
+      1.29517e-07 ,1.30685e-07 ,1.31840e-07 ,1.33013e-07 ,1.34160e-07 , &
+      1.35297e-07 ,1.36461e-07 ,1.37630e-07 ,1.38771e-07 ,1.39913e-07 , &
+      1.41053e-07 ,1.42218e-07 ,1.43345e-07 ,1.44460e-07 ,1.45692e-07 , &
+      1.46697e-07 ,1.47905e-07 ,1.49010e-07 ,1.50210e-07 ,1.51285e-07 , &
+      1.52380e-07 ,1.53555e-07 ,1.54655e-07 ,1.55805e-07 ,1.56850e-07 , &
+      1.58055e-07 ,1.59115e-07 ,1.60185e-07 ,1.61255e-07 ,1.62465e-07 , &
+      1.63575e-07 ,1.64675e-07 ,1.65760e-07 ,1.66765e-07 ,1.67945e-07 , &
+      1.69070e-07 ,1.70045e-07 ,1.71145e-07 ,1.72260e-07 ,1.73290e-07 , &
+      1.74470e-07 ,1.75490e-07 ,1.76515e-07 ,1.77555e-07 ,1.78660e-07 , &
+      1.79670e-07 ,1.80705e-07 ,1.81895e-07 ,1.82745e-07 ,1.83950e-07 /)
+      totplnkderiv(151:181, 5) = (/ &
+      1.84955e-07 ,1.85940e-07 ,1.87080e-07 ,1.88010e-07 ,1.89145e-07 , &
+      1.90130e-07 ,1.91110e-07 ,1.92130e-07 ,1.93205e-07 ,1.94230e-07 , &
+      1.95045e-07 ,1.96070e-07 ,1.97155e-07 ,1.98210e-07 ,1.99080e-07 , &
+      2.00280e-07 ,2.01135e-07 ,2.02150e-07 ,2.03110e-07 ,2.04135e-07 , &
+      2.05110e-07 ,2.06055e-07 ,2.07120e-07 ,2.08075e-07 ,2.08975e-07 , &
+      2.09950e-07 ,2.10870e-07 ,2.11830e-07 ,2.12960e-07 ,2.13725e-07 , &
+      2.14765e-07 /)
+      totplnkderiv(1:50, 6) = (/ &
+      1.36567e-08 ,1.41766e-08 ,1.47079e-08 ,1.52499e-08 ,1.58075e-08 , &
+      1.63727e-08 ,1.69528e-08 ,1.75429e-08 ,1.81477e-08 ,1.87631e-08 , &
+      1.93907e-08 ,2.00297e-08 ,2.06808e-08 ,2.13432e-08 ,2.20183e-08 , &
+      2.27076e-08 ,2.34064e-08 ,2.41181e-08 ,2.48400e-08 ,2.55750e-08 , &
+      2.63231e-08 ,2.70790e-08 ,2.78502e-08 ,2.86326e-08 ,2.94259e-08 , &
+      3.02287e-08 ,3.10451e-08 ,3.18752e-08 ,3.27108e-08 ,3.35612e-08 , &
+      3.44198e-08 ,3.52930e-08 ,3.61785e-08 ,3.70690e-08 ,3.79725e-08 , &
+      3.88845e-08 ,3.98120e-08 ,4.07505e-08 ,4.16965e-08 ,4.26515e-08 , &
+      4.36190e-08 ,4.45925e-08 ,4.55760e-08 ,4.65735e-08 ,4.75835e-08 , &
+      4.85970e-08 ,4.96255e-08 ,5.06975e-08 ,5.16950e-08 ,5.27530e-08 /)
+      totplnkderiv(51:100, 6) = (/ &
+      5.38130e-08 ,5.48860e-08 ,5.59715e-08 ,5.70465e-08 ,5.81385e-08 , &
+      5.92525e-08 ,6.03565e-08 ,6.14815e-08 ,6.26175e-08 ,6.37475e-08 , &
+      6.48855e-08 ,6.60340e-08 ,6.71980e-08 ,6.83645e-08 ,6.95430e-08 , &
+      7.07145e-08 ,7.19015e-08 ,7.30995e-08 ,7.43140e-08 ,7.55095e-08 , &
+      7.67115e-08 ,7.79485e-08 ,7.91735e-08 ,8.03925e-08 ,8.16385e-08 , &
+      8.28775e-08 ,8.41235e-08 ,8.53775e-08 ,8.66405e-08 ,8.78940e-08 , &
+      8.91805e-08 ,9.04515e-08 ,9.17290e-08 ,9.30230e-08 ,9.43145e-08 , &
+      9.56200e-08 ,9.69160e-08 ,9.82140e-08 ,9.95285e-08 ,1.00829e-07 , &
+      1.02145e-07 ,1.03478e-07 ,1.04787e-07 ,1.06095e-07 ,1.07439e-07 , &
+      1.08785e-07 ,1.10078e-07 ,1.11466e-07 ,1.12795e-07 ,1.14133e-07 /)
+      totplnkderiv(101:150, 6) = (/ &
+      1.15479e-07 ,1.16825e-07 ,1.18191e-07 ,1.19540e-07 ,1.20908e-07 , &
+      1.22257e-07 ,1.23634e-07 ,1.24992e-07 ,1.26345e-07 ,1.27740e-07 , &
+      1.29098e-07 ,1.30447e-07 ,1.31831e-07 ,1.33250e-07 ,1.34591e-07 , &
+      1.36011e-07 ,1.37315e-07 ,1.38721e-07 ,1.40103e-07 ,1.41504e-07 , &
+      1.42882e-07 ,1.44259e-07 ,1.45674e-07 ,1.46997e-07 ,1.48412e-07 , &
+      1.49794e-07 ,1.51167e-07 ,1.52577e-07 ,1.53941e-07 ,1.55369e-07 , &
+      1.56725e-07 ,1.58125e-07 ,1.59460e-07 ,1.60895e-07 ,1.62260e-07 , &
+      1.63610e-07 ,1.65085e-07 ,1.66410e-07 ,1.67805e-07 ,1.69185e-07 , &
+      1.70570e-07 ,1.71915e-07 ,1.73375e-07 ,1.74775e-07 ,1.76090e-07 , &
+      1.77485e-07 ,1.78905e-07 ,1.80190e-07 ,1.81610e-07 ,1.82960e-07 /)
+      totplnkderiv(151:181, 6) = (/ &
+      1.84330e-07 ,1.85750e-07 ,1.87060e-07 ,1.88470e-07 ,1.89835e-07 , &
+      1.91250e-07 ,1.92565e-07 ,1.93925e-07 ,1.95220e-07 ,1.96620e-07 , &
+      1.98095e-07 ,1.99330e-07 ,2.00680e-07 ,2.02090e-07 ,2.03360e-07 , &
+      2.04775e-07 ,2.06080e-07 ,2.07440e-07 ,2.08820e-07 ,2.10095e-07 , &
+      2.11445e-07 ,2.12785e-07 ,2.14050e-07 ,2.15375e-07 ,2.16825e-07 , &
+      2.18080e-07 ,2.19345e-07 ,2.20710e-07 ,2.21980e-07 ,2.23425e-07 , &
+      2.24645e-07 /)
+      totplnkderiv(1:50, 7) = (/ &
+      7.22270e-09 ,7.55350e-09 ,7.89480e-09 ,8.24725e-09 ,8.60780e-09 , &
+      8.98215e-09 ,9.36430e-09 ,9.76035e-09 ,1.01652e-08 ,1.05816e-08 , &
+      1.10081e-08 ,1.14480e-08 ,1.18981e-08 ,1.23600e-08 ,1.28337e-08 , &
+      1.33172e-08 ,1.38139e-08 ,1.43208e-08 ,1.48413e-08 ,1.53702e-08 , &
+      1.59142e-08 ,1.64704e-08 ,1.70354e-08 ,1.76178e-08 ,1.82065e-08 , &
+      1.88083e-08 ,1.94237e-08 ,2.00528e-08 ,2.06913e-08 ,2.13413e-08 , &
+      2.20058e-08 ,2.26814e-08 ,2.33686e-08 ,2.40729e-08 ,2.47812e-08 , &
+      2.55099e-08 ,2.62449e-08 ,2.69966e-08 ,2.77569e-08 ,2.85269e-08 , &
+      2.93144e-08 ,3.01108e-08 ,3.09243e-08 ,3.17433e-08 ,3.25756e-08 , &
+      3.34262e-08 ,3.42738e-08 ,3.51480e-08 ,3.60285e-08 ,3.69160e-08 /)
+      totplnkderiv(51:100, 7) = (/ &
+      3.78235e-08 ,3.87390e-08 ,3.96635e-08 ,4.06095e-08 ,4.15600e-08 , &
+      4.25180e-08 ,4.34895e-08 ,4.44800e-08 ,4.54715e-08 ,4.64750e-08 , &
+      4.74905e-08 ,4.85210e-08 ,4.95685e-08 ,5.06135e-08 ,5.16725e-08 , &
+      5.27480e-08 ,5.38265e-08 ,5.49170e-08 ,5.60120e-08 ,5.71275e-08 , &
+      5.82610e-08 ,5.93775e-08 ,6.05245e-08 ,6.17025e-08 ,6.28355e-08 , &
+      6.40135e-08 ,6.52015e-08 ,6.63865e-08 ,6.75790e-08 ,6.88120e-08 , &
+      7.00070e-08 ,7.12335e-08 ,7.24720e-08 ,7.37340e-08 ,7.49775e-08 , &
+      7.62415e-08 ,7.75185e-08 ,7.87915e-08 ,8.00875e-08 ,8.13630e-08 , &
+      8.26710e-08 ,8.39645e-08 ,8.53060e-08 ,8.66305e-08 ,8.79915e-08 , &
+      8.93080e-08 ,9.06560e-08 ,9.19860e-08 ,9.33550e-08 ,9.47305e-08 /)
+      totplnkderiv(101:150, 7) = (/ &
+      9.61180e-08 ,9.74500e-08 ,9.88850e-08 ,1.00263e-07 ,1.01688e-07 , &
+      1.03105e-07 ,1.04489e-07 ,1.05906e-07 ,1.07345e-07 ,1.08771e-07 , &
+      1.10220e-07 ,1.11713e-07 ,1.13098e-07 ,1.14515e-07 ,1.16019e-07 , &
+      1.17479e-07 ,1.18969e-07 ,1.20412e-07 ,1.21852e-07 ,1.23387e-07 , &
+      1.24851e-07 ,1.26319e-07 ,1.27811e-07 ,1.29396e-07 ,1.30901e-07 , &
+      1.32358e-07 ,1.33900e-07 ,1.35405e-07 ,1.36931e-07 ,1.38443e-07 , &
+      1.39985e-07 ,1.41481e-07 ,1.43072e-07 ,1.44587e-07 ,1.46133e-07 , &
+      1.47698e-07 ,1.49203e-07 ,1.50712e-07 ,1.52363e-07 ,1.53795e-07 , &
+      1.55383e-07 ,1.56961e-07 ,1.58498e-07 ,1.60117e-07 ,1.61745e-07 , &
+      1.63190e-07 ,1.64790e-07 ,1.66370e-07 ,1.67975e-07 ,1.69555e-07 /)
+      totplnkderiv(151:181, 7) = (/ &
+      1.71060e-07 ,1.72635e-07 ,1.74345e-07 ,1.75925e-07 ,1.77395e-07 , &
+      1.78960e-07 ,1.80620e-07 ,1.82180e-07 ,1.83840e-07 ,1.85340e-07 , &
+      1.86940e-07 ,1.88550e-07 ,1.90095e-07 ,1.91670e-07 ,1.93385e-07 , &
+      1.94895e-07 ,1.96500e-07 ,1.98090e-07 ,1.99585e-07 ,2.01280e-07 , &
+      2.02950e-07 ,2.04455e-07 ,2.06075e-07 ,2.07635e-07 ,2.09095e-07 , &
+      2.10865e-07 ,2.12575e-07 ,2.14050e-07 ,2.15630e-07 ,2.17060e-07 , &
+      2.18715e-07 /)
+      totplnkderiv(1:50, 8) = (/ &
+      4.26397e-09 ,4.48470e-09 ,4.71299e-09 ,4.94968e-09 ,5.19542e-09 , &
+      5.44847e-09 ,5.71195e-09 ,5.98305e-09 ,6.26215e-09 ,6.55290e-09 , &
+      6.85190e-09 ,7.15950e-09 ,7.47745e-09 ,7.80525e-09 ,8.14190e-09 , &
+      8.48915e-09 ,8.84680e-09 ,9.21305e-09 ,9.59105e-09 ,9.98130e-09 , &
+      1.03781e-08 ,1.07863e-08 ,1.12094e-08 ,1.16371e-08 ,1.20802e-08 , &
+      1.25327e-08 ,1.29958e-08 ,1.34709e-08 ,1.39592e-08 ,1.44568e-08 , &
+      1.49662e-08 ,1.54828e-08 ,1.60186e-08 ,1.65612e-08 ,1.71181e-08 , &
+      1.76822e-08 ,1.82591e-08 ,1.88487e-08 ,1.94520e-08 ,2.00691e-08 , &
+      2.06955e-08 ,2.13353e-08 ,2.19819e-08 ,2.26479e-08 ,2.33234e-08 , &
+      2.40058e-08 ,2.47135e-08 ,2.54203e-08 ,2.61414e-08 ,2.68778e-08 /)
+      totplnkderiv(51:100, 8) = (/ &
+      2.76265e-08 ,2.83825e-08 ,2.91632e-08 ,2.99398e-08 ,3.07389e-08 , &
+      3.15444e-08 ,3.23686e-08 ,3.31994e-08 ,3.40487e-08 ,3.49020e-08 , &
+      3.57715e-08 ,3.66515e-08 ,3.75465e-08 ,3.84520e-08 ,3.93675e-08 , &
+      4.02985e-08 ,4.12415e-08 ,4.21965e-08 ,4.31630e-08 ,4.41360e-08 , &
+      4.51220e-08 ,4.61235e-08 ,4.71440e-08 ,4.81515e-08 ,4.91905e-08 , &
+      5.02395e-08 ,5.12885e-08 ,5.23735e-08 ,5.34460e-08 ,5.45245e-08 , &
+      5.56375e-08 ,5.67540e-08 ,5.78780e-08 ,5.90065e-08 ,6.01520e-08 , &
+      6.13000e-08 ,6.24720e-08 ,6.36530e-08 ,6.48500e-08 ,6.60500e-08 , &
+      6.72435e-08 ,6.84735e-08 ,6.97025e-08 ,7.09530e-08 ,7.21695e-08 , &
+      7.34270e-08 ,7.47295e-08 ,7.59915e-08 ,7.72685e-08 ,7.85925e-08 /)
+      totplnkderiv(101:150, 8) = (/ &
+      7.98855e-08 ,8.12205e-08 ,8.25120e-08 ,8.38565e-08 ,8.52005e-08 , &
+      8.65570e-08 ,8.79075e-08 ,8.92920e-08 ,9.06535e-08 ,9.20455e-08 , &
+      9.34230e-08 ,9.48355e-08 ,9.62720e-08 ,9.76890e-08 ,9.90755e-08 , &
+      1.00528e-07 ,1.01982e-07 ,1.03436e-07 ,1.04919e-07 ,1.06368e-07 , &
+      1.07811e-07 ,1.09326e-07 ,1.10836e-07 ,1.12286e-07 ,1.13803e-07 , &
+      1.15326e-07 ,1.16809e-07 ,1.18348e-07 ,1.19876e-07 ,1.21413e-07 , &
+      1.22922e-07 ,1.24524e-07 ,1.26049e-07 ,1.27573e-07 ,1.29155e-07 , &
+      1.30708e-07 ,1.32327e-07 ,1.33958e-07 ,1.35480e-07 ,1.37081e-07 , &
+      1.38716e-07 ,1.40326e-07 ,1.41872e-07 ,1.43468e-07 ,1.45092e-07 , &
+      1.46806e-07 ,1.48329e-07 ,1.49922e-07 ,1.51668e-07 ,1.53241e-07 /)
+      totplnkderiv(151:181, 8) = (/ &
+      1.54996e-07 ,1.56561e-07 ,1.58197e-07 ,1.59884e-07 ,1.61576e-07 , &
+      1.63200e-07 ,1.64885e-07 ,1.66630e-07 ,1.68275e-07 ,1.69935e-07 , &
+      1.71650e-07 ,1.73245e-07 ,1.75045e-07 ,1.76710e-07 ,1.78330e-07 , &
+      1.79995e-07 ,1.81735e-07 ,1.83470e-07 ,1.85200e-07 ,1.86890e-07 , &
+      1.88595e-07 ,1.90300e-07 ,1.91995e-07 ,1.93715e-07 ,1.95495e-07 , &
+      1.97130e-07 ,1.98795e-07 ,2.00680e-07 ,2.02365e-07 ,2.04090e-07 , &
+      2.05830e-07 /)
+      totplnkderiv(1:50, 9) = (/ &
+      1.85410e-09 ,1.96515e-09 ,2.08117e-09 ,2.20227e-09 ,2.32861e-09 , &
+      2.46066e-09 ,2.59812e-09 ,2.74153e-09 ,2.89058e-09 ,3.04567e-09 , &
+      3.20674e-09 ,3.37442e-09 ,3.54854e-09 ,3.72892e-09 ,3.91630e-09 , &
+      4.11013e-09 ,4.31150e-09 ,4.52011e-09 ,4.73541e-09 ,4.95870e-09 , &
+      5.18913e-09 ,5.42752e-09 ,5.67340e-09 ,5.92810e-09 ,6.18995e-09 , &
+      6.46055e-09 ,6.73905e-09 ,7.02620e-09 ,7.32260e-09 ,7.62700e-09 , &
+      7.94050e-09 ,8.26370e-09 ,8.59515e-09 ,8.93570e-09 ,9.28535e-09 , &
+      9.64575e-09 ,1.00154e-08 ,1.03944e-08 ,1.07839e-08 ,1.11832e-08 , &
+      1.15909e-08 ,1.20085e-08 ,1.24399e-08 ,1.28792e-08 ,1.33280e-08 , &
+      1.37892e-08 ,1.42573e-08 ,1.47408e-08 ,1.52345e-08 ,1.57371e-08 /)
+      totplnkderiv(51:100, 9) = (/ &
+      1.62496e-08 ,1.67756e-08 ,1.73101e-08 ,1.78596e-08 ,1.84161e-08 , &
+      1.89869e-08 ,1.95681e-08 ,2.01632e-08 ,2.07626e-08 ,2.13800e-08 , &
+      2.20064e-08 ,2.26453e-08 ,2.32970e-08 ,2.39595e-08 ,2.46340e-08 , &
+      2.53152e-08 ,2.60158e-08 ,2.67235e-08 ,2.74471e-08 ,2.81776e-08 , &
+      2.89233e-08 ,2.96822e-08 ,3.04488e-08 ,3.12298e-08 ,3.20273e-08 , &
+      3.28304e-08 ,3.36455e-08 ,3.44765e-08 ,3.53195e-08 ,3.61705e-08 , &
+      3.70385e-08 ,3.79155e-08 ,3.88065e-08 ,3.97055e-08 ,4.06210e-08 , &
+      4.15490e-08 ,4.24825e-08 ,4.34355e-08 ,4.43920e-08 ,4.53705e-08 , &
+      4.63560e-08 ,4.73565e-08 ,4.83655e-08 ,4.93815e-08 ,5.04180e-08 , &
+      5.14655e-08 ,5.25175e-08 ,5.35865e-08 ,5.46720e-08 ,5.57670e-08 /)
+      totplnkderiv(101:150, 9) = (/ &
+      5.68640e-08 ,5.79825e-08 ,5.91140e-08 ,6.02515e-08 ,6.13985e-08 , &
+      6.25525e-08 ,6.37420e-08 ,6.49220e-08 ,6.61145e-08 ,6.73185e-08 , &
+      6.85520e-08 ,6.97760e-08 ,7.10050e-08 ,7.22650e-08 ,7.35315e-08 , &
+      7.48035e-08 ,7.60745e-08 ,7.73740e-08 ,7.86870e-08 ,7.99845e-08 , &
+      8.13325e-08 ,8.26615e-08 ,8.40010e-08 ,8.53640e-08 ,8.67235e-08 , &
+      8.80960e-08 ,8.95055e-08 ,9.08945e-08 ,9.23045e-08 ,9.37100e-08 , &
+      9.51555e-08 ,9.65630e-08 ,9.80235e-08 ,9.94920e-08 ,1.00966e-07 , &
+      1.02434e-07 ,1.03898e-07 ,1.05386e-07 ,1.06905e-07 ,1.08418e-07 , &
+      1.09926e-07 ,1.11454e-07 ,1.13010e-07 ,1.14546e-07 ,1.16106e-07 , &
+      1.17652e-07 ,1.19264e-07 ,1.20817e-07 ,1.22395e-07 ,1.24024e-07 /)
+      totplnkderiv(151:181, 9) = (/ &
+      1.25585e-07 ,1.27213e-07 ,1.28817e-07 ,1.30472e-07 ,1.32088e-07 , &
+      1.33752e-07 ,1.35367e-07 ,1.37018e-07 ,1.38698e-07 ,1.40394e-07 , &
+      1.42026e-07 ,1.43796e-07 ,1.45438e-07 ,1.47175e-07 ,1.48866e-07 , &
+      1.50576e-07 ,1.52281e-07 ,1.54018e-07 ,1.55796e-07 ,1.57515e-07 , &
+      1.59225e-07 ,1.60989e-07 ,1.62754e-07 ,1.64532e-07 ,1.66285e-07 , &
+      1.68070e-07 ,1.69870e-07 ,1.71625e-07 ,1.73440e-07 ,1.75275e-07 , &
+      1.77040e-07 /)
+      totplnkderiv(1:50,10) = (/ &
+      7.14917e-10 ,7.64833e-10 ,8.17460e-10 ,8.72980e-10 ,9.31380e-10 , &
+      9.92940e-10 ,1.05746e-09 ,1.12555e-09 ,1.19684e-09 ,1.27162e-09 , &
+      1.35001e-09 ,1.43229e-09 ,1.51815e-09 ,1.60831e-09 ,1.70271e-09 , &
+      1.80088e-09 ,1.90365e-09 ,2.01075e-09 ,2.12261e-09 ,2.23924e-09 , &
+      2.36057e-09 ,2.48681e-09 ,2.61814e-09 ,2.75506e-09 ,2.89692e-09 , &
+      3.04423e-09 ,3.19758e-09 ,3.35681e-09 ,3.52113e-09 ,3.69280e-09 , &
+      3.86919e-09 ,4.05205e-09 ,4.24184e-09 ,4.43877e-09 ,4.64134e-09 , &
+      4.85088e-09 ,5.06670e-09 ,5.29143e-09 ,5.52205e-09 ,5.75980e-09 , &
+      6.00550e-09 ,6.25840e-09 ,6.51855e-09 ,6.78800e-09 ,7.06435e-09 , &
+      7.34935e-09 ,7.64220e-09 ,7.94470e-09 ,8.25340e-09 ,8.57030e-09 /)
+      totplnkderiv(51:100,10) = (/ &
+      8.89680e-09 ,9.23255e-09 ,9.57770e-09 ,9.93045e-09 ,1.02932e-08 , &
+      1.06649e-08 ,1.10443e-08 ,1.14348e-08 ,1.18350e-08 ,1.22463e-08 , &
+      1.26679e-08 ,1.30949e-08 ,1.35358e-08 ,1.39824e-08 ,1.44425e-08 , &
+      1.49126e-08 ,1.53884e-08 ,1.58826e-08 ,1.63808e-08 ,1.68974e-08 , &
+      1.74159e-08 ,1.79447e-08 ,1.84886e-08 ,1.90456e-08 ,1.96124e-08 , &
+      2.01863e-08 ,2.07737e-08 ,2.13720e-08 ,2.19837e-08 ,2.26044e-08 , &
+      2.32396e-08 ,2.38856e-08 ,2.45344e-08 ,2.52055e-08 ,2.58791e-08 , &
+      2.65706e-08 ,2.72758e-08 ,2.79852e-08 ,2.87201e-08 ,2.94518e-08 , &
+      3.02063e-08 ,3.09651e-08 ,3.17357e-08 ,3.25235e-08 ,3.33215e-08 , &
+      3.41285e-08 ,3.49485e-08 ,3.57925e-08 ,3.66330e-08 ,3.74765e-08 /)
+      totplnkderiv(101:150,10) = (/ &
+      3.83675e-08 ,3.92390e-08 ,4.01330e-08 ,4.10340e-08 ,4.19585e-08 , &
+      4.28815e-08 ,4.38210e-08 ,4.47770e-08 ,4.57575e-08 ,4.67325e-08 , &
+      4.77170e-08 ,4.87205e-08 ,4.97410e-08 ,5.07620e-08 ,5.18180e-08 , &
+      5.28540e-08 ,5.39260e-08 ,5.50035e-08 ,5.60885e-08 ,5.71900e-08 , &
+      5.82940e-08 ,5.94380e-08 ,6.05690e-08 ,6.17185e-08 ,6.28860e-08 , &
+      6.40670e-08 ,6.52300e-08 ,6.64225e-08 ,6.76485e-08 ,6.88715e-08 , &
+      7.00750e-08 ,7.13760e-08 ,7.25910e-08 ,7.38860e-08 ,7.51290e-08 , &
+      7.64420e-08 ,7.77550e-08 ,7.90725e-08 ,8.03825e-08 ,8.17330e-08 , &
+      8.30810e-08 ,8.44330e-08 ,8.57720e-08 ,8.72115e-08 ,8.85800e-08 , &
+      8.99945e-08 ,9.13905e-08 ,9.28345e-08 ,9.42665e-08 ,9.56765e-08 /)
+      totplnkderiv(151:181,10) = (/ &
+      9.72000e-08 ,9.86780e-08 ,1.00105e-07 ,1.01616e-07 ,1.03078e-07 , &
+      1.04610e-07 ,1.06154e-07 ,1.07639e-07 ,1.09242e-07 ,1.10804e-07 , &
+      1.12384e-07 ,1.13871e-07 ,1.15478e-07 ,1.17066e-07 ,1.18703e-07 , &
+      1.20294e-07 ,1.21930e-07 ,1.23543e-07 ,1.25169e-07 ,1.26806e-07 , &
+      1.28503e-07 ,1.30233e-07 ,1.31834e-07 ,1.33596e-07 ,1.35283e-07 , &
+      1.36947e-07 ,1.38594e-07 ,1.40362e-07 ,1.42131e-07 ,1.43823e-07 , &
+      1.45592e-07 /)
+      totplnkderiv(1:50,11) = (/ &
+      2.25919e-10 ,2.43810e-10 ,2.62866e-10 ,2.83125e-10 ,3.04676e-10 , &
+      3.27536e-10 ,3.51796e-10 ,3.77498e-10 ,4.04714e-10 ,4.33528e-10 , &
+      4.64000e-10 ,4.96185e-10 ,5.30165e-10 ,5.65999e-10 ,6.03749e-10 , &
+      6.43579e-10 ,6.85479e-10 ,7.29517e-10 ,7.75810e-10 ,8.24440e-10 , &
+      8.75520e-10 ,9.29065e-10 ,9.85175e-10 ,1.04405e-09 ,1.10562e-09 , &
+      1.17005e-09 ,1.23742e-09 ,1.30780e-09 ,1.38141e-09 ,1.45809e-09 , &
+      1.53825e-09 ,1.62177e-09 ,1.70884e-09 ,1.79942e-09 ,1.89390e-09 , &
+      1.99205e-09 ,2.09429e-09 ,2.20030e-09 ,2.31077e-09 ,2.42510e-09 , &
+      2.54410e-09 ,2.66754e-09 ,2.79529e-09 ,2.92777e-09 ,3.06498e-09 , &
+      3.20691e-09 ,3.35450e-09 ,3.50653e-09 ,3.66427e-09 ,3.82723e-09 /)
+      totplnkderiv(51:100,11) = (/ &
+      3.99549e-09 ,4.16911e-09 ,4.34892e-09 ,4.53415e-09 ,4.72504e-09 , &
+      4.92197e-09 ,5.12525e-09 ,5.33485e-09 ,5.55085e-09 ,5.77275e-09 , &
+      6.00105e-09 ,6.23650e-09 ,6.47855e-09 ,6.72735e-09 ,6.98325e-09 , &
+      7.24695e-09 ,7.51730e-09 ,7.79480e-09 ,8.07975e-09 ,8.37170e-09 , &
+      8.67195e-09 ,8.98050e-09 ,9.29575e-09 ,9.61950e-09 ,9.95150e-09 , &
+      1.02912e-08 ,1.06397e-08 ,1.09964e-08 ,1.13611e-08 ,1.17348e-08 , &
+      1.21158e-08 ,1.25072e-08 ,1.29079e-08 ,1.33159e-08 ,1.37342e-08 , &
+      1.41599e-08 ,1.45966e-08 ,1.50438e-08 ,1.54964e-08 ,1.59605e-08 , &
+      1.64337e-08 ,1.69189e-08 ,1.74134e-08 ,1.79136e-08 ,1.84272e-08 , &
+      1.89502e-08 ,1.94845e-08 ,2.00248e-08 ,2.05788e-08 ,2.11455e-08 /)
+      totplnkderiv(101:150,11) = (/ &
+      2.17159e-08 ,2.23036e-08 ,2.28983e-08 ,2.35033e-08 ,2.41204e-08 , &
+      2.47485e-08 ,2.53860e-08 ,2.60331e-08 ,2.66891e-08 ,2.73644e-08 , &
+      2.80440e-08 ,2.87361e-08 ,2.94412e-08 ,3.01560e-08 ,3.08805e-08 , &
+      3.16195e-08 ,3.23690e-08 ,3.31285e-08 ,3.39015e-08 ,3.46820e-08 , &
+      3.54770e-08 ,3.62805e-08 ,3.70960e-08 ,3.79295e-08 ,3.87715e-08 , &
+      3.96185e-08 ,4.04860e-08 ,4.13600e-08 ,4.22500e-08 ,4.31490e-08 , &
+      4.40610e-08 ,4.49810e-08 ,4.59205e-08 ,4.68650e-08 ,4.78260e-08 , &
+      4.87970e-08 ,4.97790e-08 ,5.07645e-08 ,5.17730e-08 ,5.27960e-08 , &
+      5.38285e-08 ,5.48650e-08 ,5.59205e-08 ,5.69960e-08 ,5.80690e-08 , &
+      5.91570e-08 ,6.02640e-08 ,6.13750e-08 ,6.25015e-08 ,6.36475e-08 /)
+      totplnkderiv(151:181,11) = (/ &
+      6.47950e-08 ,6.59510e-08 ,6.71345e-08 ,6.83175e-08 ,6.95250e-08 , &
+      7.07325e-08 ,7.19490e-08 ,7.31880e-08 ,7.44315e-08 ,7.56880e-08 , &
+      7.69500e-08 ,7.82495e-08 ,7.95330e-08 ,8.08450e-08 ,8.21535e-08 , &
+      8.34860e-08 ,8.48330e-08 ,8.61795e-08 ,8.75480e-08 ,8.89235e-08 , &
+      9.03060e-08 ,9.17045e-08 ,9.31140e-08 ,9.45240e-08 ,9.59720e-08 , &
+      9.74140e-08 ,9.88825e-08 ,1.00347e-07 ,1.01825e-07 ,1.03305e-07 , &
+      1.04826e-07 /)
+      totplnkderiv(1:50,12) = (/ &
+      2.91689e-11 ,3.20300e-11 ,3.51272e-11 ,3.84803e-11 ,4.21014e-11 , &
+      4.60107e-11 ,5.02265e-11 ,5.47685e-11 ,5.96564e-11 ,6.49111e-11 , &
+      7.05522e-11 ,7.66060e-11 ,8.30974e-11 ,9.00441e-11 ,9.74820e-11 , &
+      1.05435e-10 ,1.13925e-10 ,1.22981e-10 ,1.32640e-10 ,1.42933e-10 , &
+      1.53882e-10 ,1.65527e-10 ,1.77903e-10 ,1.91054e-10 ,2.05001e-10 , &
+      2.19779e-10 ,2.35448e-10 ,2.52042e-10 ,2.69565e-10 ,2.88128e-10 , &
+      3.07714e-10 ,3.28370e-10 ,3.50238e-10 ,3.73235e-10 ,3.97433e-10 , &
+      4.22964e-10 ,4.49822e-10 ,4.78042e-10 ,5.07721e-10 ,5.38915e-10 , &
+      5.71610e-10 ,6.05916e-10 ,6.41896e-10 ,6.79600e-10 ,7.19110e-10 , &
+      7.60455e-10 ,8.03625e-10 ,8.48870e-10 ,8.96080e-10 ,9.45490e-10 /)
+      totplnkderiv(51:100,12) = (/ &
+      9.96930e-10 ,1.05071e-09 ,1.10679e-09 ,1.16521e-09 ,1.22617e-09 , &
+      1.28945e-09 ,1.35554e-09 ,1.42427e-09 ,1.49574e-09 ,1.56984e-09 , &
+      1.64695e-09 ,1.72715e-09 ,1.81034e-09 ,1.89656e-09 ,1.98613e-09 , &
+      2.07898e-09 ,2.17515e-09 ,2.27498e-09 ,2.37826e-09 ,2.48517e-09 , &
+      2.59566e-09 ,2.71004e-09 ,2.82834e-09 ,2.95078e-09 ,3.07686e-09 , &
+      3.20739e-09 ,3.34232e-09 ,3.48162e-09 ,3.62515e-09 ,3.77337e-09 , &
+      3.92614e-09 ,4.08317e-09 ,4.24567e-09 ,4.41272e-09 ,4.58524e-09 , &
+      4.76245e-09 ,4.94450e-09 ,5.13235e-09 ,5.32535e-09 ,5.52415e-09 , &
+      5.72770e-09 ,5.93815e-09 ,6.15315e-09 ,6.37525e-09 ,6.60175e-09 , &
+      6.83485e-09 ,7.07490e-09 ,7.32060e-09 ,7.57225e-09 ,7.83035e-09 /)
+      totplnkderiv(101:150,12) = (/ &
+      8.09580e-09 ,8.36620e-09 ,8.64410e-09 ,8.93110e-09 ,9.22170e-09 , &
+      9.52055e-09 ,9.82595e-09 ,1.01399e-08 ,1.04613e-08 ,1.07878e-08 , &
+      1.11223e-08 ,1.14667e-08 ,1.18152e-08 ,1.21748e-08 ,1.25410e-08 , &
+      1.29147e-08 ,1.32948e-08 ,1.36858e-08 ,1.40827e-08 ,1.44908e-08 , &
+      1.49040e-08 ,1.53284e-08 ,1.57610e-08 ,1.61995e-08 ,1.66483e-08 , &
+      1.71068e-08 ,1.75714e-08 ,1.80464e-08 ,1.85337e-08 ,1.90249e-08 , &
+      1.95309e-08 ,2.00407e-08 ,2.05333e-08 ,2.10929e-08 ,2.16346e-08 , &
+      2.21829e-08 ,2.27402e-08 ,2.33112e-08 ,2.38922e-08 ,2.44802e-08 , &
+      2.50762e-08 ,2.56896e-08 ,2.63057e-08 ,2.69318e-08 ,2.75705e-08 , &
+      2.82216e-08 ,2.88787e-08 ,2.95505e-08 ,3.02335e-08 ,3.09215e-08 /)
+      totplnkderiv(151:181,12) = (/ &
+      3.16235e-08 ,3.23350e-08 ,3.30590e-08 ,3.37960e-08 ,3.45395e-08 , &
+      3.52955e-08 ,3.60615e-08 ,3.68350e-08 ,3.76265e-08 ,3.84255e-08 , &
+      3.92400e-08 ,4.00485e-08 ,4.08940e-08 ,4.17310e-08 ,4.25860e-08 , &
+      4.34585e-08 ,4.43270e-08 ,4.52220e-08 ,4.61225e-08 ,4.70345e-08 , &
+      4.79560e-08 ,4.89000e-08 ,4.98445e-08 ,5.07985e-08 ,5.17705e-08 , &
+      5.27575e-08 ,5.37420e-08 ,5.47495e-08 ,5.57725e-08 ,5.68105e-08 , &
+      5.78395e-08 /)
+      totplnkderiv(1:50,13) = (/ &
+      5.47482e-12 ,6.09637e-12 ,6.77874e-12 ,7.52703e-12 ,8.34784e-12 , &
+      9.24486e-12 ,1.02246e-11 ,1.12956e-11 ,1.24615e-11 ,1.37321e-11 , &
+      1.51131e-11 ,1.66129e-11 ,1.82416e-11 ,2.00072e-11 ,2.19187e-11 , &
+      2.39828e-11 ,2.62171e-11 ,2.86290e-11 ,3.12283e-11 ,3.40276e-11 , &
+      3.70433e-11 ,4.02847e-11 ,4.37738e-11 ,4.75070e-11 ,5.15119e-11 , &
+      5.58120e-11 ,6.04059e-11 ,6.53208e-11 ,7.05774e-11 ,7.61935e-11 , &
+      8.21832e-11 ,8.85570e-11 ,9.53575e-11 ,1.02592e-10 ,1.10298e-10 , &
+      1.18470e-10 ,1.27161e-10 ,1.36381e-10 ,1.46161e-10 ,1.56529e-10 , &
+      1.67521e-10 ,1.79142e-10 ,1.91423e-10 ,2.04405e-10 ,2.18123e-10 , &
+      2.32608e-10 ,2.47889e-10 ,2.63994e-10 ,2.80978e-10 ,2.98843e-10 /)
+      totplnkderiv(51:100,13) = (/ &
+      3.17659e-10 ,3.37423e-10 ,3.58206e-10 ,3.80090e-10 ,4.02996e-10 , &
+      4.27065e-10 ,4.52298e-10 ,4.78781e-10 ,5.06493e-10 ,5.35576e-10 , &
+      5.65942e-10 ,5.97761e-10 ,6.31007e-10 ,6.65740e-10 ,7.02095e-10 , &
+      7.39945e-10 ,7.79575e-10 ,8.20845e-10 ,8.63870e-10 ,9.08680e-10 , &
+      9.55385e-10 ,1.00416e-09 ,1.05464e-09 ,1.10737e-09 ,1.16225e-09 , &
+      1.21918e-09 ,1.27827e-09 ,1.33988e-09 ,1.40370e-09 ,1.46994e-09 , &
+      1.53850e-09 ,1.60993e-09 ,1.68382e-09 ,1.76039e-09 ,1.83997e-09 , &
+      1.92182e-09 ,2.00686e-09 ,2.09511e-09 ,2.18620e-09 ,2.28034e-09 , &
+      2.37753e-09 ,2.47805e-09 ,2.58193e-09 ,2.68935e-09 ,2.80064e-09 , &
+      2.91493e-09 ,3.03271e-09 ,3.15474e-09 ,3.27987e-09 ,3.40936e-09 /)
+      totplnkderiv(101:150,13) = (/ &
+      3.54277e-09 ,3.68019e-09 ,3.82173e-09 ,3.96703e-09 ,4.11746e-09 , &
+      4.27104e-09 ,4.43020e-09 ,4.59395e-09 ,4.76060e-09 ,4.93430e-09 , &
+      5.11085e-09 ,5.29280e-09 ,5.48055e-09 ,5.67300e-09 ,5.86950e-09 , &
+      6.07160e-09 ,6.28015e-09 ,6.49295e-09 ,6.71195e-09 ,6.93455e-09 , &
+      7.16470e-09 ,7.39985e-09 ,7.64120e-09 ,7.88885e-09 ,8.13910e-09 , &
+      8.39930e-09 ,8.66535e-09 ,8.93600e-09 ,9.21445e-09 ,9.49865e-09 , &
+      9.78845e-09 ,1.00856e-08 ,1.04361e-08 ,1.07018e-08 ,1.10164e-08 , &
+      1.13438e-08 ,1.16748e-08 ,1.20133e-08 ,1.23575e-08 ,1.27117e-08 , &
+      1.30708e-08 ,1.34383e-08 ,1.38138e-08 ,1.41985e-08 ,1.45859e-08 , &
+      1.49846e-08 ,1.53879e-08 ,1.58042e-08 ,1.62239e-08 ,1.66529e-08 /)
+      totplnkderiv(151:181,13) = (/ &
+      1.70954e-08 ,1.75422e-08 ,1.79943e-08 ,1.84537e-08 ,1.89280e-08 , &
+      1.94078e-08 ,1.98997e-08 ,2.03948e-08 ,2.08956e-08 ,2.14169e-08 , &
+      2.19330e-08 ,2.24773e-08 ,2.30085e-08 ,2.35676e-08 ,2.41237e-08 , &
+      2.46919e-08 ,2.52720e-08 ,2.58575e-08 ,2.64578e-08 ,2.70675e-08 , &
+      2.76878e-08 ,2.83034e-08 ,2.89430e-08 ,2.95980e-08 ,3.02480e-08 , &
+      3.09105e-08 ,3.15980e-08 ,3.22865e-08 ,3.29755e-08 ,3.36775e-08 , &
+      3.43990e-08 /)
+      totplnkderiv(1:50,14) = (/ &
+      1.81489e-12 ,2.03846e-12 ,2.28659e-12 ,2.56071e-12 ,2.86352e-12 , &
+      3.19789e-12 ,3.56668e-12 ,3.97211e-12 ,4.41711e-12 ,4.90616e-12 , &
+      5.44153e-12 ,6.02790e-12 ,6.67001e-12 ,7.37018e-12 ,8.13433e-12 , &
+      8.96872e-12 ,9.87526e-12 ,1.08601e-11 ,1.19328e-11 ,1.30938e-11 , &
+      1.43548e-11 ,1.57182e-11 ,1.71916e-11 ,1.87875e-11 ,2.05091e-11 , &
+      2.23652e-11 ,2.43627e-11 ,2.65190e-11 ,2.88354e-11 ,3.13224e-11 , &
+      3.39926e-11 ,3.68664e-11 ,3.99372e-11 ,4.32309e-11 ,4.67496e-11 , &
+      5.05182e-11 ,5.45350e-11 ,5.88268e-11 ,6.34126e-11 ,6.82878e-11 , &
+      7.34973e-11 ,7.90201e-11 ,8.49075e-11 ,9.11725e-11 ,9.78235e-11 , &
+      1.04856e-10 ,1.12342e-10 ,1.20278e-10 ,1.28680e-10 ,1.37560e-10 /)
+      totplnkderiv(51:100,14) = (/ &
+      1.46953e-10 ,1.56900e-10 ,1.67401e-10 ,1.78498e-10 ,1.90161e-10 , &
+      2.02523e-10 ,2.15535e-10 ,2.29239e-10 ,2.43665e-10 ,2.58799e-10 , &
+      2.74767e-10 ,2.91522e-10 ,3.09141e-10 ,3.27625e-10 ,3.47011e-10 , &
+      3.67419e-10 ,3.88720e-10 ,4.11066e-10 ,4.34522e-10 ,4.59002e-10 , &
+      4.84657e-10 ,5.11391e-10 ,5.39524e-10 ,5.68709e-10 ,5.99240e-10 , &
+      6.31295e-10 ,6.64520e-10 ,6.99200e-10 ,7.35525e-10 ,7.73135e-10 , &
+      8.12440e-10 ,8.53275e-10 ,8.95930e-10 ,9.40165e-10 ,9.86260e-10 , &
+      1.03423e-09 ,1.08385e-09 ,1.13567e-09 ,1.18916e-09 ,1.24469e-09 , &
+      1.30262e-09 ,1.36268e-09 ,1.42479e-09 ,1.48904e-09 ,1.55557e-09 , &
+      1.62478e-09 ,1.69642e-09 ,1.77023e-09 ,1.84696e-09 ,1.92646e-09 /)
+      totplnkderiv(101:150,14) = (/ &
+      2.00831e-09 ,2.09299e-09 ,2.18007e-09 ,2.27093e-09 ,2.36398e-09 , &
+      2.46020e-09 ,2.55985e-09 ,2.66230e-09 ,2.76795e-09 ,2.87667e-09 , &
+      2.98971e-09 ,3.10539e-09 ,3.22462e-09 ,3.34779e-09 ,3.47403e-09 , &
+      3.60419e-09 ,3.73905e-09 ,3.87658e-09 ,4.01844e-09 ,4.16535e-09 , &
+      4.31470e-09 ,4.46880e-09 ,4.62765e-09 ,4.78970e-09 ,4.95735e-09 , &
+      5.12890e-09 ,5.30430e-09 ,5.48595e-09 ,5.67010e-09 ,5.86145e-09 , &
+      6.05740e-09 ,6.25725e-09 ,6.46205e-09 ,6.67130e-09 ,6.88885e-09 , &
+      7.10845e-09 ,7.33450e-09 ,7.56700e-09 ,7.80440e-09 ,8.04465e-09 , &
+      8.29340e-09 ,8.54820e-09 ,8.80790e-09 ,9.07195e-09 ,9.34605e-09 , &
+      9.62005e-09 ,9.90685e-09 ,1.01939e-08 ,1.04938e-08 ,1.07957e-08 /)
+      totplnkderiv(151:181,14) = (/ &
+      1.11059e-08 ,1.14208e-08 ,1.17447e-08 ,1.20717e-08 ,1.24088e-08 , &
+      1.27490e-08 ,1.31020e-08 ,1.34601e-08 ,1.38231e-08 ,1.41966e-08 , &
+      1.45767e-08 ,1.49570e-08 ,1.53503e-08 ,1.57496e-08 ,1.61663e-08 , &
+      1.65784e-08 ,1.70027e-08 ,1.74290e-08 ,1.78730e-08 ,1.83235e-08 , &
+      1.87810e-08 ,1.92418e-08 ,1.97121e-08 ,2.01899e-08 ,2.05787e-08 , &
+      2.11784e-08 ,2.16824e-08 ,2.21931e-08 ,2.27235e-08 ,2.32526e-08 , &
+      2.37850e-08 /)
+      totplnkderiv(1:50,15) = (/ &
+      5.39905e-13 ,6.11835e-13 ,6.92224e-13 ,7.81886e-13 ,8.81851e-13 , &
+      9.93072e-13 ,1.11659e-12 ,1.25364e-12 ,1.40562e-12 ,1.57359e-12 , &
+      1.75937e-12 ,1.96449e-12 ,2.19026e-12 ,2.43892e-12 ,2.71249e-12 , &
+      3.01233e-12 ,3.34163e-12 ,3.70251e-12 ,4.09728e-12 ,4.52885e-12 , &
+      4.99939e-12 ,5.51242e-12 ,6.07256e-12 ,6.68167e-12 ,7.34274e-12 , &
+      8.06178e-12 ,8.84185e-12 ,9.68684e-12 ,1.06020e-11 ,1.15909e-11 , &
+      1.26610e-11 ,1.38158e-11 ,1.50620e-11 ,1.64047e-11 ,1.78508e-11 , &
+      1.94055e-11 ,2.10805e-11 ,2.28753e-11 ,2.48000e-11 ,2.68699e-11 , &
+      2.90824e-11 ,3.14526e-11 ,3.39882e-11 ,3.67020e-11 ,3.95914e-11 , &
+      4.26870e-11 ,4.59824e-11 ,4.94926e-11 ,5.32302e-11 ,5.72117e-11 /)
+      totplnkderiv(51:100,15) = (/ &
+      6.14475e-11 ,6.59483e-11 ,7.07393e-11 ,7.57999e-11 ,8.11980e-11 , &
+      8.68920e-11 ,9.29390e-11 ,9.93335e-11 ,1.06101e-10 ,1.13263e-10 , &
+      1.20827e-10 ,1.28819e-10 ,1.37255e-10 ,1.46163e-10 ,1.55547e-10 , &
+      1.65428e-10 ,1.75837e-10 ,1.86816e-10 ,1.98337e-10 ,2.10476e-10 , &
+      2.23218e-10 ,2.36600e-10 ,2.50651e-10 ,2.65425e-10 ,2.80895e-10 , &
+      2.97102e-10 ,3.14100e-10 ,3.31919e-10 ,3.50568e-10 ,3.70064e-10 , &
+      3.90464e-10 ,4.11813e-10 ,4.34111e-10 ,4.57421e-10 ,4.81717e-10 , &
+      5.07039e-10 ,5.33569e-10 ,5.61137e-10 ,5.89975e-10 ,6.19980e-10 , &
+      6.51170e-10 ,6.83650e-10 ,7.17520e-10 ,7.52735e-10 ,7.89390e-10 , &
+      8.27355e-10 ,8.66945e-10 ,9.08020e-10 ,9.50665e-10 ,9.95055e-10 /)
+      totplnkderiv(101:150,15) = (/ &
+      1.04101e-09 ,1.08864e-09 ,1.13823e-09 ,1.18923e-09 ,1.24257e-09 , &
+      1.29741e-09 ,1.35442e-09 ,1.41347e-09 ,1.47447e-09 ,1.53767e-09 , &
+      1.60322e-09 ,1.67063e-09 ,1.74033e-09 ,1.81256e-09 ,1.88704e-09 , &
+      1.96404e-09 ,2.04329e-09 ,2.12531e-09 ,2.21032e-09 ,2.29757e-09 , &
+      2.38739e-09 ,2.48075e-09 ,2.57628e-09 ,2.67481e-09 ,2.77627e-09 , &
+      2.88100e-09 ,2.98862e-09 ,3.09946e-09 ,3.21390e-09 ,3.33105e-09 , &
+      3.45185e-09 ,3.57599e-09 ,3.70370e-09 ,3.83512e-09 ,3.96909e-09 , &
+      4.10872e-09 ,4.25070e-09 ,4.39605e-09 ,4.54670e-09 ,4.70015e-09 , &
+      4.85850e-09 ,5.02050e-09 ,5.18655e-09 ,5.35815e-09 ,5.53180e-09 , &
+      5.71225e-09 ,5.89495e-09 ,6.08260e-09 ,6.27485e-09 ,6.47345e-09 /)
+      totplnkderiv(151:181,15) = (/ &
+      6.67520e-09 ,6.88310e-09 ,7.09400e-09 ,7.31140e-09 ,7.53350e-09 , &
+      7.76040e-09 ,7.99215e-09 ,8.22850e-09 ,8.47235e-09 ,8.71975e-09 , &
+      8.97360e-09 ,9.23365e-09 ,9.49950e-09 ,9.76965e-09 ,1.00441e-08 , &
+      1.03270e-08 ,1.06158e-08 ,1.09112e-08 ,1.12111e-08 ,1.15172e-08 , &
+      1.18263e-08 ,1.21475e-08 ,1.24735e-08 ,1.28027e-08 ,1.32023e-08 , &
+      1.34877e-08 ,1.38399e-08 ,1.42000e-08 ,1.45625e-08 ,1.49339e-08 , &
+      1.53156e-08 /)
+      totplnkderiv(1:50,16) = (/ &
+      4.38799e-14 ,5.04835e-14 ,5.79773e-14 ,6.64627e-14 ,7.60706e-14 , &
+      8.69213e-14 ,9.91554e-14 ,1.12932e-13 ,1.28419e-13 ,1.45809e-13 , &
+      1.65298e-13 ,1.87109e-13 ,2.11503e-13 ,2.38724e-13 ,2.69058e-13 , &
+      3.02878e-13 ,3.40423e-13 ,3.82128e-13 ,4.28390e-13 ,4.79625e-13 , &
+      5.36292e-13 ,5.98933e-13 ,6.68066e-13 ,7.44216e-13 ,8.28159e-13 , &
+      9.20431e-13 ,1.02180e-12 ,1.13307e-12 ,1.25504e-12 ,1.38863e-12 , &
+      1.53481e-12 ,1.69447e-12 ,1.86896e-12 ,2.05903e-12 ,2.26637e-12 , &
+      2.49193e-12 ,2.73736e-12 ,3.00416e-12 ,3.29393e-12 ,3.60781e-12 , &
+      3.94805e-12 ,4.31675e-12 ,4.71543e-12 ,5.14627e-12 ,5.61226e-12 , &
+      6.11456e-12 ,6.65585e-12 ,7.23969e-12 ,7.86811e-12 ,8.54456e-12 /)
+      totplnkderiv(51:100,16) = (/ &
+      9.27075e-12 ,1.00516e-11 ,1.08898e-11 ,1.17884e-11 ,1.27514e-11 , &
+      1.37839e-11 ,1.48893e-11 ,1.60716e-11 ,1.73333e-11 ,1.86849e-11 , &
+      2.01237e-11 ,2.16610e-11 ,2.33001e-11 ,2.50440e-11 ,2.69035e-11 , &
+      2.88827e-11 ,3.09881e-11 ,3.32234e-11 ,3.55981e-11 ,3.81193e-11 , &
+      4.07946e-11 ,4.36376e-11 ,4.66485e-11 ,4.98318e-11 ,5.32080e-11 , &
+      5.67754e-11 ,6.05524e-11 ,6.45450e-11 ,6.87639e-11 ,7.32160e-11 , &
+      7.79170e-11 ,8.28780e-11 ,8.81045e-11 ,9.36200e-11 ,9.94280e-11 , &
+      1.05545e-10 ,1.11982e-10 ,1.18752e-10 ,1.25866e-10 ,1.33350e-10 , &
+      1.41210e-10 ,1.49469e-10 ,1.58143e-10 ,1.67233e-10 ,1.76760e-10 , &
+      1.86758e-10 ,1.97236e-10 ,2.08227e-10 ,2.19723e-10 ,2.31737e-10 /)
+      totplnkderiv(101:150,16) = (/ &
+      2.44329e-10 ,2.57503e-10 ,2.71267e-10 ,2.85647e-10 ,3.00706e-10 , &
+      3.16391e-10 ,3.32807e-10 ,3.49887e-10 ,3.67748e-10 ,3.86369e-10 , &
+      4.05746e-10 ,4.25984e-10 ,4.47060e-10 ,4.68993e-10 ,4.91860e-10 , &
+      5.15601e-10 ,5.40365e-10 ,5.66085e-10 ,5.92855e-10 ,6.20640e-10 , &
+      6.49605e-10 ,6.79585e-10 ,7.10710e-10 ,7.43145e-10 ,7.76805e-10 , &
+      8.11625e-10 ,8.47800e-10 ,8.85300e-10 ,9.24220e-10 ,9.64550e-10 , &
+      1.00623e-09 ,1.04957e-09 ,1.09429e-09 ,1.14079e-09 ,1.18882e-09 , &
+      1.23848e-09 ,1.28986e-09 ,1.34301e-09 ,1.39796e-09 ,1.45493e-09 , &
+      1.51372e-09 ,1.57440e-09 ,1.63702e-09 ,1.70173e-09 ,1.76874e-09 , &
+      1.83753e-09 ,1.90898e-09 ,1.98250e-09 ,2.05836e-09 ,2.13646e-09 /)
+      totplnkderiv(151:181,16) = (/ &
+      2.21710e-09 ,2.30027e-09 ,2.38591e-09 ,2.47432e-09 ,2.56503e-09 , &
+      2.65878e-09 ,2.75516e-09 ,2.85432e-09 ,2.95688e-09 ,3.06201e-09 , &
+      3.17023e-09 ,3.28153e-09 ,3.39604e-09 ,3.51391e-09 ,3.63517e-09 , &
+      3.75955e-09 ,3.88756e-09 ,4.01880e-09 ,4.15405e-09 ,4.29255e-09 , &
+      4.43535e-09 ,4.58145e-09 ,4.73165e-09 ,4.88560e-09 ,5.04390e-09 , &
+      5.20630e-09 ,5.37255e-09 ,5.54355e-09 ,5.71915e-09 ,5.89855e-09 , &
+      6.08280e-09 /)
+      totplk16deriv(1:50) = (/ &
+      4.35811e-14 ,5.01270e-14 ,5.75531e-14 ,6.59588e-14 ,7.54735e-14 , &
+      8.62147e-14 ,9.83225e-14 ,1.11951e-13 ,1.27266e-13 ,1.44456e-13 , &
+      1.63715e-13 ,1.85257e-13 ,2.09343e-13 ,2.36209e-13 ,2.66136e-13 , &
+      2.99486e-13 ,3.36493e-13 ,3.77582e-13 ,4.23146e-13 ,4.73578e-13 , &
+      5.29332e-13 ,5.90936e-13 ,6.58891e-13 ,7.33710e-13 ,8.16135e-13 , &
+      9.06705e-13 ,1.00614e-12 ,1.11524e-12 ,1.23477e-12 ,1.36561e-12 , &
+      1.50871e-12 ,1.66488e-12 ,1.83552e-12 ,2.02123e-12 ,2.22375e-12 , &
+      2.44389e-12 ,2.68329e-12 ,2.94338e-12 ,3.22570e-12 ,3.53129e-12 , &
+      3.86236e-12 ,4.22086e-12 ,4.60827e-12 ,5.02666e-12 ,5.47890e-12 , &
+      5.96595e-12 ,6.49057e-12 ,7.05592e-12 ,7.66401e-12 ,8.31821e-12 /)
+      totplk16deriv(51:100) = (/ &
+      9.01998e-12 ,9.77390e-12 ,1.05826e-11 ,1.14491e-11 ,1.23769e-11 , &
+      1.33709e-11 ,1.44341e-11 ,1.55706e-11 ,1.67821e-11 ,1.80793e-11 , &
+      1.94586e-11 ,2.09316e-11 ,2.25007e-11 ,2.41685e-11 ,2.59454e-11 , &
+      2.78356e-11 ,2.98440e-11 ,3.19744e-11 ,3.42355e-11 ,3.66340e-11 , &
+      3.91772e-11 ,4.18773e-11 ,4.47339e-11 ,4.77509e-11 ,5.09490e-11 , &
+      5.43240e-11 ,5.78943e-11 ,6.16648e-11 ,6.56445e-11 ,6.98412e-11 , &
+      7.42680e-11 ,7.89335e-11 ,8.38450e-11 ,8.90220e-11 ,9.44695e-11 , &
+      1.00197e-10 ,1.06221e-10 ,1.12550e-10 ,1.19193e-10 ,1.26175e-10 , &
+      1.33498e-10 ,1.41188e-10 ,1.49251e-10 ,1.57693e-10 ,1.66530e-10 , &
+      1.75798e-10 ,1.85495e-10 ,1.95661e-10 ,2.06275e-10 ,2.17357e-10 /)
+      totplk16deriv(101:150) = (/ &
+      2.28959e-10 ,2.41085e-10 ,2.53739e-10 ,2.66944e-10 ,2.80755e-10 , &
+      2.95121e-10 ,3.10141e-10 ,3.25748e-10 ,3.42057e-10 ,3.59026e-10 , &
+      3.76668e-10 ,3.95066e-10 ,4.14211e-10 ,4.34111e-10 ,4.54818e-10 , &
+      4.76295e-10 ,4.98681e-10 ,5.21884e-10 ,5.46000e-10 ,5.71015e-10 , &
+      5.97065e-10 ,6.23965e-10 ,6.51865e-10 ,6.80905e-10 ,7.11005e-10 , &
+      7.42100e-10 ,7.74350e-10 ,8.07745e-10 ,8.42355e-10 ,8.78185e-10 , &
+      9.15130e-10 ,9.53520e-10 ,9.93075e-10 ,1.03415e-09 ,1.07649e-09 , &
+      1.12021e-09 ,1.16539e-09 ,1.21207e-09 ,1.26025e-09 ,1.31014e-09 , &
+      1.36156e-09 ,1.41453e-09 ,1.46909e-09 ,1.52540e-09 ,1.58368e-09 , &
+      1.64334e-09 ,1.70527e-09 ,1.76888e-09 ,1.83442e-09 ,1.90182e-09 /)
+      totplk16deriv(151:181) = (/ &
+      1.97128e-09 ,2.04281e-09 ,2.11635e-09 ,2.19219e-09 ,2.26979e-09 , &
+      2.34989e-09 ,2.43219e-09 ,2.51660e-09 ,2.60396e-09 ,2.69317e-09 , &
+      2.78501e-09 ,2.87927e-09 ,2.97600e-09 ,3.07548e-09 ,3.17772e-09 , &
+      3.28235e-09 ,3.38982e-09 ,3.49985e-09 ,3.61307e-09 ,3.72883e-09 , &
+      3.84805e-09 ,3.96975e-09 ,4.09465e-09 ,4.22240e-09 ,4.35370e-09 , &
+      4.48800e-09 ,4.62535e-09 ,4.76640e-09 ,4.91110e-09 ,5.05850e-09 , &
+      5.20965e-09 /)
+!$acc enter data copyin(totplnkderiv,totplk16deriv)
+      end subroutine lwavplankderiv
+
+      end module rrtmg_lw_setcoef_f
+
+      module rrtmg_lw_init_f
+
+! --------------------------------------------------------------------------
+! | |
+! | Copyright 2002-2009, Atmospheric & Environmental Research, Inc. (AER). |
+! | This software may be used, copied, or redistributed as long as it is |
+! | not sold and this copyright notice is reproduced on each copy made. |
+! | This model is provided as is without any express or implied warranties. |
+! | (http:
+! | |
+! --------------------------------------------------------------------------
+
+! ------- Modules -------
+! use parkind, only : im => kind , rb => kind
+      use rrlw_wvn_f
+      use rrtmg_lw_setcoef_f, only: lwatmref, lwavplank, lwavplankderiv
+
+      implicit none
+
+      contains
+
+! **************************************************************************
+      subroutine rrtmg_lw_ini(cpdair)
+! **************************************************************************
+!
+! Original version: Michael J. Iacono; July, 1998
+! First revision for GCMs: September, 1998
+! Second revision for RRTM_V3.0: September, 2002
+!
+! This subroutine performs calculations necessary for the initialization
+! of the longwave model. Lookup tables are computed for use in the LW
+! radiative transfer, and input absorption coefficient data for each
+! spectral band are reduced from 256 g-point intervals to 140.
+! **************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw
+      use rrlw_tbl_f, only: ntbl, tblint, pade, bpade, tau_tbl, exp_tbl, tfn_tbl
+      use rrlw_vsn_f, only: hvrini, hnamini
+
+      real , intent(in) :: cpdair ! Specific heat capacity of dry air
+                                      ! at constant pressure at 273 K
+                                      ! (J kg-1 K-1)
+
+! ------- Local -------
+
+      integer :: itr, ibnd, igc, ig, ind, ipr
+      integer :: igcsm, iprsm
+
+      real :: wtsum, wtsm(mg) !
+      real :: tfn !
+
+      real , parameter :: expeps = 1.e-20 ! Smallest value for exponential table
+
+! ------- Definitions -------
+! Arrays for 10000-point look-up tables:
+! TAU_TBL Clear-sky optical depth (used in cloudy radiative transfer)
+! EXP_TBL Exponential lookup table for ransmittance
+! TFN_TBL Tau transition function; i.e. the transition of the Planck
+! function from that for the mean layer temperature to that for
+! the layer boundary temperature as a function of optical depth.
+! The "linear in tau" method is used to make the table.
+! PADE Pade approximation constant (= 0.278)
+! BPADE Inverse of the Pade approximation constant
+!
+
+      hvrini = '$Revision: 1.1.1.2 $'
+
+! Initialize model data
+      call lwdatinit(cpdair)
+      call lwcmbdat ! g-point interval reduction data
+      call lwcldpr ! cloud optical properties
+      call lwatmref ! reference MLS profile
+      call lwavplank ! Planck function
+      call lwavplankderiv ! Planck function derivative wrt temp
+! Moved to module_ra_rrtmg_lw for WRF
+! call lw_kgb01 ! molecular absorption coefficients
+! call lw_kgb02
+! call lw_kgb03
+! call lw_kgb04
+! call lw_kgb05
+! call lw_kgb06
+! call lw_kgb07
+! call lw_kgb08
+! call lw_kgb09
+! call lw_kgb10
+! call lw_kgb11
+! call lw_kgb12
+! call lw_kgb13
+! call lw_kgb14
+! call lw_kgb15
+! call lw_kgb16
+
+! Compute lookup tables for transmittance, tau transition function,
+! and clear sky tau (for the cloudy sky radiative transfer). Tau is
+! computed as a function of the tau transition function, transmittance
+! is calculated as a function of tau, and the tau transition function
+! is calculated using the linear in tau formulation at values of tau
+! above 0.01. TF is approximated as tau/6 for tau < 0.01. All tables
+! are computed at intervals of 0.001. The inverse of the constant used
+! in the Pade approximation to the tau transition function is set to b.
+
+      tau_tbl(0) = 0.0
+      tau_tbl(ntbl) = 1.e10
+      exp_tbl(0) = 1.0
+      exp_tbl(ntbl) = expeps
+      tfn_tbl(0) = 0.0
+      tfn_tbl(ntbl) = 1.0
+      bpade = 1.0 / pade
+      do itr = 1, ntbl-1
+         tfn = float(itr) / float(ntbl)
+         tau_tbl(itr) = bpade * tfn / (1. - tfn)
+         exp_tbl(itr) = exp(-tau_tbl(itr))
+         if (exp_tbl(itr) .le. expeps) exp_tbl(itr) = expeps
+         if (tau_tbl(itr) .lt. 0.06 ) then
+            tfn_tbl(itr) = tau_tbl(itr)/6.
+         else
+            tfn_tbl(itr) = 1. -2. *((1. /tau_tbl(itr))-(exp_tbl(itr)/(1.-exp_tbl(itr))))
+         endif
+      enddo
+!$acc enter data copyin(tau_tbl,exp_tbl,tfn_tbl)
+
+! Perform g-point reduction from 16 per band (256 total points) to
+! a band dependant number (140 total points) for all absorption
+! coefficient input data and Planck fraction input data.
+! Compute relative weighting for new g-point combinations.
+
+      igcsm = 0
+      do ibnd = 1,nbndlw
+         iprsm = 0
+         if (ngc(ibnd).lt.mg) then
+            do igc = 1,ngc(ibnd)
+               igcsm = igcsm + 1
+               wtsum = 0.
+               do ipr = 1, ngn(igcsm)
+                  iprsm = iprsm + 1
+                  wtsum = wtsum + wt(iprsm)
+               enddo
+               wtsm(igc) = wtsum
+            enddo
+            do ig = 1, ng(ibnd)
+               ind = (ibnd-1)*mg + ig
+               rwgt(ind) = wt(ig)/wtsm(ngm(ind))
+            enddo
+         else
+            do ig = 1, ng(ibnd)
+               igcsm = igcsm + 1
+               ind = (ibnd-1)*mg + ig
+               rwgt(ind) = 1.0
+            enddo
+         endif
+      enddo
+
+! Reduce g-points for absorption coefficient data in each LW spectral band.
+
+      call cmbgb1
+      call cmbgb2
+      call cmbgb3
+      call cmbgb4
+      call cmbgb5
+      call cmbgb6
+      call cmbgb7
+      call cmbgb8
+      call cmbgb9
+      call cmbgb10
+      call cmbgb11
+      call cmbgb12
+      call cmbgb13
+      call cmbgb14
+      call cmbgb15
+      call cmbgb16
+
+      end subroutine rrtmg_lw_ini
+
+!***************************************************************************
+      subroutine lwdatinit(cpdair)
+!***************************************************************************
+
+! --------- Modules ----------
+
+      use parrrtm_f, only : maxxsec, maxinpx
+      use rrlw_con_f, only: heatfac, grav, planck, boltz, &
+                          clight, avogad, alosmt, gascon, radcn1, radcn2, &
+                          sbcnst, secdy
+      use rrlw_vsn_f
+
+      save
+
+      real , intent(in) :: cpdair ! Specific heat capacity of dry air
+                                       ! at constant pressure at 273 K
+                                       ! (J kg-1 K-1)
+
+! Longwave spectral band limits (wavenumbers)
+      wavenum1(:) = (/ 10. , 350. , 500. , 630. , 700. , 820. , &
+                      980. ,1080. ,1180. ,1390. ,1480. ,1800. , &
+                     2080. ,2250. ,2380. ,2600. /)
+      wavenum2(:) = (/350. , 500. , 630. , 700. , 820. , 980. , &
+                     1080. ,1180. ,1390. ,1480. ,1800. ,2080. , &
+                     2250. ,2380. ,2600. ,3250. /)
+      delwave(:) = (/340. , 150. , 130. , 70. , 120. , 160. , &
+                      100. , 100. , 210. , 90. , 320. , 280. , &
+                      170. , 130. , 220. , 650. /)
+!$acc enter data copyin(wavenum1,wavenum2,delwave)
+
+! Spectral band information
+      ng(:) = (/16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16/)
+      nspa(:) = (/1,1,9,9,9,1,9,1,9,1,1,9,9,1,9,9/)
+      nspb(:) = (/1,1,5,5,5,0,1,1,1,1,1,0,0,1,0,0/)
+!$acc enter data copyin(ng,nspa,nspb)
+
+! nxmol - number of cross-sections input by user
+! ixindx(i) - index of cross-section molecule corresponding to Ith
+! cross-section specified by user
+! = 0 -- not allowed in rrtm
+! = 1 -- ccl4
+! = 2 -- cfc11
+! = 3 -- cfc12
+! = 4 -- cfc22
+      nxmol = 4
+      ixindx(1) = 1
+      ixindx(2) = 2
+      ixindx(3) = 3
+      ixindx(4) = 4
+      ixindx(5:maxinpx) = 0
+
+! Fundamental physical constants from NIST 2002
+
+      grav = 9.8066 ! Acceleration of gravity
+                                              ! (m s-2)
+      planck = 6.62606876e-27 ! Planck constant
+                                              ! (ergs s; g cm2 s-1)
+      boltz = 1.3806503e-16 ! Boltzmann constant
+                                              ! (ergs K-1; g cm2 s-2 K-1)
+      clight = 2.99792458e+10 ! Speed of light in a vacuum
+                                              ! (cm s-1)
+      avogad = 6.02214199e+23 ! Avogadro constant
+                                              ! (mol-1)
+      alosmt = 2.6867775e+19 ! Loschmidt constant
+                                              ! (cm-3)
+      gascon = 8.31447200e+07 ! Molar gas constant
+                                              ! (ergs mol-1 K-1)
+      radcn1 = 1.191042722e-12 ! First radiation constant
+                                              ! (W cm2 sr-1)
+      radcn2 = 1.4387752 ! Second radiation constant
+                                              ! (cm K)
+      sbcnst = 5.670400e-04 ! Stefan-Boltzmann constant
+                                              ! (W cm-2 K-4)
+      secdy = 8.6400e4 ! Number of seconds per day
+                                              ! (s d-1)
+!
+! units are generally cgs
+!
+! The first and second radiation constants are taken from NIST.
+! They were previously obtained from the relations:
+! radcn1 = 2.*planck*clight*clight*1.e-07
+! radcn2 = planck*clight/boltz
+
+! Heatfac is the factor by which delta-flux / delta-pressure is
+! multiplied, with flux in W/m-2 and pressure in mbar, to get
+! the heating rate in units of degrees/day. It is equal to:
+! Original value:
+! (g)x(#sec/day)x(1e-5)/(specific heat of air at const. p)
+! Here, cpdair (1.004) is in units of J g-1 K-1, and the
+! constant (1.e-5) converts mb to Pa and g-1 to kg-1.
+! = (9.8066)(86400)(1e-5)/(1.004)
+! heatfac = 8.4391
+!
+! Modified value for consistency with CAM3:
+! (g)x(#sec/day)x(1e-5)/(specific heat of air at const. p)
+! Here, cpdair (1.00464) is in units of J g-1 K-1, and the
+! constant (1.e-5) converts mb to Pa and g-1 to kg-1.
+! = (9.80616)(86400)(1e-5)/(1.00464)
+! heatfac = 8.43339130434
+!
+! Calculated value:
+! (grav) x (#sec/day) / (specific heat of dry air at const. p x 1.e2)
+! Here, cpdair is in units of J kg-1 K-1, and the constant (1.e2)
+! converts mb to Pa when heatfac is multiplied by W m-2 mb-1.
+      heatfac = grav * secdy / (cpdair * 1.e2 )
+
+      end subroutine lwdatinit
+
+!***************************************************************************
+      subroutine lwcmbdat
+!***************************************************************************
+
+      save
+
+! ------- Definitions -------
+! Arrays for the g-point reduction from 256 to 140 for the 16 LW bands:
+! This mapping from 256 to 140 points has been carefully selected to
+! minimize the effect on the resulting fluxes and cooling rates, and
+! caution should be used if the mapping is modified. The full 256
+! g-point set can be restored with ngptlw=256, ngc=16*16, ngn=256*1., etc.
+! ngptlw The total number of new g-points
+! ngc The number of new g-points in each band
+! ngs The cumulative sum of new g-points for each band
+! ngm The index of each new g-point relative to the original
+! 16 g-points for each band.
+! ngn The number of original g-points that are combined to make
+! each new g-point in each band.
+! ngb The band index for each new g-point.
+! wt RRTM weights for 16 g-points.
+
+! ------- Data statements -------
+      ngc(:) = (/10,12,16,14,16,8,12,8,12,6,8,8,4,2,2,2/)
+      ngs(:) = (/10,22,38,52,68,76,88,96,108,114,122,130,134,136,138,140/)
+      ngm(:) = (/1,2,3,3,4,4,5,5,6,6,7,7,8,8,9,10, & ! band 1
+                 1,2,3,4,5,6,7,8,9,9,10,10,11,11,12,12, & ! band 2
+                 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, & ! band 3
+                 1,2,3,4,5,6,7,8,9,10,11,12,13,14,14,14, & ! band 4
+                 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, & ! band 5
+                 1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8, & ! band 6
+                 1,1,2,2,3,4,5,6,7,8,9,10,11,11,12,12, & ! band 7
+                 1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8, & ! band 8
+                 1,2,3,4,5,6,7,8,9,9,10,10,11,11,12,12, & ! band 9
+                 1,1,2,2,3,3,4,4,5,5,5,5,6,6,6,6, & ! band 10
+                 1,2,3,3,4,4,5,5,6,6,7,7,7,8,8,8, & ! band 11
+                 1,2,3,4,5,5,6,6,7,7,7,7,8,8,8,8, & ! band 12
+                 1,1,1,2,2,2,3,3,3,3,4,4,4,4,4,4, & ! band 13
+                 1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2, & ! band 14
+                 1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2, & ! band 15
+                 1,1,1,1,2,2,2,2,2,2,2,2,2,2,2,2/) ! band 16
+      ngn(:) = (/1,1,2,2,2,2,2,2,1,1, & ! band 1
+                 1,1,1,1,1,1,1,1,2,2,2,2, & ! band 2
+                 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, & ! band 3
+                 1,1,1,1,1,1,1,1,1,1,1,1,1,3, & ! band 4
+                 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, & ! band 5
+                 2,2,2,2,2,2,2,2, & ! band 6
+                 2,2,1,1,1,1,1,1,1,1,2,2, & ! band 7
+                 2,2,2,2,2,2,2,2, & ! band 8
+                 1,1,1,1,1,1,1,1,2,2,2,2, & ! band 9
+                 2,2,2,2,4,4, & ! band 10
+                 1,1,2,2,2,2,3,3, & ! band 11
+                 1,1,1,1,2,2,4,4, & ! band 12
+                 3,3,4,6, & ! band 13
+                 8,8, & ! band 14
+                 8,8, & ! band 15
+                 4,12/) ! band 16
+      ngb(:) = (/1,1,1,1,1,1,1,1,1,1, & ! band 1
+                 2,2,2,2,2,2,2,2,2,2,2,2, & ! band 2
+                 3,3,3,3,3,3,3,3,3,3,3,3,3,3,3,3, & ! band 3
+                 4,4,4,4,4,4,4,4,4,4,4,4,4,4, & ! band 4
+                 5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5, & ! band 5
+                 6,6,6,6,6,6,6,6, & ! band 6
+                 7,7,7,7,7,7,7,7,7,7,7,7, & ! band 7
+                 8,8,8,8,8,8,8,8, & ! band 8
+                 9,9,9,9,9,9,9,9,9,9,9,9, & ! band 9
+                 10,10,10,10,10,10, & ! band 10
+                 11,11,11,11,11,11,11,11, & ! band 11
+                 12,12,12,12,12,12,12,12, & ! band 12
+                 13,13,13,13, & ! band 13
+                 14,14, & ! band 14
+                 15,15, & ! band 15
+                 16,16/) ! band 16
+      wt(:) = (/ 0.1527534276 , 0.1491729617 , 0.1420961469 , &
+                 0.1316886544 , 0.1181945205 , 0.1019300893 , &
+                 0.0832767040 , 0.0626720116 , 0.0424925000 , &
+                 0.0046269894 , 0.0038279891 , 0.0030260086 , &
+                 0.0022199750 , 0.0014140010 , 0.0005330000 , &
+                 0.0000750000 /)
+!$acc enter data copyin(wt,ngb,ngc,ngs,ngm,ngn)
+      end subroutine lwcmbdat
+
+!***************************************************************************
+      subroutine cmbgb1
+!***************************************************************************
+!
+! Original version: MJIacono; July 1998
+! Revision for GCMs: MJIacono; September 1998
+! Revision for RRTMG: MJIacono, September 2002
+! Revision for F90 reformatting: MJIacono, June 2006
+!
+! The subroutines CMBGB1->CMBGB16 input the absorption coefficient
+! data for each band, which are defined for 16 g-points and 16 spectral
+! bands. The data are combined with appropriate weighting following the
+! g-point mapping arrays specified in RRTMINIT. Plank fraction data
+! in arrays FRACREFA and FRACREFB are combined without weighting. All
+! g-point reduced data are put into new arrays for use in RRTM.
+!
+! band 1: 10-350 cm-1 (low key - h2o; low minor - n2)
+! (high key - h2o; high minor - n2)
+! note: previous versions of rrtm band 1:
+! 10-250 cm-1 (low - h2o; high - h2o)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng1
+      use rrlw_kg01_f, only: fracrefao, fracrefbo, kao, kbo, kao_mn2, kbo_mn2, &
+                           selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, absb, kb, ka_mn2, kb_mn2, &
+                           selfref, forref
+
+! ------- Local -------
+      integer :: jt, jp, igc, ipr, iprsm
+      real :: sumk, sumk1, sumk2, sumf1, sumf2
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(1)
+               sumk = 0.
+               do ipr = 1, ngn(igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(1)
+               sumk = 0.
+               do ipr = 1, ngn(igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(1)
+            sumk = 0.
+            do ipr = 1, ngn(igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(1)
+            sumk = 0.
+            do ipr = 1, ngn(igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,19
+         iprsm = 0
+         do igc = 1,ngc(1)
+            sumk1 = 0.
+            sumk2 = 0.
+            do ipr = 1, ngn(igc)
+               iprsm = iprsm + 1
+               sumk1 = sumk1 + kao_mn2(jt,iprsm)*rwgt(iprsm)
+               sumk2 = sumk2 + kbo_mn2(jt,iprsm)*rwgt(iprsm)
+            enddo
+            ka_mn2(jt,igc) = sumk1
+            kb_mn2(jt,igc) = sumk2
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(1)
+         sumf1 = 0.
+         sumf2 = 0.
+         do ipr = 1, ngn(igc)
+            iprsm = iprsm + 1
+            sumf1= sumf1+ fracrefao(iprsm)
+            sumf2= sumf2+ fracrefbo(iprsm)
+         enddo
+         fracrefa(igc) = sumf1
+         fracrefb(igc) = sumf2
+      enddo
+!$acc enter data copyin(ka,kb,selfref,forref,ka_mn2,kb_mn2,fracrefa,fracrefb)
+      end subroutine cmbgb1
+
+!***************************************************************************
+      subroutine cmbgb2
+!***************************************************************************
+!
+! band 2: 350-500 cm-1 (low key - h2o; high key - h2o)
+!
+! note: previous version of rrtm band 2:
+! 250 - 500 cm-1 (low - h2o; high - h2o)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng2
+      use rrlw_kg02_f, only: fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, absb, kb, selfref, forref
+
+! ------- Local -------
+      integer :: jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf1, sumf2
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(2)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(1)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+16)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(2)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(1)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+16)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(2)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(1)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+16)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(2)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(1)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+16)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(2)
+         sumf1 = 0.
+         sumf2 = 0.
+         do ipr = 1, ngn(ngs(1)+igc)
+            iprsm = iprsm + 1
+            sumf1= sumf1+ fracrefao(iprsm)
+            sumf2= sumf2+ fracrefbo(iprsm)
+         enddo
+         fracrefa(igc) = sumf1
+         fracrefb(igc) = sumf2
+      enddo
+!$acc enter data copyin(ka,kb,selfref,forref,fracrefa,fracrefb)
+      end subroutine cmbgb2
+
+!***************************************************************************
+      subroutine cmbgb3
+!***************************************************************************
+!
+! band 3: 500-630 cm-1 (low key - h2o,co2; low minor - n2o)
+! (high key - h2o,co2; high minor - n2o)
+!
+! old band 3: 500-630 cm-1 (low - h2o,co2; high - h2o,co2)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng3
+      use rrlw_kg03_f, only: fracrefao, fracrefbo, kao, kbo, kao_mn2o, kbo_mn2o, &
+                           selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, absb, kb, ka_mn2o, kb_mn2o, &
+                           selfref, forref
+
+! ------- Local -------
+      integer :: jn, jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(3)
+                 sumk = 0.
+                  do ipr = 1, ngn(ngs(2)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+32)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+      do jn = 1,5
+         do jt = 1,5
+            do jp = 13,59
+               iprsm = 0
+               do igc = 1,ngc(3)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(2)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kbo(jn,jt,jp,iprsm)*rwgt(iprsm+32)
+                  enddo
+                  kb(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jn = 1,9
+         do jt = 1,19
+            iprsm = 0
+            do igc = 1,ngc(3)
+              sumk = 0.
+               do ipr = 1, ngn(ngs(2)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao_mn2o(jn,jt,iprsm)*rwgt(iprsm+32)
+               enddo
+               ka_mn2o(jn,jt,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jn = 1,5
+         do jt = 1,19
+            iprsm = 0
+            do igc = 1,ngc(3)
+              sumk = 0.
+               do ipr = 1, ngn(ngs(2)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo_mn2o(jn,jt,iprsm)*rwgt(iprsm+32)
+               enddo
+               kb_mn2o(jn,jt,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(3)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(2)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+32)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(3)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(2)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+32)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(3)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(2)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefao(iprsm,jp)
+            enddo
+            fracrefa(igc,jp) = sumf
+         enddo
+      enddo
+
+      do jp = 1,5
+         iprsm = 0
+         do igc = 1,ngc(3)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(2)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefbo(iprsm,jp)
+            enddo
+            fracrefb(igc,jp) = sumf
+         enddo
+      enddo
+!$acc enter data copyin(ka,kb,selfref,forref,ka_mn2o,kb_mn2o,fracrefa,fracrefb)
+
+      end subroutine cmbgb3
+
+!***************************************************************************
+      subroutine cmbgb4
+!***************************************************************************
+!
+! band 4: 630-700 cm-1 (low key - h2o,co2; high key - o3,co2)
+!
+! old band 4: 630-700 cm-1 (low - h2o,co2; high - o3,co2)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng4
+      use rrlw_kg04_f, only: fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, absb, kb, selfref, forref
+
+! ------- Local -------
+      integer :: jn, jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(4)
+                 sumk = 0.
+                  do ipr = 1, ngn(ngs(3)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+48)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+      do jn = 1,5
+         do jt = 1,5
+            do jp = 13,59
+               iprsm = 0
+               do igc = 1,ngc(4)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(3)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kbo(jn,jt,jp,iprsm)*rwgt(iprsm+48)
+                  enddo
+                  kb(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(4)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(3)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+48)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(4)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(3)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+48)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(4)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(3)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefao(iprsm,jp)
+            enddo
+            fracrefa(igc,jp) = sumf
+         enddo
+      enddo
+
+      do jp = 1,5
+         iprsm = 0
+         do igc = 1,ngc(4)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(3)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefbo(iprsm,jp)
+            enddo
+            fracrefb(igc,jp) = sumf
+         enddo
+      enddo
+!$acc enter data copyin(ka,kb,selfref,forref,fracrefa,fracrefb)
+
+      end subroutine cmbgb4
+
+!***************************************************************************
+      subroutine cmbgb5
+!***************************************************************************
+!
+! band 5: 700-820 cm-1 (low key - h2o,co2; low minor - o3, ccl4)
+! (high key - o3,co2)
+!
+! old band 5: 700-820 cm-1 (low - h2o,co2; high - o3,co2)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng5
+      use rrlw_kg05_f, only: fracrefao, fracrefbo, kao, kbo, kao_mo3, ccl4o, &
+                           selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, absb, kb, ka_mo3, ccl4, &
+                           selfref, forref
+
+! ------- Local -------
+      integer :: jn, jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(5)
+                 sumk = 0.
+                  do ipr = 1, ngn(ngs(4)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+64)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+      do jn = 1,5
+         do jt = 1,5
+            do jp = 13,59
+               iprsm = 0
+               do igc = 1,ngc(5)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(4)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kbo(jn,jt,jp,iprsm)*rwgt(iprsm+64)
+                  enddo
+                  kb(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jn = 1,9
+         do jt = 1,19
+            iprsm = 0
+            do igc = 1,ngc(5)
+              sumk = 0.
+               do ipr = 1, ngn(ngs(4)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao_mo3(jn,jt,iprsm)*rwgt(iprsm+64)
+               enddo
+               ka_mo3(jn,jt,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(5)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(4)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+64)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(5)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(4)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+64)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(5)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(4)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefao(iprsm,jp)
+            enddo
+            fracrefa(igc,jp) = sumf
+         enddo
+      enddo
+
+      do jp = 1,5
+         iprsm = 0
+         do igc = 1,ngc(5)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(4)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefbo(iprsm,jp)
+            enddo
+            fracrefb(igc,jp) = sumf
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(5)
+         sumk = 0.
+         do ipr = 1, ngn(ngs(4)+igc)
+            iprsm = iprsm + 1
+            sumk = sumk + ccl4o(iprsm)*rwgt(iprsm+64)
+         enddo
+         ccl4(igc) = sumk
+      enddo
+!$acc enter data copyin(ccl4,ka,kb,selfref,forref,ka_mo3,fracrefa,fracrefb)
+
+      end subroutine cmbgb5
+
+!***************************************************************************
+      subroutine cmbgb6
+!***************************************************************************
+!
+! band 6: 820-980 cm-1 (low key - h2o; low minor - co2)
+! (high key - nothing; high minor - cfc11, cfc12)
+!
+! old band 6: 820-980 cm-1 (low - h2o; high - nothing)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng6
+      use rrlw_kg06_f, only: fracrefao, kao, kao_mco2, cfc11adjo, cfc12o, &
+                           selfrefo, forrefo, &
+                           fracrefa, absa, ka, ka_mco2, cfc11adj, cfc12, &
+                           selfref, forref
+
+! ------- Local -------
+      integer :: jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf, sumk1, sumk2
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(6)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(5)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+80)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,19
+         iprsm = 0
+         do igc = 1,ngc(6)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(5)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + kao_mco2(jt,iprsm)*rwgt(iprsm+80)
+            enddo
+            ka_mco2(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(6)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(5)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+80)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(6)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(5)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+80)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(6)
+         sumf = 0.
+         sumk1= 0.
+         sumk2= 0.
+         do ipr = 1, ngn(ngs(5)+igc)
+            iprsm = iprsm + 1
+            sumf = sumf + fracrefao(iprsm)
+            sumk1= sumk1+ cfc11adjo(iprsm)*rwgt(iprsm+80)
+            sumk2= sumk2+ cfc12o(iprsm)*rwgt(iprsm+80)
+         enddo
+         fracrefa(igc) = sumf
+         cfc11adj(igc) = sumk1
+         cfc12(igc) = sumk2
+      enddo
+!$acc enter data copyin(cfc11adj,cfc12,ka,selfref,forref,ka_mco2,fracrefa)
+
+      end subroutine cmbgb6
+
+!***************************************************************************
+      subroutine cmbgb7
+!***************************************************************************
+!
+! band 7: 980-1080 cm-1 (low key - h2o,o3; low minor - co2)
+! (high key - o3; high minor - co2)
+!
+! old band 7: 980-1080 cm-1 (low - h2o,o3; high - o3)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng7
+      use rrlw_kg07_f, only: fracrefao, fracrefbo, kao, kbo, kao_mco2, kbo_mco2, &
+                           selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, absb, kb, ka_mco2, kb_mco2, &
+                           selfref, forref
+
+! ------- Local -------
+      integer :: jn, jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(7)
+                 sumk = 0.
+                  do ipr = 1, ngn(ngs(6)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+96)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(7)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(6)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+96)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jn = 1,9
+         do jt = 1,19
+            iprsm = 0
+            do igc = 1,ngc(7)
+              sumk = 0.
+               do ipr = 1, ngn(ngs(6)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao_mco2(jn,jt,iprsm)*rwgt(iprsm+96)
+               enddo
+               ka_mco2(jn,jt,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,19
+         iprsm = 0
+         do igc = 1,ngc(7)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(6)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + kbo_mco2(jt,iprsm)*rwgt(iprsm+96)
+            enddo
+            kb_mco2(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(7)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(6)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+96)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(7)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(6)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+96)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(7)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(6)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefao(iprsm,jp)
+            enddo
+            fracrefa(igc,jp) = sumf
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(7)
+         sumf = 0.
+         do ipr = 1, ngn(ngs(6)+igc)
+            iprsm = iprsm + 1
+            sumf = sumf + fracrefbo(iprsm)
+         enddo
+         fracrefb(igc) = sumf
+      enddo
+!$acc enter data copyin(ka,kb,selfref,forref,ka_mco2,kb_mco2,fracrefa,fracrefb)
+
+      end subroutine cmbgb7
+
+!***************************************************************************
+      subroutine cmbgb8
+!***************************************************************************
+!
+! band 8: 1080-1180 cm-1 (low key - h2o; low minor - co2,o3,n2o)
+! (high key - o3; high minor - co2, n2o)
+!
+! old band 8: 1080-1180 cm-1 (low (i.e.>~300mb) - h2o; high - o3)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng8
+      use rrlw_kg08_f, only: fracrefao, fracrefbo, kao, kao_mco2, kao_mn2o, &
+                           kao_mo3, kbo, kbo_mco2, kbo_mn2o, selfrefo, forrefo, &
+                           cfc12o, cfc22adjo, &
+                           fracrefa, fracrefb, absa, ka, ka_mco2, ka_mn2o, &
+                           ka_mo3, absb, kb, kb_mco2, kb_mn2o, selfref, forref, &
+                           cfc12, cfc22adj
+
+! ------- Local -------
+      integer :: jt, jp, igc, ipr, iprsm
+      real :: sumk, sumk1, sumk2, sumk3, sumk4, sumk5, sumf1, sumf2
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(8)
+              sumk = 0.
+               do ipr = 1, ngn(ngs(7)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+112)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(8)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(7)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+112)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(8)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(7)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+112)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(8)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(7)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+112)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,19
+         iprsm = 0
+         do igc = 1,ngc(8)
+            sumk1 = 0.
+            sumk2 = 0.
+            sumk3 = 0.
+            sumk4 = 0.
+            sumk5 = 0.
+            do ipr = 1, ngn(ngs(7)+igc)
+               iprsm = iprsm + 1
+               sumk1 = sumk1 + kao_mco2(jt,iprsm)*rwgt(iprsm+112)
+               sumk2 = sumk2 + kbo_mco2(jt,iprsm)*rwgt(iprsm+112)
+               sumk3 = sumk3 + kao_mo3(jt,iprsm)*rwgt(iprsm+112)
+               sumk4 = sumk4 + kao_mn2o(jt,iprsm)*rwgt(iprsm+112)
+               sumk5 = sumk5 + kbo_mn2o(jt,iprsm)*rwgt(iprsm+112)
+            enddo
+            ka_mco2(jt,igc) = sumk1
+            kb_mco2(jt,igc) = sumk2
+            ka_mo3(jt,igc) = sumk3
+            ka_mn2o(jt,igc) = sumk4
+            kb_mn2o(jt,igc) = sumk5
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(8)
+         sumf1= 0.
+         sumf2= 0.
+         sumk1= 0.
+         sumk2= 0.
+         do ipr = 1, ngn(ngs(7)+igc)
+            iprsm = iprsm + 1
+            sumf1= sumf1+ fracrefao(iprsm)
+            sumf2= sumf2+ fracrefbo(iprsm)
+            sumk1= sumk1+ cfc12o(iprsm)*rwgt(iprsm+112)
+            sumk2= sumk2+ cfc22adjo(iprsm)*rwgt(iprsm+112)
+         enddo
+         fracrefa(igc) = sumf1
+         fracrefb(igc) = sumf2
+         cfc12(igc) = sumk1
+         cfc22adj(igc) = sumk2
+      enddo
+!$acc enter data copyin(cfc12,cfc22adj,ka,kb,selfref,forref,fracrefa,fracrefb, &
+!$acc   ka_mco2,kb_mco2,ka_mo3,ka_mn2o,kb_mn2o)
+
+      end subroutine cmbgb8
+
+!***************************************************************************
+      subroutine cmbgb9
+!***************************************************************************
+!
+! band 9: 1180-1390 cm-1 (low key - h2o,ch4; low minor - n2o)
+! (high key - ch4; high minor - n2o)!
+
+! old band 9: 1180-1390 cm-1 (low - h2o,ch4; high - ch4)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng9
+      use rrlw_kg09_f, only: fracrefao, fracrefbo, kao, kao_mn2o, &
+                           kbo, kbo_mn2o, selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, ka_mn2o, &
+                           absb, kb, kb_mn2o, selfref, forref
+
+! ------- Local -------
+      integer :: jn, jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(9)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(8)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+128)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(9)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(8)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+128)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jn = 1,9
+         do jt = 1,19
+            iprsm = 0
+            do igc = 1,ngc(9)
+              sumk = 0.
+               do ipr = 1, ngn(ngs(8)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao_mn2o(jn,jt,iprsm)*rwgt(iprsm+128)
+               enddo
+               ka_mn2o(jn,jt,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,19
+         iprsm = 0
+         do igc = 1,ngc(9)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(8)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + kbo_mn2o(jt,iprsm)*rwgt(iprsm+128)
+            enddo
+            kb_mn2o(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(9)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(8)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+128)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(9)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(8)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+128)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(9)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(8)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefao(iprsm,jp)
+            enddo
+            fracrefa(igc,jp) = sumf
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(9)
+         sumf = 0.
+         do ipr = 1, ngn(ngs(8)+igc)
+            iprsm = iprsm + 1
+            sumf = sumf + fracrefbo(iprsm)
+         enddo
+         fracrefb(igc) = sumf
+      enddo
+!$acc enter data copyin(ka,kb,ka_mn2o,kb_mn2o,selfref,forref,fracrefa,fracrefb)
+      end subroutine cmbgb9
+
+!***************************************************************************
+      subroutine cmbgb10
+!***************************************************************************
+!
+! band 10: 1390-1480 cm-1 (low key - h2o; high key - h2o)
+!
+! old band 10: 1390-1480 cm-1 (low - h2o; high - h2o)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng10
+      use rrlw_kg10_f, only: fracrefao, fracrefbo, kao, kbo, &
+                           selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, absb, kb, &
+                           selfref, forref
+
+! ------- Local -------
+      integer :: jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf1, sumf2
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(10)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(9)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+144)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(10)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(9)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+144)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(10)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(9)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+144)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(10)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(9)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+144)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(10)
+         sumf1= 0.
+         sumf2= 0.
+         do ipr = 1, ngn(ngs(9)+igc)
+            iprsm = iprsm + 1
+            sumf1= sumf1+ fracrefao(iprsm)
+            sumf2= sumf2+ fracrefbo(iprsm)
+         enddo
+         fracrefa(igc) = sumf1
+         fracrefb(igc) = sumf2
+      enddo
+!$acc enter data copyin(ka,kb,selfref,forref,fracrefa,fracrefb)
+
+      end subroutine cmbgb10
+
+!***************************************************************************
+      subroutine cmbgb11
+!***************************************************************************
+!
+! band 11: 1480-1800 cm-1 (low - h2o; low minor - o2)
+! (high key - h2o; high minor - o2)
+!
+! old band 11: 1480-1800 cm-1 (low - h2o; low minor - o2)
+! (high key - h2o; high minor - o2)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng11
+      use rrlw_kg11_f, only: fracrefao, fracrefbo, kao, kao_mo2, &
+                           kbo, kbo_mo2, selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, ka_mo2, &
+                           absb, kb, kb_mo2, selfref, forref
+
+! ------- Local -------
+      integer :: jt, jp, igc, ipr, iprsm
+      real :: sumk, sumk1, sumk2, sumf1, sumf2
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(11)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(10)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+160)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(11)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(10)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+160)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,19
+         iprsm = 0
+         do igc = 1,ngc(11)
+            sumk1 = 0.
+            sumk2 = 0.
+            do ipr = 1, ngn(ngs(10)+igc)
+               iprsm = iprsm + 1
+               sumk1 = sumk1 + kao_mo2(jt,iprsm)*rwgt(iprsm+160)
+               sumk2 = sumk2 + kbo_mo2(jt,iprsm)*rwgt(iprsm+160)
+            enddo
+            ka_mo2(jt,igc) = sumk1
+            kb_mo2(jt,igc) = sumk2
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(11)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(10)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+160)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(11)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(10)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+160)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(11)
+         sumf1= 0.
+         sumf2= 0.
+         do ipr = 1, ngn(ngs(10)+igc)
+            iprsm = iprsm + 1
+            sumf1= sumf1+ fracrefao(iprsm)
+            sumf2= sumf2+ fracrefbo(iprsm)
+         enddo
+         fracrefa(igc) = sumf1
+         fracrefb(igc) = sumf2
+      enddo
+!$acc enter data copyin(ka,kb,ka_mo2,kb_mo2,selfref,forref,fracrefa,fracrefb)
+
+      end subroutine cmbgb11
+
+!***************************************************************************
+      subroutine cmbgb12
+!***************************************************************************
+!
+! band 12: 1800-2080 cm-1 (low - h2o,co2; high - nothing)
+!
+! old band 12: 1800-2080 cm-1 (low - h2o,co2; high - nothing)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng12
+      use rrlw_kg12_f, only: fracrefao, kao, selfrefo, forrefo, &
+                           fracrefa, absa, ka, selfref, forref
+
+! ------- Local -------
+      integer :: jn, jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(12)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(11)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+176)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(12)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(11)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+176)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(12)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(11)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+176)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(12)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(11)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefao(iprsm,jp)
+            enddo
+            fracrefa(igc,jp) = sumf
+         enddo
+      enddo
+!$acc enter data copyin(ka,fracrefa,selfref,forref)
+
+      end subroutine cmbgb12
+
+!***************************************************************************
+      subroutine cmbgb13
+!***************************************************************************
+!
+! band 13: 2080-2250 cm-1 (low key - h2o,n2o; high minor - o3 minor)
+!
+! old band 13: 2080-2250 cm-1 (low - h2o,n2o; high - nothing)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng13
+      use rrlw_kg13_f, only: fracrefao, fracrefbo, kao, kao_mco2, kao_mco, &
+                           kbo_mo3, selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, ka_mco2, ka_mco, &
+                           kb_mo3, selfref, forref
+
+! ------- Local -------
+      integer :: jn, jt, jp, igc, ipr, iprsm
+      real :: sumk, sumk1, sumk2, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(13)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(12)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+192)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jn = 1,9
+         do jt = 1,19
+            iprsm = 0
+            do igc = 1,ngc(13)
+              sumk1 = 0.
+              sumk2 = 0.
+               do ipr = 1, ngn(ngs(12)+igc)
+                  iprsm = iprsm + 1
+                  sumk1 = sumk1 + kao_mco2(jn,jt,iprsm)*rwgt(iprsm+192)
+                  sumk2 = sumk2 + kao_mco(jn,jt,iprsm)*rwgt(iprsm+192)
+               enddo
+               ka_mco2(jn,jt,igc) = sumk1
+               ka_mco(jn,jt,igc) = sumk2
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,19
+         iprsm = 0
+         do igc = 1,ngc(13)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(12)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + kbo_mo3(jt,iprsm)*rwgt(iprsm+192)
+            enddo
+            kb_mo3(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(13)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(12)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+192)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(13)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(12)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+192)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(13)
+         sumf = 0.
+         do ipr = 1, ngn(ngs(12)+igc)
+            iprsm = iprsm + 1
+            sumf = sumf + fracrefbo(iprsm)
+         enddo
+         fracrefb(igc) = sumf
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(13)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(12)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefao(iprsm,jp)
+            enddo
+            fracrefa(igc,jp) = sumf
+         enddo
+      enddo
+!$acc enter data copyin(ka,ka_mco,ka_mco2,kb_mo3,selfref,forref,fracrefa,fracrefb)
+
+      end subroutine cmbgb13
+
+!***************************************************************************
+      subroutine cmbgb14
+!***************************************************************************
+!
+! band 14: 2250-2380 cm-1 (low - co2; high - co2)
+!
+! old band 14: 2250-2380 cm-1 (low - co2; high - co2)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng14
+      use rrlw_kg14_f, only: fracrefao, fracrefbo, kao, kbo, &
+                           selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, absb, kb, &
+                           selfref, forref
+
+! ------- Local -------
+      integer :: jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf1, sumf2
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(14)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(13)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+208)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(14)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(13)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+208)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(14)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(13)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+208)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(14)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(13)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+208)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(14)
+         sumf1= 0.
+         sumf2= 0.
+         do ipr = 1, ngn(ngs(13)+igc)
+            iprsm = iprsm + 1
+            sumf1= sumf1+ fracrefao(iprsm)
+            sumf2= sumf2+ fracrefbo(iprsm)
+         enddo
+         fracrefa(igc) = sumf1
+         fracrefb(igc) = sumf2
+      enddo
+!$acc enter data copyin(ka,kb,selfref,forref,fracrefa,fracrefb)
+
+      end subroutine cmbgb14
+
+!***************************************************************************
+      subroutine cmbgb15
+!***************************************************************************
+!
+! band 15: 2380-2600 cm-1 (low - n2o,co2; low minor - n2)
+! (high - nothing)
+!
+! old band 15: 2380-2600 cm-1 (low - n2o,co2; high - nothing)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng15
+      use rrlw_kg15_f, only: fracrefao, kao, kao_mn2, selfrefo, forrefo, &
+                           fracrefa, absa, ka, ka_mn2, selfref, forref
+
+! ------- Local -------
+      integer :: jn, jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(15)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(14)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+224)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jn = 1,9
+         do jt = 1,19
+            iprsm = 0
+            do igc = 1,ngc(15)
+              sumk = 0.
+               do ipr = 1, ngn(ngs(14)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao_mn2(jn,jt,iprsm)*rwgt(iprsm+224)
+               enddo
+               ka_mn2(jn,jt,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(15)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(14)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+224)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(15)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(14)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+224)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(15)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(14)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefao(iprsm,jp)
+            enddo
+            fracrefa(igc,jp) = sumf
+         enddo
+      enddo
+!$acc enter data copyin(ka,ka_mn2,selfref,forref,fracrefa)
+      end subroutine cmbgb15
+
+!***************************************************************************
+      subroutine cmbgb16
+!***************************************************************************
+!
+! band 16: 2600-3250 cm-1 (low key- h2o,ch4; high key - ch4)
+!
+! old band 16: 2600-3000 cm-1 (low - h2o,ch4; high - nothing)
+!***************************************************************************
+
+      use parrrtm_f, only : mg, nbndlw, ngptlw, ng16
+      use rrlw_kg16_f, only: fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo, &
+                           fracrefa, fracrefb, absa, ka, absb, kb, selfref, forref
+
+! ------- Local -------
+      integer :: jn, jt, jp, igc, ipr, iprsm
+      real :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(16)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(15)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+240)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(16)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(15)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+240)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(16)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(15)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+240)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(16)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(15)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+240)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(16)
+         sumf = 0.
+         do ipr = 1, ngn(ngs(15)+igc)
+            iprsm = iprsm + 1
+            sumf = sumf + fracrefbo(iprsm)
+         enddo
+         fracrefb(igc) = sumf
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(16)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(15)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + fracrefao(iprsm,jp)
+            enddo
+            fracrefa(igc,jp) = sumf
+         enddo
+      enddo
+!$acc enter data copyin(ka,kb,selfref,forref,fracrefa,fracrefb)
+
+      end subroutine cmbgb16
+
+!***************************************************************************
+      subroutine lwcldpr
+!***************************************************************************
+
+! --------- Modules ----------
+
+      use rrlw_cld_f, only: abscld1, absliq0, absliq1, &
+                          absice0, absice1, absice2, absice3
+
+      save
+
+! ABSCLDn is the liquid water absorption coefficient (m2/g).
+! For INFLAG = 1.
+      abscld1 = 0.0602410
+!
+! Everything below is for INFLAG = 2.
+
+! ABSICEn(J,IB) are the parameters needed to compute the liquid water
+! absorption coefficient in spectral region IB for ICEFLAG=n. The units
+! of ABSICEn(1,IB) are m2/g and ABSICEn(2,IB) has units (microns (m2/g)).
+! For ICEFLAG = 0.
+
+      absice0(:)= (/0.005 , 1.0 /)
+
+! For ICEFLAG = 1.
+      absice1(1,:) = (/0.0036 , 0.0068 , 0.0003 , 0.0016 , 0.0020 /)
+      absice1(2,:) = (/1.136 , 0.600 , 1.338 , 1.166 , 1.118 /)
+
+! For ICEFLAG = 2. In each band, the absorption
+! coefficients are listed for a range of effective radii from 5.0
+! to 131.0 microns in increments of 3.0 microns.
+! Spherical Ice Particle Parameterization
+! absorption units (abs coef/iwc): [(m^-1)/(g m^-3)]
+      absice2(:,1) = (/ &
+! band 1
+       7.798999e-02 ,6.340479e-02 ,5.417973e-02 ,4.766245e-02 ,4.272663e-02 , &
+       3.880939e-02 ,3.559544e-02 ,3.289241e-02 ,3.057511e-02 ,2.855800e-02 , &
+       2.678022e-02 ,2.519712e-02 ,2.377505e-02 ,2.248806e-02 ,2.131578e-02 , &
+       2.024194e-02 ,1.925337e-02 ,1.833926e-02 ,1.749067e-02 ,1.670007e-02 , &
+       1.596113e-02 ,1.526845e-02 ,1.461739e-02 ,1.400394e-02 ,1.342462e-02 , &
+       1.287639e-02 ,1.235656e-02 ,1.186279e-02 ,1.139297e-02 ,1.094524e-02 , &
+       1.051794e-02 ,1.010956e-02 ,9.718755e-03 ,9.344316e-03 ,8.985139e-03 , &
+       8.640223e-03 ,8.308656e-03 ,7.989606e-03 ,7.682312e-03 ,7.386076e-03 , &
+       7.100255e-03 ,6.824258e-03 ,6.557540e-03 /)
+      absice2(:,2) = (/ &
+! band 2
+       2.784879e-02 ,2.709863e-02 ,2.619165e-02 ,2.529230e-02 ,2.443225e-02 , &
+       2.361575e-02 ,2.284021e-02 ,2.210150e-02 ,2.139548e-02 ,2.071840e-02 , &
+       2.006702e-02 ,1.943856e-02 ,1.883064e-02 ,1.824120e-02 ,1.766849e-02 , &
+       1.711099e-02 ,1.656737e-02 ,1.603647e-02 ,1.551727e-02 ,1.500886e-02 , &
+       1.451045e-02 ,1.402132e-02 ,1.354084e-02 ,1.306842e-02 ,1.260355e-02 , &
+       1.214575e-02 ,1.169460e-02 ,1.124971e-02 ,1.081072e-02 ,1.037731e-02 , &
+       9.949167e-03 ,9.526021e-03 ,9.107615e-03 ,8.693714e-03 ,8.284096e-03 , &
+       7.878558e-03 ,7.476910e-03 ,7.078974e-03 ,6.684586e-03 ,6.293589e-03 , &
+       5.905839e-03 ,5.521200e-03 ,5.139543e-03 /)
+      absice2(:,3) = (/ &
+! band 3
+       1.065397e-01 ,8.005726e-02 ,6.546428e-02 ,5.589131e-02 ,4.898681e-02 , &
+       4.369932e-02 ,3.947901e-02 ,3.600676e-02 ,3.308299e-02 ,3.057561e-02 , &
+       2.839325e-02 ,2.647040e-02 ,2.475872e-02 ,2.322164e-02 ,2.183091e-02 , &
+       2.056430e-02 ,1.940407e-02 ,1.833586e-02 ,1.734787e-02 ,1.643034e-02 , &
+       1.557512e-02 ,1.477530e-02 ,1.402501e-02 ,1.331924e-02 ,1.265364e-02 , &
+       1.202445e-02 ,1.142838e-02 ,1.086257e-02 ,1.032445e-02 ,9.811791e-03 , &
+       9.322587e-03 ,8.855053e-03 ,8.407591e-03 ,7.978763e-03 ,7.567273e-03 , &
+       7.171949e-03 ,6.791728e-03 ,6.425642e-03 ,6.072809e-03 ,5.732424e-03 , &
+       5.403748e-03 ,5.086103e-03 ,4.778865e-03 /)
+      absice2(:,4) = (/ &
+! band 4
+       1.804566e-01 ,1.168987e-01 ,8.680442e-02 ,6.910060e-02 ,5.738174e-02 , &
+       4.902332e-02 ,4.274585e-02 ,3.784923e-02 ,3.391734e-02 ,3.068690e-02 , &
+       2.798301e-02 ,2.568480e-02 ,2.370600e-02 ,2.198337e-02 ,2.046940e-02 , &
+       1.912777e-02 ,1.793016e-02 ,1.685420e-02 ,1.588193e-02 ,1.499882e-02 , &
+       1.419293e-02 ,1.345440e-02 ,1.277496e-02 ,1.214769e-02 ,1.156669e-02 , &
+       1.102694e-02 ,1.052412e-02 ,1.005451e-02 ,9.614854e-03 ,9.202335e-03 , &
+       8.814470e-03 ,8.449077e-03 ,8.104223e-03 ,7.778195e-03 ,7.469466e-03 , &
+       7.176671e-03 ,6.898588e-03 ,6.634117e-03 ,6.382264e-03 ,6.142134e-03 , &
+       5.912913e-03 ,5.693862e-03 ,5.484308e-03 /)
+      absice2(:,5) = (/ &
+! band 5
+       2.131806e-01 ,1.311372e-01 ,9.407171e-02 ,7.299442e-02 ,5.941273e-02 , &
+       4.994043e-02 ,4.296242e-02 ,3.761113e-02 ,3.337910e-02 ,2.994978e-02 , &
+       2.711556e-02 ,2.473461e-02 ,2.270681e-02 ,2.095943e-02 ,1.943839e-02 , &
+       1.810267e-02 ,1.692057e-02 ,1.586719e-02 ,1.492275e-02 ,1.407132e-02 , &
+       1.329989e-02 ,1.259780e-02 ,1.195618e-02 ,1.136761e-02 ,1.082583e-02 , &
+       1.032552e-02 ,9.862158e-03 ,9.431827e-03 ,9.031157e-03 ,8.657217e-03 , &
+       8.307449e-03 ,7.979609e-03 ,7.671724e-03 ,7.382048e-03 ,7.109032e-03 , &
+       6.851298e-03 ,6.607615e-03 ,6.376881e-03 ,6.158105e-03 ,5.950394e-03 , &
+       5.752942e-03 ,5.565019e-03 ,5.385963e-03 /)
+      absice2(:,6) = (/ &
+! band 6
+       1.546177e-01 ,1.039251e-01 ,7.910347e-02 ,6.412429e-02 ,5.399997e-02 , &
+       4.664937e-02 ,4.104237e-02 ,3.660781e-02 ,3.300218e-02 ,3.000586e-02 , &
+       2.747148e-02 ,2.529633e-02 ,2.340647e-02 ,2.174723e-02 ,2.027731e-02 , &
+       1.896487e-02 ,1.778492e-02 ,1.671761e-02 ,1.574692e-02 ,1.485978e-02 , &
+       1.404543e-02 ,1.329489e-02 ,1.260066e-02 ,1.195636e-02 ,1.135657e-02 , &
+       1.079664e-02 ,1.027257e-02 ,9.780871e-03 ,9.318505e-03 ,8.882815e-03 , &
+       8.471458e-03 ,8.082364e-03 ,7.713696e-03 ,7.363817e-03 ,7.031264e-03 , &
+       6.714725e-03 ,6.413021e-03 ,6.125086e-03 ,5.849958e-03 ,5.586764e-03 , &
+       5.334707e-03 ,5.093066e-03 ,4.861179e-03 /)
+      absice2(:,7) = (/ &
+! band 7
+       7.583404e-02 ,6.181558e-02 ,5.312027e-02 ,4.696039e-02 ,4.225986e-02 , &
+       3.849735e-02 ,3.538340e-02 ,3.274182e-02 ,3.045798e-02 ,2.845343e-02 , &
+       2.667231e-02 ,2.507353e-02 ,2.362606e-02 ,2.230595e-02 ,2.109435e-02 , &
+       1.997617e-02 ,1.893916e-02 ,1.797328e-02 ,1.707016e-02 ,1.622279e-02 , &
+       1.542523e-02 ,1.467241e-02 ,1.395997e-02 ,1.328414e-02 ,1.264164e-02 , &
+       1.202958e-02 ,1.144544e-02 ,1.088697e-02 ,1.035218e-02 ,9.839297e-03 , &
+       9.346733e-03 ,8.873057e-03 ,8.416980e-03 ,7.977335e-03 ,7.553066e-03 , &
+       7.143210e-03 ,6.746888e-03 ,6.363297e-03 ,5.991700e-03 ,5.631422e-03 , &
+       5.281840e-03 ,4.942378e-03 ,4.612505e-03 /)
+      absice2(:,8) = (/ &
+! band 8
+       9.022185e-02 ,6.922700e-02 ,5.710674e-02 ,4.898377e-02 ,4.305946e-02 , &
+       3.849553e-02 ,3.484183e-02 ,3.183220e-02 ,2.929794e-02 ,2.712627e-02 , &
+       2.523856e-02 ,2.357810e-02 ,2.210286e-02 ,2.078089e-02 ,1.958747e-02 , &
+       1.850310e-02 ,1.751218e-02 ,1.660205e-02 ,1.576232e-02 ,1.498440e-02 , &
+       1.426107e-02 ,1.358624e-02 ,1.295474e-02 ,1.236212e-02 ,1.180456e-02 , &
+       1.127874e-02 ,1.078175e-02 ,1.031106e-02 ,9.864433e-03 ,9.439878e-03 , &
+       9.035637e-03 ,8.650140e-03 ,8.281981e-03 ,7.929895e-03 ,7.592746e-03 , &
+       7.269505e-03 ,6.959238e-03 ,6.661100e-03 ,6.374317e-03 ,6.098185e-03 , &
+       5.832059e-03 ,5.575347e-03 ,5.327504e-03 /)
+      absice2(:,9) = (/ &
+! band 9
+       1.294087e-01 ,8.788217e-02 ,6.728288e-02 ,5.479720e-02 ,4.635049e-02 , &
+       4.022253e-02 ,3.555576e-02 ,3.187259e-02 ,2.888498e-02 ,2.640843e-02 , &
+       2.431904e-02 ,2.253038e-02 ,2.098024e-02 ,1.962267e-02 ,1.842293e-02 , &
+       1.735426e-02 ,1.639571e-02 ,1.553060e-02 ,1.474552e-02 ,1.402953e-02 , &
+       1.337363e-02 ,1.277033e-02 ,1.221336e-02 ,1.169741e-02 ,1.121797e-02 , &
+       1.077117e-02 ,1.035369e-02 ,9.962643e-03 ,9.595509e-03 ,9.250088e-03 , &
+       8.924447e-03 ,8.616876e-03 ,8.325862e-03 ,8.050057e-03 ,7.788258e-03 , &
+       7.539388e-03 ,7.302478e-03 ,7.076656e-03 ,6.861134e-03 ,6.655197e-03 , &
+       6.458197e-03 ,6.269543e-03 ,6.088697e-03 /)
+      absice2(:,10) = (/ &
+! band 10
+       1.593628e-01 ,1.014552e-01 ,7.458955e-02 ,5.903571e-02 ,4.887582e-02 , &
+       4.171159e-02 ,3.638480e-02 ,3.226692e-02 ,2.898717e-02 ,2.631256e-02 , &
+       2.408925e-02 ,2.221156e-02 ,2.060448e-02 ,1.921325e-02 ,1.799699e-02 , &
+       1.692456e-02 ,1.597177e-02 ,1.511961e-02 ,1.435289e-02 ,1.365933e-02 , &
+       1.302890e-02 ,1.245334e-02 ,1.192576e-02 ,1.144037e-02 ,1.099230e-02 , &
+       1.057739e-02 ,1.019208e-02 ,9.833302e-03 ,9.498395e-03 ,9.185047e-03 , &
+       8.891237e-03 ,8.615185e-03 ,8.355325e-03 ,8.110267e-03 ,7.878778e-03 , &
+       7.659759e-03 ,7.452224e-03 ,7.255291e-03 ,7.068166e-03 ,6.890130e-03 , &
+       6.720536e-03 ,6.558794e-03 ,6.404371e-03 /)
+      absice2(:,11) = (/ &
+! band 11
+       1.656227e-01 ,1.032129e-01 ,7.487359e-02 ,5.871431e-02 ,4.828355e-02 , &
+       4.099989e-02 ,3.562924e-02 ,3.150755e-02 ,2.824593e-02 ,2.560156e-02 , &
+       2.341503e-02 ,2.157740e-02 ,2.001169e-02 ,1.866199e-02 ,1.748669e-02 , &
+       1.645421e-02 ,1.554015e-02 ,1.472535e-02 ,1.399457e-02 ,1.333553e-02 , &
+       1.273821e-02 ,1.219440e-02 ,1.169725e-02 ,1.124104e-02 ,1.082096e-02 , &
+       1.043290e-02 ,1.007336e-02 ,9.739338e-03 ,9.428223e-03 ,9.137756e-03 , &
+       8.865964e-03 ,8.611115e-03 ,8.371686e-03 ,8.146330e-03 ,7.933852e-03 , &
+       7.733187e-03 ,7.543386e-03 ,7.363597e-03 ,7.193056e-03 ,7.031072e-03 , &
+       6.877024e-03 ,6.730348e-03 ,6.590531e-03 /)
+      absice2(:,12) = (/ &
+! band 12
+       9.194591e-02 ,6.446867e-02 ,4.962034e-02 ,4.042061e-02 ,3.418456e-02 , &
+       2.968856e-02 ,2.629900e-02 ,2.365572e-02 ,2.153915e-02 ,1.980791e-02 , &
+       1.836689e-02 ,1.714979e-02 ,1.610900e-02 ,1.520946e-02 ,1.442476e-02 , &
+       1.373468e-02 ,1.312345e-02 ,1.257858e-02 ,1.209010e-02 ,1.164990e-02 , &
+       1.125136e-02 ,1.088901e-02 ,1.055827e-02 ,1.025531e-02 ,9.976896e-03 , &
+       9.720255e-03 ,9.483022e-03 ,9.263160e-03 ,9.058902e-03 ,8.868710e-03 , &
+       8.691240e-03 ,8.525312e-03 ,8.369886e-03 ,8.224042e-03 ,8.086961e-03 , &
+       7.957917e-03 ,7.836258e-03 ,7.721400e-03 ,7.612821e-03 ,7.510045e-03 , &
+       7.412648e-03 ,7.320242e-03 ,7.232476e-03 /)
+      absice2(:,13) = (/ &
+! band 13
+       1.437021e-01 ,8.872535e-02 ,6.392420e-02 ,4.991833e-02 ,4.096790e-02 , &
+       3.477881e-02 ,3.025782e-02 ,2.681909e-02 ,2.412102e-02 ,2.195132e-02 , &
+       2.017124e-02 ,1.868641e-02 ,1.743044e-02 ,1.635529e-02 ,1.542540e-02 , &
+       1.461388e-02 ,1.390003e-02 ,1.326766e-02 ,1.270395e-02 ,1.219860e-02 , &
+       1.174326e-02 ,1.133107e-02 ,1.095637e-02 ,1.061442e-02 ,1.030126e-02 , &
+       1.001352e-02 ,9.748340e-03 ,9.503256e-03 ,9.276155e-03 ,9.065205e-03 , &
+       8.868808e-03 ,8.685571e-03 ,8.514268e-03 ,8.353820e-03 ,8.203272e-03 , &
+       8.061776e-03 ,7.928578e-03 ,7.803001e-03 ,7.684443e-03 ,7.572358e-03 , &
+       7.466258e-03 ,7.365701e-03 ,7.270286e-03 /)
+      absice2(:,14) = (/ &
+! band 14
+       1.288870e-01 ,8.160295e-02 ,5.964745e-02 ,4.703790e-02 ,3.888637e-02 , &
+       3.320115e-02 ,2.902017e-02 ,2.582259e-02 ,2.330224e-02 ,2.126754e-02 , &
+       1.959258e-02 ,1.819130e-02 ,1.700289e-02 ,1.598320e-02 ,1.509942e-02 , &
+       1.432666e-02 ,1.364572e-02 ,1.304156e-02 ,1.250220e-02 ,1.201803e-02 , &
+       1.158123e-02 ,1.118537e-02 ,1.082513e-02 ,1.049605e-02 ,1.019440e-02 , &
+       9.916989e-03 ,9.661116e-03 ,9.424457e-03 ,9.205005e-03 ,9.001022e-03 , &
+       8.810992e-03 ,8.633588e-03 ,8.467646e-03 ,8.312137e-03 ,8.166151e-03 , &
+       8.028878e-03 ,7.899597e-03 ,7.777663e-03 ,7.662498e-03 ,7.553581e-03 , &
+       7.450444e-03 ,7.352662e-03 ,7.259851e-03 /)
+      absice2(:,15) = (/ &
+! band 15
+       8.254229e-02 ,5.808787e-02 ,4.492166e-02 ,3.675028e-02 ,3.119623e-02 , &
+       2.718045e-02 ,2.414450e-02 ,2.177073e-02 ,1.986526e-02 ,1.830306e-02 , &
+       1.699991e-02 ,1.589698e-02 ,1.495199e-02 ,1.413374e-02 ,1.341870e-02 , &
+       1.278883e-02 ,1.223002e-02 ,1.173114e-02 ,1.128322e-02 ,1.087900e-02 , &
+       1.051254e-02 ,1.017890e-02 ,9.873991e-03 ,9.594347e-03 ,9.337044e-03 , &
+       9.099589e-03 ,8.879842e-03 ,8.675960e-03 ,8.486341e-03 ,8.309594e-03 , &
+       8.144500e-03 ,7.989986e-03 ,7.845109e-03 ,7.709031e-03 ,7.581007e-03 , &
+       7.460376e-03 ,7.346544e-03 ,7.238978e-03 ,7.137201e-03 ,7.040780e-03 , &
+       6.949325e-03 ,6.862483e-03 ,6.779931e-03 /)
+      absice2(:,16) = (/ &
+! band 16
+       1.382062e-01 ,8.643227e-02 ,6.282935e-02 ,4.934783e-02 ,4.063891e-02 , &
+       3.455591e-02 ,3.007059e-02 ,2.662897e-02 ,2.390631e-02 ,2.169972e-02 , &
+       1.987596e-02 ,1.834393e-02 ,1.703924e-02 ,1.591513e-02 ,1.493679e-02 , &
+       1.407780e-02 ,1.331775e-02 ,1.264061e-02 ,1.203364e-02 ,1.148655e-02 , &
+       1.099099e-02 ,1.054006e-02 ,1.012807e-02 ,9.750215e-03 ,9.402477e-03 , &
+       9.081428e-03 ,8.784143e-03 ,8.508107e-03 ,8.251146e-03 ,8.011373e-03 , &
+       7.787140e-03 ,7.577002e-03 ,7.379687e-03 ,7.194071e-03 ,7.019158e-03 , &
+       6.854061e-03 ,6.697986e-03 ,6.550224e-03 ,6.410138e-03 ,6.277153e-03 , &
+       6.150751e-03 ,6.030462e-03 ,5.915860e-03 /)
+
+! ICEFLAG = 3; Fu parameterization. Particle size 5 - 140 micron in
+! increments of 3 microns.
+! units = m2/g
+! Hexagonal Ice Particle Parameterization
+! absorption units (abs coef/iwc): [(m^-1)/(g m^-3)]
+      absice3(:,1) = (/ &
+! band 1
+       3.110649e-03 ,4.666352e-02 ,6.606447e-02 ,6.531678e-02 ,6.012598e-02 , &
+       5.437494e-02 ,4.906411e-02 ,4.441146e-02 ,4.040585e-02 ,3.697334e-02 , &
+       3.403027e-02 ,3.149979e-02 ,2.931596e-02 ,2.742365e-02 ,2.577721e-02 , &
+       2.433888e-02 ,2.307732e-02 ,2.196644e-02 ,2.098437e-02 ,2.011264e-02 , &
+       1.933561e-02 ,1.863992e-02 ,1.801407e-02 ,1.744812e-02 ,1.693346e-02 , &
+       1.646252e-02 ,1.602866e-02 ,1.562600e-02 ,1.524933e-02 ,1.489399e-02 , &
+       1.455580e-02 ,1.423098e-02 ,1.391612e-02 ,1.360812e-02 ,1.330413e-02 , &
+       1.300156e-02 ,1.269801e-02 ,1.239127e-02 ,1.207928e-02 ,1.176014e-02 , &
+       1.143204e-02 ,1.109334e-02 ,1.074243e-02 ,1.037786e-02 ,9.998198e-03 , &
+       9.602126e-03 /)
+      absice3(:,2) = (/ &
+! band 2
+       3.984966e-04 ,1.681097e-02 ,2.627680e-02 ,2.767465e-02 ,2.700722e-02 , &
+       2.579180e-02 ,2.448677e-02 ,2.323890e-02 ,2.209096e-02 ,2.104882e-02 , &
+       2.010547e-02 ,1.925003e-02 ,1.847128e-02 ,1.775883e-02 ,1.710358e-02 , &
+       1.649769e-02 ,1.593449e-02 ,1.540829e-02 ,1.491429e-02 ,1.444837e-02 , &
+       1.400704e-02 ,1.358729e-02 ,1.318654e-02 ,1.280258e-02 ,1.243346e-02 , &
+       1.207750e-02 ,1.173325e-02 ,1.139941e-02 ,1.107487e-02 ,1.075861e-02 , &
+       1.044975e-02 ,1.014753e-02 ,9.851229e-03 ,9.560240e-03 ,9.274003e-03 , &
+       8.992020e-03 ,8.713845e-03 ,8.439074e-03 ,8.167346e-03 ,7.898331e-03 , &
+       7.631734e-03 ,7.367286e-03 ,7.104742e-03 ,6.843882e-03 ,6.584504e-03 , &
+       6.326424e-03 /)
+      absice3(:,3) = (/ &
+! band 3
+       6.933163e-02 ,8.540475e-02 ,7.701816e-02 ,6.771158e-02 ,5.986953e-02 , &
+       5.348120e-02 ,4.824962e-02 ,4.390563e-02 ,4.024411e-02 ,3.711404e-02 , &
+       3.440426e-02 ,3.203200e-02 ,2.993478e-02 ,2.806474e-02 ,2.638464e-02 , &
+       2.486516e-02 ,2.348288e-02 ,2.221890e-02 ,2.105780e-02 ,1.998687e-02 , &
+       1.899552e-02 ,1.807490e-02 ,1.721750e-02 ,1.641693e-02 ,1.566773e-02 , &
+       1.496515e-02 ,1.430509e-02 ,1.368398e-02 ,1.309865e-02 ,1.254634e-02 , &
+       1.202456e-02 ,1.153114e-02 ,1.106409e-02 ,1.062166e-02 ,1.020224e-02 , &
+       9.804381e-03 ,9.426771e-03 ,9.068205e-03 ,8.727578e-03 ,8.403876e-03 , &
+       8.096160e-03 ,7.803564e-03 ,7.525281e-03 ,7.260560e-03 ,7.008697e-03 , &
+       6.769036e-03 /)
+      absice3(:,4) = (/ &
+! band 4
+       1.765735e-01 ,1.382700e-01 ,1.095129e-01 ,8.987475e-02 ,7.591185e-02 , &
+       6.554169e-02 ,5.755500e-02 ,5.122083e-02 ,4.607610e-02 ,4.181475e-02 , &
+       3.822697e-02 ,3.516432e-02 ,3.251897e-02 ,3.021073e-02 ,2.817876e-02 , &
+       2.637607e-02 ,2.476582e-02 ,2.331871e-02 ,2.201113e-02 ,2.082388e-02 , &
+       1.974115e-02 ,1.874983e-02 ,1.783894e-02 ,1.699922e-02 ,1.622280e-02 , &
+       1.550296e-02 ,1.483390e-02 ,1.421064e-02 ,1.362880e-02 ,1.308460e-02 , &
+       1.257468e-02 ,1.209611e-02 ,1.164628e-02 ,1.122287e-02 ,1.082381e-02 , &
+       1.044725e-02 ,1.009154e-02 ,9.755166e-03 ,9.436783e-03 ,9.135163e-03 , &
+       8.849193e-03 ,8.577856e-03 ,8.320225e-03 ,8.075451e-03 ,7.842755e-03 , &
+       7.621418e-03 /)
+      absice3(:,5) = (/ &
+! band 5
+       2.339673e-01 ,1.692124e-01 ,1.291656e-01 ,1.033837e-01 ,8.562949e-02 , &
+       7.273526e-02 ,6.298262e-02 ,5.537015e-02 ,4.927787e-02 ,4.430246e-02 , &
+       4.017061e-02 ,3.669072e-02 ,3.372455e-02 ,3.116995e-02 ,2.894977e-02 , &
+       2.700471e-02 ,2.528842e-02 ,2.376420e-02 ,2.240256e-02 ,2.117959e-02 , &
+       2.007567e-02 ,1.907456e-02 ,1.816271e-02 ,1.732874e-02 ,1.656300e-02 , &
+       1.585725e-02 ,1.520445e-02 ,1.459852e-02 ,1.403419e-02 ,1.350689e-02 , &
+       1.301260e-02 ,1.254781e-02 ,1.210941e-02 ,1.169468e-02 ,1.130118e-02 , &
+       1.092675e-02 ,1.056945e-02 ,1.022757e-02 ,9.899560e-03 ,9.584021e-03 , &
+       9.279705e-03 ,8.985479e-03 ,8.700322e-03 ,8.423306e-03 ,8.153590e-03 , &
+       7.890412e-03 /)
+      absice3(:,6) = (/ &
+! band 6
+       1.145369e-01 ,1.174566e-01 ,9.917866e-02 ,8.332990e-02 ,7.104263e-02 , &
+       6.153370e-02 ,5.405472e-02 ,4.806281e-02 ,4.317918e-02 ,3.913795e-02 , &
+       3.574916e-02 ,3.287437e-02 ,3.041067e-02 ,2.828017e-02 ,2.642292e-02 , &
+       2.479206e-02 ,2.335051e-02 ,2.206851e-02 ,2.092195e-02 ,1.989108e-02 , &
+       1.895958e-02 ,1.811385e-02 ,1.734245e-02 ,1.663573e-02 ,1.598545e-02 , &
+       1.538456e-02 ,1.482700e-02 ,1.430750e-02 ,1.382150e-02 ,1.336499e-02 , &
+       1.293447e-02 ,1.252685e-02 ,1.213939e-02 ,1.176968e-02 ,1.141555e-02 , &
+       1.107508e-02 ,1.074655e-02 ,1.042839e-02 ,1.011923e-02 ,9.817799e-03 , &
+       9.522962e-03 ,9.233688e-03 ,8.949041e-03 ,8.668171e-03 ,8.390301e-03 , &
+       8.114723e-03 /)
+      absice3(:,7) = (/ &
+! band 7
+       1.222345e-02 ,5.344230e-02 ,5.523465e-02 ,5.128759e-02 ,4.676925e-02 , &
+       4.266150e-02 ,3.910561e-02 ,3.605479e-02 ,3.342843e-02 ,3.115052e-02 , &
+       2.915776e-02 ,2.739935e-02 ,2.583499e-02 ,2.443266e-02 ,2.316681e-02 , &
+       2.201687e-02 ,2.096619e-02 ,2.000112e-02 ,1.911044e-02 ,1.828481e-02 , &
+       1.751641e-02 ,1.679866e-02 ,1.612598e-02 ,1.549360e-02 ,1.489742e-02 , &
+       1.433392e-02 ,1.380002e-02 ,1.329305e-02 ,1.281068e-02 ,1.235084e-02 , &
+       1.191172e-02 ,1.149171e-02 ,1.108936e-02 ,1.070341e-02 ,1.033271e-02 , &
+       9.976220e-03 ,9.633021e-03 ,9.302273e-03 ,8.983216e-03 ,8.675161e-03 , &
+       8.377478e-03 ,8.089595e-03 ,7.810986e-03 ,7.541170e-03 ,7.279706e-03 , &
+       7.026186e-03 /)
+      absice3(:,8) = (/ &
+! band 8
+       6.711058e-02 ,6.918198e-02 ,6.127484e-02 ,5.411944e-02 ,4.836902e-02 , &
+       4.375293e-02 ,3.998077e-02 ,3.683587e-02 ,3.416508e-02 ,3.186003e-02 , &
+       2.984290e-02 ,2.805671e-02 ,2.645895e-02 ,2.501733e-02 ,2.370689e-02 , &
+       2.250808e-02 ,2.140532e-02 ,2.038609e-02 ,1.944018e-02 ,1.855918e-02 , &
+       1.773609e-02 ,1.696504e-02 ,1.624106e-02 ,1.555990e-02 ,1.491793e-02 , &
+       1.431197e-02 ,1.373928e-02 ,1.319743e-02 ,1.268430e-02 ,1.219799e-02 , &
+       1.173682e-02 ,1.129925e-02 ,1.088393e-02 ,1.048961e-02 ,1.011516e-02 , &
+       9.759543e-03 ,9.421813e-03 ,9.101089e-03 ,8.796559e-03 ,8.507464e-03 , &
+       8.233098e-03 ,7.972798e-03 ,7.725942e-03 ,7.491940e-03 ,7.270238e-03 , &
+       7.060305e-03 /)
+      absice3(:,9) = (/ &
+! band 9
+       1.236780e-01 ,9.222386e-02 ,7.383997e-02 ,6.204072e-02 ,5.381029e-02 , &
+       4.770678e-02 ,4.296928e-02 ,3.916131e-02 ,3.601540e-02 ,3.335878e-02 , &
+       3.107493e-02 ,2.908247e-02 ,2.732282e-02 ,2.575276e-02 ,2.433968e-02 , &
+       2.305852e-02 ,2.188966e-02 ,2.081757e-02 ,1.982974e-02 ,1.891599e-02 , &
+       1.806794e-02 ,1.727865e-02 ,1.654227e-02 ,1.585387e-02 ,1.520924e-02 , &
+       1.460476e-02 ,1.403730e-02 ,1.350416e-02 ,1.300293e-02 ,1.253153e-02 , &
+       1.208808e-02 ,1.167094e-02 ,1.127862e-02 ,1.090979e-02 ,1.056323e-02 , &
+       1.023786e-02 ,9.932665e-03 ,9.646744e-03 ,9.379250e-03 ,9.129409e-03 , &
+       8.896500e-03 ,8.679856e-03 ,8.478852e-03 ,8.292904e-03 ,8.121463e-03 , &
+       7.964013e-03 /)
+      absice3(:,10) = (/ &
+! band 10
+       1.655966e-01 ,1.134205e-01 ,8.714344e-02 ,7.129241e-02 ,6.063739e-02 , &
+       5.294203e-02 ,4.709309e-02 ,4.247476e-02 ,3.871892e-02 ,3.559206e-02 , &
+       3.293893e-02 ,3.065226e-02 ,2.865558e-02 ,2.689288e-02 ,2.532221e-02 , &
+       2.391150e-02 ,2.263582e-02 ,2.147549e-02 ,2.041476e-02 ,1.944089e-02 , &
+       1.854342e-02 ,1.771371e-02 ,1.694456e-02 ,1.622989e-02 ,1.556456e-02 , &
+       1.494415e-02 ,1.436491e-02 ,1.382354e-02 ,1.331719e-02 ,1.284339e-02 , &
+       1.239992e-02 ,1.198486e-02 ,1.159647e-02 ,1.123323e-02 ,1.089375e-02 , &
+       1.057679e-02 ,1.028124e-02 ,1.000607e-02 ,9.750376e-03 ,9.513303e-03 , &
+       9.294082e-03 ,9.092003e-03 ,8.906412e-03 ,8.736702e-03 ,8.582314e-03 , &
+       8.442725e-03 /)
+      absice3(:,11) = (/ &
+! band 11
+       1.775615e-01 ,1.180046e-01 ,8.929607e-02 ,7.233500e-02 ,6.108333e-02 , &
+       5.303642e-02 ,4.696927e-02 ,4.221206e-02 ,3.836768e-02 ,3.518576e-02 , &
+       3.250063e-02 ,3.019825e-02 ,2.819758e-02 ,2.643943e-02 ,2.487953e-02 , &
+       2.348414e-02 ,2.222705e-02 ,2.108762e-02 ,2.004936e-02 ,1.909892e-02 , &
+       1.822539e-02 ,1.741975e-02 ,1.667449e-02 ,1.598330e-02 ,1.534084e-02 , &
+       1.474253e-02 ,1.418446e-02 ,1.366325e-02 ,1.317597e-02 ,1.272004e-02 , &
+       1.229321e-02 ,1.189350e-02 ,1.151915e-02 ,1.116859e-02 ,1.084042e-02 , &
+       1.053338e-02 ,1.024636e-02 ,9.978326e-03 ,9.728357e-03 ,9.495613e-03 , &
+       9.279327e-03 ,9.078798e-03 ,8.893383e-03 ,8.722488e-03 ,8.565568e-03 , &
+       8.422115e-03 /)
+      absice3(:,12) = (/ &
+! band 12
+       9.465447e-02 ,6.432047e-02 ,5.060973e-02 ,4.267283e-02 ,3.741843e-02 , &
+       3.363096e-02 ,3.073531e-02 ,2.842405e-02 ,2.651789e-02 ,2.490518e-02 , &
+       2.351273e-02 ,2.229056e-02 ,2.120335e-02 ,2.022541e-02 ,1.933763e-02 , &
+       1.852546e-02 ,1.777763e-02 ,1.708528e-02 ,1.644134e-02 ,1.584009e-02 , &
+       1.527684e-02 ,1.474774e-02 ,1.424955e-02 ,1.377957e-02 ,1.333549e-02 , &
+       1.291534e-02 ,1.251743e-02 ,1.214029e-02 ,1.178265e-02 ,1.144337e-02 , &
+       1.112148e-02 ,1.081609e-02 ,1.052642e-02 ,1.025178e-02 ,9.991540e-03 , &
+       9.745130e-03 ,9.512038e-03 ,9.291797e-03 ,9.083980e-03 ,8.888195e-03 , &
+       8.704081e-03 ,8.531306e-03 ,8.369560e-03 ,8.218558e-03 ,8.078032e-03 , &
+       7.947730e-03 /)
+      absice3(:,13) = (/ &
+! band 13
+       1.560311e-01 ,9.961097e-02 ,7.502949e-02 ,6.115022e-02 ,5.214952e-02 , &
+       4.578149e-02 ,4.099731e-02 ,3.724174e-02 ,3.419343e-02 ,3.165356e-02 , &
+       2.949251e-02 ,2.762222e-02 ,2.598073e-02 ,2.452322e-02 ,2.321642e-02 , &
+       2.203516e-02 ,2.096002e-02 ,1.997579e-02 ,1.907036e-02 ,1.823401e-02 , &
+       1.745879e-02 ,1.673819e-02 ,1.606678e-02 ,1.544003e-02 ,1.485411e-02 , &
+       1.430574e-02 ,1.379215e-02 ,1.331092e-02 ,1.285996e-02 ,1.243746e-02 , &
+       1.204183e-02 ,1.167164e-02 ,1.132567e-02 ,1.100281e-02 ,1.070207e-02 , &
+       1.042258e-02 ,1.016352e-02 ,9.924197e-03 ,9.703953e-03 ,9.502199e-03 , &
+       9.318400e-03 ,9.152066e-03 ,9.002749e-03 ,8.870038e-03 ,8.753555e-03 , &
+       8.652951e-03 /)
+      absice3(:,14) = (/ &
+! band 14
+       1.559547e-01 ,9.896700e-02 ,7.441231e-02 ,6.061469e-02 ,5.168730e-02 , &
+       4.537821e-02 ,4.064106e-02 ,3.692367e-02 ,3.390714e-02 ,3.139438e-02 , &
+       2.925702e-02 ,2.740783e-02 ,2.578547e-02 ,2.434552e-02 ,2.305506e-02 , &
+       2.188910e-02 ,2.082842e-02 ,1.985789e-02 ,1.896553e-02 ,1.814165e-02 , &
+       1.737839e-02 ,1.666927e-02 ,1.600891e-02 ,1.539279e-02 ,1.481712e-02 , &
+       1.427865e-02 ,1.377463e-02 ,1.330266e-02 ,1.286068e-02 ,1.244689e-02 , &
+       1.205973e-02 ,1.169780e-02 ,1.135989e-02 ,1.104492e-02 ,1.075192e-02 , &
+       1.048004e-02 ,1.022850e-02 ,9.996611e-03 ,9.783753e-03 ,9.589361e-03 , &
+       9.412924e-03 ,9.253977e-03 ,9.112098e-03 ,8.986903e-03 ,8.878039e-03 , &
+       8.785184e-03 /)
+      absice3(:,15) = (/ &
+! band 15
+       1.102926e-01 ,7.176622e-02 ,5.530316e-02 ,4.606056e-02 ,4.006116e-02 , &
+       3.579628e-02 ,3.256909e-02 ,3.001360e-02 ,2.791920e-02 ,2.615617e-02 , &
+       2.464023e-02 ,2.331426e-02 ,2.213817e-02 ,2.108301e-02 ,2.012733e-02 , &
+       1.925493e-02 ,1.845331e-02 ,1.771269e-02 ,1.702531e-02 ,1.638493e-02 , &
+       1.578648e-02 ,1.522579e-02 ,1.469940e-02 ,1.420442e-02 ,1.373841e-02 , &
+       1.329931e-02 ,1.288535e-02 ,1.249502e-02 ,1.212700e-02 ,1.178015e-02 , &
+       1.145348e-02 ,1.114612e-02 ,1.085730e-02 ,1.058633e-02 ,1.033263e-02 , &
+       1.009564e-02 ,9.874895e-03 ,9.669960e-03 ,9.480449e-03 ,9.306014e-03 , &
+       9.146339e-03 ,9.001138e-03 ,8.870154e-03 ,8.753148e-03 ,8.649907e-03 , &
+       8.560232e-03 /)
+      absice3(:,16) = (/ &
+! band 16
+       1.688344e-01 ,1.077072e-01 ,7.994467e-02 ,6.403862e-02 ,5.369850e-02 , &
+       4.641582e-02 ,4.099331e-02 ,3.678724e-02 ,3.342069e-02 ,3.065831e-02 , &
+       2.834557e-02 ,2.637680e-02 ,2.467733e-02 ,2.319286e-02 ,2.188299e-02 , &
+       2.071701e-02 ,1.967121e-02 ,1.872692e-02 ,1.786931e-02 ,1.708641e-02 , &
+       1.636846e-02 ,1.570743e-02 ,1.509665e-02 ,1.453052e-02 ,1.400433e-02 , &
+       1.351407e-02 ,1.305631e-02 ,1.262810e-02 ,1.222688e-02 ,1.185044e-02 , &
+       1.149683e-02 ,1.116436e-02 ,1.085153e-02 ,1.055701e-02 ,1.027961e-02 , &
+       1.001831e-02 ,9.772141e-03 ,9.540280e-03 ,9.321966e-03 ,9.116517e-03 , &
+       8.923315e-03 ,8.741803e-03 ,8.571472e-03 ,8.411860e-03 ,8.262543e-03 , &
+       8.123136e-03 /)
+!$acc enter data copyin(absice1,absice2,absice3)
+! For LIQFLAG = 0.
+      absliq0 = 0.0903614
+
+! For LIQFLAG = 1. In each band, the absorption
+! coefficients are listed for a range of effective radii from 2.5
+! to 59.5 microns in increments of 1.0 micron.
+      absliq1(:, 1) = (/ &
+! band 1
+       1.64047e-03 , 6.90533e-02 , 7.72017e-02 , 7.78054e-02 , 7.69523e-02 , &
+       7.58058e-02 , 7.46400e-02 , 7.35123e-02 , 7.24162e-02 , 7.13225e-02 , &
+       6.99145e-02 , 6.66409e-02 , 6.36582e-02 , 6.09425e-02 , 5.84593e-02 , &
+       5.61743e-02 , 5.40571e-02 , 5.20812e-02 , 5.02245e-02 , 4.84680e-02 , &
+       4.67959e-02 , 4.51944e-02 , 4.36516e-02 , 4.21570e-02 , 4.07015e-02 , &
+       3.92766e-02 , 3.78747e-02 , 3.64886e-02 , 3.53632e-02 , 3.41992e-02 , &
+       3.31016e-02 , 3.20643e-02 , 3.10817e-02 , 3.01490e-02 , 2.92620e-02 , &
+       2.84171e-02 , 2.76108e-02 , 2.68404e-02 , 2.61031e-02 , 2.53966e-02 , &
+       2.47189e-02 , 2.40678e-02 , 2.34418e-02 , 2.28392e-02 , 2.22586e-02 , &
+       2.16986e-02 , 2.11580e-02 , 2.06356e-02 , 2.01305e-02 , 1.96417e-02 , &
+       1.91682e-02 , 1.87094e-02 , 1.82643e-02 , 1.78324e-02 , 1.74129e-02 , &
+       1.70052e-02 , 1.66088e-02 , 1.62231e-02 /)
+      absliq1(:, 2) = (/ &
+! band 2
+       2.19486e-01 , 1.80687e-01 , 1.59150e-01 , 1.44731e-01 , 1.33703e-01 , &
+       1.24355e-01 , 1.15756e-01 , 1.07318e-01 , 9.86119e-02 , 8.92739e-02 , &
+       8.34911e-02 , 7.70773e-02 , 7.15240e-02 , 6.66615e-02 , 6.23641e-02 , &
+       5.85359e-02 , 5.51020e-02 , 5.20032e-02 , 4.91916e-02 , 4.66283e-02 , &
+       4.42813e-02 , 4.21236e-02 , 4.01330e-02 , 3.82905e-02 , 3.65797e-02 , &
+       3.49869e-02 , 3.35002e-02 , 3.21090e-02 , 3.08957e-02 , 2.97601e-02 , &
+       2.86966e-02 , 2.76984e-02 , 2.67599e-02 , 2.58758e-02 , 2.50416e-02 , &
+       2.42532e-02 , 2.35070e-02 , 2.27997e-02 , 2.21284e-02 , 2.14904e-02 , &
+       2.08834e-02 , 2.03051e-02 , 1.97536e-02 , 1.92271e-02 , 1.87239e-02 , &
+       1.82425e-02 , 1.77816e-02 , 1.73399e-02 , 1.69162e-02 , 1.65094e-02 , &
+       1.61187e-02 , 1.57430e-02 , 1.53815e-02 , 1.50334e-02 , 1.46981e-02 , &
+       1.43748e-02 , 1.40628e-02 , 1.37617e-02 /)
+      absliq1(:, 3) = (/ &
+! band 3
+       2.95174e-01 , 2.34765e-01 , 1.98038e-01 , 1.72114e-01 , 1.52083e-01 , &
+       1.35654e-01 , 1.21613e-01 , 1.09252e-01 , 9.81263e-02 , 8.79448e-02 , &
+       8.12566e-02 , 7.44563e-02 , 6.86374e-02 , 6.36042e-02 , 5.92094e-02 , &
+       5.53402e-02 , 5.19087e-02 , 4.88455e-02 , 4.60951e-02 , 4.36124e-02 , &
+       4.13607e-02 , 3.93096e-02 , 3.74338e-02 , 3.57119e-02 , 3.41261e-02 , &
+       3.26610e-02 , 3.13036e-02 , 3.00425e-02 , 2.88497e-02 , 2.78077e-02 , &
+       2.68317e-02 , 2.59158e-02 , 2.50545e-02 , 2.42430e-02 , 2.34772e-02 , &
+       2.27533e-02 , 2.20679e-02 , 2.14181e-02 , 2.08011e-02 , 2.02145e-02 , &
+       1.96561e-02 , 1.91239e-02 , 1.86161e-02 , 1.81311e-02 , 1.76673e-02 , &
+       1.72234e-02 , 1.67981e-02 , 1.63903e-02 , 1.59989e-02 , 1.56230e-02 , &
+       1.52615e-02 , 1.49138e-02 , 1.45791e-02 , 1.42565e-02 , 1.39455e-02 , &
+       1.36455e-02 , 1.33559e-02 , 1.30761e-02 /)
+      absliq1(:, 4) = (/ &
+! band 4
+       3.00925e-01 , 2.36949e-01 , 1.96947e-01 , 1.68692e-01 , 1.47190e-01 , &
+       1.29986e-01 , 1.15719e-01 , 1.03568e-01 , 9.30028e-02 , 8.36658e-02 , &
+       7.71075e-02 , 7.07002e-02 , 6.52284e-02 , 6.05024e-02 , 5.63801e-02 , &
+       5.27534e-02 , 4.95384e-02 , 4.66690e-02 , 4.40925e-02 , 4.17664e-02 , &
+       3.96559e-02 , 3.77326e-02 , 3.59727e-02 , 3.43561e-02 , 3.28662e-02 , &
+       3.14885e-02 , 3.02110e-02 , 2.90231e-02 , 2.78948e-02 , 2.69109e-02 , &
+       2.59884e-02 , 2.51217e-02 , 2.43058e-02 , 2.35364e-02 , 2.28096e-02 , &
+       2.21218e-02 , 2.14700e-02 , 2.08515e-02 , 2.02636e-02 , 1.97041e-02 , &
+       1.91711e-02 , 1.86625e-02 , 1.81769e-02 , 1.77126e-02 , 1.72683e-02 , &
+       1.68426e-02 , 1.64344e-02 , 1.60427e-02 , 1.56664e-02 , 1.53046e-02 , &
+       1.49565e-02 , 1.46214e-02 , 1.42985e-02 , 1.39871e-02 , 1.36866e-02 , &
+       1.33965e-02 , 1.31162e-02 , 1.28453e-02 /)
+      absliq1(:, 5) = (/ &
+! band 5
+       2.64691e-01 , 2.12018e-01 , 1.78009e-01 , 1.53539e-01 , 1.34721e-01 , &
+       1.19580e-01 , 1.06996e-01 , 9.62772e-02 , 8.69710e-02 , 7.87670e-02 , &
+       7.29272e-02 , 6.70920e-02 , 6.20977e-02 , 5.77732e-02 , 5.39910e-02 , &
+       5.06538e-02 , 4.76866e-02 , 4.50301e-02 , 4.26374e-02 , 4.04704e-02 , &
+       3.84981e-02 , 3.66948e-02 , 3.50394e-02 , 3.35141e-02 , 3.21038e-02 , &
+       3.07957e-02 , 2.95788e-02 , 2.84438e-02 , 2.73790e-02 , 2.64390e-02 , &
+       2.55565e-02 , 2.47263e-02 , 2.39437e-02 , 2.32047e-02 , 2.25056e-02 , &
+       2.18433e-02 , 2.12149e-02 , 2.06177e-02 , 2.00495e-02 , 1.95081e-02 , &
+       1.89917e-02 , 1.84984e-02 , 1.80269e-02 , 1.75755e-02 , 1.71431e-02 , &
+       1.67283e-02 , 1.63303e-02 , 1.59478e-02 , 1.55801e-02 , 1.52262e-02 , &
+       1.48853e-02 , 1.45568e-02 , 1.42400e-02 , 1.39342e-02 , 1.36388e-02 , &
+       1.33533e-02 , 1.30773e-02 , 1.28102e-02 /)
+      absliq1(:, 6) = (/ &
+! band 6
+       8.81182e-02 , 1.06745e-01 , 9.79753e-02 , 8.99625e-02 , 8.35200e-02 , &
+       7.81899e-02 , 7.35939e-02 , 6.94696e-02 , 6.56266e-02 , 6.19148e-02 , &
+       5.83355e-02 , 5.49306e-02 , 5.19642e-02 , 4.93325e-02 , 4.69659e-02 , &
+       4.48148e-02 , 4.28431e-02 , 4.10231e-02 , 3.93332e-02 , 3.77563e-02 , &
+       3.62785e-02 , 3.48882e-02 , 3.35758e-02 , 3.23333e-02 , 3.11536e-02 , &
+       3.00310e-02 , 2.89601e-02 , 2.79365e-02 , 2.70502e-02 , 2.62618e-02 , &
+       2.55025e-02 , 2.47728e-02 , 2.40726e-02 , 2.34013e-02 , 2.27583e-02 , &
+       2.21422e-02 , 2.15522e-02 , 2.09869e-02 , 2.04453e-02 , 1.99260e-02 , &
+       1.94280e-02 , 1.89501e-02 , 1.84913e-02 , 1.80506e-02 , 1.76270e-02 , &
+       1.72196e-02 , 1.68276e-02 , 1.64500e-02 , 1.60863e-02 , 1.57357e-02 , &
+       1.53975e-02 , 1.50710e-02 , 1.47558e-02 , 1.44511e-02 , 1.41566e-02 , &
+       1.38717e-02 , 1.35960e-02 , 1.33290e-02 /)
+      absliq1(:, 7) = (/ &
+! band 7
+       4.32174e-02 , 7.36078e-02 , 6.98340e-02 , 6.65231e-02 , 6.41948e-02 , &
+       6.23551e-02 , 6.06638e-02 , 5.88680e-02 , 5.67124e-02 , 5.38629e-02 , &
+       4.99579e-02 , 4.86289e-02 , 4.70120e-02 , 4.52854e-02 , 4.35466e-02 , &
+       4.18480e-02 , 4.02169e-02 , 3.86658e-02 , 3.71992e-02 , 3.58168e-02 , &
+       3.45155e-02 , 3.32912e-02 , 3.21390e-02 , 3.10538e-02 , 3.00307e-02 , &
+       2.90651e-02 , 2.81524e-02 , 2.72885e-02 , 2.62821e-02 , 2.55744e-02 , &
+       2.48799e-02 , 2.42029e-02 , 2.35460e-02 , 2.29108e-02 , 2.22981e-02 , &
+       2.17079e-02 , 2.11402e-02 , 2.05945e-02 , 2.00701e-02 , 1.95663e-02 , &
+       1.90824e-02 , 1.86174e-02 , 1.81706e-02 , 1.77411e-02 , 1.73281e-02 , &
+       1.69307e-02 , 1.65483e-02 , 1.61801e-02 , 1.58254e-02 , 1.54835e-02 , &
+       1.51538e-02 , 1.48358e-02 , 1.45288e-02 , 1.42322e-02 , 1.39457e-02 , &
+       1.36687e-02 , 1.34008e-02 , 1.31416e-02 /)
+      absliq1(:, 8) = (/ &
+! band 8
+       1.41881e-01 , 7.15419e-02 , 6.30335e-02 , 6.11132e-02 , 6.01931e-02 , &
+       5.92420e-02 , 5.78968e-02 , 5.58876e-02 , 5.28923e-02 , 4.84462e-02 , &
+       4.60839e-02 , 4.56013e-02 , 4.45410e-02 , 4.31866e-02 , 4.17026e-02 , &
+       4.01850e-02 , 3.86892e-02 , 3.72461e-02 , 3.58722e-02 , 3.45749e-02 , &
+       3.33564e-02 , 3.22155e-02 , 3.11494e-02 , 3.01541e-02 , 2.92253e-02 , &
+       2.83584e-02 , 2.75488e-02 , 2.67925e-02 , 2.57692e-02 , 2.50704e-02 , &
+       2.43918e-02 , 2.37350e-02 , 2.31005e-02 , 2.24888e-02 , 2.18996e-02 , &
+       2.13325e-02 , 2.07870e-02 , 2.02623e-02 , 1.97577e-02 , 1.92724e-02 , &
+       1.88056e-02 , 1.83564e-02 , 1.79241e-02 , 1.75079e-02 , 1.71070e-02 , &
+       1.67207e-02 , 1.63482e-02 , 1.59890e-02 , 1.56424e-02 , 1.53077e-02 , &
+       1.49845e-02 , 1.46722e-02 , 1.43702e-02 , 1.40782e-02 , 1.37955e-02 , &
+       1.35219e-02 , 1.32569e-02 , 1.30000e-02 /)
+      absliq1(:, 9) = (/ &
+! band 9
+       6.72726e-02 , 6.61013e-02 , 6.47866e-02 , 6.33780e-02 , 6.18985e-02 , &
+       6.03335e-02 , 5.86136e-02 , 5.65876e-02 , 5.39839e-02 , 5.03536e-02 , &
+       4.71608e-02 , 4.63630e-02 , 4.50313e-02 , 4.34526e-02 , 4.17876e-02 , &
+       4.01261e-02 , 3.85171e-02 , 3.69860e-02 , 3.55442e-02 , 3.41954e-02 , &
+       3.29384e-02 , 3.17693e-02 , 3.06832e-02 , 2.96745e-02 , 2.87374e-02 , &
+       2.78662e-02 , 2.70557e-02 , 2.63008e-02 , 2.52450e-02 , 2.45424e-02 , &
+       2.38656e-02 , 2.32144e-02 , 2.25885e-02 , 2.19873e-02 , 2.14099e-02 , &
+       2.08554e-02 , 2.03230e-02 , 1.98116e-02 , 1.93203e-02 , 1.88482e-02 , &
+       1.83944e-02 , 1.79578e-02 , 1.75378e-02 , 1.71335e-02 , 1.67440e-02 , &
+       1.63687e-02 , 1.60069e-02 , 1.56579e-02 , 1.53210e-02 , 1.49958e-02 , &
+       1.46815e-02 , 1.43778e-02 , 1.40841e-02 , 1.37999e-02 , 1.35249e-02 , &
+       1.32585e-02 , 1.30004e-02 , 1.27502e-02 /)
+      absliq1(:,10) = (/ &
+! band 10
+       7.97040e-02 , 7.63844e-02 , 7.36499e-02 , 7.13525e-02 , 6.93043e-02 , &
+       6.72807e-02 , 6.50227e-02 , 6.22395e-02 , 5.86093e-02 , 5.37815e-02 , &
+       5.14682e-02 , 4.97214e-02 , 4.77392e-02 , 4.56961e-02 , 4.36858e-02 , &
+       4.17569e-02 , 3.99328e-02 , 3.82224e-02 , 3.66265e-02 , 3.51416e-02 , &
+       3.37617e-02 , 3.24798e-02 , 3.12887e-02 , 3.01812e-02 , 2.91505e-02 , &
+       2.81900e-02 , 2.72939e-02 , 2.64568e-02 , 2.54165e-02 , 2.46832e-02 , &
+       2.39783e-02 , 2.33017e-02 , 2.26531e-02 , 2.20314e-02 , 2.14359e-02 , &
+       2.08653e-02 , 2.03187e-02 , 1.97947e-02 , 1.92924e-02 , 1.88106e-02 , &
+       1.83483e-02 , 1.79043e-02 , 1.74778e-02 , 1.70678e-02 , 1.66735e-02 , &
+       1.62941e-02 , 1.59286e-02 , 1.55766e-02 , 1.52371e-02 , 1.49097e-02 , &
+       1.45937e-02 , 1.42885e-02 , 1.39936e-02 , 1.37085e-02 , 1.34327e-02 , &
+       1.31659e-02 , 1.29075e-02 , 1.26571e-02 /)
+      absliq1(:,11) = (/ &
+! band 11
+       1.49438e-01 , 1.33535e-01 , 1.21542e-01 , 1.11743e-01 , 1.03263e-01 , &
+       9.55774e-02 , 8.83382e-02 , 8.12943e-02 , 7.42533e-02 , 6.70609e-02 , &
+       6.38761e-02 , 5.97788e-02 , 5.59841e-02 , 5.25318e-02 , 4.94132e-02 , &
+       4.66014e-02 , 4.40644e-02 , 4.17706e-02 , 3.96910e-02 , 3.77998e-02 , &
+       3.60742e-02 , 3.44947e-02 , 3.30442e-02 , 3.17079e-02 , 3.04730e-02 , &
+       2.93283e-02 , 2.82642e-02 , 2.72720e-02 , 2.61789e-02 , 2.53277e-02 , &
+       2.45237e-02 , 2.37635e-02 , 2.30438e-02 , 2.23615e-02 , 2.17140e-02 , &
+       2.10987e-02 , 2.05133e-02 , 1.99557e-02 , 1.94241e-02 , 1.89166e-02 , &
+       1.84317e-02 , 1.79679e-02 , 1.75238e-02 , 1.70983e-02 , 1.66901e-02 , &
+       1.62983e-02 , 1.59219e-02 , 1.55599e-02 , 1.52115e-02 , 1.48761e-02 , &
+       1.45528e-02 , 1.42411e-02 , 1.39402e-02 , 1.36497e-02 , 1.33690e-02 , &
+       1.30976e-02 , 1.28351e-02 , 1.25810e-02 /)
+      absliq1(:,12) = (/ &
+! band 12
+       3.71985e-02 , 3.88586e-02 , 3.99070e-02 , 4.04351e-02 , 4.04610e-02 , &
+       3.99834e-02 , 3.89953e-02 , 3.74886e-02 , 3.54551e-02 , 3.28870e-02 , &
+       3.32576e-02 , 3.22444e-02 , 3.12384e-02 , 3.02584e-02 , 2.93146e-02 , &
+       2.84120e-02 , 2.75525e-02 , 2.67361e-02 , 2.59618e-02 , 2.52280e-02 , &
+       2.45327e-02 , 2.38736e-02 , 2.32487e-02 , 2.26558e-02 , 2.20929e-02 , &
+       2.15579e-02 , 2.10491e-02 , 2.05648e-02 , 1.99749e-02 , 1.95704e-02 , &
+       1.91731e-02 , 1.87839e-02 , 1.84032e-02 , 1.80315e-02 , 1.76689e-02 , &
+       1.73155e-02 , 1.69712e-02 , 1.66362e-02 , 1.63101e-02 , 1.59928e-02 , &
+       1.56842e-02 , 1.53840e-02 , 1.50920e-02 , 1.48080e-02 , 1.45318e-02 , &
+       1.42631e-02 , 1.40016e-02 , 1.37472e-02 , 1.34996e-02 , 1.32586e-02 , &
+       1.30239e-02 , 1.27954e-02 , 1.25728e-02 , 1.23559e-02 , 1.21445e-02 , &
+       1.19385e-02 , 1.17376e-02 , 1.15417e-02 /)
+      absliq1(:,13) = (/ &
+! band 13
+       3.11868e-02 , 4.48357e-02 , 4.90224e-02 , 4.96406e-02 , 4.86806e-02 , &
+       4.69610e-02 , 4.48630e-02 , 4.25795e-02 , 4.02138e-02 , 3.78236e-02 , &
+       3.74266e-02 , 3.60384e-02 , 3.47074e-02 , 3.34434e-02 , 3.22499e-02 , &
+       3.11264e-02 , 3.00704e-02 , 2.90784e-02 , 2.81463e-02 , 2.72702e-02 , &
+       2.64460e-02 , 2.56698e-02 , 2.49381e-02 , 2.42475e-02 , 2.35948e-02 , &
+       2.29774e-02 , 2.23925e-02 , 2.18379e-02 , 2.11793e-02 , 2.07076e-02 , &
+       2.02470e-02 , 1.97981e-02 , 1.93613e-02 , 1.89367e-02 , 1.85243e-02 , &
+       1.81240e-02 , 1.77356e-02 , 1.73588e-02 , 1.69935e-02 , 1.66392e-02 , &
+       1.62956e-02 , 1.59624e-02 , 1.56393e-02 , 1.53259e-02 , 1.50219e-02 , &
+       1.47268e-02 , 1.44404e-02 , 1.41624e-02 , 1.38925e-02 , 1.36302e-02 , &
+       1.33755e-02 , 1.31278e-02 , 1.28871e-02 , 1.26530e-02 , 1.24253e-02 , &
+       1.22038e-02 , 1.19881e-02 , 1.17782e-02 /)
+      absliq1(:,14) = (/ &
+! band 14
+       1.58988e-02 , 3.50652e-02 , 4.00851e-02 , 4.07270e-02 , 3.98101e-02 , &
+       3.83306e-02 , 3.66829e-02 , 3.50327e-02 , 3.34497e-02 , 3.19609e-02 , &
+       3.13712e-02 , 3.03348e-02 , 2.93415e-02 , 2.83973e-02 , 2.75037e-02 , &
+       2.66604e-02 , 2.58654e-02 , 2.51161e-02 , 2.44100e-02 , 2.37440e-02 , &
+       2.31154e-02 , 2.25215e-02 , 2.19599e-02 , 2.14282e-02 , 2.09242e-02 , &
+       2.04459e-02 , 1.99915e-02 , 1.95594e-02 , 1.90254e-02 , 1.86598e-02 , &
+       1.82996e-02 , 1.79455e-02 , 1.75983e-02 , 1.72584e-02 , 1.69260e-02 , &
+       1.66013e-02 , 1.62843e-02 , 1.59752e-02 , 1.56737e-02 , 1.53799e-02 , &
+       1.50936e-02 , 1.48146e-02 , 1.45429e-02 , 1.42782e-02 , 1.40203e-02 , &
+       1.37691e-02 , 1.35243e-02 , 1.32858e-02 , 1.30534e-02 , 1.28270e-02 , &
+       1.26062e-02 , 1.23909e-02 , 1.21810e-02 , 1.19763e-02 , 1.17766e-02 , &
+       1.15817e-02 , 1.13915e-02 , 1.12058e-02 /)
+      absliq1(:,15) = (/ &
+! band 15
+       5.02079e-03 , 2.17615e-02 , 2.55449e-02 , 2.59484e-02 , 2.53650e-02 , &
+       2.45281e-02 , 2.36843e-02 , 2.29159e-02 , 2.22451e-02 , 2.16716e-02 , &
+       2.11451e-02 , 2.05817e-02 , 2.00454e-02 , 1.95372e-02 , 1.90567e-02 , &
+       1.86028e-02 , 1.81742e-02 , 1.77693e-02 , 1.73866e-02 , 1.70244e-02 , &
+       1.66815e-02 , 1.63563e-02 , 1.60477e-02 , 1.57544e-02 , 1.54755e-02 , &
+       1.52097e-02 , 1.49564e-02 , 1.47146e-02 , 1.43684e-02 , 1.41728e-02 , &
+       1.39762e-02 , 1.37797e-02 , 1.35838e-02 , 1.33891e-02 , 1.31961e-02 , &
+       1.30051e-02 , 1.28164e-02 , 1.26302e-02 , 1.24466e-02 , 1.22659e-02 , &
+       1.20881e-02 , 1.19131e-02 , 1.17412e-02 , 1.15723e-02 , 1.14063e-02 , &
+       1.12434e-02 , 1.10834e-02 , 1.09264e-02 , 1.07722e-02 , 1.06210e-02 , &
+       1.04725e-02 , 1.03269e-02 , 1.01839e-02 , 1.00436e-02 , 9.90593e-03 , &
+       9.77080e-03 , 9.63818e-03 , 9.50800e-03 /)
+      absliq1(:,16) = (/ &
+! band 16
+       5.64971e-02 , 9.04736e-02 , 8.11726e-02 , 7.05450e-02 , 6.20052e-02 , &
+       5.54286e-02 , 5.03503e-02 , 4.63791e-02 , 4.32290e-02 , 4.06959e-02 , &
+       3.74690e-02 , 3.52964e-02 , 3.33799e-02 , 3.16774e-02 , 3.01550e-02 , &
+       2.87856e-02 , 2.75474e-02 , 2.64223e-02 , 2.53953e-02 , 2.44542e-02 , &
+       2.35885e-02 , 2.27894e-02 , 2.20494e-02 , 2.13622e-02 , 2.07222e-02 , &
+       2.01246e-02 , 1.95654e-02 , 1.90408e-02 , 1.84398e-02 , 1.80021e-02 , &
+       1.75816e-02 , 1.71775e-02 , 1.67889e-02 , 1.64152e-02 , 1.60554e-02 , &
+       1.57089e-02 , 1.53751e-02 , 1.50531e-02 , 1.47426e-02 , 1.44428e-02 , &
+       1.41532e-02 , 1.38734e-02 , 1.36028e-02 , 1.33410e-02 , 1.30875e-02 , &
+       1.28420e-02 , 1.26041e-02 , 1.23735e-02 , 1.21497e-02 , 1.19325e-02 , &
+       1.17216e-02 , 1.15168e-02 , 1.13177e-02 , 1.11241e-02 , 1.09358e-02 , &
+       1.07525e-02 , 1.05741e-02 , 1.04003e-02 /)
+!$acc enter data copyin(absliq1)
+
+      end subroutine lwcldpr
+
+      end module rrtmg_lw_init_f
+
+      module rrtmg_lw_rad_f
+
+! --------------------------------------------------------------------------
+! | |
+! | Copyright 2002-2009, Atmospheric & Environmental Research, Inc. (AER). |
+! | This software may be used, copied, or redistributed as long as it is |
+! | not sold and this copyright notice is reproduced on each copy made. |
+! | This model is provided as is without any express or implied warranties. |
+! | (http:
+! | |
+! --------------------------------------------------------------------------
+!
+
+
+
+
+
+      use gpu_mcica_subcol_gen_lw
+
+      use gpu_rrtmg_lw_rtrnmc
+      use gpu_rrtmg_lw_setcoef
+      use gpu_rrtmg_lw_cldprmc
+
+      use gpu_rrtmg_lw_taumol, only: taumolg, copyGPUTaumol
+      use rrlw_cld_f, only: abscld1, absliq0, absliq1, &
+                          absice0, absice1, absice2, absice3
+      use rrlw_wvn_f, only: ngb, ngs
+      use rrlw_tbl_f, only: tblint, bpade, tau_tbl, exp_tbl, tfn_tbl, ntbl
+      use rrlw_con_f, only: fluxfac, heatfac, oneminus, pi, grav, avogad
+      use rrlw_vsn_f
+
+      implicit none
+      real :: timings(10)
+      INTEGER, PARAMETER :: debug_level_lwf=100
+
+      integer,allocatable,dimension(:) :: laytrop ! tropopause layer index
+      integer,allocatable,dimension(:,:) :: jp ! lookup table index
+      integer,allocatable,dimension(:,:) :: jt ! lookup table index
+      integer,allocatable,dimension(:,:) :: jt1 ! lookup table index
+      real,allocatable,dimension(:,:,:) :: planklayd !
+      real,allocatable,dimension(:,:,:) :: planklevd !
+      real,allocatable,dimension(:,:) :: plankbndd !
+      real,allocatable,dimension(:,:) :: dplankbnd_dt !
+
+      real,allocatable,dimension(:,:) :: colh2o ! column amount (h2o)
+      real,allocatable,dimension(:,:) :: colco2 ! column amount (co2)
+      real,allocatable,dimension(:,:) :: colo3 ! column amount (o3)
+      real,allocatable,dimension(:,:) :: coln2o ! column amount (n2o)
+      real,allocatable,dimension(:,:) :: colco ! column amount (co)
+      real,allocatable,dimension(:,:) :: colch4 ! column amount (ch4)
+      real,allocatable,dimension(:,:) :: colo2 ! column amount (o2)
+      real,allocatable,dimension(:,:) :: colbrd ! column amount (broadening gases)
+
+      integer,allocatable,dimension(:,:) :: indself
+      integer,allocatable,dimension(:,:) :: indfor
+      real,allocatable,dimension(:,:) :: selffac
+      real,allocatable,dimension(:,:) :: selffrac
+      real,allocatable,dimension(:,:) :: forfac
+      real,allocatable,dimension(:,:) :: forfrac
+
+      integer,allocatable,dimension(:,:) :: indminor
+      real,allocatable,dimension(:,:) :: minorfrac
+      real,allocatable,dimension(:,:) :: scaleminor
+      real,allocatable,dimension(:,:) :: scaleminorn2
+
+
+      real,allocatable,dimension(:,:) :: & !
+                         fac00, fac01, fac10, fac11
+      real,allocatable,dimension(:,:) :: & !
+                         rat_h2oco2,rat_h2oco2_1, &
+                         rat_h2oo3,rat_h2oo3_1, &
+                         rat_h2on2o,rat_h2on2o_1, &
+                         rat_h2och4,rat_h2och4_1, &
+                         rat_n2oco2,rat_n2oco2_1, &
+                         rat_o3co2,rat_o3co2_1
+
+      real,allocatable,dimension(:,:,:) :: gurad,gdrad,gclrurad,gclrdrad
+
+      real,allocatable,dimension(:,:,:) :: gdtotuflux_dtd,gdtotuclfl_dtd
+
+      real,allocatable,dimension(:,:) :: totufluxd
+      real,allocatable,dimension(:,:) :: totdfluxd
+      real,allocatable,dimension(:,:) :: fnetd
+      real,allocatable,dimension(:,:) :: htrd
+      real,allocatable,dimension(:,:) :: totuclfld
+      real,allocatable,dimension(:,:) :: totdclfld
+      real,allocatable,dimension(:,:) :: fnetcd
+      real,allocatable,dimension(:,:) :: htrcd
+      real,allocatable,dimension(:,:) :: dtotuflux_dtd
+      real,allocatable,dimension(:,:) :: dtotuclfl_dtd
+
+      real,allocatable,dimension(:,:,:) :: ciwpmcd, clwpmcd, cswpmcd, taucmcd
+
+      real,allocatable,dimension(:,:) :: wx1,wx2,wx3,wx4
+      real,allocatable,dimension(:,:,:) :: tauaa,taug
+
+      real , dimension(16)   :: a0,a1,a2
+      integer, dimension(16) :: icb
+!------------------------------------------------------------------
+      contains
+      subroutine allocateGPUarrays(chnk,nlay,nbndlw,ngptlw)
+      integer :: chnk,nlay,nbndlw,ngptlw
+      
+      allocate(fac00(CHNK,nlay+1))
+      allocate(fac01(CHNK,nlay+1))
+      allocate(fac10(CHNK,nlay+1))
+      allocate(fac11(CHNK,nlay+1))
+      allocate(rat_h2oco2(CHNK,nlay+1))
+      allocate(rat_h2oco2_1(CHNK,nlay+1))
+      allocate(rat_h2oo3(CHNK,nlay+1))
+      allocate(rat_h2oo3_1(CHNK,nlay+1))
+      allocate(rat_h2on2o(CHNK,nlay+1))
+      allocate(rat_h2on2o_1(CHNK,nlay+1))
+      allocate(rat_h2och4(CHNK,nlay+1))
+      allocate(rat_h2och4_1(CHNK,nlay+1))
+      allocate(rat_n2oco2(CHNK,nlay+1))
+      allocate(rat_n2oco2_1(CHNK,nlay+1))
+      allocate(rat_o3co2(CHNK,nlay+1))
+      allocate(rat_o3co2_1(CHNK,nlay+1))
+      allocate(laytrop(CHNK))
+      allocate(jp(CHNK,nlay+1))
+      allocate(jt(CHNK,nlay+1))
+      allocate(jt1(CHNK,nlay+1))
+      allocate(planklayd(CHNK,nlay+1,nbndlw))
+      allocate(planklevd(CHNK,0:nlay+1,nbndlw))
+      allocate(plankbndd(CHNK,nbndlw))
+      allocate(dplankbnd_dt(CHNK,nbndlw))
+
+      allocate(colh2o(CHNK,nlay+1))
+      allocate(colco2(CHNK,nlay+1))
+      allocate(colo3(CHNK,nlay+1))
+      allocate(coln2o(CHNK,nlay+1))
+      allocate(colco(CHNK,nlay+1))
+      allocate(colch4(CHNK,nlay+1))
+      allocate(colo2(CHNK,nlay+1))
+      allocate(colbrd(CHNK,nlay+1))
+
+      allocate(indself(CHNK,nlay+1))
+      allocate(indfor(CHNK,nlay+1))
+      allocate(selffac(CHNK,nlay+1))
+      allocate(selffrac(CHNK,nlay+1))
+      allocate(forfac(CHNK,nlay+1))
+      allocate(forfrac(CHNK,nlay+1))
+
+      allocate(indminor(CHNK,nlay+1))
+      allocate(minorfrac(CHNK,nlay+1))
+      allocate(scaleminor(CHNK,nlay+1))
+      allocate(scaleminorn2(CHNK,nlay+1))
+
+!$acc enter data create(fac00, fac01, fac10, fac11)
+!$acc enter data create(rat_h2oco2,rat_h2oco2_1, &
+!$acc                   rat_h2oo3,rat_h2oo3_1, &
+!$acc                   rat_h2on2o,rat_h2on2o_1, &
+!$acc                   rat_h2och4,rat_h2och4_1, &
+!$acc                   rat_n2oco2,rat_n2oco2_1, &
+!$acc                   rat_o3co2,rat_o3co2_1)
+!$acc enter data create( laytrop, jp, jt, jt1, &
+!$acc       planklayd, planklevd, plankbndd, dplankbnd_dt,  &
+!$acc       colh2o, colco2, colo3, coln2o, colco, colch4, &
+!$acc       colo2, colbrd, indself, indfor, &
+!$acc       selffac, selffrac, forfac, forfrac, &
+!$acc       indminor, minorfrac, scaleminor, scaleminorn2)
+
+      allocate(gurad(CHNK,ngptlw,0:nlay+1))
+      allocate(gdrad(CHNK,ngptlw,0:nlay+1))
+      allocate(gclrurad(CHNK,ngptlw,0:nlay+1))
+      allocate(gclrdrad(CHNK,ngptlw,0:nlay+1))
+
+      allocate(gdtotuflux_dtd( CHNK, ngptlw, 0:nlay+1))
+      allocate(gdtotuclfl_dtd( CHNK, ngptlw, 0:nlay+1))
+
+      allocate(totufluxd(CHNK, 0:nlay+1))
+      allocate(totdfluxd(CHNK, 0:nlay+1))
+      allocate(fnetd(CHNK, 0:nlay+1))
+      allocate(htrd(CHNK, 0:nlay+1))
+      allocate(totuclfld(CHNK, 0:nlay+1))
+      allocate(totdclfld(CHNK, 0:nlay+1))
+      allocate(fnetcd(CHNK, 0:nlay+1))
+      allocate(htrcd(CHNK, 0:nlay+1))
+      allocate(dtotuflux_dtd(CHNK, 0:nlay+1))
+      allocate(dtotuclfl_dtd(CHNK, 0:nlay+1))
+!$acc enter data create(gurad,gdrad,gclrurad,gclrdrad,gdtotuflux_dtd,gdtotuclfl_dtd, &
+!$acc    totufluxd,totdfluxd,fnetd,htrd,totuclfld,totdclfld,fnetcd, &
+!$acc    htrcd, dtotuflux_dtd,dtotuclfl_dtd)
+
+      allocate(ciwpmcd(CHNK, ngptlw, nlay+1))
+      allocate(clwpmcd(CHNK, ngptlw, nlay+1))
+      allocate(cswpmcd(CHNK, ngptlw, nlay+1))
+      allocate(taucmcd(CHNK, ngptlw, nlay+1))
+!$acc enter data create(ciwpmcd, clwpmcd, cswpmcd, taucmcd)
+
+      allocate(wx1( CHNK, nlay ))
+      allocate(wx2( CHNK, nlay ))
+      allocate(wx3( CHNK, nlay ))
+      allocate(wx4( CHNK, nlay ))
+
+      allocate(tauaa( CHNK, nlay, nbndlw ))
+      allocate(taug( CHNK, nlay+1, ngptlw ))
+!$acc enter data create(wx1,wx2,wx3,wx4,tauaa,taug)      
+      icb(:) = (/ 1,2,3,3,3,4,4,4,5, 5, 5, 5, 5, 5, 5, 5 /)
+      a0 =(/ 1.66 , 1.55 , 1.58 , 1.66 , &
+                1.54 , 1.454 , 1.89 , 1.33 , &
+               1.668 , 1.66 , 1.66 , 1.66 , &
+                1.66 , 1.66 , 1.66 , 1.66 /)
+      a1=(/ 0.00 , 0.25 , 0.22 , 0.00 , &
+                0.13 , 0.446 , -0.10 , 0.40 , &
+              -0.006 , 0.00 , 0.00 , 0.00 , &
+                0.00 , 0.00 , 0.00 , 0.00 /)
+      a2 =(/ 0.00 , -12.0 , -11.7 , 0.00 , &
+               -0.72 ,-0.243 , 0.19 ,-0.062 , &
+               0.414 , 0.00 , 0.00 , 0.00 , &
+                0.00 , 0.00 , 0.00 , 0.00 /)
+!$acc enter data copyin(icb,a0,a1,a2)
+
+      end subroutine
+
+      subroutine deallocateGPUarrays
+!$acc exit data delete(icb,a0,a1,a2)
+
+!$acc exit data delete(fac00, fac01, fac10, fac11) 
+!$acc exit data delete(rat_h2oco2,rat_h2oco2_1, &
+!$acc                   rat_h2oo3,rat_h2oo3_1, &
+!$acc                   rat_h2on2o,rat_h2on2o_1, &
+!$acc                   rat_h2och4,rat_h2och4_1, &
+!$acc                   rat_n2oco2,rat_n2oco2_1, &
+!$acc                   rat_o3co2,rat_o3co2_1) 
+      deallocate(fac00)
+      deallocate(fac01)
+      deallocate(fac10)
+      deallocate(fac11)
+      deallocate(rat_h2oco2)
+      deallocate(rat_h2oco2_1)
+      deallocate(rat_h2oo3)
+      deallocate(rat_h2oo3_1)
+      deallocate(rat_h2on2o)
+      deallocate(rat_h2on2o_1)
+      deallocate(rat_h2och4)
+      deallocate(rat_h2och4_1)
+      deallocate(rat_n2oco2)
+      deallocate(rat_n2oco2_1)
+      deallocate(rat_o3co2)
+      deallocate(rat_o3co2_1)
+
+!$acc exit data delete( laytrop, jp, jt, jt1, &
+!$acc       planklayd, planklevd, plankbndd, dplankbnd_dt,  &
+!$acc       colh2o, colco2, colo3, coln2o, colco, colch4, &
+!$acc       colo2, colbrd, indself, indfor, &
+!$acc       selffac, selffrac, forfac, forfrac, &
+!$acc       indminor, minorfrac, scaleminor, scaleminorn2)
+
+
+      
+      deallocate(laytrop)
+      deallocate(jp)
+      deallocate(jt)
+      deallocate(jt1)
+      deallocate(planklayd)
+      deallocate(planklevd)
+      deallocate(plankbndd)
+      deallocate(dplankbnd_dt)
+
+      deallocate(colh2o)
+      deallocate(colco2)
+      deallocate(colo3)
+      deallocate(coln2o)
+      deallocate(colco)
+      deallocate(colch4)
+      deallocate(colo2)
+      deallocate(colbrd)
+
+      deallocate(indself)
+      deallocate(indfor)
+      deallocate(selffac)
+      deallocate(selffrac)
+      deallocate(forfac)
+      deallocate(forfrac)
+
+      deallocate(indminor)
+      deallocate(minorfrac)
+      deallocate(scaleminor)
+      deallocate(scaleminorn2)
+
+!$acc exit data delete(gurad,gdrad,gclrurad,gclrdrad,gdtotuflux_dtd,gdtotuclfl_dtd, &
+!$acc    totufluxd,totdfluxd,fnetd,htrd,totuclfld,totdclfld,fnetcd, &
+!$acc    htrcd, dtotuflux_dtd,dtotuclfl_dtd)
+      deallocate(gurad)
+      deallocate(gdrad)
+      deallocate(gclrurad)
+      deallocate(gclrdrad)
+      deallocate(gdtotuflux_dtd)
+      deallocate(gdtotuclfl_dtd)
+      deallocate(totufluxd)
+      deallocate(totdfluxd)
+      deallocate(fnetd)
+      deallocate(htrd)
+      deallocate(totuclfld)
+      deallocate(totdclfld)
+      deallocate(fnetcd)
+      deallocate(htrcd)
+      deallocate(dtotuflux_dtd)
+      deallocate(dtotuclfl_dtd)
+
+!$acc exit data delete(ciwpmcd, clwpmcd, cswpmcd, taucmcd)
+      deallocate(ciwpmcd)
+      deallocate(clwpmcd)
+      deallocate(cswpmcd)
+      deallocate(taucmcd)
+
+!$acc exit data delete(wx1,wx2,wx3,wx4,tauaa,taug)      
+      deallocate(wx1)
+      deallocate(wx2)
+      deallocate(wx3)
+      deallocate(wx4)
+
+      deallocate(tauaa)
+      deallocate(taug)
+      end subroutine
+!------------------------------------------------------------------
+      subroutine rrtmg_lw( &
+             ncol ,nlay ,icld ,idrv , &
+             play ,plev ,tlay ,tlev ,tsfc , &
+             h2ovmr ,o3vmr ,co2vmr ,ch4vmr ,n2ovmr ,o2vmr , &
+             cfc11vmr,cfc12vmr,cfc22vmr,ccl4vmr ,emis , &
+             inflglw ,iceflglw,liqflglw,cldfrac , &
+             tauc ,ciwp ,clwp ,cswp ,rei ,rel , res , &
+             tauaer , &
+             uflx ,dflx ,hr ,uflxc ,dflxc ,hrc , &
+             duflx_dt,duflxc_dt)
+! -------- Description --------
+
+! This program is the driver subroutine for RRTMG_LW, the AER LW radiation
+! model for application to GCMs, that has been adapted from RRTM_LW for
+! improved efficiency.
+!
+! NOTE: The call to RRTMG_LW_INI should be moved to the GCM initialization
+! area, since this has to be called only once.
+!
+! This routine:
+! a) calls INATM to read in the atmospheric profile from GCM;
+! all layering in RRTMG is ordered from surface to toa.
+! b) calls CLDPRMC to set cloud optical depth for McICA based
+! on input cloud properties
+! c) calls SETCOEF to calculate various quantities needed for
+! the radiative transfer algorithm
+! d) calls TAUMOL to calculate gaseous optical depths for each
+! of the 16 spectral bands
+! e) calls RTRNMC (for both clear and cloudy profiles) to perform the
+! radiative transfer calculation using McICA, the Monte-Carlo
+! Independent Column Approximation, to represent sub-grid scale
+! cloud variability
+! f) passes the necessary fluxes and cooling rates back to GCM
+!
+! Two modes of operation are possible:
+! The mode is chosen by using either rrtmg_lw.nomcica.f90 (to not use
+! McICA) or rrtmg_lw.f90 (to use McICA) to interface with a GCM.
+!
+! 1) Standard, single forward model calculation (imca = 0)
+! 2) Monte Carlo Independent Column Approximation (McICA, Pincus et al.,
+! JC, 2003) method is applied to the forward model calculation (imca = 1)
+!
+! This call to RRTMG_LW must be preceeded by a call to the module
+! mcica_subcol_gen_lw.f90 to run the McICA sub-column cloud generator,
+! which will provide the cloud physical or cloud optical properties
+! on the RRTMG quadrature point (ngpt) dimension.
+! Two random number generators are available for use when imca = 1.
+! This is chosen by setting flag irnd on input to mcica_subcol_gen_lw.
+! 1) KISSVEC (irnd = 0)
+! 2) Mersenne-Twister (irnd = 1)
+!
+! Two methods of cloud property input are possible:
+! Cloud properties can be input in one of two ways (controlled by input
+! flags inflglw, iceflglw, and liqflglw; see text file rrtmg_lw_instructions
+! and subroutine rrtmg_lw_cldprmc.f90 for further details):
+!
+! 1) Input cloud fraction and cloud optical depth directly (inflglw = 0)
+! 2) Input cloud fraction and cloud physical properties (inflglw = 1 or 2);
+! cloud optical properties are calculated by cldprmc or cldprmc based
+! on input settings of iceflglw and liqflglw. Ice particle size provided
+! must be appropriately defined for the ice parameterization selected.
+!
+! One method of aerosol property input is possible:
+! Aerosol properties can be input in only one way (controlled by input
+! flag iaer; see text file rrtmg_lw_instructions for further details):
+!
+! 1) Input aerosol optical depth directly by layer and spectral band (iaer=10);
+! band average optical depth at the mid-point of each spectral band.
+! RRTMG_LW currently treats only aerosol absorption;
+! scattering capability is not presently available.
+!
+! The optional calculation of the change in upward flux as a function of surface
+! temperature is available (controlled by input flag idrv). This can be utilized
+! to approximate adjustments to the upward flux profile caused only by a change in
+! surface temperature between full radiation calls. This feature uses the pre-
+! calculated derivative of the Planck function with respect to surface temperature.
+!
+! 1) Normal forward calculation for the input profile (idrv=0)
+! 2) Normal forward calculation with optional calculation of the change
+! in upward flux as a function of surface temperature for clear sky
+! and total sky flux. Flux partial derivatives are provided in arrays
+! duflx_dt and duflxc_dt for total and clear sky. (idrv=1)
+!
+!
+! ------- Modifications -------
+!
+! This version of RRTMG_LW has been modified from RRTM_LW to use a reduced
+! set of g-points for application to GCMs.
+!
+!-- Original version (derived from RRTM_LW), reduction of g-points, other
+! revisions for use with GCMs.
+! 1999: M. J. Iacono, AER, Inc.
+!-- Adapted for use with NCAR/CAM.
+! May 2004: M. J. Iacono, AER, Inc.
+!-- Revised to add McICA capability.
+! Nov 2005: M. J. Iacono, AER, Inc.
+!-- Conversion to F90 formatting for consistency with rrtmg_sw.
+! Feb 2007: M. J. Iacono, AER, Inc.
+!-- Modifications to formatting to use assumed-shape arrays.
+! Aug 2007: M. J. Iacono, AER, Inc.
+!-- Modified to add longwave aerosol absorption.
+! Apr 2008: M. J. Iacono, AER, Inc.
+!-- Added capability to calculate derivative of upward flux wrt surface temperature.
+! Nov 2009: M. J. Iacono, E. J. Mlawer, AER, Inc.
+!-- Added capability to run on GPU
+! Aug 2012: David Berthiaume, AER, Inc.
+! --------- Modules ----------
+
+      use parrrtm_f, only : nbndlw, ngptlw, maxxsec, mxmol, mxlay, nbndlw
+      use rrlw_con_f, only: fluxfac, heatfac, oneminus, pi
+      use rrlw_wvn_f, only: ng, ngb, nspa, nspb, wavenum1, wavenum2, delwave
+
+! ------- Declarations -------
+
+         ! integer , parameter:: maxlay = 203
+         ! integer , parameter:: mxmol = 38
+
+
+! ----- Input -----
+! Note: All volume mixing ratios are in dimensionless units of mole fraction obtained
+! by scaling mass mixing ratio (g/g) with the appropriate molecular weights (g/mol)
+      integer , intent(in) :: ncol ! Number of horizontal columns
+      integer , intent(in) :: nlay ! Number of model layers
+      integer , intent(inout) :: icld ! Cloud overlap method
+                                                      ! 0: Clear only
+                                                      ! 1: Random
+                                                      ! 2: Maximum/random
+                                                      ! 3: Maximum
+                                                      ! 4: Exponential (inactive)
+      integer , intent(in) :: idrv ! Flag for calculation of dFdT, the change
+                                                      ! in upward flux as a function of
+                                                      ! surface temperature [0=off, 1=on]
+                                                      ! 0: Normal forward calculation
+                                                      ! 1: Normal forward calculation with
+                                                      ! duflx_dt and duflxc_dt output
+
+! integer , intent(in) :: cloudMH, cloudHH ! cloud layer heights for cloudFlag
+      real , intent(in) :: play(:,:) ! Layer pressures (hPa, mb)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: plev(:,0:) ! Interface pressures (hPa, mb)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(in) :: tlay(:,:) ! Layer temperatures (K)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: tlev(:,0:) ! Interface temperatures (K)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(in) :: tsfc(:) ! Surface temperature (K)
+                                                      ! Dimensions: (ncol)
+      real , intent(in) :: h2ovmr(:,:) ! H2O volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: o3vmr(:,:) ! O3 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: co2vmr(:,:) ! CO2 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: ch4vmr(:,:) ! Methane volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: n2ovmr(:,:) ! Nitrous oxide volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: o2vmr(:,:) ! Oxygen volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: cfc11vmr(:, :) ! CFC11 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: cfc12vmr(:, :) ! CFC12 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: cfc22vmr(:, :) ! CFC22 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: ccl4vmr(:, :) ! CCL4 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: emis(:, :) ! Surface emissivity
+                                                      ! Dimensions: (ncol,nbndlw)
+
+      integer , intent(in) :: inflglw ! Flag for cloud optical properties
+      integer , intent(in) :: iceflglw ! Flag for ice particle specification
+      integer , intent(in) :: liqflglw ! Flag for liquid droplet specification
+
+      real , intent(in) :: cldfrac(:,:) ! Cloud fraction
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: ciwp(:,:) ! In-cloud ice water path (g/m2)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: clwp(:,:) ! In-cloud liquid water path (g/m2)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: cswp(:,:) ! In-cloud snow water path (g/m2)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: rei(:,:) ! Cloud ice particle effective size (microns)
+                                                      ! Dimensions: (ncol,nlay)
+                                                      ! specific definition of reicmcl depends on setting of iceflglw:
+                                                      ! iceflglw = 0: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                                      ! r_ec must be >= 10.0 microns
+                                                      ! iceflglw = 1: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                                      ! r_ec range is limited to 13.0 to 130.0 microns
+                                                      ! iceflglw = 2: ice effective radius, r_k, (Key, Streamer Ref. Manual, 1996)
+                                                      ! r_k range is limited to 5.0 to 131.0 microns
+                                                      ! iceflglw = 3: generalized effective size, dge, (Fu, 1996),
+                                                      ! dge range is limited to 5.0 to 140.0 microns
+                                                      ! [dge = 1.0315 * r_ec]
+      real , intent(in) :: rel(:, :) ! Cloud water drop effective radius (microns)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: res(:, :) ! Cloud snow effective radius (microns)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: tauc(:, :, :) ! In-cloud optical depth
+                                                      ! Dimensions: (ncol,nbndlw,nlay)
+      real , intent(in) :: tauaer(:,:,:) ! aerosol optical depth
+                                                      ! at mid-point of LW spectral bands
+                                                      ! Dimensions: (ncol,nlay,nbndlw)
+
+! ----- Output -----
+
+      real , intent(out) :: uflx(:,:) ! Total sky longwave upward flux (W/m2)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(out) :: dflx(:,:) ! Total sky longwave downward flux (W/m2)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(out) :: hr(:,:) ! Total sky longwave radiative heating rate (K/d)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(out) :: uflxc(:,:) ! Clear sky longwave upward flux (W/m2)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(out) :: dflxc(:,:) ! Clear sky longwave downward flux (W/m2)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(out) :: hrc(:,:) ! Clear sky longwave radiative heating rate (K/d)
+                                                      ! Dimensions: (ncol,nlay)
+
+! ----- Optional Output -----
+      real , intent(out), optional :: duflx_dt(:,:)
+                                                      ! change in upward longwave flux (w/m2/K)
+                                                      ! with respect to surface temperature
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(out), optional :: duflxc_dt(:,:)
+                                                      ! change in clear sky upward longwave flux (w/m2/K)
+                                                      ! with respect to surface temperature
+                                                      ! Dimensions: (ncol,nlay)
+! integer , intent(out), optional :: cloudFlag(:,:)
+
+      real, pointer :: alp(:,:)
+
+      integer :: pncol
+      integer :: colstart
+      integer :: cn, ns, i, np, mns
+      real :: minmem
+      integer :: hetflag
+      integer :: numDevices, err
+
+      integer :: numThreads
+integer,external :: omp_get_thread_num
+      CHARACTER(LEN=256) :: message
+
+      ! Cuda device information
+
+
+
+      ! store the available device global and constant memory
+      real gmem, cmem
+! mji - time
+      real t1,t2
+
+!jm write(0,*)"module_ra_rrtmg_lwf.F",14351,omp_get_thread_num()
+! (dmb 2012) Here we calculate the number of groups to partition
+! the inputs.
+
+      call allocateGPUarrays(CHNK,nlay,nbndlw,ngptlw)
+! determine the minimum GPU memory
+! force the GPUFlag off if there are no devices available
+
+
+
+
+
+! on the CPU partiion the inputs into 2 GB chunks. Runtime
+! is pretty constant on the CPU as a function of the number
+! of steps, so we pick a quantity that uses a relatively low
+! amount of CPU memory.
+      minmem = 2.0 * (1024.0**3)
+
+! set the number of 'devices' to the available number of CPUs
+
+! print *, "available working memory is ", int(minmem / (1024*1024)) , " MB"
+      cn = CHNK
+
+!
+      WRITE(message,*)'RRTMG_LWF: Number of columns is               ',ncol
+      call wrf_debug( debug_level_lwf, message)
+      WRITE(message,*)'RRTMG_LWF: Number of columns per partition is ',cn
+      call wrf_debug( debug_level_lwf, message)
+      ns = ceiling( real(ncol) / real(cn) )
+      WRITE(message,*)'RRTMG_LWF: Number of partitions is            ',ns
+      call wrf_debug( debug_level_lwf, message)
+
+! mji - time
+      call cpu_time(t1)
+
+!$acc data pcreate(play,plev,tlay,tlev,tsfc, &
+!$acc      h2ovmr ,o3vmr ,co2vmr ,ch4vmr ,n2ovmr ,o2vmr, &
+!$acc      cfc11vmr,cfc12vmr,cfc22vmr,ccl4vmr ,emis , &
+!$acc      cldfrac , tauc ,ciwp ,clwp ,cswp ,rei ,rel ,res , &
+!$acc      tauaer , uflx ,dflx ,hr ,uflxc ,dflxc, hrc)
+!!$acc update device( & !play,plev,tlay,tlev,tsfc, &
+!!$acc      tauc ,ciwp ,clwp ,cswp ,rei ,rel ,res, & !emis, o3vmr, &
+!!$acc      uflx ,dflx ,hr ,uflxc ,dflxc, hrc,tlay) !cldfrac,tauaer
+
+      do i = 1, ns
+
+!jm if ( i .eq. IDEBUG_BASE ) then
+!jm call setdebug
+!jm else
+!jm call unsetdebug
+!jm endif
+
+      call rrtmg_lw_part &
+            (ns, ncol, (i-1)*cn + 1, min(cn, ncol - (i-1)*cn), &
+             nlay ,icld ,idrv,&
+             play ,plev ,tlay ,tlev ,tsfc , &
+             h2ovmr ,o3vmr ,co2vmr ,ch4vmr ,n2ovmr ,o2vmr , &
+             cfc11vmr,cfc12vmr,cfc22vmr,ccl4vmr ,emis , &
+             inflglw ,iceflglw,liqflglw,cldfrac , &
+             tauc ,ciwp ,clwp ,cswp ,rei ,rel ,res , &
+             tauaer , &
+             uflx ,dflx ,hr ,uflxc ,dflxc, hrc, &
+             duflx_dt,duflxc_dt)
+      end do
+!$acc update host( uflx ,dflx ,hr ,uflxc ,dflxc, hrc)
+!$acc end data
+
+! mji - time
+      call deallocateGPUarrays()
+      call cpu_time(t2)
+      WRITE(message,*)'------------------------------------------------'
+      call wrf_debug( debug_level_lwf, message)
+      WRITE(message,*)'TOTAL RRTMG_LWF RUN TIME IS   ', t2-t1
+      call wrf_debug( debug_level_lwf, message)
+      WRITE(message,*)'------------------------------------------------'
+      call wrf_debug( debug_level_lwf, message)
+
+      end subroutine
+
+      subroutine rrtmg_lw_part &
+            (npart, ncol , colstart, pncol , &
+             nlay ,icld ,idrv , &
+             play ,plev ,tlay ,tlev ,tsfc , &
+             h2ovmr ,o3vmr ,co2vmr ,ch4vmr ,n2ovmr ,o2vmr , &
+             cfc11vmr,cfc12vmr,cfc22vmr,ccl4vmr ,emis , &
+             inflglw ,iceflglw,liqflglw,cldfrac , &
+             tauc ,ciwp ,clwp ,cswp ,rei ,rel ,res , &
+             tauaer , &
+             uflx ,dflx ,hr ,uflxc ,dflxc, hrc, &
+             duflx_dt,duflxc_dt)
+
+      use gpu_mcica_subcol_gen_lw, only: mcica_subcol_lwg, generate_stochastic_cloudsg
+
+      use parrrtm_f, only : nbndlw, ngptlw, maxxsec, mxmol, mxlay, nbndlw, nmol
+      use rrlw_con_f, only: fluxfac, heatfac, oneminus, pi
+      use rrlw_wvn_f, only: ng, ngb, nspa, nspb, wavenum1, wavenum2, delwave, ixindx
+
+
+! ----- Input -----
+! Note: All volume mixing ratios are in dimensionless units of mole fraction obtained
+! by scaling mass mixing ratio (g/g) with the appropriate molecular weights (g/mol)
+      integer , intent(in) :: npart
+      integer , intent(in) :: ncol ! Number of horizontal columns
+      integer , intent(in) :: nlay ! Number of model layers
+      integer , intent(inout) :: icld ! Cloud overlap method
+                                                      ! 0: Clear only
+                                                      ! 1: Random
+                                                      ! 2: Maximum/random
+                                                      ! 3: Maximum
+                                                      ! 4: Exponential (inactive)
+      integer , intent(in) :: idrv ! Flag for calculation of dFdT, the change
+                                                      ! in upward flux as a function of
+                                                      ! surface temperature [0=off, 1=on]
+                                                      ! 0: Normal forward calculation
+                                                      ! 1: Normal forward calculation with
+                                                      ! duflx_dt and duflxc_dt output
+
+      real , intent(in) :: play(:,:) ! Layer pressures (hPa, mb)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: plev(:,0:) ! Interface pressures (hPa, mb)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(in) :: tlay(:,:) ! Layer temperatures (K)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: tlev(:,0:) ! Interface temperatures (K)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(in) :: tsfc(:) ! Surface temperature (K)
+                                                      ! Dimensions: (ncol)
+      real , intent(in) :: h2ovmr(:,:) ! H2O volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: o3vmr(:,:) ! O3 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: co2vmr(:,:) ! CO2 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: ch4vmr(:,:) ! Methane volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: n2ovmr(:,:) ! Nitrous oxide volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: o2vmr(:,:) ! Oxygen volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: cfc11vmr(:, :) ! CFC11 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: cfc12vmr(:, :) ! CFC12 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: cfc22vmr(:, :) ! CFC22 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: ccl4vmr(:, :) ! CCL4 volume mixing ratio
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: emis(:, :) ! Surface emissivity
+                                                      ! Dimensions: (ncol,nbndlw)
+
+      integer , intent(in) :: inflglw ! Flag for cloud optical properties
+      integer , intent(in) :: iceflglw ! Flag for ice particle specification
+      integer , intent(in) :: liqflglw ! Flag for liquid droplet specification
+
+      real , intent(in) :: cldfrac(:,:) ! Cloud fraction
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real , intent(in) :: ciwp(:,:) ! In-cloud ice water path (g/m2)
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real , intent(in) :: clwp(:,:) ! In-cloud liquid water path (g/m2)
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real , intent(in) :: cswp(:,:) ! In-cloud snow water path (g/m2)
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real , intent(in) :: rei(:,:) ! Cloud ice particle effective size (microns)
+                                                      ! Dimensions: (ncol,nlay)
+                                                      ! specific definition of reicmcl depends on setting of iceflglw:
+                                                      ! iceflglw = 0: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                                      ! r_ec must be >= 10.0 microns
+                                                      ! iceflglw = 1: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                                      ! r_ec range is limited to 13.0 to 130.0 microns
+                                                      ! iceflglw = 2: ice effective radius, r_k, (Key, Streamer Ref. Manual, 1996)
+                                                      ! r_k range is limited to 5.0 to 131.0 microns
+                                                      ! iceflglw = 3: generalized effective size, dge, (Fu, 1996),
+                                                      ! dge range is limited to 5.0 to 140.0 microns
+                                                      ! [dge = 1.0315 * r_ec]
+      real , intent(in) :: rel(:, :) ! Cloud water drop effective radius (microns)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: res(:, :) ! Cloud snow effective radius (microns)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(in) :: tauc(:, :,:) ! In-cloud optical depth
+                                                      ! Dimensions: (ncol,nbndlw,nlay)
+
+      real , intent(in) :: tauaer(:,:,:) ! aerosol optical depth
+                                                      ! at mid-point of LW spectral bands
+                                                      ! Dimensions: (ncol,nlay,nbndlw)
+
+      integer , intent(in) :: pncol
+      integer , intent(in) :: colstart
+
+
+
+
+
+! ----- Output -----
+
+      real , intent(out) :: uflx(:,:) ! Total sky longwave upward flux (W/m2)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(out) :: dflx(:,:) ! Total sky longwave downward flux (W/m2)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(out) :: hr(:,:) ! Total sky longwave radiative heating rate (K/d)
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(out) :: uflxc(:,:) ! Clear sky longwave upward flux (W/m2)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(out) :: dflxc(:,:) ! Clear sky longwave downward flux (W/m2)
+                                                      ! Dimensions: (ncol,nlay+1)
+      real , intent(out) :: hrc(:,:) ! Clear sky longwave radiative heating rate (K/d)
+                                                      ! Dimensions: (ncol,nlay)
+
+! ----- Optional Output -----
+      real , intent(out), optional :: duflx_dt(:,:)
+                                                      ! change in upward longwave flux (w/m2/K)
+                                                      ! with respect to surface temperature
+                                                      ! Dimensions: (ncol,nlay)
+      real , intent(out), optional :: duflxc_dt(:,:)
+                                                      ! change in clear sky upward longwave flux (w/m2/K)
+                                                      ! with respect to surface temperature
+                                                      ! Dimensions: (ncol,nlay)
+! integer , intent(out), optional :: cloudFlag(:,:)
+
+
+
+
+      real :: cldfmcd(CHNK, ngptlw, nlay+1) ! layer cloud fraction [mcica]
+
+
+
+! ----- Local -----
+
+
+      integer ncol_,nlayers_,nbndlw_,ngptlw_ ! for passing through argument list
+      integer ncol__,nlayers__,nbndlw__,ngptlw__ ! for passing through argument list
+! here is where the previously allocatable things are made local variables
+      real :: pmid(CHNK, nlay)
+
+      real :: relqmc(CHNK, nlay+1), reicmc(CHNK, nlay+1)
+      real :: resnmc(CHNK, nlay+1)
+
+#if 0      
+      real :: ciwpmcd(CHNK, ngptlw, nlay+1)
+      real :: clwpmcd(CHNK, ngptlw, nlay+1)
+      real :: cswpmcd(CHNK, ngptlw, nlay+1)
+      real :: taucmcd(CHNK, ngptlw, nlay+1)
+
+      real :: pzd(CHNK, 0:nlay+1)
+      real :: pwvcmd(CHNK)
+      real :: semissd(CHNK, nbndlw)
+      real :: planklayd(CHNK,nlay+1,nbndlw)
+      real :: planklevd(CHNK, 0:nlay+1, nbndlw)
+      real :: plankbndd(CHNK,nbndlw)
+
+      real :: gurad(CHNK,ngptlw,0:nlay+1) ! upward longwave flux (w/m2)
+      real :: gdrad(CHNK,ngptlw,0:nlay+1) ! downward longwave flux (w/m2)
+      real :: gclrurad(CHNK,ngptlw,0:nlay+1) ! clear sky upward longwave flux (w/m2)
+      real :: gclrdrad(CHNK,ngptlw,0:nlay+1) ! clear sky downward longwave flux (w/m2)
+
+      real :: gdtotuflux_dtd( CHNK, ngptlw, 0:nlay+1)
+      real :: gdtotuclfl_dtd( CHNK, ngptlw, 0:nlay+1)
+
+      real :: totufluxd(CHNK, 0:nlay+1) ! upward longwave flux (w/m2)
+      real :: totdfluxd(CHNK, 0:nlay+1) ! downward longwave flux (w/m2)
+      real :: fnetd(CHNK, 0:nlay+1) ! net longwave flux (w/m2)
+      real :: htrd(CHNK, 0:nlay+1) ! longwave heating rate (k/day)
+      real :: totuclfld(CHNK, 0:nlay+1) ! clear sky upward longwave flux (w/m2)
+      real :: totdclfld(CHNK, 0:nlay+1) ! clear sky downward longwave flux (w/m2)
+      real :: fnetcd(CHNK, 0:nlay+1) ! clear sky net longwave flux (w/m2)
+      real :: htrcd(CHNK, 0:nlay+1) ! clear sky longwave heating rate (k/day)
+      real :: dtotuflux_dtd(CHNK, 0:nlay+1) ! change in upward longwave flux (w/m2/k)
+      real :: dtotuclfl_dtd(CHNK, 0:nlay+1)
+!      real :: dplankbnd_dtd(CHNK,nbndlw)
+
+!      real :: taveld( CHNK, nlay)
+!      real :: tzd( CHNK, 0:nlay)
+!      real :: tboundd( CHNK )
+!      real :: wbroadd( CHNK, nlay)
+
+      real :: wx1( CHNK, nlay )
+      real :: wx2( CHNK, nlay )
+      real :: wx3( CHNK, nlay )
+      real :: wx4( CHNK, nlay )
+
+      real :: tauaa( CHNK, nlay, nbndlw )
+      real :: taug( CHNK, nlay+1, ngptlw )
+#endif
+!jm integer :: nspad( nbndlw )
+!jm integer :: nspbd( nbndlw )
+
+!      integer :: icbd(16)
+!      integer :: ncbandsd(CHNK)
+      integer :: icldlyr(CHNK, nlay+1)
+!      real :: fracsd( CHNK, nlay+1, ngptlw )
+
+
+
+! Control
+      integer(kind=4) :: nlayers ! total number of layers
+      integer(kind=4) :: istart ! beginning band of calculation
+      integer(kind=4) :: iend ! ending band of calculation
+      integer(kind=4) :: iout ! output option flag (inactive)
+      integer :: iaer ! aerosol option flag
+      integer(kind=4) :: iplon ! column loop index
+      integer :: imca ! flag for mcica [0=off, 1=on]
+      integer :: ims ! value for changing mcica permute seed
+      integer :: k ! layer loop index
+      integer :: ig ! g-point loop index
+      real :: t1, t2
+
+! Atmosphere
+      real :: pavel(CHNK,nlay+1) ! layer pressures (mb)
+      real :: tavel(CHNK,nlay+1) ! layer temperatures (K)
+      real :: pz(CHNK,0:nlay+1) ! level (interface) pressures (hPa, mb)
+      real :: tz(CHNK,0:nlay+1) ! level (interface) temperatures (K)
+      real :: tbound(CHNK) ! surface temperature (K)
+      real :: coldry(CHNK,nlay+1) ! dry air column density (mol/cm2)
+      real :: wbrodl(CHNK,nlay+1) ! broadening gas column density (mol/cm2)
+!      real :: wkl(CHNK,mxmol,nlay+1) ! molecular amounts (mol/cm-2)
+!      real :: wx(CHNK,maxxsec,nlay+1) ! cross-section amounts (mol/cm-2)
+      real :: pwvcm(CHNK) ! precipitable water vapor (cm)
+      real :: semiss(CHNK,nbndlw) ! lw surface emissivity
+      real :: fracs(CHNK,nlay+1,ngptlw) !
+
+!      real :: taut(CHNK,nlay+1,ngptlw) ! gaseous + aerosol optical depths
+
+!      real :: taua(CHNK,nlay+1,nbndlw) ! aerosol optical depth
+! real :: ssaa(CHNK,nlay+1,nbndlw) ! aerosol single scattering albedo
+                                                      ! for future expansion
+                                                      ! (lw aerosols/scattering not yet available)
+! real :: asma(CHNK,nlay+1,nbndlw) ! aerosol asymmetry parameter
+                                                      ! for future expansion
+                                                      ! (lw aerosols/scattering not yet available)
+
+#if 0      
+! Atmosphere - setcoef
+      integer :: laytrop(CHNK) ! tropopause layer index
+      integer :: jp(CHNK,nlay+1) ! lookup table index
+      integer :: jt(CHNK,nlay+1) ! lookup table index
+      integer :: jt1(CHNK,nlay+1) ! lookup table index
+      real :: planklay(CHNK,nlay+1,nbndlw) !
+      real :: planklev(CHNK,0:nlay+1,nbndlw) !
+      real :: plankbnd(CHNK,nbndlw) !
+      real :: dplankbnd_dt(CHNK,nbndlw) !
+
+      real :: colh2o(CHNK,nlay+1) ! column amount (h2o)
+      real :: colco2(CHNK,nlay+1) ! column amount (co2)
+      real :: colo3(CHNK,nlay+1) ! column amount (o3)
+      real :: coln2o(CHNK,nlay+1) ! column amount (n2o)
+      real :: colco(CHNK,nlay+1) ! column amount (co)
+      real :: colch4(CHNK,nlay+1) ! column amount (ch4)
+      real :: colo2(CHNK,nlay+1) ! column amount (o2)
+      real :: colbrd(CHNK,nlay+1) ! column amount (broadening gases)
+
+      integer :: indself(CHNK,nlay+1)
+      integer :: indfor(CHNK,nlay+1)
+      real :: selffac(CHNK,nlay+1)
+      real :: selffrac(CHNK,nlay+1)
+      real :: forfac(CHNK,nlay+1)
+      real :: forfrac(CHNK,nlay+1)
+
+      integer :: indminor(CHNK,nlay+1)
+      real :: minorfrac(CHNK,nlay+1)
+      real :: scaleminor(CHNK,nlay+1)
+      real :: scaleminorn2(CHNK,nlay+1)
+
+      real :: & !
+                         fac00(CHNK,nlay+1), fac01(CHNK,nlay+1), &
+                         fac10(CHNK,nlay+1), fac11(CHNK,nlay+1)
+      real :: & !
+                         rat_h2oco2(CHNK,nlay+1),rat_h2oco2_1(CHNK,nlay+1), &
+                         rat_h2oo3(CHNK,nlay+1),rat_h2oo3_1(CHNK,nlay+1), &
+                         rat_h2on2o(CHNK,nlay+1),rat_h2on2o_1(CHNK,nlay+1), &
+                         rat_h2och4(CHNK,nlay+1),rat_h2och4_1(CHNK,nlay+1), &
+                         rat_n2oco2(CHNK,nlay+1),rat_n2oco2_1(CHNK,nlay+1), &
+                         rat_o3co2(CHNK,nlay+1),rat_o3co2_1(CHNK,nlay+1)
+#endif
+
+! Atmosphere/clouds - cldprop
+      integer :: ncbands(CHNK) ! number of cloud spectral bands
+      integer :: inflag(CHNK) ! flag for cloud property method
+      integer :: iceflag(CHNK) ! flag for ice cloud properties
+      integer :: liqflag(CHNK) ! flag for liquid cloud properties
+
+
+! Output
+!      real :: totuflux(CHNK,0:nlay+1) ! upward longwave flux (w/m2)
+!      real :: totdflux(CHNK,0:nlay+1) ! downward longwave flux (w/m2)
+!      real :: fnet(CHNK,0:nlay+1) ! net longwave flux (w/m2)
+!      real :: htr(CHNK,0:nlay+1) ! longwave heating rate (k/day)
+!      real :: totuclfl(CHNK,0:nlay+1) ! clear sky upward longwave flux (w/m2)
+!      real :: totdclfl(CHNK,0:nlay+1) ! clear sky downward longwave flux (w/m2)
+!      real :: fnetc(CHNK,0:nlay+1) ! clear sky net longwave flux (w/m2)
+!      real :: htrc(CHNK,0:nlay+1) ! clear sky longwave heating rate (k/day)
+!      real :: dtotuflux_dt(CHNK,0:nlay+1) ! change in upward longwave flux (w/m2/k)
+                                                      ! with respect to surface temperature
+!      real :: dtotuclfl_dt(CHNK,0:nlay+1) ! change in clear sky upward longwave flux (w/m2/k)
+                                                      ! with respect to surface temperature
+!      real :: curad(CHNK,ngptlw,0:nlay+1) ! upward longwave flux (w/m2)
+!      real :: cdrad(CHNK,ngptlw,0:nlay+1) ! downward longwave flux (w/m2)
+!      real :: cclrurad(CHNK,ngptlw,0:nlay+1) ! clear sky upward longwave flux (w/m2)
+!      real :: cclrdrad(CHNK,ngptlw,0:nlay+1) ! clear sky downward longwave flux (w/m2)
+
+      real :: cldfracq(CHNK,mxlay+1) ! Cloud fraction
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real :: ciwpq(CHNK,mxlay+1) ! In-cloud ice water path (g/m2)
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real :: clwpq(CHNK,mxlay+1) ! In-cloud liquid water path (g/m2)
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real :: cswpq(CHNK,mxlay+1) ! In-cloud snow water path (g/m2)
+                                                      ! Dimensions: (ngptlw,ncol,nlay)
+      real :: reiq(CHNK,mxlay) ! Cloud ice particle effective size (microns)
+                                                      ! Dimensions: (ncol,nlay)
+                                                      ! specific definition of reicmcl depends on setting of iceflglw:
+                                                      ! iceflglw = 0: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                                      ! r_ec must be >= 10.0 microns
+                                                      ! iceflglw = 1: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                                      ! r_ec range is limited to 13.0 to 130.0 microns
+                                                      ! iceflglw = 2: ice effective radius, r_k, (Key, Streamer Ref. Manual, 1996)
+                                                      ! r_k range is limited to 5.0 to 131.0 microns
+                                                      ! iceflglw = 3: generalized effective size, dge, (Fu, 1996),
+                                                      ! dge range is limited to 5.0 to 140.0 microns
+                                                      ! [dge = 1.0315 * r_ec]
+      real :: relq(CHNK, mxlay) ! Cloud water drop effective radius (microns)
+                                                      ! Dimensions: (ncol,nlay)
+      real :: resq(CHNK, mxlay) ! Cloud snow effective radius (microns)
+                                                      ! Dimensions: (ncol,nlay)
+      real :: taucq(CHNK, nbndlw, mxlay) ! In-cloud optical depth
+                                                      ! Dimensions: (ncol,nbndlw,nlay)
+! mji - tauaq dimensions?
+      real :: tauaq(CHNK, mxlay, nbndlw) ! aerosol optical depth
+                                                      ! Dimensions: (ncol,nlay,nbndlw)
+
+
+      integer :: permuteseed ! this is set, below
+!      integer :: icb(16)
+
+      ! local looping variables
+      integer :: i,j,kk, piplon
+
+      ! cuda return code
+          integer :: ierr
+      ! cuda thread and grid block dimensions
+
+
+
+#if 0
+      real , dimension(16) :: a0 =(/ 1.66 , 1.55 , 1.58 , 1.66 , &
+                1.54 , 1.454 , 1.89 , 1.33 , &
+               1.668 , 1.66 , 1.66 , 1.66 , &
+                1.66 , 1.66 , 1.66 , 1.66 /)
+      real , dimension(16) :: a1=(/ 0.00 , 0.25 , 0.22 , 0.00 , &
+                0.13 , 0.446 , -0.10 , 0.40 , &
+              -0.006 , 0.00 , 0.00 , 0.00 , &
+                0.00 , 0.00 , 0.00 , 0.00 /)
+      real , dimension(16) :: a2 =(/ 0.00 , -12.0 , -11.7 , 0.00 , &
+               -0.72 ,-0.243 , 0.19 ,-0.062 , &
+               0.414 , 0.00 , 0.00 , 0.00 , &
+                0.00 , 0.00 , 0.00 , 0.00 /)
+#endif
+
+      real , parameter :: amd = 28.9660 ! Effective molecular weight of dry air (g/mol)
+      real , parameter :: amw = 18.0160 ! Molecular weight of water vapor (g/mol)
+
+! (dmb 2012) these arrays were moved to the main routine so that we can bypass some of the
+! inatm inefficiencies when running on the GPU
+      real , parameter :: amdw = 1.607793 ! Molecular weight of dry air / water vapor
+      real , parameter :: amdc = 0.658114 ! Molecular weight of dry air / carbon dioxide
+      real , parameter :: amdo = 0.603428 ! Molecular weight of dry air / ozone
+      real , parameter :: amdm = 1.805423 ! Molecular weight of dry air / methane
+      real , parameter :: amdn = 0.658090 ! Molecular weight of dry air / nitrous oxide
+      real , parameter :: amdo2 = 0.905140 ! Molecular weight of dry air / oxygen
+      real , parameter :: amdc1 = 0.210852 ! Molecular weight of dry air / CFC11
+      real , parameter :: amdc2 = 0.239546 ! Molecular weight of dry air / CFC12
+      real :: amm, amttl, wvttl, wvsh, summol
+      integer :: isp, l, ix, n, imol, ib ! Loop indices
+      integer, save :: counter =0
+      real :: btemp
+!real :: gwiff1,gwiff2,gwiff3,gwiff4
+!integer :: ilay, iplon, igp
+! integer :: cloudFlagq(CHNK, 4)
+      integer :: pncold, nlayd, icldd
+integer,external :: omp_get_thread_num
+
+!
+
+
+      ncol_ = pncol ; nlayers_ = nlay ; nbndlw_ = nbndlw ; ngptlw_ = ngptlw ! for passing through argument list
+      ncol__ = pncol ; nlayers__ = nlay ; nbndlw__ = nbndlw ; ngptlw__ = ngptlw ! for passing through argument list
+
+! Initializations
+!      icb(:) = (/ 1,2,3,3,3,4,4,4,5, 5, 5, 5, 5, 5, 5, 5 /)
+
+      oneminus = 1. - 1.e-6
+      pi = 2. * asin(1. )
+      fluxfac = pi * 2.e4 ! orig: fluxfac = pi * 2.d4
+      istart = 1
+      iend = 16
+      iout = 0
+      ims = 1
+      pncold = pncol
+      nlayd = nlay
+
+!$acc data pcopy(play) create(pmid) &
+!$acc pcopy(uflx ,dflx ,hr ,uflxc ,dflxc, hrc) &
+!$acc create(cldfmcd, clwpmcd, ciwpmcd, cswpmcd, taucmcd) copyin(ngb) &
+!$acc pcreate(colh2o,colco2,colo3,coln2o,colch4,colo2,wx1,wx2,wx3,wx4,colco,tauaa,&
+!$acc    htrd,htrcd,cldfracq,ciwpq,clwpq,cswpq,reiq,relq,resq,taucq,tauaq, &
+!$acc    inflag,liqflag,iceflag,pwvcm,icldlyr,wbrodl,coldry,tbound,pz,tz,pavel,tavel,&
+!$acc    colbrd,fnetd,fnetcd)
+!!$acc data create(fac00,fac10,fac11,fac01) &
+!!$acc create(rat_o3co2,rat_n2oco2_1,rat_n2oco2,rat_h2oo3_1,rat_h2och4,rat_o3co2_1) &
+!!$acc create(rat_h2on2o,rat_h2oco2_1,rat_h2oo3,rat_h2on2o_1,rat_h2oco2,rat_h2och4_1) &
+!!$acc data create(forfac,forfrac,selffac,minorfrac,indself,jt1,jp,jt) &
+!!$acc create(indfor,laytrop,selffrac, taug, fracs) &
+!$acc data create(dplankbnd_dt,gdtotuclfl_dtd,gdtotuflux_dtd,taug, fracs) &
+!$acc create(scaleminor,indminor,scaleminorn2,semiss) &
+!$acc create(planklayd,plankbndd,planklevd) &
+!$acc pcreate(ncbands,emis) &
+!$acc create(totufluxd,totdfluxd,totuclfld,totdclfld,dtotuflux_dtd,dtotuclfl_dtd) &
+!$acc copyin(a0,a1,a2,icb,absice0) &
+!$acc create(gurad,gdrad,gclrurad,gclrdrad) 
+
+
+!$acc kernels
+      cldfracq(1:pncol,1:nlay) = cldfrac(colstart:(colstart+pncol-1), 1:nlay)
+      ciwpq(1:pncol,1:nlay) = ciwp(colstart:(colstart+pncol-1), 1:nlay)
+      clwpq(1:pncol,1:nlay) = clwp(colstart:(colstart+pncol-1), 1:nlay)
+      cswpq(1:pncol,1:nlay) = cswp(colstart:(colstart+pncol-1), 1:nlay)
+      reiq(1:pncol,1:nlay) = rei(colstart:(colstart+pncol-1), 1:nlay)
+      relq(1:pncol,1:nlay) = rel(colstart:(colstart+pncol-1), 1:nlay)
+      resq(1:pncol,1:nlay) = res(colstart:(colstart+pncol-1), 1:nlay)
+      taucq(1:pncol,1:nbndlw,1:nlay) = tauc(colstart:(colstart+pncol-1), 1:nbndlw, 1:nlay)
+      tauaq(1:pncol,1:nlay,1:nbndlw) = tauaer(colstart:(colstart+pncol-1), 1:nlay, 1:nbndlw)
+!$acc end kernels
+
+! Set imca to select calculation type:
+! imca = 0, use standard forward model calculation
+! imca = 1, use McICA for Monte Carlo treatment of sub-grid cloud variability
+
+! *** This version uses McICA (imca = 1) ***
+
+! Set icld to select of clear or cloud calculation and cloud overlap method
+! icld = 0, clear only
+! icld = 1, with clouds using random cloud overlap
+! icld = 2, with clouds using maximum/random cloud overlap
+! icld = 3, with clouds using maximum cloud overlap (McICA only)
+! icld = 4, with clouds using exponential cloud overlap (INACTIVE; McICA only)
+      if (icld.lt.0.or.icld.gt.4) icld = 2
+
+! Set iaer to select aerosol option
+! iaer = 0, no aerosols
+! icld = 10, input total aerosol optical depth (tauaer) directly
+      iaer = 10
+
+! Call model and data initialization, compute lookup tables, perform
+! reduction of g-points from 256 to 140 for input absorption coefficient
+! data and other arrays.
+!
+! In a GCM this call should be placed in the model initialization
+! area, since this has to be called only once.
+! call rrtmg_lw_ini(cpdair)
+
+! call rrtmg_lw_ini(1.004 )
+! This is the main longitude/column loop within RRTMG.
+! Prepare atmospheric profile from GCM for use in RRTMG, and define
+! other input parameters.
+
+! (dmb 2012)
+
+      nlayers = nlay
+
+
+      call allocateGPUTaumol( CHNK, nlayers, npart)
+
+
+
+
+
+!$acc kernels
+
+      tbound = tsfc(colstart:(colstart+CHNK -1))
+      pz(:,0:nlay) = plev(colstart:(colstart+CHNK -1),0:nlay)
+      tz(:,0:nlay) = tlev(colstart:(colstart+CHNK -1),0:nlay)
+      pavel(:,1:nlay) = play(colstart:(colstart+CHNK -1),1:nlay)
+      tavel(:,1:nlay) = tlay(colstart:(colstart+CHNK -1),1:nlay)
+
+
+
+      colh2o(1:CHNK, 1:nlayers) = h2ovmr( colstart:(colstart+CHNK -1), 1:nlayers)
+      colco2(1:CHNK, 1:nlayers) = co2vmr( colstart:(colstart+CHNK -1), 1:nlayers)
+      colo3(1:CHNK, 1:nlayers) = o3vmr( colstart:(colstart+CHNK -1), 1:nlayers)
+      coln2o(1:CHNK, 1:nlayers) = n2ovmr( colstart:(colstart+CHNK -1), 1:nlayers)
+
+      colch4(1:CHNK, 1:nlayers) = ch4vmr( colstart:(colstart+CHNK -1), 1:nlayers)
+      colo2(1:CHNK, 1:nlayers) = o2vmr( colstart:(colstart+CHNK -1), 1:nlayers)
+      wx1(1:CHNK, 1:nlayers) = ccl4vmr(colstart:(colstart+CHNK -1), 1:nlayers)
+      wx2(1:CHNK, 1:nlayers) = cfc11vmr(colstart:(colstart+CHNK -1), 1:nlayers)
+      wx3(1:CHNK, 1:nlayers) = cfc12vmr(colstart:(colstart+CHNK -1), 1:nlayers)
+      wx4(1:CHNK, 1:nlayers) = cfc22vmr(colstart:(colstart+CHNK -1), 1:nlayers)
+      colco(1:CHNK, :) = 0
+      if (npart > 1) then
+         tauaa(1:CHNK, :, :) = tauaer(colstart:(colstart+CHNK -1), :, :)
+      else
+         tauaa = tauaer
+      endif
+!$acc end kernels
+
+
+
+
+
+      permuteseed=150 ! if you change this, change value in module_ra_rrtmg_lw.F
+      call mcica_subcol_lwg(colstart, pncol, nlay, icld, counter, permuteseed, &
+
+                            pmid,clwp,ciwp,cswp,tauc, &
+
+                            play, cldfracq, ciwpq, &
+                            clwpq, cswpq, taucq,ngb, cldfmcd, ciwpmcd, clwpmcd, cswpmcd, &
+                            taucmcd)
+
+
+!jm write(0,*)"module_ra_rrtmg_lwf.F",14983,omp_,
+! Generate the stochastic subcolumns of cloud optical properties for the longwave;
+
+
+
+
+      if (icld > 0) then
+         call generate_stochastic_cloudsg (pncold, nlayd, icld, ngb, &
+
+                               pmid,cldfracq,clwpq,ciwpq,cswpq,taucq,permuteseed, &
+
+                               cldfmcd, clwpmcd, ciwpmcd, cswpmcd, taucmcd)
+      end if
+
+!jm write(0,*)"module_ra_rrtmg_lwf.F",15001,omp_get_thread_num()
+!$acc kernels
+      do iplon = 1, pncol
+
+        piplon = iplon + colstart - 1
+        do l = 1, nlayers
+          amm = (1. - h2ovmr(piplon,l)) * amd +h2ovmr(piplon,l) * amw
+          coldry(iplon, l) = (pz(iplon, l-1)-pz(iplon, l)) * 1.e3 * avogad / &
+                     (1.e2 * grav * amm * (1. + h2ovmr(piplon,l)))
+        end do
+      enddo
+
+      do iplon = 1, pncol
+
+        piplon = iplon + colstart - 1
+        amttl = 0.0
+        wvttl = 0.0
+        do l = 1, nlayers
+          summol = co2vmr(piplon,l) + o3vmr(piplon,l) + n2ovmr(piplon,l) + ch4vmr(piplon,l) + o2vmr(piplon,l)
+          btemp = h2ovmr(piplon, l) * coldry(iplon, l)
+          wbrodl(iplon, l) = coldry(iplon, l) * (1. - summol)
+          amttl = amttl + coldry(iplon, l)+btemp
+          wvttl = wvttl + btemp
+        enddo
+
+        wvsh = (amw * wvttl) / (amd * amttl)
+        pwvcm(iplon) = wvsh * (1.e3 * pz(iplon, 0)) / (1.e2 * grav)
+
+! Transfer aerosol optical properties to RRTM variable;
+! modify to reverse layer indexing here if necessary.
+
+        if (icld .ge. 1) then
+          inflag(iplon) = inflglw
+          iceflag(iplon) = iceflglw
+          liqflag(iplon) = liqflglw
+
+! Move incoming GCM cloud arrays to RRTMG cloud arrays.
+! For GCM input, incoming reicmcl is defined based on selected ice parameterization (inflglw)
+
+        endif
+      enddo
+
+      icldlyr = 0.0
+!$acc end kernels      
+
+
+!$acc kernels
+      semiss(1:pncol,1:nbndlw) = emis(colstart:(colstart+pncol-1),1:nbndlw)
+!$acc end kernels
+
+! (dmb 2012) Here we configure the grids and blocks to run the cldpmcd kernel
+! on the GPU. I decided to keep the block dimensions to 16x16 to coincide with
+! coalesced memory access when I am able to parition the profiles to multiples
+! of 32.
+
+
+
+
+! clwpmcd = 0
+! clwpmcd = clwpmc
+! (dmb 2012) Call the cldprmcg kernel
+      call cldprmcg (pncol, nlayers, &
+
+                inflag,iceflag,liqflag,ciwpmcd,clwpmcd,cswpmcd,relq,reiq,resq, &
+                absice0,absice1,absice2,absice3,absliq1, &
+
+                cldfmcd, taucmcd, ngb, icb, ncbands, icldlyr)
+
+! Calculate information needed by the radiative transfer routine
+! that is specific to this atmosphere, especially some of the
+! coefficients and indices needed to compute the optical depths
+! by interpolating data from stored reference atmospheres.
+
+! (dmb 2012) Initialize the grid and block dimensions and call the setcoefg kernel
+      call setcoefg (pncol, nlayers, istart &
+
+         ,ncol_,nlayers_,nbndlw_,ngptlw_ &
+         ,taucmcd,pz,pwvcm,semiss,planklayd,planklevd,plankbndd,gurad,gdrad,gclrurad,gclrdrad &
+         ,gdtotuflux_dtd,gdtotuclfl_dtd,idrv,bpade,heatfac,fluxfac,a0,a1,a2 &
+         ,delwave,totufluxd,totdfluxd,fnetd,htrd,totuclfld,totdclfld,fnetcd,htrcd,dtotuflux_dtd &
+         ,dtotuclfl_dtd,dplankbnd_dt &
+
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspa,nspb,oneminus &
+
+   ,tavel,tz,tbound,wbrodl,totplnk,totplk16,totplnkderiv,totplk16deriv &
+
+                            )
+
+! Calculate the gaseous optical depths and Planck fractions for
+! each longwave spectral band.
+
+! (dmb 2012) Call the taumolg subroutine. This subroutine calls all of the individal taumol kernels.
+      call taumolg(1, pncol,nlayers, ngb, taug, fracs &
+                    ,ncol__,nlayers__,nbndlw__,ngptlw__ &
+                    ,pavel,wx1,wx2,wx3,wx4,coldry,laytrop,jp,jt,jt1,colh2o,colco2,colo3,coln2o &
+                    ,colco,colch4,colo2,colbrd,indself,indfor,selffac,selffrac,forfac,forfrac &
+                    ,indminor,minorfrac,scaleminor,scaleminorn2,fac00,fac01,fac10,fac11 &
+                    ,rat_h2oco2,rat_h2oco2_1,rat_h2oo3,rat_h2oo3_1,rat_h2on2o,rat_h2on2o_1 &
+                    ,rat_h2och4,rat_h2och4_1,rat_n2oco2,rat_n2oco2_1,rat_o3co2,rat_o3co2_1 &
+                    ,tauaa,nspa,nspb,oneminus &
+
+                  )
+! Call the radiative transfer routine.
+! Either routine can be called to do clear sky calculation. If clouds
+! are present, then select routine based on cloud overlap assumption
+! to be used. Clear sky calculation is done simultaneously.
+! For McICA, RTRNMC is called for clear and cloudy calculations.
+
+!ARom the next function on GPU returns g*rad values which are differ from CPU version
+      call rtrnmcg (pncol,nlayers, istart, iend, iout &
+
+         ,ncol_,nlayers_,nbndlw_,ngptlw_ &
+         ,taucmcd,pz,pwvcm,semiss,planklayd,planklevd,plankbndd,gurad,gdrad,gclrurad,gclrdrad &
+         ,gdtotuflux_dtd,gdtotuclfl_dtd,idrv,bpade,heatfac,fluxfac,a0,a1,a2 &
+         ,delwave,totufluxd,totdfluxd,fnetd,htrd,totuclfld,totdclfld,fnetcd,htrcd,dtotuflux_dtd &
+         ,dtotuclfl_dtd,dplankbnd_dt &
+
+                    ,ngb, icldlyr, taug, fracs, cldfmcd)
+
+!jm write(0,*)"module_ra_rrtmg_lwf.F",15223,omp_get_thread_num()
+
+! sum up the results
+!$acc kernels
+      totufluxd = 0.0
+      totdfluxd = 0.0
+      totuclfld = 0.0
+      totdclfld = 0.0
+      dtotuflux_dtd = 0.0
+      dtotuclfl_dtd = 0.0
+
+      uflx(colstart:(colstart+pncol-1), 1:(nlayers+1)) = totufluxd(1:pncol,0:(nlayers))
+      dflx(colstart:(colstart+pncol-1), 1:(nlayers+1)) = totdfluxd(1:pncol,0:(nlayers))
+!$acc end kernels
+
+! (dmb 2012) Here we integrate across the g-point fluxes to arrive at total fluxes
+! This functionality was factored out of the original rtrnmc routine so that I could
+! parallelize across multiple dimensions.
+      call rtrnadd (pncol, nlayers, ngptlw, idrv &
+
+         ,ncol_,nlayers_,nbndlw_,ngptlw_ &
+         ,taucmcd,pz,pwvcm,semiss,planklayd,planklevd,plankbndd,gurad,gdrad,gclrurad,gclrdrad &
+         ,gdtotuflux_dtd,gdtotuclfl_dtd,idrv,bpade,heatfac,fluxfac,a0,a1,a2 &
+         ,delwave,totufluxd,totdfluxd,fnetd,htrd,totuclfld,totdclfld,fnetcd,htrcd,dtotuflux_dtd &
+         ,dtotuclfl_dtd,dplankbnd_dt &
+
+                           )
+
+!$acc kernels      
+      uflx(colstart:(colstart+pncol-1), 1:(nlayers+1)) = totufluxd(1:pncol,0:(nlayers))
+      dflx(colstart:(colstart+pncol-1), 1:(nlayers+1)) = totdfluxd(1:pncol,0:(nlayers))
+!$acc end kernels
+
+! (dmb 2012) Calculate the heating rates.
+      call rtrnheatrates (pncol, nlayers &
+
+         ,ncol_,nlayers_,nbndlw_,ngptlw_ &
+         ,taucmcd,pz,pwvcm,semiss,planklayd,planklevd,plankbndd,gurad,gdrad,gclrurad,gclrdrad &
+         ,gdtotuflux_dtd,gdtotuclfl_dtd,idrv,bpade,heatfac,fluxfac,a0,a1,a2 &
+         ,delwave,totufluxd,totdfluxd,fnetd,htrd,totuclfld,totdclfld,fnetcd,htrcd,dtotuflux_dtd &
+         ,dtotuclfl_dtd,dplankbnd_dt &
+
+                                 )
+
+
+
+! copy the partition data back to the CPU
+
+!$acc kernels
+      uflxc(colstart:(colstart+pncol-1), 1:(nlayers+1)) = totuclfld(1:pncol,0:(nlayers))
+      dflxc(colstart:(colstart+pncol-1), 1:(nlayers+1)) = totdclfld(1:pncol,0:(nlayers))
+      hr(colstart:(colstart+pncol-1), 1:(nlayers+1)) = htrd(1:pncol,0:(nlayers))
+      hrc(colstart:(colstart+pncol-1), 1:(nlayers+1)) = htrcd(1:pncol,0:(nlayers))
+!$acc end kernels
+
+      if (idrv .eq. 1) then
+!$acc update host(dtotuflux_dtd,dtotuclfl_dtd)
+         duflx_dt(colstart:(colstart+pncol-1), 1:(nlayers+1)) = dtotuflux_dtd(1:pncol,0:(nlayers))
+         duflxc_dt(colstart:(colstart+pncol-1), 1:(nlayers+1)) = dtotuclfl_dtd(1:pncol,0:(nlayers))
+
+      end if
+!$acc end data
+!$acc end data
+
+!jm write(0,*)"module_ra_rrtmg_lwf.F",15299,omp_get_thread_num()
+
+! Transfer up and down fluxes and heating rate to output arrays.
+! Vertical indexing goes from bottom to top; reverse here for GCM if necessary.
+      end subroutine rrtmg_lw_part
+
+      end module rrtmg_lw_rad_f
+
+
+
+
+
+
+
+!------------------------------------------------------------------
+      MODULE module_ra_rrtmg_lwf
+
+      use module_model_constants, only : cp
+      use module_wrf_error
+! use module_dm
+
+      use parrrtm_f, only : nbndlw, ngptlw
+      use rrtmg_lw_init_f, only: rrtmg_lw_ini
+      use rrtmg_lw_rad_f, only: rrtmg_lw
+! use mcica_subcol_gen_lw, only: mcica_subcol_lw
+
+      real retab(95)
+!$acc declare create(retab)      
+      data retab / &
+         5.92779, 6.26422, 6.61973, 6.99539, 7.39234, &
+         7.81177, 8.25496, 8.72323, 9.21800, 9.74075, 10.2930, &
+         10.8765, 11.4929, 12.1440, 12.8317, 13.5581, 14.2319, &
+         15.0351, 15.8799, 16.7674, 17.6986, 18.6744, 19.6955, &
+         20.7623, 21.8757, 23.0364, 24.2452, 25.5034, 26.8125, &
+         27.7895, 28.6450, 29.4167, 30.1088, 30.7306, 31.2943, &
+         31.8151, 32.3077, 32.7870, 33.2657, 33.7540, 34.2601, &
+         34.7892, 35.3442, 35.9255, 36.5316, 37.1602, 37.8078, &
+         38.4720, 39.1508, 39.8442, 40.5552, 41.2912, 42.0635, &
+         42.8876, 43.7863, 44.7853, 45.9170, 47.2165, 48.7221, &
+         50.4710, 52.4980, 54.8315, 57.4898, 60.4785, 63.7898, &
+         65.5604, 71.2885, 75.4113, 79.7368, 84.2351, 88.8833, &
+         93.6658, 98.5739, 103.603, 108.752, 114.025, 119.424, &
+         124.954, 130.630, 136.457, 142.446, 148.608, 154.956, &
+         161.503, 168.262, 175.248, 182.473, 189.952, 197.699, &
+         205.728, 214.055, 222.694, 231.661, 240.971, 250.639/
+    !
+      save retab
+    ! For buffer layer adjustment. Steven Cavallo, Dec 2010.
+      INTEGER , SAVE :: nlayers
+      REAL, PARAMETER :: deltap = 4. ! Pressure interval for buffer layer in mb
+
+      CONTAINS
+
+!------------------------------------------------------------------
+      SUBROUTINE RRTMG_LWRAD_FAST( &
+                       rthratenlw, &
+                       lwupt, lwuptc, lwdnt, lwdntc, &
+                       lwupb, lwupbc, lwdnb, lwdnbc, &
+! lwupflx, lwupflxc, lwdnflx, lwdnflxc, &
+                       glw, olr, lwcf, emiss, &
+                       p8w, p3d, pi3d, &
+                       dz8w, tsk, t3d, t8w, rho3d, r, g, &
+                       icloud, warm_rain, cldfra3d, &
+                       lradius,iradius, &
+                       is_cammgmp_used, &
+                       f_ice_phy, f_rain_phy, &
+                       xland, xice, snow, &
+                       qv3d, qc3d, qr3d, &
+                       qi3d, qs3d, qg3d, &
+                       o3input, o33d, &
+                       f_qv, f_qc, f_qr, f_qi, f_qs, f_qg, &
+                       re_cloud, re_ice, re_snow, & ! G. Thompson
+                       has_reqc, has_reqi, has_reqs, & ! G. Thompson
+                       tauaerlw1,tauaerlw2,tauaerlw3,tauaerlw4, & ! czhao
+                       tauaerlw5,tauaerlw6,tauaerlw7,tauaerlw8, & ! czhao
+                       tauaerlw9,tauaerlw10,tauaerlw11,tauaerlw12, & ! czhao
+                       tauaerlw13,tauaerlw14,tauaerlw15,tauaerlw16, & ! czhao
+                       aer_ra_feedback, & !czhao
+!jdfcz progn,prescribe, & !czhao
+                       progn, & !czhao
+                       qndrop3d,f_qndrop, & !czhao
+!ccc added for time varying gases.
+                       yr,julian, &
+!ccc
+                       ids,ide, jds,jde, kds,kde, &
+                       ims,ime, jms,jme, kms,kme, &
+                       its,ite, jts,jte, kts,kte, &
+                       lwupflx, lwupflxc, lwdnflx, lwdnflxc &
+                                                                  )
+!------------------------------------------------------------------
+!ccc To use clWRF time varying trace gases
+   USE MODULE_RA_CLWRF_SUPPORT, ONLY : read_CAMgases
+
+   IMPLICIT NONE
+!------------------------------------------------------------------
+   LOGICAL, INTENT(IN ) :: warm_rain
+   LOGICAL, INTENT(IN ) :: is_CAMMGMP_used ! Added for CAM5 RRTMG<->CAMMGMP
+!
+   INTEGER, INTENT(IN ) :: ids,ide, jds,jde, kds,kde, &
+                                       ims,ime, jms,jme, kms,kme, &
+                                       its,ite, jts,jte, kts,kte
+
+   INTEGER, INTENT(IN ) :: ICLOUD
+!
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ) , &
+         INTENT(IN ) :: dz8w, &
+                                                             t3d, &
+                                                             t8w, &
+                                                             p8w, &
+                                                             p3d, &
+                                                            pi3d, &
+                                                           rho3d
+
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ) , &
+         INTENT(INOUT) :: RTHRATENLW
+
+   REAL, DIMENSION( ims:ime, jms:jme ) , &
+         INTENT(INOUT) :: GLW, &
+                                                             OLR, &
+                                                            LWCF
+
+   REAL, DIMENSION( ims:ime, jms:jme ) , &
+         INTENT(IN ) :: EMISS, &
+                                                             TSK
+
+   REAL, INTENT(IN ) :: R,G
+
+   REAL, DIMENSION( ims:ime, jms:jme ) , &
+         INTENT(IN ) :: XLAND, &
+                                                            XICE, &
+                                                            SNOW
+!ccc Added for time-varying trace gases.
+   INTEGER, INTENT(IN ) :: yr
+   REAL, INTENT(IN ) :: julian
+!ccc
+
+!
+! Optional
+!
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ) , &
+         OPTIONAL , &
+         INTENT(IN ) :: &
+                                                        CLDFRA3D, &
+                                                         LRADIUS, &
+                                                         IRADIUS, &
+
+                                                            QV3D, &
+                                                            QC3D, &
+                                                            QR3D, &
+                                                            QI3D, &
+                                                            QS3D, &
+                                                            QG3D, &
+                                                        QNDROP3D
+
+!..Added by G. Thompson to couple cloud physics effective radii.
+   REAL, DIMENSION(ims:ime,kms:kme,jms:jme), INTENT(IN):: &
+                                                        re_cloud, &
+                                                          re_ice, &
+                                                         re_snow
+   INTEGER, INTENT(IN):: has_reqc, has_reqi, has_reqs
+
+   real pi,third,relconst,lwpmin,rhoh2o
+
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ) , &
+         OPTIONAL , &
+         INTENT(IN ) :: &
+                                                       F_ICE_PHY, &
+                                                      F_RAIN_PHY
+
+   LOGICAL, OPTIONAL, INTENT(IN) :: &
+                                   F_QV,F_QC,F_QR,F_QI,F_QS,F_QG,F_QNDROP
+! Optional
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), OPTIONAL , &
+         INTENT(IN ) :: tauaerlw1,tauaerlw2,tauaerlw3,tauaerlw4, & ! czhao
+                           tauaerlw5,tauaerlw6,tauaerlw7,tauaerlw8, & ! czhao
+                           tauaerlw9,tauaerlw10,tauaerlw11,tauaerlw12, & ! czhao
+                           tauaerlw13,tauaerlw14,tauaerlw15,tauaerlw16
+
+   INTEGER, INTENT(IN ), OPTIONAL :: aer_ra_feedback
+!jdfcz INTEGER, INTENT(IN ), OPTIONAL :: progn,prescribe
+   INTEGER, INTENT(IN ), OPTIONAL :: progn
+! Ozone
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ) , &
+         OPTIONAL , &
+         INTENT(IN ) :: O33D
+   INTEGER, OPTIONAL, INTENT(IN ) :: o3input
+
+      real, parameter :: thresh=1.e-9
+      real slope
+      character(len=200) :: msg
+
+
+! Top of atmosphere and surface longwave fluxes (W m-2)
+   REAL, DIMENSION( ims:ime, jms:jme ), &
+         OPTIONAL, INTENT(INOUT) :: &
+                                       LWUPT,LWUPTC,LWDNT,LWDNTC, &
+                                       LWUPB,LWUPBC,LWDNB,LWDNBC
+
+! Layer longwave fluxes (including extra layer above model top)
+! Vertical ordering is from bottom to top (W m-2)
+   REAL, DIMENSION( ims:ime, kms:kme+2, jms:jme ), &
+         OPTIONAL, INTENT(OUT) :: &
+                               LWUPFLX,LWUPFLXC,LWDNFLX,LWDNFLXC
+
+! LOCAL VARS
+
+!   REAL, DIMENSION( kts:kte+1 ) :: Pw1D, &
+!                                                            Tw1D
+
+   REAL, DIMENSION( kts:kte ) :: & !TTEN1D, &
+                                                        CLDFRA1D, &
+!                                                            DZ1D, &
+!                                                             P1D, &
+!                                                             T1D, &
+                                                            QV1D, &
+                                                            QC1D, &
+                                                            QR1D, &
+                                                            QI1D, &
+                                                            QS1D, &
+                                                            QG1D, &
+                                                            O31D, &
+                                                          qndrop1d
+
+! Added local arrays for RRTMG
+    integer :: ncol, &
+                                                            nlay, &
+                                                            idrv, &
+                                                            icld, &
+                                                         inflglw, &
+                                                        iceflglw, &
+                                                        liqflglw
+! the mod in the macro below is to quiet range checking
+#define TILEPTS (jte-jts+1)*(ite-its+1)+(CHNK-mod((jte-jts+1)*(ite-its+1),CHNK))
+! Dimension with extra layer from model top to TOA
+    real, dimension( TILEPTS, kts:nlayers+1 ) :: &
+                                                            plev, &
+                                                            tlev
+    real, dimension( TILEPTS, kts:nlayers ) :: &
+                                                            play, &
+                                                            tlay, &
+                                                          h2ovmr, &
+                                                           o3vmr, &
+                                                          co2vmr, &
+                                                           o2vmr, &
+                                                          ch4vmr, &
+                                                          n2ovmr, &
+                                                        cfc11vmr, &
+                                                        cfc12vmr, &
+                                                        cfc22vmr, &
+                                                         ccl4vmr
+    real, dimension( TILEPTS,kts:nlayers ) :: o3mmr
+! For old cloud property specification for rrtm_lw
+!    real, dimension( kts:kte ) :: clwp, &
+!                                                            ciwp, &
+!                                                            cswp, &
+!                                                            plwp, &
+!                                                            piwp
+    real ::     clwp_k, &
+                ciwp_k, &
+                cswp_k, &
+                plwp_k, &
+                piwp_k                                                   
+! Surface emissivity (for 16 LW spectral bands)
+    real, dimension( TILEPTS, nbndlw ) :: &
+                                                            emis
+! Dimension with extra layer from model top to TOA,
+! though no clouds are allowed in extra layer
+    real, dimension( TILEPTS, kts:nlayers ) :: &
+                                                          clwpth, &
+                                                          ciwpth, &
+                                                          cswpth, &
+                                                             rel, &
+                                                             rei, &
+                                                             res, &
+                                                         cldfrac
+    real, dimension( TILEPTS, nbndlw, kts:nlayers ) :: &
+                                                          taucld
+    real, dimension( TILEPTS, kts:nlayers, nbndlw ) :: &
+                                                          tauaer
+    real, dimension( TILEPTS, kts:nlayers+1 ) :: &
+                                                            uflx, &
+                                                            dflx, &
+                                                           uflxc, &
+                                                           dflxc
+    real, dimension( TILEPTS, kts:nlayers+1 ) :: &
+                                                        duflx_dt, &
+                                                       duflxc_dt
+    real, dimension( TILEPTS, kts:nlayers+1 ) :: &
+                                                              hr, &
+                                                             hrc
+
+    real, dimension ( TILEPTS ) :: &
+                                                            tsfc, &
+                                                              ps
+    real :: ro, &
+                                                              dz
+    real :: tten1d_k 
+    real:: snow_mass_factor
+
+!..We can use message interface regardless of what options are running,
+!.. so let us ask for it here.
+      CHARACTER(LEN=256) :: message
+      LOGICAL, EXTERNAL :: wrf_dm_on_monitor
+
+!ccc To add time-varying trace gases (CO2, N2O and CH4). Read the conc. from file
+! then interpolate to date of run.
+
+
+
+
+
+! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
+! carbon dioxide (379 ppmv)
+    real :: co2
+    data co2 / 379.e-6 /
+! methane (1774 ppbv)
+    real :: ch4
+    data ch4 / 1774.e-9 /
+! nitrous oxide (319 ppbv)
+    real :: n2o
+    data n2o / 319.e-9 /
+! cfc-11 (251 ppt)
+    real :: cfc11
+    data cfc11 / 0.251e-9 /
+! cfc-12 (538 ppt)
+    real :: cfc12
+    data cfc12 / 0.538e-9 /
+
+! cfc-22 (169 ppt)
+    real :: cfc22
+    data cfc22 / 0.169e-9 /
+! ccl4 (93 ppt)
+    real :: ccl4
+    data ccl4 / 0.093e-9 /
+! Set oxygen volume mixing ratio (for o2mmr=0.23143)
+    real :: o2
+    data o2 / 0.209488 /
+
+    integer :: iplon, irng, permuteseed
+    integer :: nb
+
+! For old cloud property specification for rrtm_lw
+! Cloud and precipitation absorption coefficients
+    real :: abcw,abice,abrn,absn
+    data abcw /0.144/
+    data abice /0.0735/
+    data abrn /0.330e-3/
+    data absn /2.34e-3/
+
+! Molecular weights and ratios for converting mmr to vmr units
+! real :: amd ! Effective molecular weight of dry air (g/mol)
+! real :: amw ! Molecular weight of water vapor (g/mol)
+! real :: amo ! Molecular weight of ozone (g/mol)
+! real :: amo2 ! Molecular weight of oxygen (g/mol)
+! Atomic weights for conversion from mass to volume mixing ratios
+! data amd / 28.9660 /
+! data amw / 18.0160 /
+! data amo / 47.9998 /
+! data amo2 / 31.9999 /
+
+    real :: amdw ! Molecular weight of dry air / water vapor
+    real :: amdo ! Molecular weight of dry air / ozone
+    real :: amdo2 ! Molecular weight of dry air / oxygen
+    data amdw / 1.607793 /
+    data amdo / 0.603461 /
+    data amdo2 / 0.905190 /
+
+!!
+    real, dimension( (jte-jts+1)*(ite-its+1), 1:kte-kts+1 ) :: pdel ! Layer pressure thickness (mb)
+
+    real, dimension( (jte-jts+1)*(ite-its+1), 1:kte-kts+1) :: cicewp, & ! in-cloud cloud ice water path
+                                             cliqwp, & ! in-cloud cloud liquid water path
+                                             csnowp, & ! in-cloud snow water path
+                                              reliq, & ! effective drop radius (microns)
+                                              reice ! effective ice crystal size (microns)
+    real, dimension( (jte-jts+1)*(ite-its+1), 1:kte-kts+1):: recloud1d, &
+                                            reice1d, &
+                                           resnow1d
+
+    real :: gliqwp, gicewp, gsnowp, gravmks
+
+!
+! REAL :: TSFC,GLW0,OLR0,EMISS0,FP
+
+    real, dimension ((jte-jts+1)*(ite-its+1)) :: landfrac, landm, snowh, icefrac
+
+    integer :: pcols, pver
+    integer :: icol,padding
+!
+    INTEGER :: i,j,K, idx_rei
+    REAL :: corr,QV1D_K
+    LOGICAL :: predicate,PRESENT_CLDFRA3D,present_o33d
+    LOGICAL :: PRESENT_F_QC,PRESENT_F_QR,PRESENT_F_QI,PRESENT_F_QS,PRESENT_F_QG
+    LOGICAL :: PRESENT_QC3D,PRESENT_QR3D,PRESENT_QI3D,PRESENT_QS3D,PRESENT_QG3D
+    LOGICAL ::  PRESENT_QNDROP3D, PRESENT_progn,PRESENT_F_QNDROP,PRESENT_F_ICE_PHY 
+
+! Added for top of model adjustment. Steven Cavallo NCAR/MMM December 2010
+    INTEGER, PARAMETER :: nproflevs = 60 ! Constant, from the table
+    INTEGER :: L, LL, klev ! Loop indices
+    REAL, DIMENSION( kts:nlayers+1 ) :: varint
+    REAL :: wght,vark,vark1
+
+    real :: corr
+    integer :: index
+    real,parameter :: tmelt=273.16   ! freezing temperature of fresh water (K)
+    real,parameter :: rliqland=14.0  ! liquid drop size if over land
+    real,parameter :: rliqocean=14.0 ! liquid drop size if over ocean
+    real,parameter :: rliqice=8.0    ! liquid drop size if over sea ice
+    
+	REAL :: PPROF(nproflevs), TPROF(nproflevs)
+    ! Weighted mean pressure and temperature profiles from midlatitude
+    ! summer (MLS),midlatitude winter (MLW), sub-Arctic
+    ! winter (SAW),sub-Arctic summer (SAS), and tropical (TROP)
+    ! standard atmospheres.
+    DATA PPROF /1000.00,855.47,731.82,626.05,535.57,458.16, &
+                  391.94,335.29,286.83,245.38,209.91,179.57, &
+                  153.62,131.41,112.42,96.17,82.27,70.38, &
+                  60.21,51.51,44.06,37.69,32.25,27.59, &
+                  23.60,20.19,17.27,14.77,12.64,10.81, &
+                  9.25,7.91,6.77,5.79,4.95,4.24, &
+                  3.63,3.10,2.65,2.27,1.94,1.66, &
+                  1.42,1.22,1.04,0.89,0.76,0.65, &
+                  0.56,0.48,0.41,0.35,0.30,0.26, &
+                  0.22,0.19,0.16,0.14,0.12,0.10/
+    DATA TPROF /286.96,281.07,275.16,268.11,260.56,253.02, &
+                  245.62,238.41,231.57,225.91,221.72,217.79, &
+                  215.06,212.74,210.25,210.16,210.69,212.14, &
+                  213.74,215.37,216.82,217.94,219.03,220.18, &
+                  221.37,222.64,224.16,225.88,227.63,229.51, &
+                  231.50,233.73,236.18,238.78,241.60,244.44, &
+                  247.35,250.33,253.32,256.30,259.22,262.12, &
+                  264.80,266.50,267.59,268.44,268.69,267.76, &
+                  266.13,263.96,261.54,258.93,256.15,253.23, &
+                  249.89,246.67,243.48,240.25,236.66,233.86/
+!!$acc routine(relcalc) seq
+!!$acc routine(reicalc) seq
+!$acc update device(retab)
+ !------------------------------------------------------------------
+!-----CALCULATE LONG WAVE RADIATION
+!
+! All fields are ordered vertically from bottom to top
+! Pressures are in mb
+!
+!ccc Read time-varying trace gases concentrations and interpolate them to run date.
+!
+!ccc
+
+   ncol = (jte-jts+1)*(ite-its+1)
+
+! This logic is tortured because cannot test F_QI unless
+! it is present, and order of evaluation of expressions
+! is not specified in Fortran
+
+   IF ( PRESENT ( F_QI ) ) THEN
+     predicate = F_QI
+   ELSE
+     predicate = .FALSE.
+   ENDIF
+
+   PRESENT_CLDFRA3D = PRESENT( CLDFRA3D )
+   present_o33d = present(o33d)
+   PRESENT_F_QC = PRESENT(F_QC)
+   PRESENT_F_QR = PRESENT(F_QR)
+   PRESENT_F_QI = PRESENT(F_QI)
+   PRESENT_F_QS = PRESENT(F_QS)
+   PRESENT_F_QG = PRESENT(F_QG)
+   PRESENT_QC3D = PRESENT(QC3D)
+   PRESENT_QR3D = PRESENT(QR3D)
+   PRESENT_QI3D = PRESENT(QI3D)
+   PRESENT_QS3D = PRESENT(QS3D)
+   PRESENT_QG3D = PRESENT(QG3D)
+   PRESENT_F_QNDROP = PRESENT(F_QNDROP)
+   PRESENT_QNDROP3D = PRESENT(QNDROP3D)
+   PRESENT_progn    = PRESENT( progn )     
+   PRESENT_F_ICE_PHY = PRESENT(F_ICE_PHY)
+
+!$acc update self(tsk)
+!   WRITE(message,*) __FILE__, sum(tsk)
+!   call wrf_debug(0,message)
+#ifdef _OPENACC
+   if(is_CAMMGMP_used) call wrf_error_fatal('is_CAMMGMP_used .eq. .true. was not tested with OpenaCC')
+   if(PRESENT_progn) call wrf_error_fatal('progn .eq. .true. was not tested with OpenaCC')
+#endif
+
+!$acc data create(cldfrac,emis,o3vmr,o3mmr,taucld,ciwpth,clwpth,cswpth,rei,rel,res) &
+!$acc      create(plev,tlev,tsfc,play,pdel,tlay,tlev,h2ovmr,co2vmr,o2vmr,ch4vmr,n2ovmr, &
+!$acc             cfc11vmr,cfc12vmr,cfc22vmr,ccl4vmr,varint) &
+!$acc       create(snowh,resnow1d,reice1d,recloud1d) &
+!$acc      copyin(SNOW,XICE,XLAND,cldfra3d) ! & ! copyin(p3d,t3d,dz8w,p8w,t8w) !&
+!$acc enter data copyin(re_ice) if(has_reqi)
+!$acc enter data copyin(re_cloud) if(has_reqc)
+!$acc enter data copyin(re_snow) if(has_reqs)
+
+!$acc kernels
+   cldfrac(:,:) = 0.0
+
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent private(cldfra1d)
+      do i = its,ite
+         do k = kts, kte
+            cldfra1d(k) = 0.
+         enddo
+         IF (ICLOUD .ne. 0 .and. PRESENT_CLDFRA3D  ) THEN
+            DO K=kts,kte
+               CLDFRA1D(k)=CLDFRA3D(I,K,J)
+            ENDDO
+         ENDIF
+
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+         
+         if (inflglw .ge. 0) then
+!$acc loop independent
+            do k = kts, kte
+               cldfrac(icol,k) = cldfra1d(k)
+            enddo
+         endif
+      enddo
+   enddo   
+
+
+! Layer indexing goes bottom to top here for all fields.
+! Water vapor and ozone are converted from mmr to vmr.
+! Pressures are in units of mb here.
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent 
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+         plev(icol,1) = p8w(I,1,J)/100. !pw1d(1)
+
+
+         tlev(icol,1) = t8w(I,1,J) !tw1d(1)
+         tsfc(icol) = tsk(i,j)
+         do k = kts, kte
+            plev(icol,k+1) = p8w(I,K+1,J)/100.   !pw1d(k+1)
+         enddo
+         do k = kts, kte
+            QV1D_K=QV3D(I,K,J)
+            QV1D_K=max(0.,QV1D_K)
+            QV1D_K=AMAX1(QV1D_K,1.E-12)
+            play(icol,k) = P3D(I,K,J)/100.  !p1d(k)
+            pdel(icol,k) = plev(icol,k) - plev(icol,k+1)
+            tlay(icol,k) = T3D(I,K,J)    !t1d(k)
+            tlev(icol,k+1) = t8w(I,K+1,J)   !tw1d(k+1)
+            h2ovmr(icol,k) = qv1d_k * amdw
+            co2vmr(icol,k) = co2
+            o2vmr(icol,k) = o2
+            ch4vmr(icol,k) = ch4
+            n2ovmr(icol,k) = n2o
+            cfc11vmr(icol,k) = cfc11
+            cfc12vmr(icol,k) = cfc12
+            cfc22vmr(icol,k) = cfc22
+            ccl4vmr(icol,k) = ccl4
+         enddo
+      enddo
+   enddo   
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent 
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+       ! Calculate the column pressure buffer levels above the
+       ! model top
+       do L=kte+1,nlayers,1
+          plev(icol,L+1) = plev(icol,L) - deltap
+          play(icol,L) = 0.5*(plev(icol,L) + plev(icol,L+1))
+       enddo
+       ! Add zero as top level. This gets the temperature max at the
+       ! stratopause, reducing the downward flux errors in the top
+       ! levels. If zero happened to be the top level already,
+       ! this will add another level with zero, but will not affect
+       ! the radiative transfer calculation.
+       plev(icol,nlayers+1) = 0.00
+       play(icol,nlayers) = 0.5*(plev(icol,nlayers) + plev(icol,nlayers+1))
+
+       ! Interpolate the table temperatures to column pressure levels
+       do L=1,nlayers+1,1
+          if ( PPROF(nproflevs) .lt. plev(icol,L) ) then
+             do LL=2,nproflevs,1
+                if ( PPROF(LL) .lt. plev(icol,L) ) then
+                   klev = LL - 1
+                   exit
+                endif
+             enddo
+
+          else
+             klev = nproflevs
+          endif
+
+          if (klev .ne. nproflevs ) then
+             vark = TPROF(klev)
+             vark1 = TPROF(klev+1)
+             wght=(plev(icol,L)-PPROF(klev) )/( PPROF(klev+1)-PPROF(klev))
+          else
+             vark = TPROF(klev)
+             vark1 = TPROF(klev)
+             wght = 0.0
+          endif
+          varint(L) = wght*(vark1-vark)+vark
+
+       enddo
+
+       ! Match the interpolated table temperature profile to WRF column
+       do L=kte+1,nlayers+1,1
+          tlev(icol,L) = varint(L) + (tlev(icol,kte) - varint(kte))
+          !if ( L .le. nlay ) then
+          tlay(icol,L-1) = 0.5*(tlev(icol,L) + tlev(icol,L-1))
+          !endif
+       enddo
+
+       ! Now the chemical species (except for ozone)
+       do L=kte+1,nlayers,1
+          h2ovmr(icol,L) = h2ovmr(icol,kte)
+          co2vmr(icol,L) = co2vmr(icol,kte)
+          o2vmr(icol,L) = o2vmr(icol,kte)
+          ch4vmr(icol,L) = ch4vmr(icol,kte)
+          n2ovmr(icol,L) = n2ovmr(icol,kte)
+          cfc11vmr(icol,L) = cfc11vmr(icol,kte)
+          cfc12vmr(icol,L) = cfc12vmr(icol,kte)
+          cfc22vmr(icol,L) = cfc22vmr(icol,kte)
+          ccl4vmr(icol,L) = ccl4vmr(icol,kte)
+       enddo
+      enddo
+   enddo   
+!$acc end kernels
+!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+! Get ozone profile including amount in extra layer above model top.
+! Steven Cavallo: Must pass nlay-1 into subroutine to get nlayers
+! dimension for o3mmr
+! Steven Cavallo, December 2010
+         nlay = nlayers ! Keep these indices the same
+! call inirad (o3mmr,plev,kts,nlay-1)
+    padding = (CHNK-mod((jte-jts+1)*(ite-its+1),CHNK)) 
+    call inirad_1 (o3mmr,plev,its,ite,kts,nlay-1,jts,jte,padding)
+
+!$acc kernels
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent 
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+! Steven Cavallo: Changed to nlayers from kte+1
+        if(present_o33d) then
+         do k = kts, nlayers
+            o3vmr(icol,k) = o3mmr(icol,k) * amdo
+!            IF ( PRESENT( O33D ) ) THEN
+            if(o3input .eq. 2)then
+               if(k.le.kte)then
+                 o3vmr(icol,k) = O33D(I,K,J)  !o31d(k)
+               else
+! apply shifted climatology profile above model top
+                 o3vmr(icol,k) = O33D(I,kte,J) - o3mmr(icol,kte)*amdo + o3mmr(icol,k)*amdo
+!                 o3vmr(icol,k) = o31d(kte) - o3mmr(kte)*amdo + o3mmr(k)*amdo
+                 if(o3vmr(icol,k) .le. 0.)o3vmr(icol,k) = o3mmr(icol,k)*amdo
+               endif
+            endif
+ !           ENDIF
+         enddo
+        else
+         do k = kts, nlayers
+            o3vmr(icol,k) = o3mmr(icol,k) * amdo
+         enddo
+        endif
+
+! Set surface emissivity in each RRTMG longwave band
+         do nb = 1, nbndlw
+            emis(icol, nb) = emiss(i,j)
+         enddo
+      enddo
+   enddo   
+!$acc end kernels
+
+!$acc kernels
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent private(QC1D,QR1D,QI1D,QS1D,QG1D,qndrop1d)
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+               DO K=kts,kte
+                  recloud1D(icol,K) = 5.0
+                  reice1D(icol,K) = 10.0
+                  resnow1D(icol,K) = 10.0
+               ENDDO
+      enddo
+   enddo   
+!$acc end kernels
+ 
+         IF (ICLOUD .ne. 0) THEN
+            IF ( has_reqc .ne. 0) THEN
+!$acc kernels
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent 
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+               DO K=kts,kte
+                  recloud1D(icol,K) = MAX(2.5, re_cloud(I,K,J)*1.E6)
+                  if (recloud1D(icol,K).LE.2.5.AND.cldfra3d(i,k,j).gt.0. &
+     & .AND. (XLAND(I,J)-1.5).GT.0.) then !--- Ocean
+                     recloud1D(icol,K) = 10.5
+                  elseif(recloud1D(icol,K).LE.2.5.AND.cldfra3d(i,k,j).gt.0. &
+     & .AND. (XLAND(I,J)-1.5).LT.0.) then !--- Land
+                     recloud1D(icol,K) = 7.5
+                  endif
+               ENDDO
+      enddo
+   enddo   
+!$acc end kernels
+           ENDIF
+
+            IF ( has_reqi .ne. 0) THEN
+!$acc kernels
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+               DO K=kts,kte
+                  reice1D(icol,K) = MAX(10., re_ice(I,K,J)*1.E6)
+                  if (reice1D(icol,K).LE.10..AND.cldfra3d(i,k,j).gt.0.) then
+                     idx_rei = int(t3d(i,k,j)-179.)
+                     idx_rei = min(max(idx_rei,1),75)
+                     corr = t3d(i,k,j) - int(t3d(i,k,j))
+                     reice1D(icol,K) = retab(idx_rei)*(1.-corr) + &
+     & retab(idx_rei+1)*corr
+                     reice1D(icol,K) = MAX(reice1D(icol,K), 10.0)
+                  endif
+               ENDDO
+      enddo
+   enddo   
+!$acc end kernels
+            ENDIF
+
+            IF ( has_reqs .ne. 0) THEN
+!$acc kernels
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent 
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+               DO K=kts,kte
+                  resnow1D(icol,K) = MAX(10., re_snow(I,K,J)*1.E6)
+               ENDDO
+      enddo
+   enddo   
+!$acc end kernels
+            ENDIF
+         ENDIF
+
+
+!$acc kernels
+! latitude loop
+!$acc loop independent
+   j_loop: do j = jts,jte
+
+! longitude loop
+!$acc loop independent private(QC1D,QR1D,QI1D,QS1D,QG1D,qndrop1d)
+      i_loop: do i = its,ite
+
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+
+!         do k=kts,kte+1
+!            Pw1D(K) = p8w(I,K,J)/100.
+!            Tw1D(K) = t8w(I,K,J)
+!         enddo
+
+         DO K=kts,kte
+!            QV1D(K)=0.
+            QC1D(K)=0.
+            QR1D(K)=0.
+            QI1D(K)=0.
+            QS1D(K)=0.
+!            CLDFRA1D(k)=0.
+         ENDDO
+
+#if 0
+         DO K=kts,kte
+            QV1D(K)=QV3D(I,K,J)
+            QV1D(K)=max(0.,QV1D(K))
+            QV1D(K)=AMAX1(QV1D(K),1.E-12)
+         ENDDO
+#endif
+
+!         IF (PRESENT(O33D)) THEN
+!            DO K=kts,kte
+!               O31D(K)=O33D(I,K,J)
+!            ENDDO
+!         ELSE
+!            DO K=kts,kte
+!               O31D(K)=0.0
+!            ENDDO
+!         ENDIF
+
+!         DO K=kts,kte
+!            TTEN1D(K)=0.
+!            T1D(K)=T3D(I,K,J)
+!            P1D(K)=P3D(I,K,J)/100.
+!            DZ1D(K)=dz8w(I,K,J)
+!         ENDDO
+
+! moist variables
+
+         IF (ICLOUD .ne. 0) THEN
+!            IF ( PRESENT( CLDFRA3D ) ) THEN
+!              DO K=kts,kte
+!                 CLDFRA1D(k)=CLDFRA3D(I,K,J)
+!              ENDDO
+!            ENDIF
+
+            IF (PRESENT_F_QC .AND. PRESENT_QC3D) THEN
+              IF ( F_QC) THEN
+                 DO K=kts,kte
+                    QC1D(K)=QC3D(I,K,J)
+                    QC1D(K)=max(0.,QC1D(K))
+                 ENDDO
+              ENDIF
+            ENDIF
+
+            IF (PRESENT_F_QR .AND. PRESENT_QR3D) THEN
+              IF ( F_QR) THEN
+                 DO K=kts,kte
+                    QR1D(K)=QR3D(I,K,J)
+                    QR1D(K)=max(0.,QR1D(K))
+                 ENDDO
+              ENDIF
+            ENDIF
+
+            IF ( PRESENT_F_QNDROP.AND.PRESENT_QNDROP3D) THEN
+             IF (F_QNDROP) THEN
+              DO K=kts,kte
+               qndrop1d(K)=qndrop3d(I,K,J)
+              ENDDO
+             ENDIF
+            ENDIF
+
+! For MP option 3
+            IF (.NOT. predicate .and. .not. warm_rain) THEN
+               DO K=kts,kte
+!                  IF (T1D(K) .lt. 273.15) THEN
+                  IF (T3D(I,K,J) .lt. 273.15) THEN
+                  QI1D(K)=QC1D(K)
+                  QS1D(K)=QR1D(K)
+                  QC1D(K)=0.
+                  QR1D(K)=0.
+                  ENDIF
+               ENDDO
+            ENDIF
+
+            IF (PRESENT_F_QI .AND. PRESENT_QI3D) THEN
+               IF (F_QI) THEN
+                  DO K=kts,kte
+                     QI1D(K)=QI3D(I,K,J)
+                     QI1D(K)=max(0.,QI1D(K))
+                  ENDDO
+               ENDIF
+            ENDIF
+
+            IF (PRESENT_F_QS .AND. PRESENT_QS3D) THEN
+               IF (F_QS) THEN
+                  DO K=kts,kte
+                     QS1D(K)=QS3D(I,K,J)
+                     QS1D(K)=max(0.,QS1D(K))
+                  ENDDO
+               ENDIF
+            ENDIF
+
+            IF (PRESENT_F_QG .AND. PRESENT_QG3D) THEN
+               IF (F_QG) THEN
+                  DO K=kts,kte
+                     QG1D(K)=QG3D(I,K,J)
+                     QG1D(K)=max(0.,QG1D(K))
+                  ENDDO
+               ENDIF
+            ENDIF
+
+! mji - For MP option 5
+            IF ( PRESENT_F_QI .and. PRESENT_F_QC .and. PRESENT_F_QS .and. PRESENT_F_ICE_PHY ) THEN
+               IF ( F_QC .and. .not. F_QI .and. F_QS ) THEN
+                  DO K=kts,kte
+                     qi1d(k) = 0.1*qs3d(i,k,j)
+                     qs1d(k) = 0.9*qs3d(i,k,j)
+                     qc1d(k) = qc3d(i,k,j)
+                     qi1d(k) = max(0.,qi1d(k))
+                     qc1d(k) = max(0.,qc1d(k))
+                  ENDDO
+               ENDIF
+            ENDIF
+
+        ENDIF
+
+! EMISS0=EMISS(I,J)
+! GLW0=0.
+! OLR0=0.
+! TSFC=TSK(I,J)
+
+! Set up input for longwave
+! ncol = 1
+! Add extra layer from top of model to top of atmosphere
+! nlay = (kte - kts + 1) + 1
+! Edited for top of model adjustment (nlayers = kte + 1).
+! Steven Cavallo, December 2010
+         nlay = nlayers ! Keep these indices the same
+
+! For optional calculation of the approximate change in upward flux as a function
+! of surface temperature only between full radiation calls (0=off, 1=on)
+         idrv = 0
+
+! Select cloud liquid and ice optics parameterization options
+! For passing in cloud optical properties directly:
+! icld = 2
+! inflglw = 0
+! iceflglw = 0
+! liqflglw = 0
+! For passing in cloud physical properties; cloud optics parameterized in RRTMG:
+         icld = 2
+         inflglw = 2
+         iceflglw = 3
+         liqflglw = 1
+
+!Mukul change the flags here with reference to the new effective cloud/ice/snow radius
+         IF (ICLOUD .ne. 0) THEN
+            IF ( has_reqc .ne. 0) THEN
+#ifndef _OPENACC            
+               IF ( wrf_dm_on_monitor() ) THEN
+                 WRITE(message,*)'RRTMG: pre-computed cloud droplet effective ',&
+                                 'radius found, setting inflglw=3'
+                 call wrf_debug(150, message)
+               ENDIF
+#endif               
+               inflglw = 3
+            ENDIF
+
+            IF ( has_reqi .ne. 0) THEN
+#ifndef _OPENACC            
+               IF ( wrf_dm_on_monitor() ) THEN
+                 WRITE(message,*)'RRTMG: pre-computed cloud ice effective radius found, setting inflglw=4 and iceflglw=4'
+                 call wrf_debug(150, message)
+               ENDIF
+#endif               
+               inflglw = 4
+               iceflglw = 4
+            ENDIF
+
+            IF ( has_reqs .ne. 0) THEN
+#ifndef _OPENACC            
+               IF ( wrf_dm_on_monitor() ) THEN
+                 WRITE(message,*)'RRTMG: pre-computed snow effective radius found, setting inflglw=5 and iceflglw=5'
+                 call wrf_debug(150, message)
+               ENDIF
+#endif               
+               inflglw = 5
+               iceflglw = 5
+            ENDIF
+         ENDIF
+
+! Define cloud optical properties for radiation (inflglw = 0)
+! This is approach used with older RRTM_LW;
+! Cloud and precipitation paths in g/m2
+! qi=0 if no ice phase
+! qs=0 if no ice phase
+         if (inflglw .eq. 0) then
+            do k = kts,kte
+               ro = (P3D(I,K,J)/100.) / (r * T3D(I,K,J))*100.
+!               ro = p1d(k) / (r * t1d(k))*100.
+               dz = dz8w(I,K,J) !dz1d(k)
+               clwp_k = ro*qc1d(k)*dz*1000.
+               ciwp_k = ro*qi1d(k)*dz*1000.
+               plwp_k = (ro*qr1d(k))**0.75*dz*1000.
+               piwp_k = (ro*qs1d(k))**0.75*dz*1000.
+!            enddo
+
+! Cloud fraction and cloud optical depth; old approach used with RRTM_LW
+!            do k = kts, kte
+!               cldfrac(icol,k) = cldfra1d(k)
+               do nb = 1, nbndlw
+                  taucld(icol,nb,k) = abcw*clwp_k + abice*ciwp_k &
+                            +abrn*plwp_k + absn*piwp_k
+                  if (taucld(icol,nb,k) .gt. 0.01) cldfrac(icol,k) = 1.
+               enddo
+            enddo
+
+! Zero out cloud physical property arrays; not used when passing optical properties
+! into radiation
+            do k = kts, kte
+               clwpth(icol,k) = 0.0
+               ciwpth(icol,k) = 0.0
+               rel(icol,k) = 10.0
+               rei(icol,k) = 10.0
+            enddo
+         endif
+
+! Define cloud physical properties for radiation (inflglw = 1 or 2)
+! Cloud fraction
+! Set cloud arrays if passing cloud physical properties into radiation
+         if (inflglw .gt. 0) then
+!            do k = kts, kte
+!               cldfrac(icol,k) = cldfra1d(k)
+!            enddo
+
+! Compute cloud water/ice paths and particle sizes for input to radiation (CAM method)
+            pcols = ncol
+            pver = kte - kts + 1
+            gravmks = g
+            landfrac(icol) = 2.-XLAND(I,J)
+            landm(icol) = landfrac(icol)
+            snowh(icol) = 0.001*SNOW(I,J)
+            icefrac(icol) = XICE(I,J)
+
+! From module_ra_cam: Convert liquid and ice mixing ratios to water paths;
+! pdel is in mb here; convert back to Pa (*100.)
+! Water paths are in units of g/m2
+! snow added as ice cloud (JD 091022)
+            do k = kts, kte
+               gicewp = (qi1d(k)+qs1d(k)) * pdel(icol,k)*100.0 / gravmks * 1000.0 ! Grid box ice water path.
+               gliqwp = qc1d(k) * pdel(icol,k)*100.0 / gravmks * 1000.0 ! Grid box liquid water path.
+               cicewp(icol,k) = gicewp / max(0.01,cldfrac(icol,k)) ! In-cloud ice water path.
+               cliqwp(icol,k) = gliqwp / max(0.01,cldfrac(icol,k)) ! In-cloud liquid water path.
+            end do
+
+
+! Mukul
+!..The ice water path is already sum of cloud ice and snow, but when we have explicit
+!.. ice effective radius, overwrite the ice path with only the cloud ice variable,
+!.. leaving out the snow for its own effect.
+           if(iceflglw.ge.4)then
+              do k = kts, kte
+                     gicewp = qi1d(k) * pdel(icol,k)*100.0 / gravmks * 1000.0 ! Grid box ice water path.
+                     cicewp(icol,k) = gicewp / max(0.01,cldfrac(icol,k)) ! In-cloud ice water path.
+              end do
+           end if
+
+!..Here the snow path is adjusted if (radiation) effective radius of snow is
+!.. larger than what we currently have in the lookup tables. Since mass goes
+!.. rather close to diameter squared, adjust the mixing ratio of snow used
+!.. to compute its water path in combination with the max diameter. Not a
+!.. perfect fix, but certainly better than using all snow mass when diameter is
+!.. far larger than table currently contains and crystal sizes much larger than
+!.. about 140 microns have lesser impact than those much smaller sizes.
+
+           if(iceflglw.eq.5)then
+              do k = kts, kte
+                 snow_mass_factor = 1.0
+                 if (resnow1d(icol,k) .gt. 130.)then
+                     snow_mass_factor = (130.0/resnow1d(icol,k))*(130.0/resnow1d(icol,k))
+                     resnow1d(icol,k) = 130.0
+#ifndef _OPENACC                     
+                     IF ( wrf_dm_on_monitor() ) THEN
+                       WRITE(message,*)'RRTMG:  reducing snow mass (cloud path) to ', &
+                                       nint(snow_mass_factor*100.), ' percent of full value'
+                       call wrf_debug(150, message)
+                     ENDIF
+#endif                     
+                 endif
+                 gsnowp = qs1d(k) * snow_mass_factor * pdel(icol,k)*100.0 / gravmks * 1000.0 ! Grid box snow water path.
+                 csnowp(icol,k) = gsnowp / max(0.01,cldfrac(icol,k))
+              end do
+           end if
+
+
+
+#ifndef _OPENACC
+!link the aerosol feedback to cloud -czhao
+  if( PRESENT_progn ) then
+    if (progn == 1) then
+!jdfcz if(prescribe==0) then
+
+      pi = 4.*atan(1.0)
+      third=1./3.
+      rhoh2o=1.e3
+      relconst=3/(4.*pi*rhoh2o)
+! minimun liquid water path to calculate rel
+! corresponds to optical depth of 1.e-3 for radius 4 microns.
+      lwpmin=3.e-5
+      do k = kts, kte
+         reliq(icol,k) = 10.
+         if( PRESENT_F_QNDROP ) then
+            if( F_QNDROP ) then
+              if ( qc1d(k)*pdel(icol,k).gt.lwpmin.and. &
+                   qndrop1d(k).gt.1000. ) then
+               reliq(icol,k)=(relconst*qc1d(k)/qndrop1d(k))**third ! effective radius in m
+! apply scaling from Martin et al., JAS 51, 1830.
+               reliq(icol,k)=1.1*reliq(icol,k)
+               reliq(icol,k)=reliq(icol,k)*1.e6 ! convert from m to microns
+               reliq(icol,k)=max(reliq(icol,k),4.)
+               reliq(icol,k)=min(reliq(icol,k),20.)
+              end if
+            end if
+         end if
+      end do
+!jdfcz else ! prescribe
+! following Kiehl
+! call relcalc(icol, pcols, pver, tlay, landfrac, landm, icefrac, reliq, snowh)
+! write(0,*) 'lw prescribe aerosol',maxval(qndrop3d)
+!jdfcz endif
+    else ! progn
+      call relcalc(icol, pcols, pver, tlay, landfrac, landm, icefrac, reliq, snowh)
+    endif
+  else !present(progn)
+#endif  
+!      call relcalc(icol, pcols, pver, tlay, landfrac, landm, icefrac, reliq, snowh)
+   do k=kts,kte
+          ! Start with temperature-dependent value appropriate for continental air
+          ! Note: findmcnew has a pressure dependence here
+          reliq(icol,k) = rliqland + (rliqocean-rliqland) * min(1.0,max(0.0,(tmelt-tlay(icol,k))*0.05))
+          ! Modify for snow depth over land
+          reliq(icol,k) = reliq(icol,k) + (rliqocean-reliq(icol,k)) * min(1.0,max(0.0,snowh(icol)*10.))
+          ! Ramp between polluted value over land to clean value over ocean.
+          reliq(icol,k) = reliq(icol,k) + (rliqocean-reliq(icol,k)) * min(1.0,max(0.0,1.0-landm(icol)))
+          ! Ramp between the resultant value and a sea ice value in the presence of ice.
+          reliq(icol,k) = reliq(icol,k) + (rliqice-reliq(icol,k)) * min(1.0,max(0.0,icefrac(icol)))
+    end do
+! ======= End of relcalc
+#ifndef _OPENACC      
+  endif
+#endif  
+
+! following Kristjansson and Mitchell
+!            call reicalc(icol, pcols, pver, tlay, reice)
+    do k=kts,kte
+          index = int(tlay(icol,k)-179.)
+          index = min(max(index,1),94)
+          corr = tlay(icol,k) - int(tlay(icol,k))
+          reice(icol,k) = retab(index)*(1.-corr) &
+               +retab(index+1)*corr
+    end do
+! ==== End of reicalc
+
+!..If we already have effective radius of cloud and ice, then just overwrite what
+!.. was computed in the relcalc and reicalc subroutines above.
+
+      if (inflglw .ge. 3) then
+         do k = kts, kte
+            reliq(icol,k) = recloud1d(icol,k)
+         end do
+      endif
+      if (iceflglw .ge. 4) then
+         do k = kts, kte
+            reice(icol,k) = reice1d(icol,k)
+         end do
+      endif
+
+! Limit upper bound of reice for Fu ice parameterization and convert
+! from effective radius to generalized effective size (*1.0315; Fu, 1996)
+            if (iceflglw .eq. 3) then
+               do k = kts, kte
+                  reice(icol,k) = reice(icol,k) * 1.0315
+                  reice(icol,k) = min(140.0,reice(icol,k))
+               end do
+            endif
+#ifndef _OPENACC
+!if CAMMGMP is used, use output from CAMMGMP
+            if(is_CAMMGMP_used) then
+               do k = kts, kte
+                  if ( qi1d(k) .gt. 1.e-20 .or. qs1d(k) .gt. 1.e-20) then
+                     reice(icol,k) = iradius(i,k,j)
+                  else
+                     reice(icol,k) = 25.
+                  end if
+                  reice(icol,k) = max(5., min(140.0,reice(icol,k)))
+                  if ( qc1d(k) .gt. 1.e-20) then
+                     reliq(icol,k) = lradius(i,k,j)
+                  else
+                     reliq(icol,k) = 10.
+                  end if
+                  reliq(icol,k) = max(2.5, min(60.0,reliq(icol,k)))
+               enddo
+            endif
+#endif
+
+! Set cloud physical property arrays
+            do k = kts, kte
+               clwpth(icol,k) = cliqwp(icol,k)
+               ciwpth(icol,k) = cicewp(icol,k)
+               rel(icol,k) = reliq(icol,k)
+               rei(icol,k) = reice(icol,k)
+            enddo
+
+!Mukul
+            if (inflglw .eq. 5) then
+               do k = kts, kte
+                  cswpth(icol,k) = csnowp(icol,k)
+                  res(icol,k) = resnow1d(icol,k)
+               end do
+            else
+               do k = kts, kte
+                  cswpth(icol,k) = 0.
+                  res(icol,k) = 10.
+               end do
+            endif
+
+! Zero out cloud optical properties here; not used when passing physical properties
+! to radiation and taucld is calculated in radiation
+            do k = kts, kte
+               do nb = 1, nbndlw
+                  taucld(icol,nb,k) = 0.0
+               enddo
+            enddo
+         endif
+
+! No clouds are allowed in the extra layer from model top to TOA
+#if 0         
+         ! Steven Cavallo: Edited out for buffer adjustment below
+         if ( 1 == 0 ) then
+
+
+         clwpth(icol,kte+1) = 0.
+         ciwpth(icol,kte+1) = 0.
+         cswpth(icol,kte+1) = 0.
+         rel(icol,kte+1) = 10.
+         rei(icol,kte+1) = 10.
+         res(icol,kte+1) = 10.
+         cldfrac(icol,kte+1) = 0.
+         do nb = 1, nbndlw
+            taucld(icol,nb,kte+1) = 0.
+         enddo
+
+         endif
+#endif
+         ! Buffer adjustment. Steven Cavallo December 2010
+         do k=kte+1,nlayers
+            clwpth(icol,k) = 0.
+            ciwpth(icol,k) = 0.
+            cswpth(icol,k) = 0.
+            rel(icol,k) = 10.
+            rei(icol,k) = 10.
+            res(icol,k) = 10.
+!            cldfrac(icol,k) = 0.
+            do nb = 1,nbndlw
+               taucld(icol,nb,k) = 0.
+            enddo
+         enddo
+
+      end do i_loop
+   end do j_loop
+!$acc end kernels
+
+! mji - mcica sub-column generator called inside rrtmg_lw for gpu
+! iplon = 1
+! irng = 0
+! Sub-column generator for McICA
+! call mcica_subcol_lw(iplon, ncol, nlay, icld, permuteseed, irng, play, &
+! cldfrac, ciwpth, clwpth, cswpth, rei, rel, res, taucld, cldfmcl, &
+! ciwpmcl, clwpmcl, cswpmcl, reicmcl, relqmcl, resnmcl, taucmcl)
+
+!--------------------------------------------------------------------------
+! Aerosol optical depth, single scattering albedo and asymmetry parameter -czhao 03/2010
+!--------------------------------------------------------------------------
+! Aerosol optical depth by layer for each RRTMG longwave band
+! No aerosols in layer above model top (kte+1)
+! Steven Cavallo: Upper bound of loop changed to nlayers from kte+1
+! do nb = 1, nbndlw
+! do k = kts, kte+1
+! tauaer(ncol,k,nb) = 0.
+! enddo
+! enddo
+!$acc data create(tauaer)
+
+!$acc kernels
+
+   do nb = 1, nbndlw
+   do k = kts,nlayers
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+
+! ... Aerosol effects. Added aerosol feedbacks from Chem , 03/2010 -czhao
+!
+         tauaer(icol,k,nb) = 0.
+!
+      end do 
+   end do 
+   end do
+   end do
+!$acc end kernels
+
+
+!!$acc update host(taucld,ciwpth,clwpth,cswpth,rei,rel,res)
+!   WRITE(message,*) 'cldfrac:', sum(cldfrac)
+!   call wrf_debug(0,message)
+!   WRITE(message,*) sum(plev),sum(tlev),sum(tsfc),sum(play),sum(pdel),sum(tlay),sum(tlev),sum(h2ovmr),sum(co2vmr),sum(o2vmr)
+!   call wrf_debug(0,message)
+!   WRITE(message,*) sum(taucld),sum(ciwpth),sum(clwpth),sum(cswpth),sum(rei),sum(rel),sum(res)
+!   call wrf_debug(0,message)
+!   WRITE(message,*) sum(ch4vmr),sum(n2ovmr),sum(cfc11vmr),sum(cfc12vmr),sum(cfc22vmr),sum(ccl4vmr),sum(o3vmr),sum(emis)
+!   call wrf_debug(0,message)
+
+! Call RRTMG longwave radiation model for full grid for gpu
+         call rrtmg_lw &
+            (ncol ,nlay ,icld ,idrv , &
+             play ,plev ,tlay ,tlev ,tsfc , &
+             h2ovmr ,o3vmr ,co2vmr ,ch4vmr ,n2ovmr ,o2vmr , &
+             cfc11vmr,cfc12vmr,cfc22vmr,ccl4vmr ,emis , &
+             inflglw ,iceflglw,liqflglw,cldfrac , &
+             taucld ,ciwpth ,clwpth ,cswpth ,rei ,rel ,res , &
+             tauaer , &
+             uflx ,dflx ,hr ,uflxc ,dflxc, hrc, &
+             duflx_dt,duflxc_dt)
+
+!$acc exit data delete(re_ice) if(has_reqi)
+!$acc exit data delete(re_cloud) if(has_reqc)
+!$acc exit data delete(re_snow) if(has_reqs)
+!$acc end data
+!$acc end data
+
+! Output downard surface flux, and outgoing longwave flux and cloud forcing
+! at the top of atmosphere (W/m2)
+! latitude loop
+   j_loop2: do j = jts,jte
+
+! longitude loop
+      i_loop2: do i = its,ite
+
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+
+         glw(i,j) = dflx(icol,1)
+! olr(i,j) = uflx(icol,kte+2)
+! lwcf(i,j) = uflxc(icol,kte+2) - uflx(icol,kte+2)
+! Steven Cavallo: Changed OLR to be valid at the top of atmosphere instead
+! of top of model. Dec 2010.
+         olr(i,j) = uflx(icol,nlayers+1)
+         lwcf(i,j) = uflxc(icol,nlayers+1) - uflx(icol,nlayers+1)
+
+         if (present(lwupt)) then
+! Output up and down toa fluxes for total and clear sky
+            lwupt(i,j) = uflx(icol,kte+2)
+            lwuptc(i,j) = uflxc(icol,kte+2)
+            lwdnt(i,j) = dflx(icol,kte+2)
+            lwdntc(i,j) = dflxc(icol,kte+2)
+! Output up and down surface fluxes for total and clear sky
+            lwupb(i,j) = uflx(icol,1)
+            lwupbc(i,j) = uflxc(icol,1)
+            lwdnb(i,j) = dflx(icol,1)
+            lwdnbc(i,j) = dflxc(icol,1)
+         endif
+
+! Output up and down layer fluxes for total and clear sky.
+! Vertical ordering is from bottom to top in units of W m-2.
+         if ( present (lwupflx) ) then
+         do k=kts,kte+2
+            lwupflx(i,k,j) = uflx(icol,k)
+            lwupflxc(i,k,j) = uflxc(icol,k)
+            lwdnflx(i,k,j) = dflx(icol,k)
+            lwdnflxc(i,k,j) = dflxc(icol,k)
+         enddo
+         endif
+
+! Output heating rate tendency; convert heating rate from K/d to K/s
+! Heating rate arrays are ordered vertically from bottom to top here.
+         do k=kts,kte
+            tten1d_k = hr(icol,k)/86400.
+            rthratenlw(i,k,j) = tten1d_k/pi3d(i,k,j)
+         enddo
+!
+      end do i_loop2
+   end do j_loop2
+!-------------------------------------------------------------------
+
+   END SUBROUTINE RRTMG_LWRAD_FAST
+
+
+!-------------------------------------------------------------------------
+   SUBROUTINE INIRAD_1 (O3PROF,Plev, its,ite,kts,kte,jts,jte,padding)
+!-------------------------------------------------------------------------
+      IMPLICIT NONE
+!-------------------------------------------------------------------------
+   INTEGER, INTENT(IN ) :: kts,kte,its,ite,jts,jte,padding
+#define TILEPTS (jte-jts+1)*(ite-its+1)+padding
+   REAL, DIMENSION(TILEPTS, kts:kte+1 ),INTENT(INOUT) :: O3PROF
+
+   REAL, DIMENSION(TILEPTS, kts:kte+2 ),INTENT(IN ) :: Plev
+
+! LOCAL VAR
+
+   INTEGER :: k
+
+!
+! COMPUTE OZONE MIXING RATIO DISTRIBUTION
+!
+!$acc kernels
+      O3PROF(:,:) = 0.
+!$acc end kernels  
+
+!   DO K=kts,kte+1
+!      O3PROF(K)=0.
+!   ENDDO
+
+   CALL O3DATA_1(O3PROF, Plev, its,ite,kts,kte,jts,jte,padding)
+
+   END SUBROUTINE INIRAD_1
+
+!-------------------------------------------------------------------------
+   SUBROUTINE O3DATA_1 (O3PROF, Plev, its,ite,kts,kte,jts,jte,padding)
+!-------------------------------------------------------------------------
+   IMPLICIT NONE
+!-------------------------------------------------------------------------
+!
+   INTEGER, INTENT(IN ) :: kts, kte,its,ite,jts,jte,padding
+!
+#define TILEPTS (jte-jts+1)*(ite-its+1)+padding
+   REAL, DIMENSION(TILEPTS, kts:kte+1 ),INTENT(INOUT) :: O3PROF
+
+   REAL, DIMENSION(TILEPTS, kts:kte+2 ),INTENT(IN ) :: Plev
+
+! LOCAL VAR
+   INTEGER :: K, JJ,i,j,icol
+
+   REAL :: PRLEVH(kts:kte+2),PPWRKH(32), &
+               O3WRK(31),PPWRK(31),O3SUM(31),PPSUM(31), &
+               O3WIN(31),PPWIN(31),O3ANN(31),PPANN(31)
+
+   REAL :: PB1, PB2, PT1, PT2
+
+   DATA O3SUM /5.297E-8,5.852E-8,6.579E-8,7.505E-8, &
+        8.577E-8,9.895E-8,1.175E-7,1.399E-7,1.677E-7,2.003E-7, &
+        2.571E-7,3.325E-7,4.438E-7,6.255E-7,8.168E-7,1.036E-6, &
+        1.366E-6,1.855E-6,2.514E-6,3.240E-6,4.033E-6,4.854E-6, &
+        5.517E-6,6.089E-6,6.689E-6,1.106E-5,1.462E-5,1.321E-5, &
+        9.856E-6,5.960E-6,5.960E-6/
+
+   DATA PPSUM /955.890,850.532,754.599,667.742,589.841, &
+        519.421,455.480,398.085,347.171,301.735,261.310,225.360, &
+        193.419,165.490,141.032,120.125,102.689, 87.829, 75.123, &
+         64.306, 55.086, 47.209, 40.535, 34.795, 29.865, 19.122, &
+          9.277, 4.660, 2.421, 1.294, 0.647/
+!
+   DATA O3WIN /4.629E-8,4.686E-8,5.017E-8,5.613E-8, &
+        6.871E-8,8.751E-8,1.138E-7,1.516E-7,2.161E-7,3.264E-7, &
+        4.968E-7,7.338E-7,1.017E-6,1.308E-6,1.625E-6,2.011E-6, &
+        2.516E-6,3.130E-6,3.840E-6,4.703E-6,5.486E-6,6.289E-6, &
+        6.993E-6,7.494E-6,8.197E-6,9.632E-6,1.113E-5,1.146E-5, &
+        9.389E-6,6.135E-6,6.135E-6/
+
+   DATA PPWIN /955.747,841.783,740.199,649.538,568.404, &
+        495.815,431.069,373.464,322.354,277.190,237.635,203.433, &
+        174.070,148.949,127.408,108.915, 93.114, 79.551, 67.940, &
+         58.072, 49.593, 42.318, 36.138, 30.907, 26.362, 16.423, &
+          7.583, 3.620, 1.807, 0.938, 0.469/
+!
+
+!$acc data create(PPWRKH,O3WRK,PPWRK,O3SUM,PPSUM,O3WIN,PPWIN,O3ANN,PPANN) &
+!$acc      copyin(O3SUM,PPSUM,O3WIN,PPWIN) present(O3PROF,Plev)
+!$acc kernels
+   DO K=1,31
+     PPANN(K)=PPSUM(K)
+   ENDDO
+!
+   O3ANN(1)=0.5*(O3SUM(1)+O3WIN(1))
+!
+   DO K=2,31
+      O3ANN(K)=O3WIN(K-1)+(O3WIN(K)-O3WIN(K-1))/(PPWIN(K)-PPWIN(K-1))* &
+               (PPSUM(K)-PPWIN(K-1))
+   ENDDO
+!
+   DO K=2,31
+      O3ANN(K)=0.5*(O3ANN(K)+O3SUM(K))
+   ENDDO
+!
+   DO K=1,31
+      O3WRK(K)=O3ANN(K)
+      PPWRK(K)=PPANN(K)
+   ENDDO
+!
+! CALCULATE HALF PRESSURE LEVELS FOR MODEL AND DATA LEVELS
+!
+
+! Plev is total P at model levels, from bottom to top
+! Plev is in mb
+
+!   DO K=kts,kte+2
+!      Plev(icol,K)=Plev(K)
+!   ENDDO
+!
+   PPWRKH(1)=1100.
+   DO K=2,31
+      PPWRKH(K)=(PPWRK(K)+PPWRK(K-1))/2.
+   ENDDO
+   PPWRKH(32)=0.
+
+   DO K=kts,kte+1
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent 
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+      DO 25 JJ=1,31
+         IF((-(Plev(icol,K)-PPWRKH(JJ))).GE.0.)THEN
+           PB1=0.
+         ELSE
+           PB1=Plev(icol,K)-PPWRKH(JJ)
+         ENDIF
+         IF((-(Plev(icol,K)-PPWRKH(JJ+1))).GE.0.)THEN
+           PB2=0.
+         ELSE
+           PB2=Plev(icol,K)-PPWRKH(JJ+1)
+         ENDIF
+         IF((-(Plev(icol,K+1)-PPWRKH(JJ))).GE.0.)THEN
+           PT1=0.
+         ELSE
+           PT1=Plev(icol,K+1)-PPWRKH(JJ)
+         ENDIF
+         IF((-(Plev(icol,K+1)-PPWRKH(JJ+1))).GE.0.)THEN
+           PT2=0.
+         ELSE
+           PT2=Plev(icol,K+1)-PPWRKH(JJ+1)
+         ENDIF
+         O3PROF(icol,K)=O3PROF(icol,K)+(PB2-PB1-PT2+PT1)*O3WRK(JJ)
+  25 CONTINUE
+      O3PROF(icol,K)=O3PROF(icol,K)/(Plev(icol,K)-Plev(icol,K+1))
+   enddo
+   enddo
+
+   ENDDO
+!$acc end kernels   
+!$acc end data
+!
+   END SUBROUTINE O3DATA_1
+
+!------------------------------------------------------------------
+
+!-------------------------------------------------------------------------
+   SUBROUTINE INIRAD (O3PROF,Plev, kts,kte)
+!-------------------------------------------------------------------------
+      IMPLICIT NONE
+!-------------------------------------------------------------------------
+   INTEGER, INTENT(IN ) :: kts,kte
+   REAL, DIMENSION( kts:kte+1 ),INTENT(INOUT) :: O3PROF
+
+   REAL, DIMENSION( kts:kte+2 ),INTENT(IN ) :: Plev
+
+! LOCAL VAR
+
+   INTEGER :: k
+
+!
+! COMPUTE OZONE MIXING RATIO DISTRIBUTION
+!
+
+   DO K=kts,kte+1
+      O3PROF(K)=0.
+   ENDDO
+
+   CALL O3DATA(O3PROF, Plev, kts,kte)
+
+   END SUBROUTINE INIRAD
+
+!-------------------------------------------------------------------------
+   SUBROUTINE O3DATA (O3PROF, Plev, kts,kte)
+!-------------------------------------------------------------------------
+   IMPLICIT NONE
+!-------------------------------------------------------------------------
+!
+   INTEGER, INTENT(IN ) :: kts, kte
+!
+   REAL, DIMENSION( kts:kte+1 ),INTENT(INOUT) :: O3PROF
+
+   REAL, DIMENSION( kts:kte+2 ),INTENT(IN ) :: Plev
+
+! LOCAL VAR
+   INTEGER :: K, JJ
+
+   REAL :: PRLEVH(kts:kte+2),PPWRKH(32), &
+               O3WRK(31),PPWRK(31),O3SUM(31),PPSUM(31), &
+               O3WIN(31),PPWIN(31),O3ANN(31),PPANN(31)
+
+   REAL :: PB1, PB2, PT1, PT2
+
+   DATA O3SUM /5.297E-8,5.852E-8,6.579E-8,7.505E-8, &
+        8.577E-8,9.895E-8,1.175E-7,1.399E-7,1.677E-7,2.003E-7, &
+        2.571E-7,3.325E-7,4.438E-7,6.255E-7,8.168E-7,1.036E-6, &
+        1.366E-6,1.855E-6,2.514E-6,3.240E-6,4.033E-6,4.854E-6, &
+        5.517E-6,6.089E-6,6.689E-6,1.106E-5,1.462E-5,1.321E-5, &
+        9.856E-6,5.960E-6,5.960E-6/
+
+   DATA PPSUM /955.890,850.532,754.599,667.742,589.841, &
+        519.421,455.480,398.085,347.171,301.735,261.310,225.360, &
+        193.419,165.490,141.032,120.125,102.689, 87.829, 75.123, &
+         64.306, 55.086, 47.209, 40.535, 34.795, 29.865, 19.122, &
+          9.277, 4.660, 2.421, 1.294, 0.647/
+!
+   DATA O3WIN /4.629E-8,4.686E-8,5.017E-8,5.613E-8, &
+        6.871E-8,8.751E-8,1.138E-7,1.516E-7,2.161E-7,3.264E-7, &
+        4.968E-7,7.338E-7,1.017E-6,1.308E-6,1.625E-6,2.011E-6, &
+        2.516E-6,3.130E-6,3.840E-6,4.703E-6,5.486E-6,6.289E-6, &
+        6.993E-6,7.494E-6,8.197E-6,9.632E-6,1.113E-5,1.146E-5, &
+        9.389E-6,6.135E-6,6.135E-6/
+
+   DATA PPWIN /955.747,841.783,740.199,649.538,568.404, &
+        495.815,431.069,373.464,322.354,277.190,237.635,203.433, &
+        174.070,148.949,127.408,108.915, 93.114, 79.551, 67.940, &
+         58.072, 49.593, 42.318, 36.138, 30.907, 26.362, 16.423, &
+          7.583, 3.620, 1.807, 0.938, 0.469/
+!
+
+   DO K=1,31
+     PPANN(K)=PPSUM(K)
+   ENDDO
+!
+   O3ANN(1)=0.5*(O3SUM(1)+O3WIN(1))
+!
+   DO K=2,31
+      O3ANN(K)=O3WIN(K-1)+(O3WIN(K)-O3WIN(K-1))/(PPWIN(K)-PPWIN(K-1))* &
+               (PPSUM(K)-PPWIN(K-1))
+   ENDDO
+!
+   DO K=2,31
+      O3ANN(K)=0.5*(O3ANN(K)+O3SUM(K))
+   ENDDO
+!
+   DO K=1,31
+      O3WRK(K)=O3ANN(K)
+      PPWRK(K)=PPANN(K)
+   ENDDO
+!
+! CALCULATE HALF PRESSURE LEVELS FOR MODEL AND DATA LEVELS
+!
+
+! Plev is total P at model levels, from bottom to top
+! Plev is in mb
+
+   DO K=kts,kte+2
+      PRLEVH(K)=Plev(K)
+   ENDDO
+!
+   PPWRKH(1)=1100.
+   DO K=2,31
+      PPWRKH(K)=(PPWRK(K)+PPWRK(K-1))/2.
+   ENDDO
+   PPWRKH(32)=0.
+
+   DO K=kts,kte+1
+      DO 25 JJ=1,31
+         IF((-(PRLEVH(K)-PPWRKH(JJ))).GE.0.)THEN
+           PB1=0.
+         ELSE
+           PB1=PRLEVH(K)-PPWRKH(JJ)
+         ENDIF
+         IF((-(PRLEVH(K)-PPWRKH(JJ+1))).GE.0.)THEN
+           PB2=0.
+         ELSE
+           PB2=PRLEVH(K)-PPWRKH(JJ+1)
+         ENDIF
+         IF((-(PRLEVH(K+1)-PPWRKH(JJ))).GE.0.)THEN
+           PT1=0.
+         ELSE
+           PT1=PRLEVH(K+1)-PPWRKH(JJ)
+         ENDIF
+         IF((-(PRLEVH(K+1)-PPWRKH(JJ+1))).GE.0.)THEN
+           PT2=0.
+         ELSE
+           PT2=PRLEVH(K+1)-PPWRKH(JJ+1)
+         ENDIF
+         O3PROF(K)=O3PROF(K)+(PB2-PB1-PT2+PT1)*O3WRK(JJ)
+  25 CONTINUE
+      O3PROF(K)=O3PROF(K)/(Plev(K)-PRLEVH(K+1))
+
+   ENDDO
+!
+   END SUBROUTINE O3DATA
+
+!------------------------------------------------------------------
+
+!====================================================================
+   SUBROUTINE rrtmg_lwinit_fast( &
+                       p_top, allowed_to_read , &
+                       ids, ide, jds, jde, kds, kde, &
+                       ims, ime, jms, jme, kms, kme, &
+                       its, ite, jts, jte, kts, kte )
+!--------------------------------------------------------------------
+   IMPLICIT NONE
+!--------------------------------------------------------------------
+
+   LOGICAL , INTENT(IN) :: allowed_to_read
+   INTEGER , INTENT(IN) :: ids, ide, jds, jde, kds, kde, &
+                                     ims, ime, jms, jme, kms, kme, &
+                                     its, ite, jts, jte, kts, kte
+   REAL, INTENT(IN) :: p_top
+
+! Steven Cavallo. Added for buffer layer adjustment. December 2010.
+   NLAYERS = kme + nint(p_top*0.01/deltap)- 1 ! Model levels plus new levels.
+                                              ! nlayers will subsequently
+                                              ! replace kte+1
+
+! Read in absorption coefficients and other data
+   IF ( allowed_to_read ) THEN
+     CALL rrtmg_lwlookuptable
+   ENDIF
+
+! Perform g-point reduction and other initializations
+! Specific heat of dry air (cp) used in flux to heating rate conversion factor.
+   call rrtmg_lw_ini(cp)
+
+   END SUBROUTINE rrtmg_lwinit_fast
+
+
+! **************************************************************************
+      SUBROUTINE rrtmg_lwlookuptable
+! **************************************************************************
+
+IMPLICIT NONE
+
+! Local
+      INTEGER :: i
+      LOGICAL :: opened
+      LOGICAL , EXTERNAL :: wrf_dm_on_monitor
+
+      CHARACTER*80 errmess
+      INTEGER rrtmg_unit
+
+      IF ( wrf_dm_on_monitor() ) THEN
+        DO i = 10,99
+          INQUIRE ( i , OPENED = opened )
+          IF ( .NOT. opened ) THEN
+            rrtmg_unit = i
+            GOTO 2010
+          ENDIF
+        ENDDO
+        rrtmg_unit = -1
+ 2010 CONTINUE
+      ENDIF
+      CALL wrf_dm_bcast_bytes ( rrtmg_unit , IWORDSIZE )
+      IF ( rrtmg_unit < 0 ) THEN
+        CALL wrf_error_fatal ( 'module_ra_rrtmg_lwf: rrtm_lwlookuptable: Can not find unused fortran unit to read in lookup table.' )
+      ENDIF
+
+      IF ( wrf_dm_on_monitor() ) THEN
+        OPEN(rrtmg_unit,FILE='RRTMG_LW_DATA', &
+             FORM='UNFORMATTED',STATUS='OLD',ERR=9009)
+      ENDIF
+
+      call lw_kgb01(rrtmg_unit)
+      call lw_kgb02(rrtmg_unit)
+      call lw_kgb03(rrtmg_unit)
+      call lw_kgb04(rrtmg_unit)
+      call lw_kgb05(rrtmg_unit)
+      call lw_kgb06(rrtmg_unit)
+      call lw_kgb07(rrtmg_unit)
+      call lw_kgb08(rrtmg_unit)
+      call lw_kgb09(rrtmg_unit)
+      call lw_kgb10(rrtmg_unit)
+      call lw_kgb11(rrtmg_unit)
+      call lw_kgb12(rrtmg_unit)
+      call lw_kgb13(rrtmg_unit)
+      call lw_kgb14(rrtmg_unit)
+      call lw_kgb15(rrtmg_unit)
+      call lw_kgb16(rrtmg_unit)
+
+     IF ( wrf_dm_on_monitor() ) CLOSE (rrtmg_unit)
+
+     RETURN
+9009 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error opening RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+     END SUBROUTINE rrtmg_lwlookuptable
+
+! **************************************************************************
+! RRTMG Longwave Radiative Transfer Model
+! Atmospheric and Environmental Research, Inc., Cambridge, MA
+!
+! Original version: E. J. Mlawer, et al.
+! Revision for GCMs: Michael J. Iacono; October, 2002
+! Revision for F90 formatting: Michael J. Iacono; June 2006
+!
+! This file contains 16 READ statements that include the
+! absorption coefficients and other data for each of the 16 longwave
+! spectral bands used in RRTMG_LW. Here, the data are defined for 16
+! g-points, or sub-intervals, per band. These data are combined and
+! weighted using a mapping procedure in module RRTMG_LW_INIT to reduce
+! the total number of g-points from 256 to 140 for use in the GCM.
+! **************************************************************************
+
+! **************************************************************************
+      subroutine lw_kgb01(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg01_f, only : fracrefao, fracrefbo, kao, kbo, kao_mn2, kbo_mn2, &
+                           absa, absb, &
+                      selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels: P = 212.7250 mbar, T = 223.06 K
+
+! The array KAO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels > ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the corresponding TREF for this pressure level,
+! JT = 2 refers to the temperatureTREF-15, JT = 1 is for TREF-30,
+! JT = 4 is for TREF+15, and JT = 5 is for TREF+30. The second
+! index, JP, runs from 1 to 13 and refers to the corresponding
+! pressure level in PREF (e.g. JP = 1 is for a pressure of 1053.63 mb).
+! The third index, IG, goes from 1 to 16, and tells us which
+! g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels < ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+! TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.
+! The second index, JP, runs from 13 to 59 and refers to the JPth
+! reference pressure level (see taumol.f for the value of these
+! pressure levels in mb). The third index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The arrays kao_mn2 and kbo_mn2 contain the coefficients of the
+! nitrogen continuum for the upper and lower atmosphere.
+! Minor gas mapping levels:
+! Lower - n2: P = 142.5490 mbar, T = 215.70 K
+! Upper - n2: P = 142.5490 mbar, T = 215.70 K
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, kao_mn2, kbo_mn2, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mn2 , size ( kao_mn2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo_mn2 , size ( kbo_mn2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb01
+
+! **************************************************************************
+      subroutine lw_kgb02(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg02_f, only : fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P = 1053.630 mbar, T = 294.2 K
+! Upper: P = 3.206e-2 mb, T = 197.92 K
+
+! The array KAO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels > ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the corresponding TREF for this pressure level,
+! JT = 2 refers to the temperatureTREF-15, JT = 1 is for TREF-30,
+! JT = 4 is for TREF+15, and JT = 5 is for TREF+30. The second
+! index, JP, runs from 1 to 13 and refers to the corresponding
+! pressure level in PREF (e.g. JP = 1 is for a pressure of 1053.63 mb).
+! The third index, IG, goes from 1 to 16, and tells us which
+! g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels < ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+! TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.
+! The second index, JP, runs from 13 to 59 and refers to the JPth
+! reference pressure level (see taumol.f for the value of these
+! pressure levels in mb). The third index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb02
+
+! **************************************************************************
+      subroutine lw_kgb03(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg03_f, only : fracrefao, fracrefbo, kao, kbo, kao_mn2o, &
+                            kbo_mn2o, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P = 212.7250 mbar, T = 223.06 K
+! Upper: P = 95.8 mbar, T = 215.7 k
+
+! The array KAO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels > ~100mb, temperatures, and ratios
+! of water vapor to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels < ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+! TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.
+! The second index, JP, runs from 13 to 59 and refers to the JPth
+! reference pressure level (see taumol.f for the value of these
+! pressure levels in mb). The third index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KAO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level below 100~ mb. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2. The second index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The third index
+! runs over the g-channel (1 to 16).
+
+! The array KBO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level above 100~ mb. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amounts ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1 to
+! that of gas2. The second index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The third index
+! runs over the g-channel (1 to 16).
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, kao_mn2o, kbo_mn2o, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mn2o , size ( kao_mn2o ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo_mn2o , size ( kbo_mn2o ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb03
+
+! **************************************************************************
+      subroutine lw_kgb04(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg04_f, only : fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower : P = 142.5940 mbar, T = 215.70 K
+! Upper : P = 95.58350 mb, T = 215.70 K
+
+! The array KAO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels > ~100mb, temperatures, and ratios
+! of water vapor to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels < ~100mb, temperatures, and ratios
+! of H2O to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2. The second index, JT, which
+! runs from 1 to 5, corresponds to different temperatures. More
+! specifically, JT = 3 means that the data are for the corresponding
+! reference temperature TREF for this pressure level, JT = 2 refers
+! to the TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and
+! JT = 5 is for TREF+30. The third index, JP, runs from 13 to 59 and
+! refers to the corresponding pressure level in PREF (e.g. JP = 13 is
+! for a pressure of 95.5835 mb). The fourth index, IG, goes from 1 to
+! 16, and tells us which g-interval the absorption coefficients are for.
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb04
+
+! **************************************************************************
+      subroutine lw_kgb05(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg05_f, only : fracrefao, fracrefbo, kao, kbo, kao_mo3, &
+                            selfrefo, forrefo, ccl4o
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P = 473.42 mb, T = 259.83
+! Upper: P = 0.2369280 mbar, T = 253.60 K
+
+! The arrays kao_mo3 and ccl4o contain the coefficients for
+! ozone and ccl4 in the lower atmosphere.
+! Minor gas mapping level:
+! Lower - o3: P = 317.34 mbar, T = 240.77 k
+! Lower - ccl4:
+
+! The array KAO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels > ~100mb, temperatures, and ratios
+! of water vapor to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels < ~100mb, temperatures, and ratios
+! of H2O to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2. The second index, JT, which
+! runs from 1 to 5, corresponds to different temperatures. More
+! specifically, JT = 3 means that the data are for the corresponding
+! reference temperature TREF for this pressure level, JT = 2 refers
+! to the TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and
+! JT = 5 is for TREF+30. The third index, JP, runs from 13 to 59 and
+! refers to the corresponding pressure level in PREF (e.g. JP = 13 is
+! for a pressure of 95.5835 mb). The fourth index, IG, goes from 1 to
+! 16, and tells us which g-interval the absorption coefficients are for.
+
+! The array KAO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level below 100~ mb. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2. The second index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The third index
+! runs over the g-channel (1 to 16).
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, kao_mo3, ccl4o, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mo3 , size ( kao_mo3 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( ccl4o , size ( ccl4o ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb05
+
+! **************************************************************************
+      subroutine lw_kgb06(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg06_f, only : fracrefao, kao, kao_mco2, selfrefo, forrefo, &
+                            cfc11adjo, cfc12o
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: : P = 473.4280 mb, T = 259.83 K
+
+! The arrays kao_mco2, cfc11adjo and cfc12o contain the coefficients for
+! carbon dioxide in the lower atmosphere and cfc11 and cfc12 in the upper
+! atmosphere.
+! Original cfc11 is multiplied by 1.385 to account for the 1060-1107 cm-1 band.
+! Minor gas mapping level:
+! Lower - co2: P = 706.2720 mb, T = 294.2 k
+! Upper - cfc11, cfc12
+
+! The array KAO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels > ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the corresponding TREF for this pressure level,
+! JT = 2 refers to the temperatureTREF-15, JT = 1 is for TREF-30,
+! JT = 4 is for TREF+15, and JT = 5 is for TREF+30. The second
+! index, JP, runs from 1 to 13 and refers to the corresponding
+! pressure level in PREF (e.g. JP = 1 is for a pressure of 1053.63 mb).
+! The third index, IG, goes from 1 to 16, and tells us which
+! g-interval the absorption coefficients are for.
+
+! The array KAO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level below 100~ mb. The first index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The second index
+! runs over the g-channel (1 to 16).
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, kao, kao_mco2, cfc11adjo, cfc12o, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mco2 , size ( kao_mco2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( cfc11adjo , size ( cfc11adjo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( cfc12o , size ( cfc12o ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb06
+
+! **************************************************************************
+      subroutine lw_kgb07(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg07_f, only : fracrefao, fracrefbo, kao, kbo, kao_mco2, &
+                            kbo_mco2, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower : P = 706.27 mb, T = 278.94 K
+! Upper : P = 95.58 mbar, T= 215.70 K
+
+! The array KAO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels > ~100mb, temperatures, and ratios
+! of water vapor to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels < ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+! TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.
+! The second index, JP, runs from 13 to 59 and refers to the JPth
+! reference pressure level (see taumol.f for the value of these
+! pressure levels in mb). The third index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KAO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level below 100~ mb. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2. The second index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The third index
+! runs over the g-channel (1 to 16).
+
+! The array KBO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level above 100~ mb. The first index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The second index
+! runs over the g-channel (1 to 16).
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296_rb,260_rb,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, kao_mco2, kbo_mco2, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mco2 , size ( kao_mco2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo_mco2 , size ( kbo_mco2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb07
+
+! **************************************************************************
+      subroutine lw_kgb08(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg08_f, only : fracrefao, fracrefbo, kao, kao_mco2, kao_mn2o, &
+                            kao_mo3, kbo, kbo_mco2, kbo_mn2o, selfrefo, forrefo, &
+                            cfc12o, cfc22adjo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P=473.4280 mb, T = 259.83 K
+! Upper: P=95.5835 mb, T= 215.7 K
+
+! The arrays kao_mco2, kbo_mco2, kao_mn2o, kbo_mn2o contain the coefficients for
+! carbon dioxide and n2o in the lower and upper atmosphere.
+! The array kao_mo3 contains the coefficients for ozone in the lower atmosphere,
+! and arrays cfc12o and cfc12adjo contain the coefficients for cfc12 and cfc22.
+! Original cfc22 is multiplied by 1.485 to account for the 780-850 cm-1
+! and 1290-1335 cm-1 bands.
+! Minor gas mapping level:
+! Lower - co2: P = 1053.63 mb, T = 294.2 k
+! Lower - o3: P = 317.348 mb, T = 240.77 k
+! Lower - n2o: P = 706.2720 mb, T= 278.94 k
+! Lower - cfc12, cfc22
+! Upper - co2: P = 35.1632 mb, T = 223.28 k
+! Upper - n2o: P = 8.716e-2 mb, T = 226.03 k
+
+! The array KAO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels > ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the corresponding TREF for this pressure level,
+! JT = 2 refers to the temperatureTREF-15, JT = 1 is for TREF-30,
+! JT = 4 is for TREF+15, and JT = 5 is for TREF+30. The second
+! index, JP, runs from 1 to 13 and refers to the corresponding
+! pressure level in PREF (e.g. JP = 1 is for a pressure of 1053.63 mb).
+! The third index, IG, goes from 1 to 16, and tells us which
+! g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels < ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+! TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.
+! The second index, JP, runs from 13 to 59 and refers to the JPth
+! reference pressure level (see taumol.f for the value of these
+! pressure levels in mb). The third index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KAO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level below 100~ mb. The first index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The second index
+! runs over the g-channel (1 to 16).
+
+! The array KBO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level above 100~ mb. The first index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The second index
+! runs over the g-channel (1 to 16).
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, kao_mco2, kbo_mco2, kao_mn2o, &
+         kbo_mn2o, kao_mo3, cfc12o, cfc22adjo, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mco2 , size ( kao_mco2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo_mco2 , size ( kbo_mco2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mn2o , size ( kao_mn2o ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo_mn2o , size ( kbo_mn2o ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mo3 , size ( kao_mo3 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( cfc12o , size ( cfc12o ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( cfc22adjo , size ( cfc22adjo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb08
+
+! **************************************************************************
+      subroutine lw_kgb09(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg09_f, only : fracrefao, fracrefbo, kao, kbo, kao_mn2o, &
+                            kbo_mn2o, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P=212.7250 mb, T = 223.06 K
+! Upper: P=3.20e-2 mb, T = 197.92 k
+
+! The array KAO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels > ~100mb, temperatures, and ratios
+! of water vapor to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels < ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+! TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.
+! The second index, JP, runs from 13 to 59 and refers to the JPth
+! reference pressure level (see taumol.f for the value of these
+! pressure levels in mb). The third index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KAO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level below 100~ mb. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2. The second index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The third index
+! runs over the g-channel (1 to 16).
+
+! The array KBO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level above 100~ mb. The first index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The second index
+! runs over the g-channel (1 to 16).
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, kao_mn2o, kbo_mn2o, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mn2o , size ( kao_mn2o ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo_mn2o , size ( kbo_mn2o ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb09
+
+! **************************************************************************
+      subroutine lw_kgb10(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg10_f, only : fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P = 212.7250 mb, T = 223.06 K
+! Upper: P = 95.58350 mb, T = 215.70 K
+
+! The array KAO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels > ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the corresponding TREF for this pressure level,
+! JT = 2 refers to the temperatureTREF-15, JT = 1 is for TREF-30,
+! JT = 4 is for TREF+15, and JT = 5 is for TREF+30. The second
+! index, JP, runs from 1 to 13 and refers to the corresponding
+! pressure level in PREF (e.g. JP = 1 is for a pressure of 1053.63 mb).
+! The third index, IG, goes from 1 to 16, and tells us which
+! g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels < ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+! TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.
+! The second index, JP, runs from 13 to 59 and refers to the JPth
+! reference pressure level (see taumol.f for the value of these
+! pressure levels in mb). The third index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb10
+
+! **************************************************************************
+      subroutine lw_kgb11(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg11_f, only : fracrefao, fracrefbo, kao, kbo, kao_mo2, &
+                            kbo_mo2, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P=1053.63 mb, T= 294.2 K
+! Upper: P=0.353 mb, T = 262.11 K
+
+! The array KAO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels > ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the corresponding TREF for this pressure level,
+! JT = 2 refers to the temperatureTREF-15, JT = 1 is for TREF-30,
+! JT = 4 is for TREF+15, and JT = 5 is for TREF+30. The second
+! index, JP, runs from 1 to 13 and refers to the corresponding
+! pressure level in PREF (e.g. JP = 1 is for a pressure of 1053.63 mb).
+! The third index, IG, goes from 1 to 16, and tells us which
+! g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels < ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+! TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.
+! The second index, JP, runs from 13 to 59 and refers to the JPth
+! reference pressure level (see taumol.f for the value of these
+! pressure levels in mb). The third index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KAO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level below 100~ mb. The first index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The second index
+! runs over the g-channel (1 to 16).
+
+! The array KBO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level above 100~ mb. The first index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The second index
+! runs over the g-channel (1 to 16).
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, kao_mo2, kbo_mo2, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mo2 , size ( kao_mo2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo_mo2 , size ( kbo_mo2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb11
+
+! **************************************************************************
+      subroutine lw_kgb12(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg12_f, only : fracrefao, kao, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P = 174.1640 mbar, T= 215.78 K
+
+! The array KAO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels > ~100mb, temperatures, and ratios
+! of water vapor to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, kao, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb12
+
+! **************************************************************************
+      subroutine lw_kgb13(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg13_f, only : fracrefao, fracrefbo, kao, kao_mco2, kao_mco, &
+                            kbo_mo3, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P=473.4280 mb, T = 259.83 K
+! Upper: P=4.758820 mb, T = 250.85 K
+
+! The array KAO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels > ~100mb, temperatures, and ratios
+! of water vapor to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KAO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level below 100~ mb. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2. The second index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The third index
+! runs over the g-channel (1 to 16).
+
+! The array KBO_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level above 100~ mb. The first index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The second index
+! runs over the g-channel (1 to 16).
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kao_mco2, kao_mco, kbo_mo3, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mco2 , size ( kao_mco2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mco , size ( kao_mco ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo_mo3 , size ( kbo_mo3 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb13
+
+! **************************************************************************
+      subroutine lw_kgb14(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg14_f, only : fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P = 142.5940 mb, T = 215.70 K
+! Upper: P = 4.758820 mb, T = 250.85 K
+
+! The array KAO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels > ~100mb, temperatures, and ratios
+! of water vapor to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels < ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+! TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.
+! The second index, JP, runs from 13 to 59 and refers to the JPth
+! reference pressure level (see taumol.f for the value of these
+! pressure levels in mb). The third index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb14
+
+! **************************************************************************
+      subroutine lw_kgb15(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg15_f, only : fracrefao, kao, kao_mn2, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P = 1053. mb, T = 294.2 K
+
+! The array KAO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels > ~100mb, temperatures, and ratios
+! of water vapor to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KA_Mxx contains the absorption coefficient for
+! a minor species at the 16 chosen g-values for a reference pressure
+! level below 100~ mb. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2. The second index refers to temperature
+! in 7.2 degree increments. For instance, JT = 1 refers to a
+! temperature of 188.0, JT = 2 refers to 195.2, etc. The third index
+! runs over the g-channel (1 to 16).
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, kao, kao_mn2, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao_mn2 , size ( kao_mn2 ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb15
+
+! **************************************************************************
+      subroutine lw_kgb16(rrtmg_unit)
+! **************************************************************************
+
+      use rrlw_kg16_f, only : fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local
+      character*80 errmess
+      logical, external :: wrf_dm_on_monitor
+
+! Arrays fracrefao and fracrefbo are the Planck fractions for the lower
+! and upper atmosphere.
+! Planck fraction mapping levels:
+! Lower: P = 387.6100 mbar, T = 250.17 K
+! Upper: P=95.58350 mb, T = 215.70 K
+
+! The array KAO contains absorption coefs for each of the 16 g-intervals
+! for a range of pressure levels > ~100mb, temperatures, and ratios
+! of water vapor to CO2. The first index in the array, JS, runs
+! from 1 to 10, and corresponds to different gas column amount ratios,
+! as expressed through the binary species parameter eta, defined as
+! eta = gas1/(gas1 + (rat) * gas2), where rat is the
+! ratio of the reference MLS column amount value of gas 1
+! to that of gas2.
+! The 2nd index in the array, JT, which runs from 1 to 5, corresponds
+! to different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature
+! TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+! is for TREF+30. The third index, JP, runs from 1 to 13 and refers
+! to the reference pressure level (e.g. JP = 1 is for a
+! pressure of 1053.63 mb). The fourth index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array KBO contains absorption coefs at the 16 chosen g-values
+! for a range of pressure levels < ~100mb and temperatures. The first
+! index in the array, JT, which runs from 1 to 5, corresponds to
+! different temperatures. More specifically, JT = 3 means that the
+! data are for the reference temperature TREF for this pressure
+! level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+! TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.
+! The second index, JP, runs from 13 to 59 and refers to the JPth
+! reference pressure level (see taumol.f for the value of these
+! pressure levels in mb). The third index, IG, goes from 1 to 16,
+! and tells us which g-interval the absorption coefficients are for.
+
+! The array FORREFO contains the coefficient of the water vapor
+! foreign-continuum (including the energy term). The first
+! index refers to reference temperature (296,260,224,260) and
+! pressure (970,475,219,3 mbar) levels. The second index
+! runs over the g-channel (1 to 16).
+
+! The array SELFREFO contains the coefficient of the water vapor
+! self-continuum (including the energy term). The first index
+! refers to temperature in 7.2 degree increments. For instance,
+! JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+! etc. The second index runs over the g-channel (1 to 16).
+
+
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         fracrefao, fracrefbo, kao, kbo, selfrefo, forrefo
+      CALL wrf_dm_bcast_bytes ( fracrefao , size ( fracrefao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( fracrefbo , size ( fracrefbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kao , size ( kao ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( kbo , size ( kbo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( selfrefo , size ( selfrefo ) * RWORDSIZE )
+      CALL wrf_dm_bcast_bytes ( forrefo , size ( forrefo ) * RWORDSIZE )
+
+     RETURN
+9010 CONTINUE
+     WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_lwf: error reading RRTMG_LW_DATA on unit ',rrtmg_unit
+     CALL wrf_error_fatal(errmess)
+
+      end subroutine lw_kgb16
+
+!===============================================================================
+  subroutine relcalc(icol, pcols, pver, t, landfrac, landm, icefrac, rel, snowh)
+!$acc routine seq  
+!-----------------------------------------------------------------------
+!
+! Purpose:
+! Compute cloud water size
+!
+! Method:
+! analytic formula following the formulation originally developed by J. T. Kiehl
+!
+! Author: Phil Rasch
+!
+!-----------------------------------------------------------------------
+    implicit none
+!------------------------------Arguments--------------------------------
+!
+! Input arguments
+!
+    integer, intent(in) :: icol
+    integer, intent(in) :: pcols, pver
+    real, intent(in) :: landfrac(pcols) ! Land fraction
+    real, intent(in) :: icefrac(pcols) ! Ice fraction
+    real, intent(in) :: snowh(pcols) ! Snow depth over land, water equivalent (m)
+    real, intent(in) :: landm(pcols) ! Land fraction ramping to zero over ocean
+    real, intent(in) :: t(pcols,pver) ! Temperature
+
+!
+! Output arguments
+!
+    real, intent(out) :: rel(pcols,pver) ! Liquid effective drop size (microns)
+!
+!---------------------------Local workspace-----------------------------
+!
+    integer i,k ! Lon, lev indices
+    real tmelt ! freezing temperature of fresh water (K)
+    real rliqland ! liquid drop size if over land
+    real rliqocean ! liquid drop size if over ocean
+    real rliqice ! liquid drop size if over sea ice
+!
+!-----------------------------------------------------------------------
+!
+    tmelt = 273.16
+    rliqocean = 14.0
+    rliqice = 14.0
+    rliqland = 8.0
+    do k=1,pver
+! do i=1,ncol
+! jrm Reworked effective radius algorithm
+          ! Start with temperature-dependent value appropriate for continental air
+          ! Note: findmcnew has a pressure dependence here
+          rel(icol,k) = rliqland + (rliqocean-rliqland) * min(1.0,max(0.0,(tmelt-t(icol,k))*0.05))
+          ! Modify for snow depth over land
+          rel(icol,k) = rel(icol,k) + (rliqocean-rel(icol,k)) * min(1.0,max(0.0,snowh(icol)*10.))
+          ! Ramp between polluted value over land to clean value over ocean.
+          rel(icol,k) = rel(icol,k) + (rliqocean-rel(icol,k)) * min(1.0,max(0.0,1.0-landm(icol)))
+          ! Ramp between the resultant value and a sea ice value in the presence of ice.
+          rel(icol,k) = rel(icol,k) + (rliqice-rel(icol,k)) * min(1.0,max(0.0,icefrac(icol)))
+! end jrm
+! end do
+    end do
+  end subroutine relcalc
+!===============================================================================
+  subroutine reicalc(icol, pcols, pver, t, re)
+!$acc routine seq    
+    !
+
+    integer, intent(in) :: icol, pcols, pver
+    real, intent(out) :: re(pcols,pver)
+    real, intent(in) :: t(pcols,pver)
+    real corr
+    integer i
+    integer k
+    integer index
+    !
+    ! Tabulated values of re(T) in the temperature interval
+    ! 180 K -- 274 K; hexagonal columns assumed:
+    !
+    !
+    do k=1,pver
+! do i=1,ncol
+          index = int(t(icol,k)-179.)
+          index = min(max(index,1),94)
+          corr = t(icol,k) - int(t(icol,k))
+          re(icol,k) = retab(index)*(1.-corr) &
+               +retab(index+1)*corr
+          ! re(icol,k) = amax1(amin1(re(icol,k),30.),10.)
+! end do
+    end do
+    !
+    return
+  end subroutine reicalc
+!------------------------------------------------------------------
+
+END MODULE module_ra_rrtmg_lwf

--- a/src/fromNVIDIA/module_ra_rrtmg_swf.F
+++ b/src/fromNVIDIA/module_ra_rrtmg_swf.F
@@ -1,0 +1,13971 @@
+!!MODULE module_ra_rrtmg_swf
+#define CHNK 512
+! CHNK size must be the same for lwf and swf
+
+!#define CHNK 1849
+!#define CHNK 43
+!#define CHNK 1
+
+!  --------------------------------------------------------------------------
+! |                                                                          |
+! |  Copyright 2002-2013, Atmospheric & Environmental Research, Inc. (AER).  |
+! |  This software may be used, copied, or redistributed as long as it is    |
+! |  not sold and this copyright notice is reproduced on each copy made.     |
+! |  This model is provided as is without any express or implied warranties. |
+! |                       (http://www.rtweb.aer.com/)                        |
+! |                                                                          |
+!  --------------------------------------------------------------------------
+
+#ifndef _OPENACC
+! this set of macros reverses the storage order of some of the array variables
+! defined in rrtmg_sw_sub and used in various sections of the code.  Here is a 
+! correspondencet table for the variables as they are known in rrtmg_sw_sub and
+! in the subroutines that rrtmg_sw_sub calls:
+
+!jm     rrtmg_sw_sub    
+!jm      |        mcica_sw        
+!jm      |         |            cldprmc_sw      
+!jm      |         |                |     spcvmc_sw       
+!jm      |         |                |       |       reftra_sw
+!jm     tauc      tauc              |       |         |   
+!jm     ssac      ssac              |       |         |   
+!jm     asmc      asmc              |       |         |   
+!jm     fsfc      fsfc              |       |         |   
+!jm     taucmc    tauc_stoch        |     ptaucmc     |
+!jm     taormc     |                |     ptaormc     |
+!jm     ssacmc    ssac_stoch        |     pomgcmc     |
+!jm     asmcmc    asmc_stoch        |     pasycmc     |
+!jm     fsfcmc    fsfc_stoch        |       |         |           
+!jm     cldfmcl   cld_stoch       cldmfc  pcldfmc   pcldfmc
+!jm     ciwpmcl   ciwp_stoch      ciwpmc    |     
+!jm     clwpmcl   clwp_stoch      clwpmc    |     
+!jm     cswpmcl   cswp_stoch      cswpmc    |     
+!jm     ztauc                               |
+!jm     ztaucorig                           |     
+!jm     zasyc                               |
+!jm     zomgc                               |
+!jm     taua                              ptaua   
+!jm     asya                              pasya   
+!jm     omga                              pomga   
+
+#define tauc(A,B,C)  TAUC(A,C,B)
+#define ssac(A,B,C)  SSAC(A,C,B)
+#define asmc(A,B,C)  ASMC(A,C,B)
+#define fsfc(A,B,C)  FSFC(A,C,B)
+#define taucmc(A,B,C)   TAUCMC(A,C,B)
+#define tauc_stoch(A,B,C) TAUC_STOCH(A,C,B)
+#define ptaucmc(A,B,C)  pTAUCMC(A,C,B)
+#define taormc(A,B,C)   TAORMC(A,C,B)
+#define ptaormc(A,B,C)  pTAORMC(A,C,B)
+#define ssacmc(A,B,C)   SSACMC(A,C,B)
+#define ssac_stoch(A,B,C)   SSAC_STOCH(A,C,B)
+#define pomgcmc(A,B,C)  pOMGCMC(A,C,B)
+#define asmcmc(A,B,C)   ASMCMC(A,C,B)
+#define asmc_stoch(A,B,C)   ASMC_STOCH(A,C,B)
+#define pasycmc(A,B,C)  pASYCMC(A,C,B)
+#define fsfcmc(A,B,C)   FSFCMC(A,C,B)
+#define fsfc_stoch(A,B,C)   FSFC_STOCH(A,C,B)
+
+#define cldfmcl(A,B,C)   CLDFMCL(A,C,B)
+#define cld_stoch(A,B,C) CLD_STOCH(A,C,B)
+#define cldfmc(A,B,C)    CLDFMC(A,C,B)
+#define pcldfmc(A,B,C)   pCLDFMC(A,C,B)
+
+#define ciwpmcl(A,B,C)    CIWPMCL(A,C,B)
+#define ciwp_stoch(A,B,C) CIWP_STOCH(A,C,B)
+#define ciwpmc(A,B,C)     CIWPMC(A,C,B)
+
+#define clwpmcl(A,B,C)    CLWPMCL(A,C,B)
+#define clwp_stoch(A,B,C) CLWP_STOCH(A,C,B)
+#define clwpmc(A,B,C)     CLWPMC(A,C,B)
+
+#define cswpmcl(A,B,C)    CSWPMCL(A,C,B)
+#define cswp_stoch(A,B,C) CSWP_STOCH(A,C,B)
+#define cswpmc(A,B,C)     CSWPMC(A,C,B)
+
+#define taua(A,B,C)  TAUA(A,C,B)
+#define asya(A,B,C)  ASYA(A,C,B)
+#define omga(A,B,C)  OMGA(A,C,B)
+#define ptaua(A,B,C) pTAUA(A,C,B)
+#define pasya(A,B,C) pASYA(A,C,B)
+#define pomga(A,B,C) pOMGA(A,C,B)
+
+#endif
+
+! Uncomment to use GPU, or comment to use CPU
+!#define _OPENACC
+
+#ifdef _OPENACC
+#define gpu_device ,device
+#else
+#define gpu_device 
+#endif
+
+      module parrrsw_f
+
+!     implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_sw main parameters
+!
+! Initial version:  JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+!  name     type     purpose
+! -----  :  ----   : ----------------------------------------------
+! mxlay  :  integer: maximum number of layers
+! mg     :  integer: number of original g-intervals per spectral band
+! nbndsw :  integer: number of spectral bands
+! naerec :  integer: number of aerosols (iaer=6, ecmwf aerosol option)
+! ngptsw :  integer: total number of reduced g-intervals for rrtmg_lw
+! ngNN   :  integer: number of reduced g-intervals per spectral band
+! ngsNN  :  integer: cumulative number of g-intervals per band
+!------------------------------------------------------------------
+
+      integer , parameter :: mxlay  = 203   !jplay, klev
+      integer , parameter :: mg     = 16     !jpg
+      integer , parameter :: nbndsw = 14     !jpsw, ksw
+      integer , parameter :: naerec  = 6     !jpaer
+      integer , parameter :: mxmol  = 38
+      integer , parameter :: nstr   = 2
+      integer , parameter :: nmol   = 7
+! Use for 112 g-point model   
+      integer , parameter :: ngptsw = 112    !jpgpt
+! Use for 224 g-point model   
+!      integer , parameter :: ngptsw = 224   !jpgpt
+
+! may need to rename these - from v2.6
+      integer , parameter :: jpband   = 29
+      integer , parameter :: jpb1     = 16   !istart
+      integer , parameter :: jpb2     = 29   !iend
+
+      integer , parameter :: jmcmu    = 32
+      integer , parameter :: jmumu    = 32
+      integer , parameter :: jmphi    = 3
+      integer , parameter :: jmxang   = 4
+      integer , parameter :: jmxstr   = 16
+! ^
+
+! Use for 112 g-point model   
+      integer , parameter :: ng16 = 6
+      integer , parameter :: ng17 = 12
+      integer , parameter :: ng18 = 8
+      integer , parameter :: ng19 = 8
+      integer , parameter :: ng20 = 10
+      integer , parameter :: ng21 = 10
+      integer , parameter :: ng22 = 2
+      integer , parameter :: ng23 = 10
+      integer , parameter :: ng24 = 8
+      integer , parameter :: ng25 = 6
+      integer , parameter :: ng26 = 6
+      integer , parameter :: ng27 = 8
+      integer , parameter :: ng28 = 6
+      integer , parameter :: ng29 = 12
+
+      integer , parameter :: ngs16 = 6
+      integer , parameter :: ngs17 = 18
+      integer , parameter :: ngs18 = 26
+      integer , parameter :: ngs19 = 34
+      integer , parameter :: ngs20 = 44
+      integer , parameter :: ngs21 = 54
+      integer , parameter :: ngs22 = 56
+      integer , parameter :: ngs23 = 66
+      integer , parameter :: ngs24 = 74
+      integer , parameter :: ngs25 = 80
+      integer , parameter :: ngs26 = 86
+      integer , parameter :: ngs27 = 94
+      integer , parameter :: ngs28 = 100
+      integer , parameter :: ngs29 = 112
+
+! Use for 224 g-point model   
+!      integer , parameter :: ng16 = 16
+!      integer , parameter :: ng17 = 16
+!      integer , parameter :: ng18 = 16
+!      integer , parameter :: ng19 = 16
+!      integer , parameter :: ng20 = 16
+!      integer , parameter :: ng21 = 16
+!      integer , parameter :: ng22 = 16
+!      integer , parameter :: ng23 = 16
+!      integer , parameter :: ng24 = 16
+!      integer , parameter :: ng25 = 16
+!      integer , parameter :: ng26 = 16
+!      integer , parameter :: ng27 = 16
+!      integer , parameter :: ng28 = 16
+!      integer , parameter :: ng29 = 16
+
+!      integer , parameter :: ngs16 = 16
+!      integer , parameter :: ngs17 = 32
+!      integer , parameter :: ngs18 = 48
+!      integer , parameter :: ngs19 = 64
+!      integer , parameter :: ngs20 = 80
+!      integer , parameter :: ngs21 = 96
+!      integer , parameter :: ngs22 = 112
+!      integer , parameter :: ngs23 = 128
+!      integer , parameter :: ngs24 = 144
+!      integer , parameter :: ngs25 = 160
+!      integer , parameter :: ngs26 = 176
+!      integer , parameter :: ngs27 = 192
+!      integer , parameter :: ngs28 = 208
+!      integer , parameter :: ngs29 = 224
+
+! Source function solar constant
+      real , parameter :: rrsw_scon = 1.36822e+03     ! W/m2
+ 
+      end module parrrsw_f
+
+      module rrsw_aer_f
+
+      use parrrsw_f, only : nbndsw, naerec
+
+!     implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_sw aerosol optical properties
+!
+!  Data derived from six ECMWF aerosol types and defined for
+!  the rrtmg_sw spectral intervals
+!
+! Initial: J.-J. Morcrette, ECMWF, mar2003
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+!
+!-- The six ECMWF aerosol types are respectively:
+!
+!  1/ continental average                 2/ maritime
+!  3/ desert                              4/ urban
+!  5/ volcanic active                     6/ stratospheric background
+!
+! computed from Hess and Koepke (con, mar, des, urb)
+!          from Bonnel et al.   (vol, str)
+!
+! rrtmg_sw 14 spectral intervals (microns):
+!  3.846 -  3.077
+!  3.077 -  2.500
+!  2.500 -  2.150
+!  2.150 -  1.942
+!  1.942 -  1.626
+!  1.626 -  1.299
+!  1.299 -  1.242
+!  1.242 -  0.7782
+!  0.7782-  0.6250
+!  0.6250-  0.4415
+!  0.4415-  0.3448
+!  0.3448-  0.2632
+!  0.2632-  0.2000
+! 12.195 -  3.846
+!
+!------------------------------------------------------------------
+!
+!  name     type     purpose
+! -----   : ----   : ----------------------------------------------
+! rsrtaua : real   : ratio of average optical thickness in 
+!                    spectral band to that at 0.55 micron
+! rsrpiza : real   : average single scattering albedo (unitless)
+! rsrasya : real   : average asymmetry parameter (unitless)
+!------------------------------------------------------------------
+
+      real  :: rsrtaua(nbndsw,naerec)
+      real  :: rsrpiza(nbndsw,naerec)
+      real  :: rsrasya(nbndsw,naerec)
+
+      end module rrsw_aer_f
+
+      module rrsw_cld_f
+
+!     implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_sw cloud property coefficients
+!
+! Initial: J.-J. Morcrette, ECMWF, oct1999
+! Revised: J. Delamere/MJIacono, AER, aug2005
+! Revised: MJIacono, AER, nov2005
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+!
+!  name     type     purpose
+! -----  :  ----   : ----------------------------------------------
+! xxxliq1 : real   : optical properties (extinction coefficient, single 
+!                    scattering albedo, assymetry factor) from
+!                    Hu & Stamnes, j. clim., 6, 728-742, 1993.  
+! xxxice2 : real   : optical properties (extinction coefficient, single 
+!                    scattering albedo, assymetry factor) from streamer v3.0,
+!                    Key, streamer user's guide, cooperative institude 
+!                    for meteorological studies, 95 pp., 2001.
+! xxxice3 : real   : optical properties (extinction coefficient, single 
+!                    scattering albedo, assymetry factor) from
+!                    Fu, j. clim., 9, 1996.
+! xbari   : real   : optical property coefficients for five spectral 
+!                    intervals (2857-4000, 4000-5263, 5263-7692, 7692-14285,
+!                    and 14285-40000 wavenumbers) following 
+!                    Ebert and Curry, jgr, 97, 3831-3836, 1992.
+!------------------------------------------------------------------
+
+      real  :: extliq1(58,16:29), ssaliq1(58,16:29), asyliq1(58,16:29)
+      real  :: extice2(43,16:29), ssaice2(43,16:29), asyice2(43,16:29)
+      real  :: extice3(46,16:29), ssaice3(46,16:29), asyice3(46,16:29)
+      real  :: fdlice3(46,16:29)
+      real  :: abari(5),bbari(5),cbari(5),dbari(5),ebari(5),fbari(5)
+
+      end module rrsw_cld_f
+
+      module rrsw_con_f
+
+!     implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_sw constants
+
+! Initial version: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+!  name     type     purpose
+! -----  :  ----   : ----------------------------------------------
+! fluxfac:  real   : radiance to flux conversion factor 
+! heatfac:  real   : flux to heating rate conversion factor
+!oneminus:  real   : 1.-1.e-6
+! pi     :  real   : pi
+! grav   :  real   : acceleration of gravity
+! planck :  real   : planck constant
+! boltz  :  real   : boltzmann constant
+! clight :  real   : speed of light
+! avogad :  real   : avogadro constant 
+! alosmt :  real   : loschmidt constant
+! gascon :  real   : molar gas constant
+! radcn1 :  real   : first radiation constant
+! radcn2 :  real   : second radiation constant
+! sbcnst :  real   : stefan-boltzmann constant
+!  secdy :  real   : seconds per day
+!------------------------------------------------------------------
+
+      real  :: fluxfac, heatfac
+      real  :: oneminus, pi, grav
+      real  :: planck, boltz, clight
+      real  :: avogad, alosmt, gascon
+      real  :: radcn1, radcn2
+      real  :: sbcnst, secdy
+
+      end module rrsw_con_f
+
+      module rrsw_kg16_f
+
+      use parrrsw_f, only : ng16
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 16
+! band 16:  2600-3250 cm-1 (low - h2o,ch4; high - ch4)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+! selfrefo: real     
+! forrefo : real
+!sfluxrefo: real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no16 = 16
+
+      real  :: kao(9,5,13,no16)
+      real  :: kbo(5,13:59,no16)
+      real  :: selfrefo(10,no16), forrefo(3,no16)
+      real  :: sfluxrefo(no16)
+
+      integer :: layreffr
+      real  :: rayl, strrat1
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 16
+! band 16:  2600-3250 cm-1 (low - h2o,ch4; high - ch4)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! absa    : real
+! absb    : real
+! selfref : real     
+! forref  : real
+! sfluxref: real     
+!-----------------------------------------------------------------
+
+      real  :: ka(9,5,13,ng16) , absa(585,ng16)
+      real  :: kb(5,13:59,ng16), absb(235,ng16)
+      real  :: selfref(10,ng16), forref(3,ng16)
+      real  :: sfluxref(ng16)
+
+      equivalence (ka(1,1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      end module rrsw_kg16_f
+
+      module rrsw_kg17_f
+
+      use parrrsw_f, only : ng17
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 17
+! band 17:  3250-4000 cm-1 (low - h2o,co2; high - h2o,co2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+! selfrefo: real     
+! forrefo : real
+!sfluxrefo: real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no17 = 16
+
+      real  :: kao(9,5,13,no17)
+      real  :: kbo(5,5,13:59,no17)
+      real  :: selfrefo(10,no17), forrefo(4,no17)
+      real  :: sfluxrefo(no17,5)
+
+      integer :: layreffr
+      real  :: rayl, strrat
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 17
+! band 17:  3250-4000 cm-1 (low - h2o,co2; high - h2o,co2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! absa    : real
+! absb    : real
+! selfref : real     
+! forref  : real
+! sfluxref: real     
+!-----------------------------------------------------------------
+
+      real  :: ka(9,5,13,ng17) , absa(585,ng17)
+      real  :: kb(5,5,13:59,ng17), absb(1175,ng17)
+      real  :: selfref(10,ng17), forref(4,ng17)
+      real  :: sfluxref(ng17,5)
+
+      equivalence (ka(1,1,1,1),absa(1,1)), (kb(1,1,13,1),absb(1,1))
+
+      end module rrsw_kg17_f
+
+      module rrsw_kg18_f
+
+      use parrrsw_f, only : ng18
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 18
+! band 18:  4000-4650 cm-1 (low - h2o,ch4; high - ch4)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+! selfrefo: real     
+! forrefo : real
+!sfluxrefo: real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no18 = 16
+
+      real  :: kao(9,5,13,no18)
+      real  :: kbo(5,13:59,no18)
+      real  :: selfrefo(10,no18), forrefo(3,no18)
+      real  :: sfluxrefo(no18,9)
+
+      integer :: layreffr
+      real  :: rayl, strrat
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 18
+! band 18:  4000-4650 cm-1 (low - h2o,ch4; high - ch4)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! absa    : real
+! absb    : real
+! selfref : real     
+! forref  : real
+! sfluxref: real     
+!-----------------------------------------------------------------
+
+      real  :: ka(9,5,13,ng18), absa(585,ng18)
+      real  :: kb(5,13:59,ng18), absb(235,ng18)
+      real  :: selfref(10,ng18), forref(3,ng18)
+      real  :: sfluxref(ng18,9)
+
+      equivalence (ka(1,1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      end module rrsw_kg18_f
+
+      module rrsw_kg19_f
+
+      use parrrsw_f, only : ng19
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 19
+! band 19:  4650-5150 cm-1 (low - h2o,co2; high - co2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+! selfrefo: real     
+! forrefo : real
+!sfluxrefo: real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no19 = 16
+
+      real  :: kao(9,5,13,no19)
+      real  :: kbo(5,13:59,no19)
+      real  :: selfrefo(10,no19), forrefo(3,no19)
+      real  :: sfluxrefo(no19,9)
+
+      integer :: layreffr
+      real  :: rayl, strrat
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 19
+! band 19:  4650-5150 cm-1 (low - h2o,co2; high - co2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! absa    : real
+! absb    : real
+! selfref : real     
+! forref  : real
+! sfluxref: real     
+!-----------------------------------------------------------------
+
+      real  :: ka(9,5,13,ng19), absa(585,ng19)
+      real  :: kb(5,13:59,ng19), absb(235,ng19)
+      real  :: selfref(10,ng19), forref(3,ng19)
+      real  :: sfluxref(ng19,9)
+
+      equivalence (ka(1,1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      end module rrsw_kg19_f
+
+      module rrsw_kg20_f
+
+      use parrrsw_f, only : ng20
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 20
+! band 20:  5150-6150 cm-1 (low - h2o; high - h2o)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+! selfrefo: real     
+! forrefo : real
+!sfluxrefo: real     
+! absch4o : real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no20 = 16
+
+      real  :: kao(5,13,no20)
+      real  :: kbo(5,13:59,no20)
+      real  :: selfrefo(10,no20), forrefo(4,no20)
+      real  :: sfluxrefo(no20)
+      real  :: absch4o(no20)
+
+      integer :: layreffr
+      real  :: rayl 
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 20
+! band 20:  5150-6150 cm-1 (low - h2o; high - h2o)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! absa    : real
+! absb    : real
+! selfref : real     
+! forref  : real
+! sfluxref: real     
+! absch4  : real     
+!-----------------------------------------------------------------
+
+      real  :: ka(5,13,ng20), absa(65,ng20)
+      real  :: kb(5,13:59,ng20), absb(235,ng20)
+      real  :: selfref(10,ng20), forref(4,ng20)
+      real  :: sfluxref(ng20)
+      real  :: absch4(ng20)
+
+      equivalence (ka(1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      end module rrsw_kg20_f
+
+      module rrsw_kg21_f
+
+      use parrrsw_f, only : ng21
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 21
+! band 21:  6150-7700 cm-1 (low - h2o,co2; high - h2o,co2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+! selfrefo: real     
+! forrefo : real
+!sfluxrefo: real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no21 = 16
+
+      real  :: kao(9,5,13,no21)
+      real  :: kbo(5,5,13:59,no21)
+      real  :: selfrefo(10,no21), forrefo(4,no21)
+      real  :: sfluxrefo(no21,9)
+
+      integer :: layreffr
+      real  :: rayl, strrat
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 21
+! band 21:  6150-7700 cm-1 (low - h2o,co2; high - h2o,co2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! absa    : real
+! absb    : real
+! selfref : real     
+! forref  : real
+! sfluxref: real     
+!-----------------------------------------------------------------
+
+      real  :: ka(9,5,13,ng21), absa(585,ng21)
+      real  :: kb(5,5,13:59,ng21), absb(1175,ng21)
+      real  :: selfref(10,ng21), forref(4,ng21)
+      real  :: sfluxref(ng21,9)
+
+      equivalence (ka(1,1,1,1),absa(1,1)), (kb(1,1,13,1),absb(1,1))
+
+      end module rrsw_kg21_f
+
+      module rrsw_kg22_f
+
+      use parrrsw_f, only : ng22
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 22
+! band 22:  7700-8050 cm-1 (low - h2o,o2; high - o2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+! selfrefo: real     
+! forrefo : real
+!sfluxrefo: real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no22 = 16
+
+      real  :: kao(9,5,13,no22)
+      real  :: kbo(5,13:59,no22)
+      real  :: selfrefo(10,no22), forrefo(3,no22)
+      real  :: sfluxrefo(no22,9)
+
+      integer :: layreffr
+      real  :: rayl, strrat
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 22
+! band 22:  7700-8050 cm-1 (low - h2o,o2; high - o2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! absa    : real
+! absb    : real
+! selfref : real     
+! forref  : real
+! sfluxref: real     
+!-----------------------------------------------------------------
+
+      real  :: ka(9,5,13,ng22), absa(585,ng22)
+      real  :: kb(5,13:59,ng22), absb(235,ng22)
+      real  :: selfref(10,ng22), forref(3,ng22)
+      real  :: sfluxref(ng22,9)
+
+      equivalence (ka(1,1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      end module rrsw_kg22_f
+
+      module rrsw_kg23_f
+
+      use parrrsw_f, only : ng23
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 23
+! band 23:  8050-12850 cm-1 (low - h2o; high - nothing)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+! selfrefo: real     
+! forrefo : real
+!sfluxrefo: real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no23 = 16
+
+      real  :: kao(5,13,no23)
+      real  :: selfrefo(10,no23), forrefo(3,no23)
+      real  :: sfluxrefo(no23)
+      real  :: raylo(no23)
+
+      integer :: layreffr
+      real :: givfac
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 23
+! band 23:  8050-12850 cm-1 (low - h2o; high - nothing)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! absa    : real
+! absb    : real
+! selfref : real     
+! forref  : real
+! sfluxref: real     
+!-----------------------------------------------------------------
+
+      real  :: ka(5,13,ng23), absa(65,ng23)
+      real  :: selfref(10,ng23), forref(3,ng23)
+      real  :: sfluxref(ng23), rayl(ng23)
+
+      equivalence (ka(1,1,1),absa(1,1))
+
+      end module rrsw_kg23_f
+
+      module rrsw_kg24_f
+
+      use parrrsw_f, only : ng24
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 24
+! band 24: 12850-16000 cm-1 (low - h2o,o2; high - o2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+! selfrefo: real     
+! forrefo : real
+!sfluxrefo: real     
+! abso3ao : real     
+! abso3bo : real     
+! raylao  : real     
+! raylbo  : real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no24 = 16
+
+      real  :: kao(9,5,13,no24)
+      real  :: kbo(5,13:59,no24)
+      real  :: selfrefo(10,no24), forrefo(3,no24)
+      real  :: sfluxrefo(no24,9)
+      real  :: abso3ao(no24), abso3bo(no24)
+      real  :: raylao(no24,9), raylbo(no24)
+
+      integer :: layreffr
+      real :: strrat
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 24
+! band 24: 12850-16000 cm-1 (low - h2o,o2; high - o2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! absa    : real
+! absb    : real
+! selfref : real     
+! forref  : real
+! sfluxref: real     
+! abso3a  : real     
+! abso3b  : real     
+! rayla   : real     
+! raylb   : real     
+!-----------------------------------------------------------------
+
+      real  :: ka(9,5,13,ng24), absa(585,ng24)
+      real  :: kb(5,13:59,ng24), absb(235,ng24)
+      real  :: selfref(10,ng24), forref(3,ng24)
+      real  :: sfluxref(ng24,9)
+      real  :: abso3a(ng24), abso3b(ng24)
+      real  :: rayla(ng24,9), raylb(ng24)
+
+      equivalence (ka(1,1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      end module rrsw_kg24_f
+
+      module rrsw_kg25_f
+
+      use parrrsw_f, only : ng25
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 25
+! band 25: 16000-22650 cm-1 (low - h2o; high - nothing)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+!sfluxrefo: real     
+! abso3ao : real     
+! abso3bo : real     
+! raylo   : real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no25 = 16
+
+      real  :: kao(5,13,no25)
+      real  :: sfluxrefo(no25)
+      real  :: abso3ao(no25), abso3bo(no25)
+      real  :: raylo(no25)
+
+      integer :: layreffr
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 25
+! band 25: 16000-22650 cm-1 (low - h2o; high - nothing)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! absa    : real
+! sfluxref: real     
+! abso3a  : real     
+! abso3b  : real     
+! rayl    : real     
+!-----------------------------------------------------------------
+
+      real  :: ka(5,13,ng25), absa(65,ng25)
+      real  :: sfluxref(ng25)
+      real  :: abso3a(ng25), abso3b(ng25)
+      real  :: rayl(ng25)
+
+      equivalence (ka(1,1,1),absa(1,1))
+
+      end module rrsw_kg25_f
+
+      module rrsw_kg26_f
+
+      use parrrsw_f, only : ng26
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 26
+! band 26: 22650-29000 cm-1 (low - nothing; high - nothing)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+!sfluxrefo: real     
+! raylo   : real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no26 = 16
+
+      real  :: sfluxrefo(no26)
+      real  :: raylo(no26)
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 26
+! band 26: 22650-29000 cm-1 (low - nothing; high - nothing)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! sfluxref: real     
+! rayl    : real     
+!-----------------------------------------------------------------
+
+      real  :: sfluxref(ng26)
+      real  :: rayl(ng26)
+
+      end module rrsw_kg26_f
+
+      module rrsw_kg27_f
+
+      use parrrsw_f, only : ng27
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 27
+! band 27: 29000-38000 cm-1 (low - o3; high - o3)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+!sfluxrefo: real     
+! raylo   : real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no27 = 16
+
+      real  :: kao(5,13,no27)
+      real  :: kbo(5,13:59,no27)
+      real  :: sfluxrefo(no27)
+      real  :: raylo(no27)
+
+      integer :: layreffr
+      real :: scalekur
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 27
+! band 27: 29000-38000 cm-1 (low - o3; high - o3)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! absa    : real
+! absb    : real
+! sfluxref: real     
+! rayl    : real     
+!-----------------------------------------------------------------
+
+      real  :: ka(5,13,ng27), absa(65,ng27)
+      real  :: kb(5,13:59,ng27), absb(235,ng27)
+      real  :: sfluxref(ng27)
+      real  :: rayl(ng27)
+
+      equivalence (ka(1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      end module rrsw_kg27_f
+
+      module rrsw_kg28_f
+
+      use parrrsw_f, only : ng28
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 28
+! band 28: 38000-50000 cm-1 (low - o3, o2; high - o3, o2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+!sfluxrefo: real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no28 = 16
+
+      real  :: kao(9,5,13,no28)
+      real  :: kbo(5,5,13:59,no28)
+      real  :: sfluxrefo(no28,5)
+
+      integer :: layreffr
+      real  :: rayl, strrat
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 28
+! band 28: 38000-50000 cm-1 (low - o3, o2; high - o3, o2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! sfluxref: real     
+!-----------------------------------------------------------------
+
+      real  :: ka(9,5,13,ng28), absa(585,ng28)
+      real  :: kb(5,5,13:59,ng28), absb(1175,ng28)
+      real  :: sfluxref(ng28,5)
+
+      equivalence (ka(1,1,1,1),absa(1,1)), (kb(1,1,13,1),absb(1,1))
+
+      end module rrsw_kg28_f
+
+      module rrsw_kg29_f
+
+      use parrrsw_f, only : ng29
+
+!     implicit none
+      save
+
+!-----------------------------------------------------------------
+! rrtmg_sw ORIGINAL abs. coefficients for interval 29
+! band 29:  820-2600 cm-1 (low - h2o; high - co2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! kao     : real     
+! kbo     : real     
+! selfrefo: real     
+! forrefo : real     
+!sfluxrefo: real     
+! absh2oo : real     
+! absco2o : real     
+!-----------------------------------------------------------------
+
+      integer , parameter :: no29 = 16
+
+      real  :: kao(5,13,no29)
+      real  :: kbo(5,13:59,no29)
+      real  :: selfrefo(10,no29), forrefo(4,no29)
+      real  :: sfluxrefo(no29)
+      real  :: absh2oo(no29), absco2o(no29)
+
+      integer :: layreffr
+      real  :: rayl
+
+!-----------------------------------------------------------------
+! rrtmg_sw COMBINED abs. coefficients for interval 29
+! band 29:  820-2600 cm-1 (low - h2o; high - co2)
+!
+! Initial version:  JJMorcrette, ECMWF, oct1999
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!-----------------------------------------------------------------
+!
+!  name     type     purpose
+!  ----   : ----   : ---------------------------------------------
+! ka      : real     
+! kb      : real     
+! selfref : real     
+! forref  : real     
+! sfluxref: real     
+! absh2o  : real     
+! absco2  : real     
+!-----------------------------------------------------------------
+
+      real  :: ka(5,13,ng29), absa(65,ng29)
+      real  :: kb(5,13:59,ng29), absb(235,ng29)
+      real  :: selfref(10,ng29), forref(4,ng29)
+      real  :: sfluxref(ng29)
+      real  :: absh2o(ng29), absco2(ng29)
+
+      equivalence (ka(1,1,1),absa(1,1)), (kb(1,13,1),absb(1,1))
+
+      end module rrsw_kg29_f
+
+      module rrsw_ref_f
+
+!      implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_sw reference atmosphere 
+! Based on standard mid-latitude summer profile
+!
+! Initial version:  JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jun2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+!  name     type     purpose
+! -----  :  ----   : ----------------------------------------------
+! pref   :  real   : Reference pressure levels
+! preflog:  real   : Reference pressure levels, ln(pref)
+! tref   :  real   : Reference temperature levels for MLS profile
+!------------------------------------------------------------------
+
+      real  , dimension(59) :: pref
+      real  , dimension(59) :: preflog
+      real  , dimension(59) :: tref
+
+      end module rrsw_ref_f
+
+      module rrsw_tbl_f
+
+!     implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_sw lookup table arrays
+
+! Initial version: MJIacono, AER, may2007
+! Revised: MJIacono, AER, aug2007
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+!  name     type     purpose
+! -----  :  ----   : ----------------------------------------------
+! ntbl   :  integer: Lookup table dimension
+! tblint :  real   : Lookup table conversion factor
+! tau_tbl:  real   : Clear-sky optical depth 
+! exp_tbl:  real   : Exponential lookup table for transmittance
+! od_lo  :  real   : Value of tau below which expansion is used
+!                  : in place of lookup table
+! pade   :  real   : Pade approximation constant
+! bpade  :  real   : Inverse of Pade constant
+!------------------------------------------------------------------
+
+      integer , parameter :: ntbl = 10000
+
+      real , parameter :: tblint = 10000.0 
+
+      real , parameter :: od_lo = 0.06 
+
+      real :: tau_tbl
+      real , dimension(0:ntbl) :: exp_tbl
+
+      real , parameter :: pade = 0.278 
+      real :: bpade
+
+      end module rrsw_tbl_f
+
+      module rrsw_vsn_f
+
+!     implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_sw version information
+
+! Initial version:  JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+!  name     type     purpose
+! -----  :  ----   : ----------------------------------------------
+!hnamrtm :character: 
+!hnamini :character: 
+!hnamcld :character: 
+!hnamclc :character: 
+!hnamrft :character: 
+!hnamspv :character: 
+!hnamspc :character: 
+!hnamset :character: 
+!hnamtau :character: 
+!hnamvqd :character: 
+!hnamatm :character: 
+!hnamutl :character: 
+!hnamext :character: 
+!hnamkg  :character: 
+!
+! hvrrtm :character: 
+! hvrini :character: 
+! hvrcld :character: 
+! hvrclc :character: 
+! hvrrft :character: 
+! hvrspv :character: 
+! hvrspc :character: 
+! hvrset :character: 
+! hvrtau :character: 
+! hvrvqd :character: 
+! hvratm :character: 
+! hvrutl :character: 
+! hvrext :character: 
+! hvrkg  :character: 
+!------------------------------------------------------------------
+
+      character*18 hvrrtm,hvrini,hvrcld,hvrclc,hvrrft,hvrspv, &
+                   hvrspc,hvrset,hvrtau,hvrvqd,hvratm,hvrutl,hvrext
+      character*20 hnamrtm,hnamini,hnamcld,hnamclc,hnamrft,hnamspv, &
+                   hnamspc,hnamset,hnamtau,hnamvqd,hnamatm,hnamutl,hnamext
+
+      character*18 hvrkg
+      character*20 hnamkg
+
+      end module rrsw_vsn_f
+
+      module rrsw_wvn_f
+
+      use parrrsw_f, only : nbndsw, mg, ngptsw, jpb1, jpb2
+
+!     implicit none
+      save
+
+!------------------------------------------------------------------
+! rrtmg_sw spectral information
+
+! Initial version:  JJMorcrette, ECMWF, jul1998
+! Revised: MJIacono, AER, jul2006
+! Revised: MJIacono, AER, aug2008
+!------------------------------------------------------------------
+
+!  name     type     purpose
+! -----  :  ----   : ----------------------------------------------
+! ng     :  integer: Number of original g-intervals in each spectral band
+! nspa   :  integer: 
+! nspb   :  integer: 
+!wavenum1:  real   : Spectral band lower boundary in wavenumbers
+!wavenum2:  real   : Spectral band upper boundary in wavenumbers
+! delwave:  real   : Spectral band width in wavenumbers
+!
+! ngc    :  integer: The number of new g-intervals in each band
+! ngs    :  integer: The cumulative sum of new g-intervals for each band
+! ngm    :  integer: The index of each new g-interval relative to the
+!                    original 16 g-intervals in each band
+! ngn    :  integer: The number of original g-intervals that are 
+!                    combined to make each new g-intervals in each band
+! ngb    :  integer: The band index for each new g-interval
+! wt     :  real   : RRTM weights for the original 16 g-intervals
+! rwgt   :  real   : Weights for combining original 16 g-intervals 
+!                    (224 total) into reduced set of g-intervals 
+!                    (112 total)
+!------------------------------------------------------------------
+
+      integer  :: ng(jpb1:jpb2)
+      integer  :: nspa(jpb1:jpb2)
+      integer  :: nspb(jpb1:jpb2)
+
+      real  :: wavenum1(jpb1:jpb2)
+      real  :: wavenum2(jpb1:jpb2)
+      real  :: delwave(jpb1:jpb2)
+      integer :: icxa(jpb1:jpb2)
+
+      integer  :: ngc(nbndsw)
+      integer  :: ngs(nbndsw)
+      integer  :: ngn(ngptsw)
+      integer  :: ngb(ngptsw)
+      integer  :: ngm(nbndsw*mg)
+
+      real  :: wt(mg)
+      real  :: rwgt(nbndsw*mg)
+
+      end module rrsw_wvn_f
+
+
+      module mcica_subcol_gen_sw_f
+
+      use parrrsw_f, only : nbndsw, ngptsw
+      use rrsw_con_f, only: grav
+      use rrsw_wvn_f, only: ngb
+      use rrsw_vsn_f
+
+      implicit none
+
+      public :: mcica_sw      
+      
+      contains
+!-------------------------------------------------------------------------------------------------
+      subroutine mcica_sw(ncol, nlay, nsubcol, icld, irng, play, cld, ciwp, clwp, cswp, &
+                          tauc, ssac, asmc, fsfc, cld_stoch, ciwp_stoch, clwp_stoch, cswp_stoch, &
+                          tauc_stoch, ssac_stoch, asmc_stoch, fsfc_stoch, changeSeed )
+!-------------------------------------------------------------------------------------------------
+
+  !----------------------------------------------------------------------------------------------------------------
+  ! ---------------------
+  ! Contact: Cecile Hannay (hannay@ucar.edu)
+  ! 
+  ! Original code: Based on Raisanen et al., QJRMS, 2004.
+  !
+  ! Modifications: Generalized for use with RRTMG and added Mersenne Twister as the default
+  !   random number generator, which can be changed to the optional kissvec random number generator
+  !   with flag 'irng'. Some extra functionality has been commented or removed.  
+  !   Michael J. Iacono, AER, Inc., February 2007
+  !
+  ! Given a profile of cloud fraction, cloud water and cloud ice, we produce a set of subcolumns.
+  ! Each layer within each subcolumn is homogeneous, with cloud fraction equal to zero or one 
+  ! and uniform cloud liquid and cloud ice concentration.
+  ! The ensemble as a whole reproduces the probability function of cloud liquid and ice within each layer 
+  ! and obeys an overlap assumption in the vertical.   
+  ! 
+  ! Overlap assumption:
+  !  The cloud are consistent with 4 overlap assumptions: random, maximum, maximum-random and exponential. 
+  !  The default option is maximum-random (option 3)
+  !  The options are: 1=random overlap, 2=max/random, 3=maximum overlap, 4=exponential overlap
+  !  This is set with the variable "overlap" 
+  !mji - Exponential overlap option (overlap=4) has been deactivated in this version
+  !  The exponential overlap uses also a length scale, Zo. (real,    parameter  :: Zo = 2500. ) 
+  ! 
+  ! Seed:
+  !  If the stochastic cloud generator is called several times during the same timestep, 
+  !  one should change the seed between the call to insure that the subcolumns are different.
+  !  This is done by changing the argument 'changeSeed'
+  !  For example, if one wants to create a set of columns for the shortwave and another set for the longwave ,
+  !  use 'changeSeed = 1' for the first call and'changeSeed = 2' for the second call 
+  !
+  ! PDF assumption:
+  !  We can use arbitrary complicated PDFS. 
+  !  In the present version, we produce homogeneuous clouds (the simplest case).  
+  !  Future developments include using the PDF scheme of Ben Johnson. 
+  !
+  ! History file:
+  !  Option to add diagnostics variables in the history file. (using FINCL in the namelist)
+  !  nsubcol = number of subcolumns
+  !  overlap = overlap type (1-3)
+  !  Zo = length scale 
+  !  CLOUD_S = mean of the subcolumn cloud fraction ('_S" means Stochastic)
+  !  CLDLIQ_S = mean of the subcolumn cloud water
+  !  CLDICE_S = mean of the subcolumn cloud ice 
+  !
+  ! Note:
+  !   Here: we force that the cloud condensate to be consistent with the cloud fraction 
+  !   i.e we only have cloud condensate when the cell is cloudy. 
+  !   In CAM: The cloud condensate and the cloud fraction are obtained from 2 different equations 
+  !   and the 2 quantities can be inconsistent (i.e. CAM can produce cloud fraction 
+  !   without cloud condensate or the opposite).
+  !---------------------------------------------------------------------------------------------------------------
+
+      use mcica_random_numbers_f
+! The Mersenne Twister random number engine
+      !use MersenneTwister, only: randomNumberSequence, &   
+      !                           new_RandomNumberSequence, getRandomReal
+
+      !type(randomNumberSequence) :: randomNumbers
+
+! -- Arguments
+
+      integer , intent(in) :: ncol            ! number of layers
+      integer , intent(in) :: nlay            ! number of layers
+      integer , intent(in) :: icld            ! clear/cloud, cloud overlap flag
+      integer , intent(inout) :: irng         ! flag for random number generator
+                                                      !  0 = kissvec
+                                                      !  1 = Mersenne Twister
+      integer , intent(in) :: nsubcol         ! number of sub-columns (g-point intervals)
+      integer , optional, intent(in) :: changeSeed     ! allows permuting seed
+
+! Column state (cloud fraction, cloud water, cloud ice) + variables needed to read physics state 
+      real , intent(in) :: play(:,:)          ! layer pressure (Pa)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: cld(:,:)           ! cloud fraction 
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: clwp(:,:)          ! in-cloud liquid water path (g/m2)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: ciwp(:,:)          ! in-cloud ice water path (g/m2)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: cswp(:,:)          ! in-cloud snow water path (g/m2)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: tauc(:,:,:)        ! in-cloud optical depth (non-delta scaled)
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+      real , intent(in) :: ssac(:,:,:)        ! in-cloud single scattering albedo (non-delta scaled)
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+      real , intent(in) :: asmc(:,:,:)        ! in-cloud asymmetry parameter (non-delta scaled)
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+      real , intent(in) :: fsfc(:,:,:)        ! in-cloud forward scattering fraction (non-delta scaled)
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+
+      real , intent(out) :: cld_stoch(:,:,:)  ! subcolumn cloud fraction 
+                                                      !    Dimensions: (ngptsw,ncol,nlay)
+      real , intent(out) :: clwp_stoch(:,:,:) ! subcolumn in-cloud liquid water path
+                                                      !    Dimensions: (ngptsw,ncol,nlay)
+      real , intent(out) :: ciwp_stoch(:,:,:) ! subcolumn in-cloud ice water path
+                                                      !    Dimensions: (ngptsw,ncol,nlay)
+      real , intent(out) :: cswp_stoch(:,:,:) ! subcolumn in-cloud snow water path
+                                                      !    Dimensions: (ngptsw,ncol,nlay)
+      real , intent(out) :: tauc_stoch(:,:,:) ! subcolumn in-cloud optical depth
+                                                      !    Dimensions: (ncol,nlay,ngptsw)
+      real , intent(out) :: ssac_stoch(:,:,:) ! subcolumn in-cloud single scattering albedo
+                                                      !    Dimensions: (ncol,nlay,ngptsw)
+      real , intent(out) :: asmc_stoch(:,:,:) ! subcolumn in-cloud asymmetry parameter
+                                                      !    Dimensions: (ncol,nlay,ngptsw)
+      real , intent(out) :: fsfc_stoch(:,:,:) ! subcolumn in-cloud forward scattering fraction
+                                                      !    Dimensions: (ncol,nlay,ngptsw)
+      
+! -- Local variables
+
+! Constants (min value for cloud fraction and cloud water and ice)
+      real , parameter :: cldmin = 1.0e-20  ! min cloud fraction
+
+#ifndef _OPENACC
+# define ncol CHNK
+#endif
+
+! Variables related to random number and seed 
+     
+      real, dimension(ncol, nlay, nsubcol)  :: CDF       
+#ifdef _OPENACC
+      integer :: seed1, seed2, seed3, seed4  ! seed to create random number
+#else
+      integer, dimension(ncol) :: seed1, seed2, seed3, seed4  ! seed to create random number
+#endif
+    
+      integer  :: iseed                        ! seed to create random number (Mersenne Twister)
+!      real  :: rand_num_mt                     ! random number (Mersenne Twister)
+      real  :: kiss
+
+
+! Indices
+      integer  :: ilev, isubcol, i, n, ngbm, iplon   ! indices
+#ifndef _OPENACC
+      integer :: m, k
+! inline function
+      m(k, n) = ieor (k, ishft (k, n) )
+#endif
+!------------------------------------------------------------------------------------------ 
+
+! Check that irng is in bounds; if not, set to default
+! Note: in GPU version of code, only kissvec method is used, Mersenne Twister not installed
+
+! Pass input cloud overlap setting to local variable
+!$acc data create(CDF)
+
+! ------ Apply overlap assumption --------
+
+! generate the random numbers  
+
+! Random cloud overlap
+      if (icld==1) then
+!$acc kernels 
+           
+#ifdef _OPENACC
+            do ilev = 1,nlay
+               do i = 1, ncol
+                  seed1 = (play(i,1) - int(play(i,1)))  * 100000000 - ilev
+                  seed2 = (play(i,2) - int(play(i,2)))  * 100000000 + ilev
+                  seed3 = (play(i,3) - int(play(i,3)))  * 100000000 + ilev * 6.2
+                  seed4 = (play(i,4) - int(play(i,4)))  * 100000000           
+                  do isubcol = 1,nsubcol
+                     seed1 = 69069  * seed1 + 132721785 
+                     seed2 = 11002  * iand (seed2, 65535 ) + ishft (seed2, - 16 )
+                     seed3 = 18000  * iand (seed3, 65535 ) + ishft (seed3, - 16 )
+                     seed4 = 30903  * iand (seed4, 65535 ) + ishft (seed4, - 16 )
+                     kiss = seed1 + seed2 + ishft (seed3, 16 ) + seed4
+                     CDF(i,ilev,isubcol) = kiss*2.328306e-10  + 0.5 
+                  end do
+               end do
+            end do
+#else
+         CALL wrf_error_fatal("icld == 1 not supported in module_ra_rrtmg_swf.F")
+#endif
+
+!$acc end kernels      
+      endif
+
+! Maximum-Random cloud overlap
+      if (icld==2) then
+#ifdef _OPENACC
+!$acc kernels 
+           
+            do ilev = 1,nlay
+               do i = 1, ncol
+                  seed1 = (play(i,1) - int(play(i,1)))  * 100000000 - ilev
+                  seed2 = (play(i,2) - int(play(i,2)))  * 100000000 + ilev
+                  seed3 = (play(i,3) - int(play(i,3)))  * 100000000 + ilev * 6.2
+                  seed4 = (play(i,4) - int(play(i,4)))  * 100000000           
+                  do isubcol = 1,nsubcol
+                     seed1 = 69069  * seed1 + 132721785 
+                     seed2 = 11002  * iand (seed2, 65535 ) + ishft (seed2, - 16 )
+                     seed3 = 18000  * iand (seed3, 65535 ) + ishft (seed3, - 16 )
+                     seed4 = 30903  * iand (seed4, 65535 ) + ishft (seed4, - 16 )
+                     kiss = seed1 + seed2 + ishft (seed3, 16 ) + seed4
+                     CDF(i,ilev,isubcol) = kiss*2.328306e-10  + 0.5 
+                  end do
+               end do
+            end do
+
+            do ilev = 2,nlay
+!$acc loop gang vector   
+               do i = 1, ncol
+!$acc loop gang   
+                  do isubcol = 1,nsubcol
+                     if (CDF(i,ilev-1,isubcol) > 1.  - cld(i, ilev-1)) then 
+                        CDF(i,ilev,isubcol) = CDF(i,ilev-1,isubcol)
+                     else
+                        CDF(i,ilev,isubcol) = CDF(i,ilev,isubcol) * (1. - cld(i, ilev-1))
+                     end if
+                  end do
+               end do
+            end do
+            
+!$acc end kernels      
+#else
+!jm set up to match the ra_sw_physics=4 random number generator '
+
+!jm moved isubcol loop out of here and put in the ilev.eq.1 conditional for initial
+!jm computation of seeds so we get the same results as the ra_sw_physics=4 option
+           do isubcol = 1,nsubcol
+           do ilev = 1,nlay
+               do i = 1, ncol
+                if (ilev.eq.1.and.isubcol.eq.1)then
+                  seed1(i) = (play(i,1)*100 - int(play(i,1)*100))  * 1000000000  !jm
+                  seed2(i) = (play(i,2)*100 - int(play(i,2)*100))  * 1000000000  !jm
+                  seed3(i) = (play(i,3)*100 - int(play(i,3)*100))  * 1000000000  !jm
+                  seed4(i) = (play(i,4)*100 - int(play(i,4)*100))  * 1000000000
+                     seed1(i) = 69069  * seed1(i) + 1327217885
+                     seed2(i) = m (m (m (seed2(i), 13), - 17), 5)
+                     seed3(i) = 18000  * iand (seed3(i), 65535 ) + ishft (seed3(i), - 16 )
+                     seed4(i) = 30903  * iand (seed4(i), 65535 ) + ishft (seed4(i), - 16 )
+                     kiss = seed1(i) + seed2(i) + ishft (seed3(i), 16 ) + seed4(i)
+                 endif
+
+                 seed1(i) = 69069  * seed1(i) + 1327217885
+                 seed2(i) = m (m (m (seed2(i), 13), - 17), 5)
+                 seed3(i) = 18000  * iand (seed3(i), 65535 ) + ishft (seed3(i), - 16 )
+                 seed4(i) = 30903  * iand (seed4(i), 65535 ) + ishft (seed4(i), - 16 )
+                 kiss = seed1(i) + seed2(i) + ishft (seed3(i), 16 ) + seed4(i)
+
+                 CDF(i,ilev,isubcol) = kiss*2.328306e-10  + 0.5
+               end do
+            end do
+            end do
+
+            do ilev = 2,nlay
+               do i = 1, ncol
+                  do isubcol = 1,nsubcol
+                     if (CDF(i,ilev-1,isubcol) > 1.  - cld(i, ilev-1)) then
+                        CDF(i,ilev,isubcol) = CDF(i,ilev-1,isubcol)
+                     else
+                        CDF(i,ilev,isubcol) = CDF(i,ilev,isubcol) * (1. - cld(i, ilev-1))
+                     end if
+                  end do
+               end do
+            end do
+#endif
+      endif
+
+! Maximum cloud overlap
+      if (icld==3) then
+!$acc kernels 
+           
+#ifdef _OPENACC
+            do i = 1, ncol
+               seed1 = (play(i,1) - int(play(i,1)))  * 100000000 - ilev
+               seed2 = (play(i,2) - int(play(i,2)))  * 100000000 + ilev
+               seed3 = (play(i,3) - int(play(i,3)))  * 100000000 + ilev * 6.2
+               seed4 = (play(i,4) - int(play(i,4)))  * 100000000           
+               do isubcol = 1,nsubcol
+                  seed1 = 69069  * seed1 + 132721785 
+                  seed2 = 11002  * iand (seed2, 65535 ) + ishft (seed2, - 16 )
+                  seed3 = 18000  * iand (seed3, 65535 ) + ishft (seed3, - 16 )
+                  seed4 = 30903  * iand (seed4, 65535 ) + ishft (seed4, - 16 )
+                  kiss = seed1 + seed2 + ishft (seed3, 16 ) + seed4
+                  do ilev = 1,nlay
+                     CDF(i,ilev,isubcol) = kiss*2.328306e-10  + 0.5 
+                  end do
+               end do
+            end do
+#else
+         CALL wrf_error_fatal("icld == 3 not supported in module_ra_rrtmg_swf.F")
+#endif
+
+!$acc end kernels      
+      endif
+
+      ngbm = ngb(1) - 1
+!$acc kernels 
+      do ilev = 1,nlay
+         do i = 1, ncol
+            do isubcol = 1, nsubcol
+
+               if ( CDF(i,ilev,isubcol)>=(1.0 - cld(i,ilev)) ) then
+                  cld_stoch(i,ilev,isubcol) = 1.0 
+                  clwp_stoch(i,ilev,isubcol) = clwp(i,ilev)
+                  ciwp_stoch(i,ilev,isubcol) = ciwp(i,ilev)
+                  cswp_stoch(i,ilev,isubcol) = cswp(i,ilev)
+                  n = ngb(isubcol) - ngbm
+                  tauc_stoch(i,ilev,isubcol) = tauc(i,ilev,n)
+                  ssac_stoch(i,ilev,isubcol) = ssac(i,ilev,n)
+                  asmc_stoch(i,ilev,isubcol) = asmc(i,ilev,n)
+                  fsfc_stoch(i,ilev,isubcol) = fsfc(i,ilev,n)
+               else
+                  cld_stoch(i,ilev,isubcol) = 0. 
+                  clwp_stoch(i,ilev,isubcol) = 0. 
+                  ciwp_stoch(i,ilev,isubcol) = 0. 
+                  cswp_stoch(i,ilev,isubcol) = 0. 
+                  tauc_stoch(i,ilev,isubcol) = 0. 
+                  ssac_stoch(i,ilev,isubcol) = 1. 
+                  asmc_stoch(i,ilev,isubcol) = 0. 
+                  fsfc_stoch(i,ilev,isubcol) = 0. 
+               endif
+            enddo
+         enddo
+      enddo
+!$acc end kernels
+!$acc end data
+#ifndef _OPENACC
+# undef ncol
+#endif
+
+      end subroutine mcica_sw
+
+      end module mcica_subcol_gen_sw_f
+
+      module rrtmg_sw_cldprmc_f
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ngptsw, jpband, jpb1, jpb2
+      use rrsw_cld_f, only : extliq1, ssaliq1, asyliq1, &
+                           extice2, ssaice2, asyice2, &
+                           extice3, ssaice3, asyice3, fdlice3, &
+                           abari, bbari, cbari, dbari, ebari, fbari
+      use rrsw_wvn_f, only : wavenum2, ngb, icxa
+      use rrsw_vsn_f, only : hvrclc, hnamclc
+
+      implicit none
+
+      contains
+
+! ----------------------------------------------------------------------------
+      subroutine cldprmc_sw(ncol, nlayers, inflag, iceflag, liqflag, cldfmc, &
+                            ciwpmc, clwpmc, cswpmc, reicmc, relqmc, resnmc, &
+                            taormc, taucmc, ssacmc, asmcmc, fsfcmc)
+! ----------------------------------------------------------------------------
+
+! Purpose: Compute the cloud optical properties for each cloudy layer
+! and g-point interval for use by the McICA method.  
+! Note: Only inflag = 0 and inflag=2/liqflag=1/iceflag=1,2,3 are available;
+! (Hu & Stamnes, Ebert and Curry, Key, and Fu) are implemented. 
+
+! ------- Input -------
+
+      integer , intent(in) :: nlayers         ! total number of layers
+      integer , intent(in) :: inflag          ! see definitions
+      integer , intent(in) :: iceflag         ! see definitions
+      integer , intent(in) :: liqflag         ! see definitions
+      integer , intent(in) :: ncol
+
+      real , intent(in) :: cldfmc(:,:,:)          ! cloud fraction [mcica]
+                                                      !    Dimensions: (ngptsw,nlayers)
+      real , intent(in) :: ciwpmc(:,:,:)          ! cloud ice water path [mcica]
+                                                      !    Dimensions: (ngptsw,nlayers)
+      real , intent(in) :: clwpmc(:,:,:)          ! cloud liquid water path [mcica]
+                                                      !    Dimensions: (ngptsw,nlayers)
+      real , intent(in) :: cswpmc(:,:,:)          ! cloud snow water path [mcica]
+                                                      !    Dimensions: (ngptsw,nlayers)
+      real , intent(in) :: relqmc(:,:)           ! cloud liquid particle effective radius (microns)
+                                                      !    Dimensions: (nlayers)
+      real , intent(in) :: resnmc(:,:)           ! cloud snow particle effective radius (microns)
+                                                      !    Dimensions: (nlayers)
+      real , intent(in) :: reicmc(:,:)           ! cloud ice particle effective radius (microns)
+                                                      !    Dimensions: (nlayers)
+                                                      ! specific definition of reicmc depends on setting of iceflag:
+                                                      ! iceflag = 0: (inactive)
+                                                      !              
+                                                      ! iceflag = 1: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                                      !              r_ec range is limited to 13.0 to 130.0 microns
+                                                      ! iceflag = 2: ice effective radius, r_k, (Key, Streamer Ref. Manual, 1996)
+                                                      !              r_k range is limited to 5.0 to 131.0 microns
+                                                      ! iceflag = 3: generalized effective size, dge, (Fu, 1996),
+                                                      !              dge range is limited to 5.0 to 140.0 microns
+                                                      !              [dge = 1.0315 * r_ec]
+      real , intent(in) :: fsfcmc(:,:,:)          ! cloud forward scattering fraction
+                                                      !    Dimensions: (ngptsw,nlayers)
+
+! ------- Output -------
+
+      real , intent(inout) :: taucmc(:,:,:)       ! cloud optical depth (delta scaled)
+                                                      !    Dimensions: (ncol,nlayers,ngptsw)
+      real , intent(inout) :: ssacmc(:,:,:)       ! single scattering albedo (delta scaled)
+                                                      !    Dimensions: (ncol,nlayers,ngptsw)
+      real , intent(inout) :: asmcmc(:,:,:)       ! asymmetry parameter (delta scaled)
+                                                      !    Dimensions: (ncol,nlayers,ngptsw)
+      real , intent(out) :: taormc(:,:,:)         ! cloud optical depth (non-delta scaled)
+                                                      !    Dimensions: (ncol,nlayers,ngptsw)
+
+! ------- Local -------
+
+!      integer  :: ncbands
+      integer  :: ib, lay, istr, index, icx, ig, iplon
+
+      real , parameter :: eps = 1.e-06      ! epsilon
+      real , parameter :: cldmin = 1.e-20   ! minimum value for cloud quantities
+      real  :: cwp                            ! total cloud water path
+      real  :: radliq                         ! cloud liquid droplet radius (microns)
+      real  :: radice                         ! cloud ice effective size (microns)
+      real  :: radsno                         ! cloud snow effective size (microns)
+      real  :: factor
+      real  :: fint
+
+      real  :: taucldorig_a, taucloud_a, ssacloud_a, ffp, ffp1, ffpssa
+      real  :: tauiceorig, scatice, ssaice, tauice, tauliqorig, scatliq, ssaliq, tauliq
+      real  :: tausnoorig, scatsno, ssasno, tausno
+
+      real  :: fdelta
+      real  :: extcoice, gice
+      real  :: ssacoice, forwice
+      real  :: extcoliq, gliq
+      real  :: ssacoliq, forwliq
+      real  :: extcosno, gsno
+      real  :: ssacosno, forwsno
+
+! Initialize
+
+
+!$acc kernels
+
+      taormc   = taucmc
+  
+!$acc end kernels    
+
+#ifndef _OPENACC
+#  define ncol CHNK
+#endif
+
+! Main layer loop
+
+!$acc kernels loop present(cldfmc, ciwpmc, clwpmc, cswpmc, relqmc, reicmc, resnmc, fsfcmc,taucmc, ssacmc, asmcmc, taormc)
+    do iplon = 1, ncol
+      !$acc loop 
+      do lay = 1, nlayers
+
+         !$acc loop private(fdelta,extcoice,gice,ssacoice,forwice,extcoliq,gliq,ssacoliq,forwliq,gsno,forwsno,scatsno)
+         do ig = 1, ngptsw 
+            cwp = ciwpmc(iplon,lay,ig) + clwpmc(iplon,lay,ig) + cswpmc(iplon,lay,ig)  
+
+            if (cldfmc(iplon,lay,ig)   .ge. cldmin .and. &
+               (cwp .ge. cldmin .or. taucmc(iplon,lay,ig)   .ge. cldmin)) then
+
+! (inflag=0): Cloud optical properties input directly
+               if (inflag .eq. 0) then
+! Cloud optical properties already defined in taucmc, ssacmc, asmcmc are unscaled;
+! Apply delta-M scaling here (using Henyey-Greenstein approximation)
+                  taucldorig_a = taucmc(iplon,lay,ig)  
+                  ffp = fsfcmc(iplon,lay,ig)  
+                  ffp1 = 1.0  - ffp
+                  ffpssa = 1.0  - ffp * ssacmc(iplon,lay,ig)  
+                  ssacloud_a = ffp1 * ssacmc(iplon,lay,ig)   / ffpssa
+                  taucloud_a = ffpssa * taucldorig_a
+
+                  taormc(iplon,lay,ig)   = taucldorig_a
+                  ssacmc(iplon,lay,ig)   = ssacloud_a
+                  taucmc(iplon,lay,ig)   = taucloud_a
+                  asmcmc(iplon,lay,ig)   = (asmcmc(iplon,lay,ig)   - ffp) / (ffp1)
+
+! (inflag=2): Separate treatement of ice clouds and water clouds.
+               elseif (inflag .ge. 2) then       
+                  radice = reicmc(iplon,lay) 
+
+! Calculation of absorption coefficients due to ice clouds.
+                  if (ciwpmc(iplon,lay,ig) + cswpmc(iplon,lay,ig) .eq. 0.0 ) then
+                     extcoice = 0.0 
+                     ssacoice = 0.0 
+                     gice     = 0.0 
+                     forwice  = 0.0 
+
+                     extcosno = 0.0
+                     ssacosno = 0.0
+                     gsno     = 0.0
+                     forwsno  = 0.0
+
+! (iceflag = 1): 
+! Note: This option uses Ebert and Curry approach for all particle sizes similar to
+! CAM3 implementation, though this is somewhat unjustified for large ice particles
+                  elseif (iceflag .eq. 1) then
+                   
+                     ib = ngb(ig )
+                     ib = icxa(ib)
+  
+                     extcoice = (abari(ib) + bbari(ib)/radice)
+                     ssacoice = 1.  - cbari(ib) - dbari(ib) * radice
+                     gice = ebari(ib) + fbari(ib) * radice
+! Check to ensure upper limit of gice is within physical limits for large particles
+                     if (gice.ge.1. ) gice = 1.  - eps
+                     forwice = gice*gice
+! Check to ensure all calculated quantities are within physical limits.
+! mji - added checks below
+                     if (extcoice .lt. 0.0) extcoice = 0.0
+                     if (ssacoice .gt. 1.0) ssacoice = 1.0
+                     if (ssacoice .lt. 0.0) ssacoice = 0.0
+                     if (gice .gt. 1.0) gice = 1.0
+                     if (gice .lt. 0.0) gice = 0.0
+                  
+
+! For iceflag=2 option, ice particle effective radius is limited to 5.0 to 131.0 microns
+
+                  elseif (iceflag .eq. 2) then
+                     
+                     factor = (radice - 2. )/3. 
+                     index = int(factor)
+! mji - temporary fix to prevent out of range subscripts
+                     if (index .le. 0) index = 1
+                     if (index .ge. 43) index = 42
+!                     if (index .eq. 43) index = 42
+                     fint = factor - float(index)
+                     ib = ngb(ig)
+                     extcoice = extice2(index,ib) + fint * &
+                                   (extice2(index+1,ib) -  extice2(index,ib))
+                     ssacoice = ssaice2(index,ib) + fint * &
+                                   (ssaice2(index+1,ib) -  ssaice2(index,ib))
+                     gice = asyice2(index,ib) + fint * &
+                                   (asyice2(index+1,ib) -  asyice2(index,ib))
+                     forwice = gice*gice
+! Check to ensure all calculated quantities are within physical limits.
+! mji - added checks below
+                     if (extcoice .lt. 0.0) extcoice = 0.0
+                     if (ssacoice .gt. 1.0) ssacoice = 1.0
+                     if (ssacoice .lt. 0.0) ssacoice = 0.0
+                     if (gice .gt. 1.0) gice = 1.0
+                     if (gice .lt. 0.0) gice = 0.0
+                 
+
+! For iceflag=3 option, ice particle generalized effective size is limited to 5.0 to 140.0 microns
+
+                  elseif (iceflag .ge. 3) then
+                    
+                     factor = (radice - 2. )/3. 
+                     index = int(factor)
+! mji - temporary fix to prevent out of range subscripts
+                     if (index .le. 0) index = 1
+                     if (index .ge. 46) index = 45
+!                     if (index .eq. 46) index = 45
+                     fint = factor - float(index)
+                     ib = ngb(ig)
+                     extcoice = extice3(index,ib) + fint * &
+                                   (extice3(index+1,ib) - extice3(index,ib))
+                     ssacoice = ssaice3(index,ib) + fint * &
+                                   (ssaice3(index+1,ib) - ssaice3(index,ib))
+                     gice = asyice3(index,ib) + fint * &
+                               (asyice3(index+1,ib) - asyice3(index,ib))
+                     fdelta = fdlice3(index,ib) + fint * &
+                                 (fdlice3(index+1,ib) - fdlice3(index,ib))
+                  
+                     forwice = fdelta + 0.5  / ssacoice
+! See Fu 1996 p. 2067 
+                     if (forwice .gt. gice) forwice = gice
+! Check to ensure all calculated quantities are within physical limits.  
+! mji - added checks below
+                     if (extcoice .lt. 0.0) extcoice = 0.0
+                     if (ssacoice .gt. 1.0) ssacoice = 1.0
+                     if (ssacoice .lt. 0.0) ssacoice = 0.0
+                     if (gice .gt. 1.0) gice = 1.0
+                     if (gice .lt. 0.0) gice = 0.0
+                  
+                  endif
+
+!!!!!!!!!!!!!!!!!! Mukul !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!!!!  INSERT THE EQUIVALENT SNOW VARIABLE CODE HERE
+!!!! Although far from perfect, the snow will utilize the
+!!!! same lookup table constants as cloud ice.  Changes
+!!!! to those constants for larger particle snow would be
+!!!! an improvement.
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+                  if (cswpmc(iplon,lay,ig).gt.0.0 .and. iceflag .eq. 5) then
+                     radsno = resnmc(iplon,lay)
+                     factor = (radsno - 2.)/3.
+                     index = int(factor)
+! mji - temporary fix to prevent out of range subscripts
+                     if (index .le. 0) index = 1
+                     if (index .ge. 46) index = 45
+!                     if (index .eq. 46) index = 45
+                     fint = factor - float(index)
+                     ib = ngb(ig)
+                     extcosno = extice3(index,ib) + fint * &
+                                   (extice3(index+1,ib) - extice3(index,ib))
+                     ssacosno = ssaice3(index,ib) + fint * &
+                                   (ssaice3(index+1,ib) - ssaice3(index,ib))
+                     gsno = asyice3(index,ib) + fint * &
+                               (asyice3(index+1,ib) - asyice3(index,ib))
+                     fdelta = fdlice3(index,ib) + fint * &
+                                 (fdlice3(index+1,ib) - fdlice3(index,ib))
+                     forwsno = fdelta + 0.5 / ssacosno
+! See Fu 1996 p. 2067
+                     if (forwsno .gt. gsno) forwsno = gsno
+! Check to ensure all calculated quantities are within physical limits.  
+! mji - added checks below
+                     if (extcosno .lt. 0.0) extcosno = 0.0
+                     if (ssacosno .gt. 1.0) ssacosno = 1.0
+                     if (ssacosno .lt. 0.0) ssacosno = 0.0
+                     if (gsno .gt. 1.0) gsno = 1.0
+                     if (gsno .lt. 0.0) gsno = 0.0
+!
+                  else
+                     extcosno = 0.0
+                     ssacosno = 0.0
+                     gsno     = 0.0
+                     forwsno  = 0.0
+                  endif
+
+! Calculation of absorption coefficients due to water clouds.
+                  if (clwpmc(iplon,lay,ig)   .eq. 0.0 ) then
+                     extcoliq = 0.0 
+                     ssacoliq = 0.0 
+                     gliq = 0.0 
+                     forwliq = 0.0 
+
+                  elseif (liqflag .eq. 1) then
+                     radliq = relqmc(iplon,lay) 
+                   
+                     index = int(radliq - 1.5 )
+! mji - temporary fix to prevent out of range subscripts
+                     if (index .le. 0) index = 1
+                     if (index .ge. 58) index = 57
+!                     if (index .eq. 0) index = 1
+!                     if (index .eq. 58) index = 57
+                     fint = radliq - 1.5  - float(index)
+                     ib = ngb(ig)
+                     extcoliq = extliq1(index,ib) + fint * &
+                                   (extliq1(index+1,ib) - extliq1(index,ib))
+                     ssacoliq = ssaliq1(index,ib) + fint * &
+                                   (ssaliq1(index+1,ib) - ssaliq1(index,ib))
+                     if (fint .lt. 0.  .and. ssacoliq .gt. 1. ) &
+                                    ssacoliq = ssaliq1(index,ib)
+                     gliq = asyliq1(index,ib) + fint * &
+                               (asyliq1(index+1,ib) - asyliq1(index,ib))
+                     forwliq = gliq*gliq
+! Check to ensure all calculated quantities are within physical limits.
+! mji - added checks below
+                     if (extcoliq .lt. 0.0) extcoliq = 0.0
+                     if (ssacoliq .gt. 1.0) ssacoliq = 1.0
+                     if (ssacoliq .lt. 0.0) ssacoliq = 0.0
+                     if (gliq .gt. 1.0) gliq = 1.0
+                     if (gliq .lt. 0.0) gliq = 0.0
+!
+                  endif
+   
+                  if (iceflag .lt. 5) then
+                     tauliqorig = clwpmc(iplon,lay,ig)   * extcoliq
+                     tauiceorig = ciwpmc(iplon,lay,ig)   * extcoice
+                     taormc(iplon,lay,ig)   = tauliqorig + tauiceorig
+
+                     ssaliq = ssacoliq * (1.  - forwliq) / &
+                             (1.  - forwliq * ssacoliq)
+                     tauliq = (1.  - forwliq * ssacoliq) * tauliqorig
+                     ssaice = ssacoice * (1.  - forwice) / &
+                             (1.  - forwice * ssacoice)
+                     tauice = (1.  - forwice * ssacoice) * tauiceorig
+
+                     scatliq = ssaliq * tauliq
+                     scatice = ssaice * tauice
+                     taucmc(iplon,lay,ig)   = tauliq + tauice
+                  else
+                     tauliqorig = clwpmc(iplon,lay,ig)   * extcoliq
+                     tauiceorig = ciwpmc(iplon,lay,ig)   * extcoice
+                     tausnoorig = cswpmc(iplon,lay,ig)   * extcosno
+                     taormc(iplon,lay,ig)   = tauliqorig + tauiceorig + tausnoorig
+
+                     ssaliq = ssacoliq * (1.  - forwliq) / &
+                             (1.  - forwliq * ssacoliq)
+                     tauliq = (1.  - forwliq * ssacoliq) * tauliqorig
+                     ssaice = ssacoice * (1.  - forwice) / &
+                             (1.  - forwice * ssacoice)
+                     tauice = (1.  - forwice * ssacoice) * tauiceorig
+                     ssasno = ssacosno * (1.  - forwsno) / &
+                             (1.  - forwsno * ssacosno)
+                     tausno = (1.  - forwsno * ssacosno) * tausnoorig
+
+                     scatliq = ssaliq * tauliq
+                     scatice = ssaice * tauice
+                     scatsno = ssasno * tausno
+                     taucmc(iplon,lay,ig)   = tauliq + tauice + tausno
+                  endif
+
+! Ensure non-zero taucmc and scatice
+                  if(taucmc(iplon,lay,ig)  .eq.0.) taucmc(iplon,lay,ig)   = cldmin
+                  if(scatice.eq.0.) scatice = cldmin
+                  if(scatsno.eq.0.) scatsno = cldmin
+
+                  if (iceflag .lt. 5) then
+                     ssacmc(iplon,lay,ig)   = (scatliq + scatice) / taucmc(iplon,lay,ig)  
+                  else
+                     ssacmc(iplon,lay,ig)   = (scatliq + scatice + scatsno) / taucmc(iplon,lay,ig)  
+                  endif
+
+                  if (iceflag .eq. 3 .or. iceflag.eq.4) then
+! In accordance with the 1996 Fu paper, equation A.3, 
+! the moments for ice were calculated depending on whether using spheres
+! or hexagonal ice crystals.
+! Set asymetry parameter to first moment (istr=1)
+                     istr = 1
+                     asmcmc(iplon,lay,ig)   = (1.0 /(scatliq+scatice))* &
+                        (scatliq*(gliq**istr - forwliq) / &
+                        (1.0  - forwliq) + scatice * ((gice-forwice)/ &
+                        (1.0  - forwice))**istr)
+
+                  elseif (iceflag .eq. 5) then
+                     istr = 1
+                     asmcmc(iplon,lay,ig) = (1.0 /(scatliq+scatice+scatsno)) * &
+                                    (scatliq*(gliq**istr - forwliq)/(1.0 - forwliq)  &
+                                    + scatice * ((gice-forwice)/(1.0 - forwice))        &
+                                    + scatsno * ((gsno-forwsno)/(1.0 - forwsno))**istr)
+
+                  else 
+! This code is the standard method for delta-m scaling. 
+! Set asymetry parameter to first moment (istr=1)
+                     istr = 1
+                     asmcmc(iplon,lay,ig)   = (scatliq *  &
+                        (gliq**istr - forwliq) / &
+                        (1.0  - forwliq) + scatice * (gice**istr - forwice) / &
+                        (1.0  - forwice))/(scatliq + scatice)
+                  endif 
+
+               endif
+
+            endif
+
+! End g-point interval loop
+         enddo
+
+! End layer loop
+      enddo
+! End column loop
+      enddo
+!$acc end kernels
+#ifndef _OPENACC
+#  undef ncol
+#endif
+
+      end subroutine cldprmc_sw
+
+      end module rrtmg_sw_cldprmc_f
+
+      module rrtmg_sw_setcoef_f
+
+! ------- Modules -------
+
+      use parrrsw_f, only : mxmol
+      use rrsw_ref_f, only : pref, preflog, tref
+      use rrsw_vsn_f, only : hvrset, hnamset
+
+      implicit none
+
+      contains
+
+!----------------------------------------------------------------------------
+      subroutine setcoef_sw(ncol, nlayers, pavel, tavel, pz, tz, tbound, coldry, wkl, &
+                            laytrop, layswtch, laylow, jp, jt, jt1, &
+                            co2mult, colch4, colco2, colh2o, colmol, coln2o, &
+                            colo2, colo3, fac00, fac01, fac10, fac11, &
+                            selffac, selffrac, indself, forfac, forfrac, indfor)
+!----------------------------------------------------------------------------
+!
+! Purpose:  For a given atmosphere, calculate the indices and
+! fractions related to the pressure and temperature interpolations.
+
+! Modifications:
+! Original: J. Delamere, AER, Inc. (version 2.5, 02/04/01)
+! Revised: Rewritten and adapted to ECMWF F90, JJMorcrette 030224
+! Revised: For uniform rrtmg formatting, MJIacono, Jul 2006
+
+! ------ Declarations -------
+
+! ----- Input -----
+      integer, intent(in) :: ncol
+
+      integer , intent(in) :: nlayers         ! total number of layers
+      
+      real , intent(in) :: pavel(:,:)            ! layer pressures (mb) 
+                                                      !    Dimensions: (nlayers)
+      real , intent(in) :: tavel(:,:)            ! layer temperatures (K)
+                                                      !    Dimensions: (nlayers)
+      real , intent(in) :: pz(:,0:)              ! level (interface) pressures (hPa, mb)
+                                                      !    Dimensions: (0:nlayers)
+      real , intent(in) :: tz(:,0:)              ! level (interface) temperatures (K)
+                                                      !    Dimensions: (0:nlayers)
+      real , intent(in) :: tbound(:)             ! surface temperature (K)
+      real , intent(in) :: coldry(:,:)           ! dry air column density (mol/cm2)
+                                                      !    Dimensions: (nlayers)
+      real , intent(in) :: wkl(:,:,:)            ! molecular amounts (mol/cm-2)
+                                                      !    Dimensions: (mxmol,nlayers)
+
+! ----- Output -----
+      integer , intent(out) :: laytrop(:)        ! tropopause layer index
+      integer , intent(out) :: layswtch(:)       ! 
+      integer , intent(out) :: laylow(:)         ! 
+
+      integer , intent(out) :: jp(:,:)           ! 
+                                                      !    Dimensions: (nlayers)
+      integer , intent(out) :: jt(:,:)           !
+                                                      !    Dimensions: (nlayers)
+      integer , intent(out) :: jt1(:,:)          !
+                                                      !    Dimensions: (nlayers)
+
+      real , intent(out) :: colh2o(:,:)          ! column amount (h2o)
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: colco2(:,:)          ! column amount (co2)
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: colo3(:,:)           ! column amount (o3)
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: coln2o(:,:)          ! column amount (n2o)
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: colch4(:,:)          ! column amount (ch4)
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: colo2(:,:)           ! column amount (o2)
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: colmol(:,:)          ! 
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: co2mult(:,:)         !
+                                                      !    Dimensions: (nlayers)
+
+      integer , intent(out) :: indself(:,:) 
+                                                      !    Dimensions: (nlayers)
+      integer , intent(out) :: indfor(:,:) 
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: selffac(:,:) 
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: selffrac(:,:) 
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: forfac(:,:) 
+                                                      !    Dimensions: (nlayers)
+      real , intent(out) :: forfrac(:,:) 
+                                                      !    Dimensions: (nlayers)
+
+      real , intent(out) :: fac00(:,:) , fac01(:,:) , fac10(:,:) , fac11(:,:)  
+
+! ----- Local -----
+
+      integer  :: indbound
+      integer  :: indlev0
+      integer  :: lay
+      integer  :: jp1
+      integer  :: iplon
+
+      real  :: stpfac
+      real  :: tbndfrac
+      real  :: t0frac
+      real  :: plog
+      real  :: fp
+      real  :: ft
+      real  :: ft1
+      real  :: water
+      real  :: scalefac
+      real  :: factor
+      real  :: co2reg
+      real  :: compfp
+
+#ifndef _OPENACC
+#  define ncol CHNK
+#endif
+
+
+! Initializations
+      stpfac = 296. /1013. 
+
+
+!$acc kernels present(pavel, layswtch, laytrop, laylow)
+      layswtch = 0
+      laytrop = 0
+      laylow = 0
+      do iplon = 1, ncol
+         do lay = 1, nlayers
+            plog = log(pavel(iplon,lay) )
+            if (plog .ge. 4.56) laytrop(iplon) = laytrop(iplon) + 1
+            if (plog .ge. 6.62) laylow(iplon) = laylow(iplon) + 1
+         end do
+      end do
+!$acc end kernels
+
+
+!$acc kernels loop present(pavel, tavel, pz, tz, tbound) &
+!$acc present(coldry, wkl, jp, jt, jt1, colh2o, colco2) &
+!$acc present(colo3, coln2o, colch4, colo2, colmol, co2mult, indself) &
+!$acc present(indfor, selffac, selffrac, forfac, forfrac, fac00, fac01, fac10, fac11)
+
+! Begin column loop
+      do iplon = 1, ncol
+
+      indbound = tbound(iplon) - 159. 
+      tbndfrac = tbound(iplon) - int(tbound(iplon))
+      
+      indlev0  = tz(iplon,0)  - 159. 
+      t0frac   = tz(iplon,0)  - int(tz(iplon,0) )
+
+! Begin layer loop
+
+       do lay = 1, nlayers
+! Find the two reference pressures on either side of the
+! layer pressure.  Store them in JP and JP1.  Store in FP the
+! fraction of the difference (in ln(pressure)) between these
+! two values that the layer pressure lies.
+
+         plog = log(pavel(iplon,lay) )
+         jp(iplon,lay)  = int(36.  - 5*(plog+0.04 ))
+         if (jp(iplon,lay)  .lt. 1) then
+            jp(iplon,lay)  = 1
+         elseif (jp(iplon,lay)  .gt. 58) then
+            jp(iplon,lay)  = 58
+         endif
+         jp1 = jp(iplon,lay)  + 1
+         fp = 5.  * (preflog(jp(iplon,lay) ) - plog)
+
+! Determine, for each reference pressure (JP and JP1), which
+! reference temperature (these are different for each  
+! reference pressure) is nearest the layer temperature but does
+! not exceed it.  Store these indices in JT and JT1, resp.
+! Store in FT (resp. FT1) the fraction of the way between JT
+! (JT1) and the next highest reference temperature that the 
+! layer temperature falls.
+
+         jt(iplon,lay)  = int(3.  + (tavel(iplon,lay) -tref(jp(iplon,lay) ))/15. )
+         if (jt(iplon,lay)  .lt. 1) then
+            jt(iplon,lay)  = 1
+         elseif (jt(iplon,lay)  .gt. 4) then
+            jt(iplon,lay)  = 4
+         endif
+         ft = ((tavel(iplon,lay) -tref(jp(iplon,lay) ))/15. ) - float(jt(iplon,lay) -3)
+         jt1(iplon,lay)  = int(3.  + (tavel(iplon,lay) -tref(jp1))/15. )
+         if (jt1(iplon,lay)  .lt. 1) then
+            jt1(iplon,lay)  = 1
+         elseif (jt1(iplon,lay)  .gt. 4) then
+            jt1(iplon,lay)  = 4
+         endif
+         ft1 = ((tavel(iplon,lay) -tref(jp1))/15. ) - float(jt1(iplon,lay) -3)
+
+         water = wkl(iplon,1,lay) /coldry(iplon,lay) 
+         scalefac = pavel(iplon,lay)  * stpfac / tavel(iplon,lay) 
+
+! If the pressure is less than ~100mb, perform a different
+! set of species interpolations.
+
+         if (plog .le. 4.56 ) then
+
+         forfac(iplon,lay)  = scalefac / (1.+water)
+         factor = (tavel(iplon,lay) -188.0 )/36.0 
+         indfor(iplon,lay)  = 3
+         forfrac(iplon,lay)  = factor - 1.0 
+
+! Calculate needed column amounts.
+
+         colh2o(iplon,lay)  = 1.e-20  * wkl(iplon,1,lay) 
+         colco2(iplon,lay)  = 1.e-20  * wkl(iplon,2,lay) 
+         colo3(iplon,lay)   = 1.e-20  * wkl(iplon,3,lay) 
+         coln2o(iplon,lay)  = 1.e-20  * wkl(iplon,4,lay) 
+         colch4(iplon,lay)  = 1.e-20  * wkl(iplon,6,lay) 
+         colo2(iplon,lay)   = 1.e-20  * wkl(iplon,7,lay) 
+         colmol(iplon,lay)  = 1.e-20  * coldry(iplon,lay)  + colh2o(iplon,lay) 
+         if (colco2(iplon,lay)  .eq. 0. ) colco2(iplon,lay)  = 1.e-32  * coldry(iplon,lay) 
+         if (coln2o(iplon,lay)  .eq. 0. ) coln2o(iplon,lay)  = 1.e-32  * coldry(iplon,lay) 
+         if (colch4(iplon,lay)  .eq. 0. ) colch4(iplon,lay)  = 1.e-32  * coldry(iplon,lay) 
+         if (colo2(iplon,lay)   .eq. 0. ) colo2(iplon,lay)   = 1.e-32  * coldry(iplon,lay) 
+         co2reg = 3.55e-24  * coldry(iplon,lay) 
+         co2mult(iplon,lay) = (colco2(iplon,lay)  - co2reg) * &
+               272.63 *exp(-1919.4 /tavel(iplon,lay) )/(8.7604e-4 *tavel(iplon,lay) )
+
+         selffac(iplon,lay)  = 0. 
+         selffrac(iplon,lay) = 0. 
+         indself(iplon,lay)  = 0
+
+
+         else
+
+
+! Set up factors needed to separately include the water vapor
+! foreign-continuum in the calculation of absorption coefficient.
+
+         forfac(iplon,lay)  = scalefac / (1.+water)
+         factor = (332.0 -tavel(iplon,lay) )/36.0 
+         indfor(iplon,lay)  = min(2, max(1, int(factor)))
+         forfrac(iplon,lay)  = factor - float(indfor(iplon,lay) )
+
+! Set up factors needed to separately include the water vapor
+! self-continuum in the calculation of absorption coefficient.
+
+         selffac(iplon,lay)  = water * forfac(iplon,lay) 
+         factor = (tavel(iplon,lay) -188.0 )/7.2 
+         indself(iplon,lay)  = min(9, max(1, int(factor)-7))
+         selffrac(iplon,lay)  = factor - float(indself(iplon,lay)  + 7)
+
+! Calculate needed column amounts.
+
+         colh2o(iplon,lay)  = 1.e-20  * wkl(iplon,1,lay) 
+         colco2(iplon,lay)  = 1.e-20  * wkl(iplon,2,lay) 
+         colo3(iplon,lay)  = 1.e-20  * wkl(iplon,3,lay) 
+!           colo3(lay) = 0. 
+!           colo3(lay) = colo3(lay)/1.16 
+         coln2o(iplon,lay)  = 1.e-20  * wkl(iplon,4,lay) 
+         colch4(iplon,lay)  = 1.e-20  * wkl(iplon,6,lay) 
+         colo2(iplon,lay)  = 1.e-20  * wkl(iplon,7,lay) 
+         colmol(iplon,lay)  = 1.e-20  * coldry(iplon,lay)  + colh2o(iplon,lay) 
+!           colco2(lay) = 0. 
+!           colo3(lay) = 0. 
+!           coln2o(lay) = 0. 
+!           colch4(lay) = 0. 
+!           colo2(lay) = 0. 
+!           colmol(lay) = 0. 
+         if (colco2(iplon,lay)  .eq. 0. ) colco2(iplon,lay)  = 1.e-32  * coldry(iplon,lay) 
+         if (coln2o(iplon,lay)  .eq. 0. ) coln2o(iplon,lay)  = 1.e-32  * coldry(iplon,lay) 
+         if (colch4(iplon,lay)  .eq. 0. ) colch4(iplon,lay)  = 1.e-32  * coldry(iplon,lay) 
+         if (colo2(iplon,lay)  .eq. 0. ) colo2(iplon,lay)  = 1.e-32  * coldry(iplon,lay) 
+! Using E = 1334.2 cm-1.
+         co2reg = 3.55e-24  * coldry(iplon,lay) 
+         co2mult(iplon,lay) = (colco2(iplon,lay)  - co2reg) * &
+               272.63 *exp(-1919.4 /tavel(iplon,lay) )/(8.7604e-4 *tavel(iplon,lay) )
+      
+         end if
+! We have now isolated the layer ln pressure and temperature,
+! between two reference pressures and two reference temperatures 
+! (for each reference pressure).  We multiply the pressure 
+! fraction FP with the appropriate temperature fractions to get 
+! the factors that will be needed for the interpolation that yields
+! the optical depths (performed in routines TAUGBn for band n).
+
+         compfp = 1.  - fp
+         fac10(iplon,lay)  = compfp * ft
+         fac00(iplon,lay)  = compfp * (1.  - ft)
+         fac11(iplon,lay)  = fp * ft1
+         fac01(iplon,lay)  = fp * (1.  - ft1)
+
+! End layer loop
+       end do
+
+! End column loop
+      end do
+!$acc end kernels
+#ifndef _OPENACC
+#  undef ncol
+#endif
+
+end subroutine setcoef_sw
+
+!***************************************************************************
+      subroutine swatmref
+!***************************************************************************
+
+      save
+ 
+! These pressures are chosen such that the ln of the first pressure
+! has only a few non-zero digits (i.e. ln(PREF(1)) = 6.96000) and
+! each subsequent ln(pressure) differs from the previous one by 0.2.
+
+      pref(:) = (/ &
+          1.05363e+03 ,8.62642e+02 ,7.06272e+02 ,5.78246e+02 ,4.73428e+02 , &
+          3.87610e+02 ,3.17348e+02 ,2.59823e+02 ,2.12725e+02 ,1.74164e+02 , &
+          1.42594e+02 ,1.16746e+02 ,9.55835e+01 ,7.82571e+01 ,6.40715e+01 , &
+          5.24573e+01 ,4.29484e+01 ,3.51632e+01 ,2.87892e+01 ,2.35706e+01 , &
+          1.92980e+01 ,1.57998e+01 ,1.29358e+01 ,1.05910e+01 ,8.67114e+00 , &
+          7.09933e+00 ,5.81244e+00 ,4.75882e+00 ,3.89619e+00 ,3.18993e+00 , &
+          2.61170e+00 ,2.13828e+00 ,1.75067e+00 ,1.43333e+00 ,1.17351e+00 , &
+          9.60789e-01 ,7.86628e-01 ,6.44036e-01 ,5.27292e-01 ,4.31710e-01 , &
+          3.53455e-01 ,2.89384e-01 ,2.36928e-01 ,1.93980e-01 ,1.58817e-01 , &
+          1.30029e-01 ,1.06458e-01 ,8.71608e-02 ,7.13612e-02 ,5.84256e-02 , &
+          4.78349e-02 ,3.91639e-02 ,3.20647e-02 ,2.62523e-02 ,2.14936e-02 , &
+          1.75975e-02 ,1.44076e-02 ,1.17959e-02 ,9.65769e-03  /)
+
+      preflog(:) = (/ &
+           6.9600e+00 , 6.7600e+00 , 6.5600e+00 , 6.3600e+00 , 6.1600e+00 , &
+           5.9600e+00 , 5.7600e+00 , 5.5600e+00 , 5.3600e+00 , 5.1600e+00 , &
+           4.9600e+00 , 4.7600e+00 , 4.5600e+00 , 4.3600e+00 , 4.1600e+00 , &
+           3.9600e+00 , 3.7600e+00 , 3.5600e+00 , 3.3600e+00 , 3.1600e+00 , &
+           2.9600e+00 , 2.7600e+00 , 2.5600e+00 , 2.3600e+00 , 2.1600e+00 , &
+           1.9600e+00 , 1.7600e+00 , 1.5600e+00 , 1.3600e+00 , 1.1600e+00 , &
+           9.6000e-01 , 7.6000e-01 , 5.6000e-01 , 3.6000e-01 , 1.6000e-01 , &
+          -4.0000e-02 ,-2.4000e-01 ,-4.4000e-01 ,-6.4000e-01 ,-8.4000e-01 , &
+          -1.0400e+00 ,-1.2400e+00 ,-1.4400e+00 ,-1.6400e+00 ,-1.8400e+00 , &
+          -2.0400e+00 ,-2.2400e+00 ,-2.4400e+00 ,-2.6400e+00 ,-2.8400e+00 , &
+          -3.0400e+00 ,-3.2400e+00 ,-3.4400e+00 ,-3.6400e+00 ,-3.8400e+00 , &
+          -4.0400e+00 ,-4.2400e+00 ,-4.4400e+00 ,-4.6400e+00  /)
+
+! These are the temperatures associated with the respective 
+! pressures for the MLS standard atmosphere. 
+
+      tref(:) = (/ &
+           2.9420e+02 , 2.8799e+02 , 2.7894e+02 , 2.6925e+02 , 2.5983e+02 , &
+           2.5017e+02 , 2.4077e+02 , 2.3179e+02 , 2.2306e+02 , 2.1578e+02 , &
+           2.1570e+02 , 2.1570e+02 , 2.1570e+02 , 2.1706e+02 , 2.1858e+02 , &
+           2.2018e+02 , 2.2174e+02 , 2.2328e+02 , 2.2479e+02 , 2.2655e+02 , &
+           2.2834e+02 , 2.3113e+02 , 2.3401e+02 , 2.3703e+02 , 2.4022e+02 , &
+           2.4371e+02 , 2.4726e+02 , 2.5085e+02 , 2.5457e+02 , 2.5832e+02 , &
+           2.6216e+02 , 2.6606e+02 , 2.6999e+02 , 2.7340e+02 , 2.7536e+02 , &
+           2.7568e+02 , 2.7372e+02 , 2.7163e+02 , 2.6955e+02 , 2.6593e+02 , &
+           2.6211e+02 , 2.5828e+02 , 2.5360e+02 , 2.4854e+02 , 2.4348e+02 , & 
+           2.3809e+02 , 2.3206e+02 , 2.2603e+02 , 2.2000e+02 , 2.1435e+02 , &
+           2.0887e+02 , 2.0340e+02 , 1.9792e+02 , 1.9290e+02 , 1.8809e+02 , &
+           1.8329e+02 , 1.7849e+02 , 1.7394e+02 , 1.7212e+02  /)
+
+      end subroutine swatmref
+
+      end module rrtmg_sw_setcoef_f
+
+      module rrtmg_sw_taumol_f
+
+! ------- Modules -------
+
+      use rrsw_con_f, only: oneminus
+      use rrsw_wvn_f, only: nspa, nspb
+      use rrsw_vsn_f, only: hvrtau, hnamtau
+
+      implicit none
+
+      contains
+
+!----------------------------------------------------------------------------
+      subroutine taumol_sw(ncol, nlayers, &
+                           colh2o, colco2, colch4, colo2, colo3, colmol, &
+                           laytrop, jp, jt, jt1, &
+                           fac00, fac01, fac10, fac11, &
+                           selffac, selffrac, indself, forfac, forfrac, indfor, &
+                           sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &  
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real , intent(inout) :: sfluxzen(:,:)   ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real , intent(inout) :: taug(:,:,:)     ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real , intent(inout) :: taur(:,:,:)     ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Calculate gaseous optical depth and planck fractions for each spectral band.
+
+      call taumol16(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol17(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol18(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol19(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol20(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol21(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol22(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol23(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol24(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol25(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol26(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol27(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol28(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      call taumol29(ncol, nlayers, &
+                    colh2o, colco2, colch4, colo2, colo3, colmol, &
+                    laytrop, jp, jt, jt1, &
+                    fac00, fac01, fac10, fac11, &
+                    selffac, selffrac, indself, forfac, forfrac, indfor, &
+                    sfluxzen, taug, taur)
+
+      end subroutine
+
+
+!----------------------------------------------------------------------------
+      subroutine taumol16(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 16:  2600-3250 cm-1 (low - h2o,ch4; high - ch4)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng16
+      use rrsw_kg16_f, only : absa, ka, absb, kb, forref, selfref, &
+                            sfluxref, rayl, layreffr, strrat1
+!                            sfluxref, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , & 
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(inout) :: sfluxzen(:,:)    ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(inout) :: taug(:,:,:)             ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(inout) :: taur(:,:,:)             ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+# define IKLOOP1_S do iplon=1,ncol;do lay=1,nlayers
+# define IKLOOP1_E enddo;enddo
+# define IKLOOP2_S do iplon=1,ncol;laysolfr=nlayers;do lay=laytrop(iplon)+1,nlayers;if(jp(iplon,lay-1).lt.layreffr.and.jp(iplon,lay).ge.layreffr)laysolfr=lay
+# define IKLOOP2_E
+#else
+# define ncol CHNK
+# define IKLOOP1_S do lay = 1, nlayers ; do iplon = 1, ncol
+# define IKLOOP1_E enddo;enddo
+# define IKLOOP2_S do lay=2,nlayers;do iplon=1,ncol;if(lay>laytrop(iplon))then;laysolfr=nlayers
+# define IKLOOP2_E endif;enddo;enddo
+#endif
+
+
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                       fac110, fac111, fs, speccomb, specmult, specparm, &
+                       tauray
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                          layreffr
+!      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+!                       fac110, fac111, fs, speccomb, specmult, specparm, &
+!                       tauray, strrat1
+      integer :: iplon
+!      strrat1 = 252.131 
+!      layreffr = 18
+!$acc kernels 
+#ifdef _OPENACC
+      do iplon=1,ncol
+! Compute the optical depth by interpolating in ln(pressure),
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.
+
+! Lower atmosphere loop
+      do lay = 1, nlayers
+#else
+IKLOOP1_S
+#endif
+         if (lay <= laytrop(iplon)) then
+         speccomb = colh2o(iplon,lay)  + strrat1*colch4(iplon,lay)
+         specparm = colh2o(iplon,lay) /speccomb
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay)
+         fac010 = (1.  - fs) * fac10(iplon,lay)
+         fac100 = fs * fac00(iplon,lay)
+         fac110 = fs * fac10(iplon,lay)
+         fac001 = (1.  - fs) * fac01(iplon,lay)
+         fac011 = (1.  - fs) * fac11(iplon,lay)
+         fac101 = fs * fac01(iplon,lay)
+         fac111 = fs * fac11(iplon,lay)
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(16) + js
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(16) + js
+         inds = indself(iplon,lay)
+         indf = indfor(iplon,lay)
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng16
+            taug(iplon,lay,ig)  = speccomb * &
+                (fac000 * absa(ind0   ,ig) + &
+                 fac100 * absa(ind0 +1,ig) + &
+                 fac010 * absa(ind0 +9,ig) + &
+                 fac110 * absa(ind0+10,ig) + &
+                 fac001 * absa(ind1   ,ig) + &
+                 fac101 * absa(ind1 +1,ig) + &
+                 fac011 * absa(ind1 +9,ig) + &
+                 fac111 * absa(ind1+10,ig)) + &
+                 colh2o(iplon,lay)  * &
+                 (selffac(iplon,lay)  * (selfref(inds,ig) + &
+                 selffrac(iplon,lay)  * &
+                 (selfref(inds+1,ig) - selfref(inds,ig))) + &
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig)))) 
+!            ssa(lay,ig) = tauray/taug(lay,ig)
+            taur(iplon,lay,ig)  = tauray
+         enddo
+         end if
+#ifdef _OPENACC
+      enddo
+      enddo
+!$acc end kernels
+
+! Upper atmosphere loop
+!$acc kernels 
+      do iplon=1,ncol
+        laysolfr = nlayers
+! mji - fix for out of bounds issue on absb - added to pass bounds checking; FINAL
+      do lay = laytrop(iplon)+1, nlayers
+!        if (lay > laytrop(iplon)) then
+!          !do lay = laytrop(iplon) +1, nlayers
+         if (jp(iplon,lay-1)  .lt. layreffr .and. jp(iplon,lay)  .ge.  layreffr) then
+            laysolfr = lay
+         end if
+#else
+IKLOOP1_E
+IKLOOP2_S
+#endif
+
+!#ifdef _OPENACC
+!      do iplon=1,ncol
+!        laysolfr = nlayers
+!! mji - fix for out of bounds issue on absb - added to pass bounds checking; FINAL
+!      do lay = laytrop(iplon)+1, nlayers
+!!        if (lay > laytrop(iplon)) then
+!!          !do lay = laytrop(iplon) +1, nlayers
+!         if (jp(iplon,lay-1)  .lt. layreffr .and. jp(iplon,lay)  .ge. layreffr) then
+!            laysolfr = lay
+!         end if
+!#else
+!      do lay = minval(laytrop(1:ncol)),nlayers
+!       do iplon=1,ncol
+!        if (lay > laytrop(iplon)) then
+!         laysolfr = nlayers
+!
+!#endif
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(16) + 1
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(16) + 1
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng16
+            taug(iplon,lay,ig)  = colch4(iplon,lay)  * &
+                (fac00(iplon,lay)  * absb(ind0  ,ig) + &
+                 fac10(iplon,lay)  * absb(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absb(ind1  ,ig) + &
+                 fac11(iplon,lay)  * absb(ind1+1,ig)) 
+
+            if (laysolfr == lay) sfluxzen(iplon,ig)  = sfluxref(ig) 
+            taur(iplon,lay,ig)  = tauray  
+         enddo
+#ifdef _OPENACC
+         enddo
+         enddo
+#else
+IKLOOP2_E
+#endif
+!$acc end kernels
+# undef ncol
+ end subroutine taumol16
+
+!----------------------------------------------------------------------------
+      subroutine taumol17(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 17:  3250-4000 cm-1 (low - h2o,co2; high - h2o,co2)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng17, ngs16
+      use rrsw_kg17_f, only : absa, ka, absb, kb, forref, selfref, &
+                            sfluxref, rayl, layreffr, strrat
+!      use rrsw_kg17_f, only : absa, ka, absb, kb, forref, selfref, &
+!                            sfluxref, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifndef _OPENACC
+# define ncol CHNK
+#endif
+
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                       fac110, fac111, fs, speccomb, specmult, specparm, &
+                       tauray
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                          layreffr
+!      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+!                       fac110, fac111, fs, speccomb, specmult, specparm, &
+!                       tauray, strrat
+      integer :: iplon
+
+!      layreffr = 30
+!      strrat = 0.364641 
+    
+#ifdef _OPENACC
+!$acc kernels loop
+      do iplon=1,ncol
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+! Lower atmosphere loop
+!$acc loop private(js, fs)
+      do lay = 1, nlayers 
+#else
+IKLOOP1_S
+#endif
+        if (lay <= laytrop(iplon)) then
+          !do lay = 1, laytrop(iplon) 
+         speccomb = colh2o(iplon,lay)  + strrat*colco2(iplon,lay) 
+         specparm = colh2o(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay) 
+         fac010 = (1.  - fs) * fac10(iplon,lay) 
+         fac100 = fs * fac00(iplon,lay) 
+         fac110 = fs * fac10(iplon,lay) 
+         fac001 = (1.  - fs) * fac01(iplon,lay) 
+         fac011 = (1.  - fs) * fac11(iplon,lay) 
+         fac101 = fs * fac01(iplon,lay) 
+         fac111 = fs * fac11(iplon,lay) 
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(17) + js
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(17) + js
+         inds = indself(iplon,lay) 
+         indf = indfor(iplon,lay) 
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng17
+            taug(iplon,lay,ngs16+ig)  = speccomb * &
+                (fac000 * absa(ind0,ig) + &
+                 fac100 * absa(ind0+1,ig) + &
+                 fac010 * absa(ind0+9,ig) + &
+                 fac110 * absa(ind0+10,ig) + &
+                 fac001 * absa(ind1,ig) + &
+                 fac101 * absa(ind1+1,ig) + &
+                 fac011 * absa(ind1+9,ig) + &
+                 fac111 * absa(ind1+10,ig)) + &
+                 colh2o(iplon,lay)  * &
+                 (selffac(iplon,lay)  * (selfref(inds,ig) + &
+                 selffrac(iplon,lay)  * &
+                 (selfref(inds+1,ig) - selfref(inds,ig))) + &
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig)))) 
+            taur(iplon,lay,ngs16+ig)  = tauray
+         enddo
+
+         else
+         
+        
+         speccomb = colh2o(iplon,lay)  + strrat*colco2(iplon,lay) 
+         specparm = colh2o(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 4. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay) 
+         fac010 = (1.  - fs) * fac10(iplon,lay) 
+         fac100 = fs * fac00(iplon,lay) 
+         fac110 = fs * fac10(iplon,lay) 
+         fac001 = (1.  - fs) * fac01(iplon,lay) 
+         fac011 = (1.  - fs) * fac11(iplon,lay) 
+         fac101 = fs * fac01(iplon,lay) 
+         fac111 = fs * fac11(iplon,lay) 
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(17) + js
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(17) + js
+         indf = indfor(iplon,lay) 
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng17
+            taug(iplon,lay,ngs16+ig)  = speccomb * &
+                (fac000 * absb(ind0,ig) + &
+                 fac100 * absb(ind0+1,ig) + &
+                 fac010 * absb(ind0+5,ig) + &
+                 fac110 * absb(ind0+6,ig) + &
+                 fac001 * absb(ind1,ig) + &
+                 fac101 * absb(ind1+1,ig) + &
+                 fac011 * absb(ind1+5,ig) + &
+                 fac111 * absb(ind1+6,ig)) + &
+                 colh2o(iplon,lay)  * &
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig))) 
+!            ssa(lay,ngs16+ig) = tauray/taug(lay,ngs16+ig)
+           
+            taur(iplon,lay,ngs16+ig)  = tauray
+         enddo
+        endif
+      enddo
+      enddo
+!$acc end kernels
+
+!$acc kernels
+#ifdef _OPENACC
+      do iplon = 1, ncol
+! Upper atmosphere loop
+        laysolfr = nlayers
+      do lay = 2, nlayers
+        if (lay > laytrop(iplon)) then
+#else
+IKLOOP2_S
+#endif
+          
+        if ((jp(iplon,lay-1)  .lt. layreffr) .and. (jp(iplon,lay)  .ge. layreffr)) then
+            laysolfr = lay
+        end if
+          
+        if (lay == laysolfr) then
+              
+          speccomb = colh2o(iplon,lay)  + strrat*colco2(iplon,lay) 
+          specparm = colh2o(iplon,lay) /speccomb 
+          if (specparm .ge. oneminus) specparm = oneminus
+          specmult = 4. *(specparm)
+          js = 1 + int(specmult)
+          fs = mod(specmult, 1.  )
+          do ig = 1, ng17 
+            sfluxzen(iplon,ngs16+ig)  = sfluxref(ig,js) &
+               + fs * (sfluxref(ig,js+1) - sfluxref(ig,js))
+          end do
+        end if
+#ifdef _OPENACC
+        end if
+      enddo
+      enddo
+#else
+IKLOOP2_E
+#endif
+!$acc end kernels      
+# undef ncol
+      end subroutine taumol17
+
+!----------------------------------------------------------------------------
+      subroutine taumol18(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 18:  4000-4650 cm-1 (low - h2o,ch4; high - ch4)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng18, ngs17
+      use rrsw_kg18_f, only : absa, ka, absb, kb, forref, selfref, &
+                            sfluxref, rayl, layreffr, strrat
+!      use rrsw_kg18_f, only : absa, ka, absb, kb, forref, selfref, &
+!                            sfluxref, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , & 
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifndef _OPENACC
+# define ncol CHNK
+#endif
+
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                       fac110, fac111, fs, speccomb, specmult, specparm, &
+                       tauray
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                          layreffr
+!      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+!                       fac110, fac111, fs, speccomb, specmult, specparm, &
+!                       tauray, strrat
+      integer :: iplon
+
+    
+!      strrat = 38.9589 
+!      layreffr = 6
+!$acc kernels      
+
+#ifdef _OPENACC
+      do iplon = 1, ncol
+          laysolfr = laytrop(iplon)
+          do lay = 1, laytrop(iplon)
+#else
+      laysolfr = laytrop
+#define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+              speccomb = colh2o(iplon,lay)  + strrat*colch4(iplon,lay) 
+              specparm = colh2o(iplon,lay) /speccomb 
+              if (specparm .ge. oneminus) specparm = oneminus
+              specmult = 8. *(specparm)
+              js = 1 + int(specmult)
+              fs = mod(specmult, 1.  )
+              if (jp(iplon,lay)  .lt. layreffr .and. jp(iplon,lay+1)  .ge. layreffr) &
+              laysolfr = min(lay+1,laytrop(iplon) )
+              do ig = 1, ng18
+                if (lay .eq. laysolfr) sfluxzen(iplon,ngs17+ig)  = sfluxref(ig,js) &
+                  + fs * (sfluxref(ig,js+1) - sfluxref(ig,js))
+              end do
+#ifdef _OPENACC
+#else
+# undef laysolfr
+         endif
+#endif
+          end do
+      end do
+!$acc end kernels
+      
+!$acc kernels 
+IKLOOP1_S
+        if (lay <= laytrop(iplon)) then
+          !do lay = 1, laytrop(iplon) 
+       
+         speccomb = colh2o(iplon,lay)  + strrat*colch4(iplon,lay) 
+         specparm = colh2o(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay) 
+         fac010 = (1.  - fs) * fac10(iplon,lay) 
+         fac100 = fs * fac00(iplon,lay) 
+         fac110 = fs * fac10(iplon,lay) 
+         fac001 = (1.  - fs) * fac01(iplon,lay) 
+         fac011 = (1.  - fs) * fac11(iplon,lay) 
+         fac101 = fs * fac01(iplon,lay) 
+         fac111 = fs * fac11(iplon,lay) 
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(18) + js
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(18) + js
+         inds = indself(iplon,lay) 
+         indf = indfor(iplon,lay) 
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng18
+            taug(iplon,lay,ngs17+ig)  = speccomb * &
+                (fac000 * absa(ind0,ig) + &
+                 fac100 * absa(ind0+1,ig) + &
+                 fac010 * absa(ind0+9,ig) + &
+                 fac110 * absa(ind0+10,ig) + &
+                 fac001 * absa(ind1,ig) + &
+                 fac101 * absa(ind1+1,ig) + &
+                 fac011 * absa(ind1+9,ig) + &
+                 fac111 * absa(ind1+10,ig)) + &
+                 colh2o(iplon,lay)  * &
+                 (selffac(iplon,lay)  * (selfref(inds,ig) + &
+                 selffrac(iplon,lay)  * &
+                 (selfref(inds+1,ig) - selfref(inds,ig))) + &
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig)))) 
+!            ssa(lay,ngs17+ig) = tauray/taug(lay,ngs17+ig)
+        
+            taur(iplon,lay,ngs17+ig)  = tauray
+         enddo
+      
+        else
+
+! Upper atmosphere loop
+              
+!do lay = laytrop(iplon) +1, nlayers
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(18) + 1
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(18) + 1
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng18
+            taug(iplon,lay,ngs17+ig)  = colch4(iplon,lay)  * &
+                (fac00(iplon,lay)  * absb(ind0,ig) + &
+                 fac10(iplon,lay)  * absb(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absb(ind1,ig) + &	  
+                 fac11(iplon,lay)  * absb(ind1+1,ig)) 
+!           ssa(lay,ngs17+ig) = tauray/taug(lay,ngs17+ig)
+           taur(iplon,lay,ngs17+ig)  = tauray
+         enddo
+        end if
+IKLOOP1_E       
+
+!$acc end kernels
+# undef ncol
+      end subroutine taumol18
+
+!----------------------------------------------------------------------------
+      subroutine taumol19(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 19:  4650-5150 cm-1 (low - h2o,co2; high - co2)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng19, ngs18
+      use rrsw_kg19_f, only : absa, ka, absb, kb, forref, selfref, &
+                            sfluxref, rayl, layreffr, strrat
+!      use rrsw_kg19_f, only : absa, ka, absb, kb, forref, selfref, &
+!                            sfluxref, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &  
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+#else
+# define ncol CHNK
+#endif
+
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                  layreffr
+!      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+!                  fac110, fac111, fs, speccomb, specmult, specparm, &
+!                  tauray, strrat
+      integer :: iplon
+
+	        
+      strrat = 5.49281 
+      layreffr = 3      
+      
+#ifdef _OPENACC
+!$acc kernels 
+      do iplon=1,ncol
+
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+      laysolfr = laytrop(iplon) 
+  
+! Lower atmosphere loop      
+      do lay = 1, laytrop(iplon) 
+#else
+      laysolfr = laytrop
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+            
+        if (jp(iplon,lay)  .lt. layreffr .and. jp(iplon,lay+1)  .ge. layreffr) &
+            laysolfr = min(lay+1,laytrop(iplon) )
+     
+         if (lay .eq. laysolfr) then 
+                 speccomb = colh2o(iplon,lay)  + strrat*colco2(iplon,lay) 
+         specparm = colh2o(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+        
+         do ig = 1 , ng19
+            sfluxzen(iplon,ngs18+ig)  = sfluxref(ig,js) &
+               + fs * (sfluxref(ig,js+1) - sfluxref(ig,js))
+         end do
+         endif
+#ifdef _OPENACC
+#else
+# undef laysolfr
+         endif
+#endif
+
+      end do
+      end do
+!$acc end kernels
+      
+      
+!$acc kernels 
+IKLOOP1_S
+
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+! Lower atmosphere loop      
+         if (lay <= laytrop(iplon)) then
+       
+         speccomb = colh2o(iplon,lay)  + strrat*colco2(iplon,lay) 
+         specparm = colh2o(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay) 
+         fac010 = (1.  - fs) * fac10(iplon,lay) 
+         fac100 = fs * fac00(iplon,lay) 
+         fac110 = fs * fac10(iplon,lay) 
+         fac001 = (1.  - fs) * fac01(iplon,lay) 
+         fac011 = (1.  - fs) * fac11(iplon,lay) 
+         fac101 = fs * fac01(iplon,lay) 
+         fac111 = fs * fac11(iplon,lay) 
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(19) + js
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(19) + js
+         inds = indself(iplon,lay) 
+         indf = indfor(iplon,lay) 
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1 , ng19
+            taug(iplon,lay,ngs18+ig)  = speccomb * &
+                (fac000 * absa(ind0,ig) + &
+                 fac100 * absa(ind0+1,ig) + &
+                 fac010 * absa(ind0+9,ig) + &
+                 fac110 * absa(ind0+10,ig) + &
+                 fac001 * absa(ind1,ig) + &
+                 fac101 * absa(ind1+1,ig) + &
+                 fac011 * absa(ind1+9,ig) + &
+                 fac111 * absa(ind1+10,ig)) + &
+                 colh2o(iplon,lay)  * &
+                 (selffac(iplon,lay)  * (selfref(inds,ig) + &
+                 selffrac(iplon,lay)  * &
+                 (selfref(inds+1,ig) - selfref(inds,ig))) + & 
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig)))) 
+!            ssa(lay,ngs18+ig) = tauray/taug(lay,ngs18+ig)
+            taur(iplon,lay,ngs18+ig)  = tauray   
+         enddo
+        else
+
+! Upper atmosphere loop
+  
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(19) + 1
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(19) + 1
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1 , ng19
+            taug(iplon,lay,ngs18+ig)  = colco2(iplon,lay)  * &
+                (fac00(iplon,lay)  * absb(ind0,ig) + &
+                 fac10(iplon,lay)  * absb(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absb(ind1,ig) + &
+                 fac11(iplon,lay)  * absb(ind1+1,ig)) 
+!            ssa(lay,ngs18+ig) = tauray/taug(lay,ngs18+ig) 
+            taur(iplon,lay,ngs18+ig)  = tauray   
+         enddo
+        end if
+IKLOOP1_E       
+!$acc end kernels
+# undef ncol
+      end subroutine taumol19
+
+!----------------------------------------------------------------------------
+      subroutine taumol20(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 20:  5150-6150 cm-1 (low - h2o; high - h2o)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng20, ngs19
+      use rrsw_kg20_f, only : absa, ka, absb, kb, forref, selfref, &
+                            sfluxref, absch4, rayl, layreffr
+!      use rrsw_kg20_f, only : absa, ka, absb, kb, forref, selfref, &
+!                            sfluxref, absch4, rayl
+
+      implicit none
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &  
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+# define ncol CHNK
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                  layreffr
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray
+      integer :: iplon
+
+!      layreffr = 3        
+
+#ifdef _OPENACC
+!$acc kernels loop independent private(laysolfr)
+      do iplon = 1, ncol
+      laysolfr = laytrop(iplon)
+      do lay = 1, laytrop(iplon)
+#else
+      laysolfr = laytrop
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+
+         if (jp(iplon,lay)  .lt. layreffr .and. jp(iplon,lay+1)  .ge. layreffr) &
+            laysolfr = min(lay+1,laytrop(iplon) )
+         if (lay .eq. laysolfr) then 
+             do ig = 1, ng20 
+                 sfluxzen(iplon,ngs19+ig)  = sfluxref(ig) 
+             end do
+         end if
+#ifdef _OPENACC
+#else
+# undef laysolfr
+         endif
+#endif
+      end do
+      end do
+!$acc end kernels
+       
+!$acc kernels 
+IKLOOP1_S
+         if (lay <= laytrop(iplon)) then
+         
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(20) + 1
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(20) + 1
+         inds = indself(iplon,lay) 
+         indf = indfor(iplon,lay) 
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng20
+            taug(iplon,lay,ngs19+ig)  = colh2o(iplon,lay)  * &
+               ((fac00(iplon,lay)  * absa(ind0,ig) + &
+                 fac10(iplon,lay)  * absa(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absa(ind1,ig) + &
+                 fac11(iplon,lay)  * absa(ind1+1,ig)) + &
+                 selffac(iplon,lay)  * (selfref(inds,ig) + & 
+                 selffrac(iplon,lay)  * &
+                 (selfref(inds+1,ig) - selfref(inds,ig))) + &
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig)))) &
+                 + colch4(iplon,lay)  * absch4(ig)
+!            ssa(lay,ngs19+ig) = tauray/taug(lay,ngs19+ig)
+            taur(iplon,lay,ngs19+ig)  = tauray 
+           
+         enddo
+         else
+
+! Upper atmosphere loop
+      
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(20) + 1
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(20) + 1
+         indf = indfor(iplon,lay) 
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng20
+            taug(iplon,lay,ngs19+ig)  = colh2o(iplon,lay)  * &
+                (fac00(iplon,lay)  * absb(ind0,ig) + &
+                 fac10(iplon,lay)  * absb(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absb(ind1,ig) + &
+                 fac11(iplon,lay)  * absb(ind1+1,ig) + &
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig)))) + &
+                 colch4(iplon,lay)  * absch4(ig)
+!            ssa(lay,ngs19+ig) = tauray/taug(lay,ngs19+ig)
+            taur(iplon,lay,ngs19+ig)  = tauray 
+         enddo
+         end if
+IKLOOP1_E
+
+!$acc end kernels
+# undef ncol
+      end subroutine taumol20
+
+!----------------------------------------------------------------------------
+      subroutine taumol21(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 21:  6150-7700 cm-1 (low - h2o,co2; high - h2o,co2)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng21, ngs20
+      use rrsw_kg21_f, only : absa, ka, absb, kb, forref, selfref, &
+                            sfluxref, rayl, layreffr, strrat
+!      use rrsw_kg21_f, only : absa, ka, absb, kb, forref, selfref, &
+!                            sfluxref, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &  
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+# define ncol CHNK
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                  layreffr
+!      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+!                  fac110, fac111, fs, speccomb, specmult, specparm, &
+!                  tauray, strrat
+      integer :: iplon
+        
+!      strrat = 0.0045321 
+!      layreffr = 8
+     
+#ifdef _OPENACC
+!$acc kernels loop independent private(laysolfr)
+      do iplon = 1, ncol
+      laysolfr = laytrop(iplon)
+      do lay = 1, laytrop(iplon)
+#else
+      laysolfr = laytrop
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+
+         if (jp(iplon,lay)  .lt. layreffr .and. jp(iplon,lay+1)  .ge. layreffr) &
+            laysolfr = min(lay+1,laytrop(iplon) )
+         if (lay .eq. laysolfr) then 
+                speccomb = colh2o(iplon,lay)  + strrat*colco2(iplon,lay) 
+         specparm = colh2o(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+               do ig = 1, ng21
+              sfluxzen(iplon,ngs20+ig)  = sfluxref(ig,js) &
+               + fs * (sfluxref(ig,js+1) - sfluxref(ig,js))
+               end do
+          end if
+
+#ifdef _OPENACC
+#else
+# undef laysolfr
+         endif
+#endif
+      end do
+      end do        
+!$acc end kernels
+
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+      
+! Lower atmosphere loop
+        
+!$acc kernels 
+IKLOOP1_S
+         if (lay <= laytrop(iplon)) then
+         speccomb = colh2o(iplon,lay)  + strrat*colco2(iplon,lay) 
+         specparm = colh2o(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay) 
+         fac010 = (1.  - fs) * fac10(iplon,lay) 
+         fac100 = fs * fac00(iplon,lay) 
+         fac110 = fs * fac10(iplon,lay) 
+         fac001 = (1.  - fs) * fac01(iplon,lay) 
+         fac011 = (1.  - fs) * fac11(iplon,lay) 
+         fac101 = fs * fac01(iplon,lay) 
+         fac111 = fs * fac11(iplon,lay) 
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(21) + js
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(21) + js
+         inds = indself(iplon,lay) 
+         indf = indfor(iplon,lay) 
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng21
+            taug(iplon,lay,ngs20+ig)  = speccomb * &
+                (fac000 * absa(ind0,ig) + &
+                 fac100 * absa(ind0+1,ig) + &
+                 fac010 * absa(ind0+9,ig) + &
+                 fac110 * absa(ind0+10,ig) + &
+                 fac001 * absa(ind1,ig) + &
+                 fac101 * absa(ind1+1,ig) + &
+                 fac011 * absa(ind1+9,ig) + &
+                 fac111 * absa(ind1+10,ig)) + &
+                 colh2o(iplon,lay)  * &
+                 (selffac(iplon,lay)  * (selfref(inds,ig) + &
+                 selffrac(iplon,lay)  * &
+                 (selfref(inds+1,ig) - selfref(inds,ig))) + &
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig))))
+!            ssa(lay,ngs20+ig) = tauray/taug(lay,ngs20+ig)
+          
+            taur(iplon,lay,ngs20+ig)  = tauray
+         enddo
+        else
+
+! Upper atmosphere loop
+
+         speccomb = colh2o(iplon,lay)  + strrat*colco2(iplon,lay) 
+         specparm = colh2o(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 4. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay) 
+         fac010 = (1.  - fs) * fac10(iplon,lay) 
+         fac100 = fs * fac00(iplon,lay) 
+         fac110 = fs * fac10(iplon,lay) 
+         fac001 = (1.  - fs) * fac01(iplon,lay) 
+         fac011 = (1.  - fs) * fac11(iplon,lay) 
+         fac101 = fs * fac01(iplon,lay) 
+         fac111 = fs * fac11(iplon,lay) 
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(21) + js
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(21) + js
+         indf = indfor(iplon,lay) 
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng21
+            taug(iplon,lay,ngs20+ig)  = speccomb * &
+                (fac000 * absb(ind0,ig) + &
+                 fac100 * absb(ind0+1,ig) + &
+                 fac010 * absb(ind0+5,ig) + &
+                 fac110 * absb(ind0+6,ig) + &
+                 fac001 * absb(ind1,ig) + &
+                 fac101 * absb(ind1+1,ig) + &
+                 fac011 * absb(ind1+5,ig) + &
+                 fac111 * absb(ind1+6,ig)) + &
+                 colh2o(iplon,lay)  * &
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig)))
+!            ssa(lay,ngs20+ig) = tauray/taug(lay,ngs20+ig)
+            taur(iplon,lay,ngs20+ig)  = tauray
+         enddo
+        end if
+IKLOOP1_E
+      
+!$acc end kernels
+# undef ncol
+      end subroutine taumol21
+
+!----------------------------------------------------------------------------
+      subroutine taumol22(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 22:  7700-8050 cm-1 (low - h2o,o2; high - o2)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng22, ngs21
+      use rrsw_kg22_f, only : absa, ka, absb, kb, forref, selfref, &
+                            sfluxref, rayl, layreffr, strrat
+!      use rrsw_kg22_f, only : absa, ka, absb, kb, forref, selfref, &
+!                            sfluxref, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &  
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+# define ncol CHNK
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray, o2adj, o2cont
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                  layreffr
+!      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+!                  fac110, fac111, fs, speccomb, specmult, specparm, &
+!                  tauray, o2adj, o2cont, strrat
+      integer :: iplon
+
+! The following factor is the ratio of total O2 band intensity (lines 
+! and Mate continuum) to O2 band intensity (line only).  It is needed
+! to adjust the optical depths since the k's include only lines.
+      o2adj = 1.6 
+      
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+!      strrat = 0.022708 
+!      layreffr = 2
+      
+#ifdef _OPENACC
+!$acc kernels loop independent private(laysolfr)
+      do iplon=1,ncol
+
+      laysolfr = laytrop(iplon) 
+
+! Lower atmosphere loop
+!$acc loop seq
+         do lay = 1, laytrop(iplon) 
+#else
+      laysolfr = laytrop
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+
+            if (jp(iplon,lay)  .lt. layreffr .and. jp(iplon,lay+1)  .ge. layreffr) &
+            laysolfr = min(lay+1,laytrop(iplon) )
+                 
+            if (lay .eq. laysolfr) then 
+            speccomb = colh2o(iplon,lay)  + o2adj*strrat*colo2(iplon,lay) 
+            specparm = colh2o(iplon,lay) /speccomb 
+            if (specparm .ge. oneminus) specparm = oneminus
+            specmult = 8. *(specparm)
+    !         odadj = specparm + o2adj * (1.  - specparm)
+            js = 1 + int(specmult)
+            fs = mod(specmult, 1.  )
+            do ig = 1, ng22                                 
+                                 
+               sfluxzen(iplon,ngs21+ig)  = sfluxref(ig,js) &
+                + fs * (sfluxref(ig,js+1) - sfluxref(ig,js))
+            end do
+            end if
+#ifdef _OPENACC
+#else
+# undef laysolfr
+         endif
+#endif
+         end do
+      end do
+ !$acc end kernels
+ 
+! Lower atmosphere loop
+!$acc kernels 
+IKLOOP1_S
+
+         if (lay<=laytrop(iplon)) then
+  
+         o2cont = 4.35e-4 *colo2(iplon,lay) /(350.0 *2.0 )
+         speccomb = colh2o(iplon,lay)  + o2adj*strrat*colo2(iplon,lay) 
+         specparm = colh2o(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 8. *(specparm)
+!         odadj = specparm + o2adj * (1.  - specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay) 
+         fac010 = (1.  - fs) * fac10(iplon,lay) 
+         fac100 = fs * fac00(iplon,lay) 
+         fac110 = fs * fac10(iplon,lay) 
+         fac001 = (1.  - fs) * fac01(iplon,lay) 
+         fac011 = (1.  - fs) * fac11(iplon,lay) 
+         fac101 = fs * fac01(iplon,lay) 
+         fac111 = fs * fac11(iplon,lay) 
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(22) + js
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(22) + js
+         inds = indself(iplon,lay) 
+         indf = indfor(iplon,lay) 
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng22
+            taug(iplon,lay,ngs21+ig)  = speccomb * &
+                (fac000 * absa(ind0,ig) + &
+                 fac100 * absa(ind0+1,ig) + &
+                 fac010 * absa(ind0+9,ig) + &
+                 fac110 * absa(ind0+10,ig) + &
+                 fac001 * absa(ind1,ig) + &
+                 fac101 * absa(ind1+1,ig) + &
+                 fac011 * absa(ind1+9,ig) + &
+                 fac111 * absa(ind1+10,ig)) + &
+                 colh2o(iplon,lay)  * &
+                 (selffac(iplon,lay)  * (selfref(inds,ig) + &
+                 selffrac(iplon,lay)  * &
+                  (selfref(inds+1,ig) - selfref(inds,ig))) + &
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig)))) &
+                 + o2cont
+!            ssa(lay,ngs21+ig) = tauray/taug(lay,ngs21+ig)
+
+            taur(iplon,lay,ngs21+ig)  = tauray
+         enddo
+
+         else
+
+! Upper atmosphere loop
+      
+         o2cont = 4.35e-4 *colo2(iplon,lay) /(350.0 *2.0 )
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(22) + 1
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(22) + 1
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng22
+            taug(iplon,lay,ngs21+ig)  = colo2(iplon,lay)  * o2adj * &
+                (fac00(iplon,lay)  * absb(ind0,ig) + &
+                 fac10(iplon,lay)  * absb(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absb(ind1,ig) + &
+                 fac11(iplon,lay)  * absb(ind1+1,ig)) + &
+                 o2cont
+!            ssa(lay,ngs21+ig) = tauray/taug(lay,ngs21+ig)
+            taur(iplon,lay,ngs21+ig)  = tauray
+         enddo
+         end if
+IKLOOP1_E
+      
+!$acc end kernels
+# undef ncol
+      end subroutine taumol22
+
+!----------------------------------------------------------------------------
+      subroutine taumol23(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 23:  8050-12850 cm-1 (low - h2o; high - nothing)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng23, ngs22
+      use rrsw_kg23_f, only : absa, ka, forref, selfref, &
+                            sfluxref, rayl, layreffr, givfac
+!      use rrsw_kg23_f, only : absa, ka, forref, selfref, &
+!                            sfluxref, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &  
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+# define ncol CHNK
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                  layreffr
+!      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+!                  fac110, fac111, fs, speccomb, specmult, specparm, &
+!                  tauray, givfac
+      integer :: iplon
+
+
+! Average Giver et al. correction factor for this band.
+!      givfac = 1.029 
+
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+!      layreffr = 6    
+      
+#ifdef _OPENACC
+!$acc kernels loop independent private(laysolfr)
+      do iplon=1,ncol
+
+      laysolfr = laytrop(iplon) 
+
+! Lower atmosphere loop
+!$acc loop seq
+      do lay = 1, laytrop(iplon) 
+#else
+      laysolfr = laytrop
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+
+          if (jp(iplon,lay)  .lt. layreffr .and. jp(iplon,lay+1)  .ge. layreffr) &
+            laysolfr = min(lay+1,laytrop(iplon) )
+         
+          if (lay .eq. laysolfr) then 
+            do ig = 1, ng23
+              sfluxzen(iplon,ngs22+ig)  = sfluxref(ig) 
+            end do
+          end if
+#ifdef _OPENACC
+#else
+# undef laysolfr
+         endif
+#endif
+      end do
+      end do      
+!$acc end kernels   
+      
+
+! Lower atmosphere loop
+!$acc kernels 
+IKLOOP1_S
+         if (lay <= laytrop(iplon)) then
+         if (jp(iplon,lay)  .lt. layreffr .and. jp(iplon,lay+1)  .ge. layreffr) &
+            laysolfr = min(lay+1,laytrop(iplon) )
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(23) + 1
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(23) + 1
+         inds = indself(iplon,lay) 
+         indf = indfor(iplon,lay) 
+
+         do ig = 1, ng23
+            tauray = colmol(iplon,lay)  * rayl(ig)
+            taug(iplon,lay,ngs22+ig)  = colh2o(iplon,lay)  * &
+                (givfac * (fac00(iplon,lay)  * absa(ind0,ig) + &
+                 fac10(iplon,lay)  * absa(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absa(ind1,ig) + &
+                 fac11(iplon,lay)  * absa(ind1+1,ig)) + &
+                 selffac(iplon,lay)  * (selfref(inds,ig) + &
+                 selffrac(iplon,lay)  * &
+                 (selfref(inds+1,ig) - selfref(inds,ig))) + &
+                 forfac(iplon,lay)  * (forref(indf,ig) + &
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig)))) 
+!            ssa(lay,ngs22+ig) = tauray/taug(lay,ngs22+ig)
+           
+            taur(iplon,lay,ngs22+ig)  = tauray
+         enddo
+
+         else
+
+! Upper atmosphere loop
+      
+         do ig = 1, ng23
+!            taug(lay,ngs22+ig) = colmol(lay) * rayl(ig)
+!            ssa(lay,ngs22+ig) = 1.0 
+            taug(iplon,lay,ngs22+ig)  = 0. 
+            taur(iplon,lay,ngs22+ig)  = colmol(iplon,lay)  * rayl(ig) 
+         enddo
+         end if
+
+IKLOOP1_E
+      
+!$acc end kernels
+# undef ncol
+      end subroutine taumol23
+
+!----------------------------------------------------------------------------
+      subroutine taumol24(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 24:  12850-16000 cm-1 (low - h2o,o2; high - o2)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng24, ngs23
+      use rrsw_kg24_f, only : absa, ka, absb, kb, forref, selfref, &
+                            sfluxref, abso3a, abso3b, rayla, raylb, &
+                            layreffr, strrat
+!      use rrsw_kg24_f, only : absa, ka, absb, kb, forref, selfref, &
+!                            sfluxref, abso3a, abso3b, rayla, raylb
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , & 
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+# define ncol CHNK
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                  layreffr
+!      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+!                  fac110, fac111, fs, speccomb, specmult, specparm, &
+!                  tauray, strrat
+      integer :: iplon
+
+!      strrat = 0.124692 
+!      layreffr = 1   
+        
+#ifdef _OPENACC
+!$acc kernels loop independent private(laysolfr)
+      do iplon=1,ncol
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+      laysolfr = laytrop(iplon) 
+
+! Lower atmosphere loop
+!$acc loop independent
+      do lay = 1, laytrop(iplon) 
+#else
+      laysolfr = laytrop
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+
+          if (jp(iplon,lay)  .lt. layreffr .and. jp(iplon,lay+1)  .ge. layreffr) &
+            laysolfr = min(lay+1,laytrop(iplon) )
+          if (lay .eq. laysolfr) then
+                 speccomb = colh2o(iplon,lay)  + strrat*colo2(iplon,lay) 
+            specparm = colh2o(iplon,lay) /speccomb 
+            if (specparm .ge. oneminus) specparm = oneminus
+            specmult = 8. *(specparm)
+            js = 1 + int(specmult)
+            fs = mod(specmult, 1.  )
+          do ig = 1, ng24
+           sfluxzen(iplon,ngs23+ig)  = sfluxref(ig,js) &
+               + fs * (sfluxref(ig,js+1) - sfluxref(ig,js))
+          end do
+          end if
+#ifdef _OPENACC
+#else
+# undef laysolfr
+         endif
+#endif
+      end do
+      end do
+!$acc end kernels
+        
+!$acc kernels 
+IKLOOP1_S
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+! Lower atmosphere loop
+         if (lay <= laytrop(iplon)) then
+
+         speccomb = colh2o(iplon,lay)  + strrat*colo2(iplon,lay) 
+         specparm = colh2o(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay) 
+         fac010 = (1.  - fs) * fac10(iplon,lay) 
+         fac100 = fs * fac00(iplon,lay) 
+         fac110 = fs * fac10(iplon,lay) 
+         fac001 = (1.  - fs) * fac01(iplon,lay) 
+         fac011 = (1.  - fs) * fac11(iplon,lay) 
+         fac101 = fs * fac01(iplon,lay) 
+         fac111 = fs * fac11(iplon,lay) 
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(24) + js
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(24) + js
+         inds = indself(iplon,lay) 
+         indf = indfor(iplon,lay) 
+
+         do ig = 1, ng24
+            tauray = colmol(iplon,lay)  * (rayla(ig,js) + &
+               fs * (rayla(ig,js+1) - rayla(ig,js)))
+            taug(iplon,lay,ngs23+ig)  = speccomb * &
+                (fac000 * absa(ind0,ig) + &
+                 fac100 * absa(ind0+1,ig) + &
+                 fac010 * absa(ind0+9,ig) + &
+                 fac110 * absa(ind0+10,ig) + &
+                 fac001 * absa(ind1,ig) + &
+                 fac101 * absa(ind1+1,ig) + &
+                 fac011 * absa(ind1+9,ig) + &
+                 fac111 * absa(ind1+10,ig)) + &
+                 colo3(iplon,lay)  * abso3a(ig) + &
+                 colh2o(iplon,lay)  * & 
+                 (selffac(iplon,lay)  * (selfref(inds,ig) + &
+                 selffrac(iplon,lay)  * &
+                 (selfref(inds+1,ig) - selfref(inds,ig))) + &
+                 forfac(iplon,lay)  * (forref(indf,ig) + & 
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig))))
+!            ssa(lay,ngs23+ig) = tauray/taug(lay,ngs23+ig)
+           
+            taur(iplon,lay,ngs23+ig)  = tauray
+         enddo
+
+         else
+
+! Upper atmosphere loop
+      
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(24) + 1
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(24) + 1
+
+         do ig = 1, ng24
+            tauray = colmol(iplon,lay)  * raylb(ig)
+            taug(iplon,lay,ngs23+ig)  = colo2(iplon,lay)  * &
+                (fac00(iplon,lay)  * absb(ind0,ig) + &
+                 fac10(iplon,lay)  * absb(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absb(ind1,ig) + &
+                 fac11(iplon,lay)  * absb(ind1+1,ig)) + &
+                 colo3(iplon,lay)  * abso3b(ig)
+!            ssa(lay,ngs23+ig) = tauray/taug(lay,ngs23+ig)
+            taur(iplon,lay,ngs23+ig)  = tauray
+         enddo
+         endif
+
+IKLOOP1_E
+      
+!$acc end kernels
+# undef ncol
+      end subroutine taumol24
+
+!----------------------------------------------------------------------------
+      subroutine taumol25(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 25:  16000-22650 cm-1 (low - h2o; high - nothing)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng25, ngs24
+      use rrsw_kg25_f, only : absa, ka, &
+                            sfluxref, abso3a, abso3b, rayl, layreffr
+!      use rrsw_kg25_f, only : absa, ka, &
+!                            sfluxref, abso3a, abso3b, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &  
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+# define ncol CHNK
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+
+
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                  layreffr
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray
+      integer :: iplon
+
+#ifdef _OPENACC
+!$acc kernels 
+      do iplon=1,ncol
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+!      layreffr = 2
+      laysolfr = laytrop(iplon) 
+
+! Lower atmosphere loop
+      do lay = 1, laytrop(iplon) 
+#else
+      laysolfr = laytrop
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+         if (jp(iplon,lay)  .lt. layreffr .and. jp(iplon,lay+1)  .ge. layreffr) &
+            laysolfr = min(lay+1,laytrop(iplon) )
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(25) + 1
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(25) + 1
+
+         do ig = 1, ng25
+            tauray = colmol(iplon,lay)  * rayl(ig)
+            taug(iplon,lay,ngs24+ig)  = colh2o(iplon,lay)  * &
+                (fac00(iplon,lay)  * absa(ind0,ig) + &
+                 fac10(iplon,lay)  * absa(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absa(ind1,ig) + &
+                 fac11(iplon,lay)  * absa(ind1+1,ig)) + &
+                 colo3(iplon,lay)  * abso3a(ig) 
+!            ssa(lay,ngs24+ig) = tauray/taug(lay,ngs24+ig)
+            if (lay .eq. laysolfr) sfluxzen(iplon,ngs24+ig)  = sfluxref(ig) 
+            taur(iplon,lay,ngs24+ig)  = tauray
+         enddo
+#ifdef _OPENACC
+      enddo
+! Upper atmosphere loop
+      do lay = laytrop(iplon) +1, nlayers
+#else
+      else 
+#endif
+
+         do ig = 1, ng25
+            tauray = colmol(iplon,lay)  * rayl(ig)
+            taug(iplon,lay,ngs24+ig)  = colo3(iplon,lay)  * abso3b(ig) 
+!            ssa(lay,ngs24+ig) = tauray/taug(lay,ngs24+ig)
+            taur(iplon,lay,ngs24+ig)  = tauray
+         enddo
+#ifdef _OPENACC
+#else
+# undef laysolfr
+      endif
+#endif
+      enddo
+      enddo
+      
+!$acc end kernels
+# undef ncol
+      end subroutine taumol25
+
+!----------------------------------------------------------------------------
+      subroutine taumol26(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 26:  22650-29000 cm-1 (low - nothing; high - nothing)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng26, ngs25
+      use rrsw_kg26_f, only : sfluxref, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &  
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+# define ncol CHNK
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray
+      integer :: iplon
+
+#ifdef _OPENACC
+!$acc kernels 
+      do iplon=1,ncol
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+      laysolfr = laytrop(iplon) 
+
+! Lower atmosphere loop
+      do lay = 1, laytrop(iplon) 
+#else
+      laysolfr = laytrop
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+         do ig = 1, ng26 
+!            taug(lay,ngs25+ig) = colmol(lay) * rayl(ig)
+!            ssa(lay,ngs25+ig) = 1.0 
+            if (lay .eq. laysolfr) sfluxzen(iplon,ngs25+ig)  = sfluxref(ig) 
+            taug(iplon,lay,ngs25+ig)  = 0. 
+            taur(iplon,lay,ngs25+ig)  = colmol(iplon,lay)  * rayl(ig) 
+         enddo
+#ifdef _OPENACC
+      enddo
+      do lay = laytrop(iplon) +1, nlayers
+#else
+      else
+#endif
+
+! Upper atmosphere loop
+         do ig = 1, ng26
+!            taug(lay,ngs25+ig) = colmol(lay) * rayl(ig)
+!            ssa(lay,ngs25+ig) = 1.0 
+            taug(iplon,lay,ngs25+ig)  = 0. 
+            taur(iplon,lay,ngs25+ig)  = colmol(iplon,lay)  * rayl(ig) 
+         enddo
+#ifdef _OPENACC
+#else
+# undef laysolfr
+      endif
+#endif
+      enddo
+      enddo
+      
+!$acc end kernels
+# undef ncol
+      end subroutine taumol26
+
+!----------------------------------------------------------------------------
+      subroutine taumol27(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 27:  29000-38000 cm-1 (low - o3; high - o3)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng27, ngs26
+      use rrsw_kg27_f, only : absa, ka, absb, kb, &
+                            sfluxref, rayl, layreffr, scalekur
+!      use rrsw_kg27_f, only : absa, ka, absb, kb, sfluxref, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &  
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+# define ncol CHNK
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                  layreffr
+!      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+!                  fac110, fac111, fs, speccomb, specmult, specparm, &
+!                  tauray, scalekur
+      integer :: iplon
+       
+#ifdef _OPENACC
+!$acc kernels 
+      do iplon=1,ncol
+! Kurucz solar source function
+! The values in sfluxref were obtained using the "low resolution"
+! version of the Kurucz solar source function.  For unknown reasons,
+! the total irradiance in this band differs from the corresponding
+! total in the "high-resolution" version of the Kurucz function.
+! Therefore, these values are scaled below by the factor SCALEKUR.
+
+!      scalekur = 50.15 /48.37 
+
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+!      layreffr = 32
+
+! Lower atmosphere loop
+      do lay = 1, laytrop(iplon) 
+#else
+      laysolfr = nlayers
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(27) + 1
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(27) + 1
+
+         do ig = 1, ng27
+            tauray = colmol(iplon,lay)  * rayl(ig)
+            taug(iplon,lay,ngs26+ig)  = colo3(iplon,lay)  * &
+                (fac00(iplon,lay)  * absa(ind0,ig) + &
+                 fac10(iplon,lay)  * absa(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absa(ind1,ig) + &
+                 fac11(iplon,lay)  * absa(ind1+1,ig))
+!            ssa(lay,ngs26+ig) = tauray/taug(lay,ngs26+ig)
+            taur(iplon,lay,ngs26+ig)  = tauray
+         enddo
+#ifdef _OPENACC
+      enddo
+
+      laysolfr = nlayers
+
+! Upper atmosphere loop
+      do lay = laytrop(iplon) +1, nlayers
+#else
+      else
+#endif
+         if (jp(iplon,lay-1)  .lt. layreffr .and. jp(iplon,lay)  .ge. layreffr) &
+            laysolfr = lay
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(27) + 1
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(27) + 1
+
+         do ig = 1, ng27
+            tauray = colmol(iplon,lay)  * rayl(ig)
+            taug(iplon,lay,ngs26+ig)  = colo3(iplon,lay)  * &
+                (fac00(iplon,lay)  * absb(ind0,ig) + &
+                 fac10(iplon,lay)  * absb(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absb(ind1,ig) + & 
+                 fac11(iplon,lay)  * absb(ind1+1,ig))
+!            ssa(lay,ngs26+ig) = tauray/taug(lay,ngs26+ig)
+            if (lay.eq.laysolfr) sfluxzen(iplon,ngs26+ig)  = scalekur * sfluxref(ig) 
+            taur(iplon,lay,ngs26+ig)  = tauray
+         enddo
+#ifdef _OPENACC
+#else
+# undef laysolfr
+      endif
+#endif
+      enddo
+      enddo
+      
+!$acc end kernels
+# undef ncol
+      end subroutine taumol27
+
+!----------------------------------------------------------------------------
+      subroutine taumol28(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 28:  38000-50000 cm-1 (low - o3,o2; high - o3,o2)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng28, ngs27
+      use rrsw_kg28_f, only : absa, ka, absb, kb, &
+                            sfluxref, rayl, layreffr, strrat
+!      use rrsw_kg28_f, only : absa, ka, absb, kb, sfluxref, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , & 
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+# define ncol CHNK
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                  layreffr
+!      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+!                  fac110, fac111, fs, speccomb, specmult, specparm, &
+!                  tauray, strrat
+      integer :: iplon
+
+#ifdef _OPENACC
+!$acc kernels 
+      do iplon=1,ncol
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+!      strrat = 6.67029e-07 
+!      layreffr = 58
+
+! Lower atmosphere loop
+      do lay = 1, laytrop(iplon) 
+#else
+      laysolfr = nlayers
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay <= laytrop(iplon)) then
+#endif
+         speccomb = colo3(iplon,lay)  + strrat*colo2(iplon,lay) 
+         specparm = colo3(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 8. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay) 
+         fac010 = (1.  - fs) * fac10(iplon,lay) 
+         fac100 = fs * fac00(iplon,lay) 
+         fac110 = fs * fac10(iplon,lay) 
+         fac001 = (1.  - fs) * fac01(iplon,lay) 
+         fac011 = (1.  - fs) * fac11(iplon,lay) 
+         fac101 = fs * fac01(iplon,lay) 
+         fac111 = fs * fac11(iplon,lay) 
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(28) + js
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(28) + js
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng28
+            taug(iplon,lay,ngs27+ig)  = speccomb * &
+                (fac000 * absa(ind0,ig) + &
+                 fac100 * absa(ind0+1,ig) + &
+                 fac010 * absa(ind0+9,ig) + &
+                 fac110 * absa(ind0+10,ig) + &
+                 fac001 * absa(ind1,ig) + &
+                 fac101 * absa(ind1+1,ig) + &
+                 fac011 * absa(ind1+9,ig) + &
+                 fac111 * absa(ind1+10,ig)) 
+!            ssa(lay,ngs27+ig) = tauray/taug(lay,ngs27+ig)
+            taur(iplon,lay,ngs27+ig)  = tauray
+         enddo
+#ifdef _OPENACC
+      enddo
+
+      laysolfr = nlayers
+
+! Upper atmosphere loop
+      do lay = laytrop(iplon) +1, nlayers
+#else
+      else
+#endif
+         if (jp(iplon,lay-1)  .lt. layreffr .and. jp(iplon,lay)  .ge. layreffr) &
+            laysolfr = lay
+         speccomb = colo3(iplon,lay)  + strrat*colo2(iplon,lay) 
+         specparm = colo3(iplon,lay) /speccomb 
+         if (specparm .ge. oneminus) specparm = oneminus
+         specmult = 4. *(specparm)
+         js = 1 + int(specmult)
+         fs = mod(specmult, 1.  )
+         fac000 = (1.  - fs) * fac00(iplon,lay) 
+         fac010 = (1.  - fs) * fac10(iplon,lay) 
+         fac100 = fs * fac00(iplon,lay) 
+         fac110 = fs * fac10(iplon,lay) 
+         fac001 = (1.  - fs) * fac01(iplon,lay) 
+         fac011 = (1.  - fs) * fac11(iplon,lay) 
+         fac101 = fs * fac01(iplon,lay) 
+         fac111 = fs * fac11(iplon,lay) 
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(28) + js
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(28) + js
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng28
+            taug(iplon,lay,ngs27+ig)  = speccomb * &
+                (fac000 * absb(ind0,ig) + &
+                 fac100 * absb(ind0+1,ig) + &
+                 fac010 * absb(ind0+5,ig) + &
+                 fac110 * absb(ind0+6,ig) + &
+                 fac001 * absb(ind1,ig) + &
+                 fac101 * absb(ind1+1,ig) + &
+                 fac011 * absb(ind1+5,ig) + &
+                 fac111 * absb(ind1+6,ig)) 
+!            ssa(lay,ngs27+ig) = tauray/taug(lay,ngs27+ig)
+            if (lay .eq. laysolfr) sfluxzen(iplon,ngs27+ig)  = sfluxref(ig,js) &
+               + fs * (sfluxref(ig,js+1) - sfluxref(ig,js))
+            taur(iplon,lay,ngs27+ig)  = tauray
+         enddo
+#ifdef _OPENACC
+#else
+# undef laysolfr
+      endif
+#endif
+      enddo
+      enddo
+      
+!$acc end kernels
+# undef ncol
+      end subroutine taumol28
+
+!----------------------------------------------------------------------------
+      subroutine taumol29(ncol, nlayers, &
+                          colh2o, colco2, colch4, colo2, colo3, colmol, &
+                          laytrop, jp, jt, jt1, &
+                          fac00, fac01, fac10, fac11, &
+                          selffac, selffrac, indself, forfac, forfrac, indfor, &
+                          sfluxzen, taug, taur)
+!----------------------------------------------------------------------------
+!
+!     band 29:  820-2600 cm-1 (low - h2o; high - co2)
+!
+!----------------------------------------------------------------------------
+
+! ------- Modules -------
+
+      use parrrsw_f, only : ng29, ngs28
+      use rrsw_kg29_f, only : absa, ka, absb, kb, forref, selfref, &
+                            sfluxref, absh2o, absco2, rayl, layreffr
+!      use rrsw_kg29_f, only : absa, ka, absb, kb, forref, selfref, &
+!                            sfluxref, absh2o, absco2, rayl
+
+! ------- Declarations -------
+      integer , intent(in) :: ncol
+      integer , intent(in) :: nlayers               ! total number of layers
+
+      integer , intent(in) :: laytrop(:)            ! tropopause layer index
+      integer , intent(in) :: jp(:,:)               ! 
+      integer , intent(in) :: jt(:,:)               !
+      integer , intent(in) :: jt1(:,:)              !
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: colh2o(:,:)              ! column amount (h2o)
+      real , intent(in) :: colco2(:,:)              ! column amount (co2)
+      real , intent(in) :: colo3(:,:)               ! column amount (o3)
+      real , intent(in) :: colch4(:,:)              ! column amount (ch4)
+      real , intent(in) :: colo2(:,:)               ! column amount (o2)
+      real , intent(in) :: colmol(:,:)              ! 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      integer , intent(in) :: indself(:,:)     
+      integer , intent(in) :: indfor(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+                                                    !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: &                        !
+                       fac00(:,:) , fac01(:,:) , &  
+                       fac10(:,:) , fac11(:,:)  
+                                                    !   Dimensions: (ncol,nlayers)
+
+! ----- Output -----
+      real, intent(out) :: sfluxzen(:,:)      ! solar source function
+                                                         !   Dimensions: (ncol,ngptsw)
+      real, intent(out) :: taug(:,:,:)        ! gaseous optical depth 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+      real, intent(out) :: taur(:,:,:)        ! Rayleigh 
+                                                         !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Local
+#ifdef _OPENACC
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr
+#else
+# define ncol CHNK
+      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr(ncol)
+#endif
+
+!      integer  :: ig, ind0, ind1, inds, indf, js, lay, laysolfr, &
+!                  layreffr
+      real  :: fac000, fac001, fac010, fac011, fac100, fac101, &
+                  fac110, fac111, fs, speccomb, specmult, specparm, &
+                  tauray
+      integer :: iplon
+
+!      layreffr = 49  
+        
+#ifdef _OPENACC
+!$acc kernels loop independent private (laysolfr)
+      do iplon=1,ncol
+        
+        laysolfr = nlayers
+!$acc loop seq
+        do lay = laytrop(iplon) +1, nlayers
+#else
+      laysolfr = nlayers
+# define laysolfr LAYSOLFR(iplon)
+      do lay = 1, nlayers
+        do iplon = 1, ncol
+          if (lay > laytrop(iplon)) then
+#endif
+         if (jp(iplon,lay-1)  .lt. layreffr .and. jp(iplon,lay)  .ge. layreffr) &
+            laysolfr = lay
+
+            if (lay .eq. laysolfr) then 
+                do ig = 1, ng29
+                sfluxzen(iplon,ngs28+ig)  = sfluxref(ig) 
+                end do
+            end if
+#ifdef _OPENACC
+#else
+# undef laysolfr
+         endif
+#endif
+        end do
+      end do
+!$acc end kernels
+       
+#ifdef _OPENACC
+!$acc kernels 
+      do iplon=1,ncol
+! Compute the optical depth by interpolating in ln(pressure), 
+! temperature, and appropriate species.  Below LAYTROP, the water
+! vapor self-continuum is interpolated (in temperature) separately.  
+
+! Lower atmosphere loop
+      do lay = 1, nlayers 
+#else
+    do lay = 1, nlayers 
+      do iplon=1,ncol
+#endif
+         if (lay <= laytrop(iplon)) then
+         ind0 = ((jp(iplon,lay) -1)*5+(jt(iplon,lay) -1))*nspa(29) + 1
+         ind1 = (jp(iplon,lay) *5+(jt1(iplon,lay) -1))*nspa(29) + 1
+         inds = indself(iplon,lay) 
+         indf = indfor(iplon,lay) 
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng29
+            taug(iplon,lay,ngs28+ig)  = colh2o(iplon,lay)  * &
+               ((fac00(iplon,lay)  * absa(ind0,ig) + &
+                 fac10(iplon,lay)  * absa(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absa(ind1,ig) + &
+                 fac11(iplon,lay)  * absa(ind1+1,ig)) + &
+                 selffac(iplon,lay)  * (selfref(inds,ig) + &
+                 selffrac(iplon,lay)  * &
+                 (selfref(inds+1,ig) - selfref(inds,ig))) + &
+                 forfac(iplon,lay)  * (forref(indf,ig) + & 
+                 forfrac(iplon,lay)  * &
+                 (forref(indf+1,ig) - forref(indf,ig)))) &
+                 + colco2(iplon,lay)  * absco2(ig) 
+!            ssa(lay,ngs28+ig) = tauray/taug(lay,ngs28+ig)
+            taur(iplon,lay,ngs28+ig)  = tauray
+         enddo
+
+         else 
+
+! Upper atmosphere loop
+         ind0 = ((jp(iplon,lay) -13)*5+(jt(iplon,lay) -1))*nspb(29) + 1
+         ind1 = ((jp(iplon,lay) -12)*5+(jt1(iplon,lay) -1))*nspb(29) + 1
+         tauray = colmol(iplon,lay)  * rayl
+
+         do ig = 1, ng29
+            taug(iplon,lay,ngs28+ig)  = colco2(iplon,lay)  * &
+                (fac00(iplon,lay)  * absb(ind0,ig) + &
+                 fac10(iplon,lay)  * absb(ind0+1,ig) + &
+                 fac01(iplon,lay)  * absb(ind1,ig) + &
+                 fac11(iplon,lay)  * absb(ind1+1,ig)) &  
+                 + colh2o(iplon,lay)  * absh2o(ig) 
+!            ssa(lay,ngs28+ig) = tauray/taug(lay,ngs28+ig)
+        
+            taur(iplon,lay,ngs28+ig)  = tauray
+         enddo
+         end if
+
+      enddo
+      enddo
+      
+!$acc end kernels
+# undef ncol
+      end subroutine taumol29
+
+# undef IKLOOP1_S
+# undef IKLOOP1_E
+# undef IKLOOP2_S 
+# undef IKLOOP2_E
+
+      end module rrtmg_sw_taumol_f
+
+      module rrtmg_sw_init_f
+
+! ------- Modules -------
+
+      use rrsw_wvn_f
+      use rrtmg_sw_setcoef_f, only: swatmref
+      
+      implicit none
+
+      public rrtmg_sw_ini
+      
+      contains
+
+! **************************************************************************
+      subroutine rrtmg_sw_ini(cpdair)
+! **************************************************************************
+!
+!  Original version:   Michael J. Iacono; February, 2004
+!  Revision for F90 formatting:  M. J. Iacono, July, 2006
+!
+!  This subroutine performs calculations necessary for the initialization
+!  of the shortwave model.  Lookup tables are computed for use in the SW
+!  radiative transfer, and input absorption coefficient data for each
+!  spectral band are reduced from 224 g-point intervals to 112.
+! **************************************************************************
+
+      use parrrsw_f, only : mg, nbndsw, ngptsw
+      use rrsw_tbl_f, only: ntbl, tblint, pade, bpade, tau_tbl, exp_tbl
+      use rrsw_vsn_f, only: hvrini, hnamini
+
+      real , intent(in) :: cpdair     ! Specific heat capacity of dry air
+                                      ! at constant pressure at 273 K
+                                      ! (J kg-1 K-1)
+
+! ------- Local -------
+
+      integer  :: ibnd, igc, ig, ind, ipr
+      integer  :: igcsm, iprsm
+      integer  :: itr
+
+      real  :: wtsum, wtsm(mg)
+      real  :: tfn
+
+      real , parameter :: expeps = 1.e-20    ! Smallest value for exponential table
+
+! ------- Definitions -------
+!     Arrays for 10000-point look-up tables:
+!     TAU_TBL  Clear-sky optical depth 
+!     EXP_TBL  Exponential lookup table for transmittance
+!     PADE     Pade approximation constant (= 0.278)
+!     BPADE    Inverse of the Pade approximation constant
+!
+
+      hvrini = '$Revision: 1.5 $'
+
+! Initialize model data
+      call swdatinit(cpdair)
+      call swcmbdat              ! g-point interval reduction data
+      call swaerpr               ! aerosol optical properties
+      call swcldpr               ! cloud optical properties
+      call swatmref              ! reference MLS profile
+! Moved to module_ra_rrtmg_swf for WRF
+!      call sw_kgb16              ! molecular absorption coefficients
+!      call sw_kgb17
+!      call sw_kgb18
+!      call sw_kgb19
+!      call sw_kgb20
+!      call sw_kgb21
+!      call sw_kgb22
+!      call sw_kgb23
+!      call sw_kgb24
+!      call sw_kgb25
+!      call sw_kgb26
+!      call sw_kgb27
+!      call sw_kgb28
+!      call sw_kgb29
+
+! Define exponential lookup tables for transmittance. Tau is
+! computed as a function of the tau transition function, and transmittance 
+! is calculated as a function of tau.  All tables are computed at intervals 
+! of 0.0001.  The inverse of the constant used in the Pade approximation to 
+! the tau transition function is set to bpade.
+
+      exp_tbl(0) = 1.0 
+      exp_tbl(ntbl) = expeps
+      bpade = 1.0  / pade
+      do itr = 1, ntbl-1
+         tfn = float(itr) / float(ntbl)
+         tau_tbl = bpade * tfn / (1.  - tfn)
+         exp_tbl(itr) = exp(-tau_tbl)
+         if (exp_tbl(itr) .le. expeps) exp_tbl(itr) = expeps
+      enddo
+
+! Perform g-point reduction from 16 per band (224 total points) to
+! a band dependent number (112 total points) for all absorption
+! coefficient input data and Planck fraction input data.
+! Compute relative weighting for new g-point combinations.
+
+      igcsm = 0
+      do ibnd = 1,nbndsw
+         iprsm = 0
+         if (ngc(ibnd).lt.mg) then
+            do igc = 1,ngc(ibnd)
+               igcsm = igcsm + 1
+               wtsum = 0.
+               do ipr = 1, ngn(igcsm)
+                  iprsm = iprsm + 1
+                  wtsum = wtsum + wt(iprsm)
+               enddo
+               wtsm(igc) = wtsum
+            enddo
+            do ig = 1, ng(ibnd+15)
+               ind = (ibnd-1)*mg + ig
+               rwgt(ind) = wt(ig)/wtsm(ngm(ind))
+            enddo
+         else
+            do ig = 1, ng(ibnd+15)
+               igcsm = igcsm + 1
+               ind = (ibnd-1)*mg + ig
+               rwgt(ind) = 1.0 
+            enddo
+         endif
+      enddo
+
+! Reduce g-points for absorption coefficient data in each LW spectral band.
+
+      call cmbgb16s
+      call cmbgb17
+      call cmbgb18
+      call cmbgb19
+      call cmbgb20
+      call cmbgb21
+      call cmbgb22
+      call cmbgb23
+      call cmbgb24
+      call cmbgb25
+      call cmbgb26
+      call cmbgb27
+      call cmbgb28
+      call cmbgb29
+
+      end subroutine rrtmg_sw_ini
+
+!***************************************************************************
+      subroutine swdatinit(cpdair)
+!***************************************************************************
+
+! --------- Modules ----------
+
+      use rrsw_con_f, only: heatfac, grav, planck, boltz, &
+                          clight, avogad, alosmt, gascon, radcn1, radcn2, &
+                          sbcnst, secdy 
+      use rrsw_vsn_f
+
+      save 
+ 
+      real , intent(in) :: cpdair     ! Specific heat capacity of dry air
+                                      ! at constant pressure at 273 K
+                                      ! (J kg-1 K-1)
+
+! Shortwave spectral band limits (wavenumbers)
+      wavenum1(:) = (/2600. , 3250. , 4000. , 4650. , 5150. , 6150. , 7700. , &
+                      8050. ,12850. ,16000. ,22650. ,29000. ,38000. ,  820. /)
+      wavenum2(:) = (/3250. , 4000. , 4650. , 5150. , 6150. , 7700. , 8050. , &
+                     12850. ,16000. ,22650. ,29000. ,38000. ,50000. , 2600. /)
+      delwave(:) =  (/ 650. ,  750. ,  650. ,  500. , 1000. , 1550. ,  350. , &
+                      4800. , 3150. , 6650. , 6350. , 9000. ,12000. , 1780. /)
+     
+! Spectral band information
+      ng(:) = (/16,16,16,16,16,16,16,16,16,16,16,16,16,16/)
+      nspa(:) = (/9,9,9,9,1,9,9,1,9,1,0,1,9,1/)
+      nspb(:) = (/1,5,1,1,1,5,1,0,1,0,0,1,5,1/)
+      icxa(:) = (/ 5 ,5 ,4 ,4 ,3 ,3 ,2 ,2 ,1 ,1 ,1 ,1 ,1 ,5/)
+
+! Fundamental physical constants from NIST 2002
+
+      grav = 9.8066                         ! Acceleration of gravity
+                                              ! (m s-2)
+      planck = 6.62606876e-27               ! Planck constant
+                                              ! (ergs s; g cm2 s-1)
+      boltz = 1.3806503e-16                 ! Boltzmann constant
+                                              ! (ergs K-1; g cm2 s-2 K-1)
+      clight = 2.99792458e+10               ! Speed of light in a vacuum  
+                                              ! (cm s-1)
+      avogad = 6.02214199e+23               ! Avogadro constant
+                                              ! (mol-1)
+      alosmt = 2.6867775e+19                ! Loschmidt constant
+                                              ! (cm-3)
+      gascon = 8.31447200e+07               ! Molar gas constant
+                                              ! (ergs mol-1 K-1)
+      radcn1 = 1.191042772e-12              ! First radiation constant
+                                              ! (W cm2 sr-1)
+      radcn2 = 1.4387752                    ! Second radiation constant
+                                              ! (cm K)
+      sbcnst = 5.670400e-04                 ! Stefan-Boltzmann constant
+                                              ! (W cm-2 K-4)
+      secdy = 8.6400e4                      ! Number of seconds per day
+                                              ! (s d-1)
+!
+!     units are generally cgs
+!
+!     The first and second radiation constants are taken from NIST.
+!     They were previously obtained from the relations:
+!          radcn1 = 2.*planck*clight*clight*1.e-07
+!          radcn2 = planck*clight/boltz
+
+!     Heatfac is the factor by which delta-flux / delta-pressure is
+!     multiplied, with flux in W/m-2 and pressure in mbar, to get 
+!     the heating rate in units of degrees/day.  It is equal to:
+!     Original value:
+!           (g)x(#sec/day)x(1e-5)/(specific heat of air at const. p)
+!           Here, cpdair (1.004) is in units of J g-1 K-1, and the 
+!           constant (1.e-5) converts mb to Pa and g-1 to kg-1.
+!        =  (9.8066)(86400)(1e-5)/(1.004)
+!      heatfac = 8.4391 
+!
+!     Modified value for consistency with CAM3:
+!           (g)x(#sec/day)x(1e-5)/(specific heat of air at const. p)
+!           Here, cpdair (1.00464) is in units of J g-1 K-1, and the
+!           constant (1.e-5) converts mb to Pa and g-1 to kg-1.
+!        =  (9.80616)(86400)(1e-5)/(1.00464)
+!      heatfac = 8.43339130434 
+!
+!     Calculated value (from constants above and input cpdair)
+!        (grav) x (#sec/day) / (specific heat of dry air at const. p x 1.e2)
+!           Here, cpdair is in units of J kg-1 K-1, and the constant (1.e2) 
+!           converts mb to Pa when heatfac is multiplied by W m-2 mb-1. 
+      heatfac = grav * secdy / (cpdair * 1.e2 )
+
+      end subroutine swdatinit
+
+!***************************************************************************
+      subroutine swcmbdat
+!***************************************************************************
+
+      save
+ 
+! ------- Definitions -------
+!     Arrays for the g-point reduction from 224 to 112 for the 16 LW bands:
+!     This mapping from 224 to 112 points has been carefully selected to 
+!     minimize the effect on the resulting fluxes and cooling rates, and
+!     caution should be used if the mapping is modified.  The full 224
+!     g-point set can be restored with ngpt=224, ngc=16*16, ngn=224*1., etc.
+!     ngpt    The total number of new g-points
+!     ngc     The number of new g-points in each band
+!     ngs     The cumulative sum of new g-points for each band
+!     ngm     The index of each new g-point relative to the original
+!             16 g-points for each band.  
+!     ngn     The number of original g-points that are combined to make
+!             each new g-point in each band.
+!     ngb     The band index for each new g-point.
+!     wt      RRTM weights for 16 g-points.
+
+! Use this set for 112 quadrature point (g-point) model
+! ------- Data statements -------
+      ngc(:) = (/ 6,12, 8, 8,10,10, 2,10, 8, 6, 6, 8, 6,12 /)
+      ngs(:) = (/ 6,18,26,34,44,54,56,66,74,80,86,94,100,112 /)
+      ngm(:) = (/ 1,1,2,2,3,3,4,4,5,5,5,5,6,6,6,6, &           ! band 16
+                  1,2,3,4,5,6,6,7,8,8,9,10,10,11,12,12, &      ! band 17
+                  1,2,3,4,5,5,6,6,7,7,7,7,8,8,8,8, &           ! band 18
+                  1,2,3,4,5,5,6,6,7,7,7,7,8,8,8,8, &           ! band 19
+                  1,2,3,4,5,6,7,8,9,9,10,10,10,10,10,10, &     ! band 20
+                  1,2,3,4,5,6,7,8,9,9,10,10,10,10,10,10, &     ! band 21
+                  1,1,1,1,1,1,1,1,2,2,2,2,2,2,2,2, &           ! band 22
+                  1,1,2,2,3,4,5,6,7,8,9,9,10,10,10,10, &       ! band 23
+                  1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8, &           ! band 24
+                  1,2,3,3,4,4,5,5,5,5,6,6,6,6,6,6, &           ! band 25
+                  1,2,3,3,4,4,5,5,5,5,6,6,6,6,6,6, &           ! band 26
+                  1,2,3,4,5,6,7,7,7,7,8,8,8,8,8,8, &           ! band 27
+                  1,2,3,3,4,4,5,5,5,5,6,6,6,6,6,6, &           ! band 28
+                  1,2,3,4,5,5,6,6,7,7,8,8,9,10,11,12 /)        ! band 29
+      ngn(:) = (/ 2,2,2,2,4,4, &                               ! band 16
+                  1,1,1,1,1,2,1,2,1,2,1,2, &                   ! band 17
+                  1,1,1,1,2,2,4,4, &                           ! band 18
+                  1,1,1,1,2,2,4,4, &                           ! band 19
+                  1,1,1,1,1,1,1,1,2,6, &                       ! band 20
+                  1,1,1,1,1,1,1,1,2,6, &                       ! band 21
+                  8,8, &                                       ! band 22
+                  2,2,1,1,1,1,1,1,2,4, &                       ! band 23
+                  2,2,2,2,2,2,2,2, &                           ! band 24
+                  1,1,2,2,4,6, &                               ! band 25
+                  1,1,2,2,4,6, &                               ! band 26
+                  1,1,1,1,1,1,4,6, &                           ! band 27
+                  1,1,2,2,4,6, &                               ! band 28
+                  1,1,1,1,2,2,2,2,1,1,1,1 /)                   ! band 29
+      ngb(:) = (/ 16,16,16,16,16,16, &                         ! band 16
+                  17,17,17,17,17,17,17,17,17,17,17,17, &       ! band 17
+                  18,18,18,18,18,18,18,18, &                   ! band 18
+                  19,19,19,19,19,19,19,19, &                   ! band 19
+                  20,20,20,20,20,20,20,20,20,20, &             ! band 20
+                  21,21,21,21,21,21,21,21,21,21, &             ! band 21
+                  22,22, &                                     ! band 22
+                  23,23,23,23,23,23,23,23,23,23, &             ! band 23
+                  24,24,24,24,24,24,24,24, &                   ! band 24
+                  25,25,25,25,25,25, &                         ! band 25
+                  26,26,26,26,26,26, &                         ! band 26
+                  27,27,27,27,27,27,27,27, &                   ! band 27
+                  28,28,28,28,28,28, &                         ! band 28
+                  29,29,29,29,29,29,29,29,29,29,29,29 /)       ! band 29
+
+! Use this set for full 224 quadrature point (g-point) model
+! ------- Data statements -------
+!      ngc(:) = (/ 16,16,16,16,16,16,16,16,16,16,16,16,16,16 /)
+!      ngs(:) = (/ 16,32,48,64,80,96,112,128,144,160,176,192,208,224 /)
+!      ngm(:) = (/ 1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 16
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 17
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 18
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 19
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 20
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 21
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 22
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 23
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 24
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 25
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 26
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 27
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16, &    ! band 28
+!                  1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16 /)    ! band 29
+!      ngn(:) = (/ 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 16
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 17
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 18
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 19
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 20
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 21
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 22
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 23
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 24
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 25
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 26
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 27
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, &           ! band 28
+!                  1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1 /)           ! band 29
+!      ngb(:) = (/ 16,16,16,16,16,16,16,16,16,16,16,16,16,16,16,16, &   ! band 16
+!                  17,17,17,17,17,17,17,17,17,17,17,17,17,17,17,17, &   ! band 17
+!                  18,18,18,18,18,18,18,18,18,18,18,18,18,18,18,18, &   ! band 18
+!                  19,19,19,19,19,19,19,19,19,19,19,19,19,19,19,19, &   ! band 19
+!                  20,20,20,20,20,20,20,20,20,20,20,20,20,20,20,20, &   ! band 20
+!                  21,21,21,21,21,21,21,21,21,21,21,21,21,21,21,21, &   ! band 21
+!                  22,22,22,22,22,22,22,22,22,22,22,22,22,22,22,22, &   ! band 22
+!                  23,23,23,23,23,23,23,23,23,23,23,23,23,23,23,23, &   ! band 23
+!                  24,24,24,24,24,24,24,24,24,24,24,24,24,24,24,24, &   ! band 24
+!                  25,25,25,25,25,25,25,25,25,25,25,25,25,25,25,25, &   ! band 25
+!                  26,26,26,26,26,26,26,26,26,26,26,26,26,26,26,26, &   ! band 26
+!                  27,27,27,27,27,27,27,27,27,27,27,27,27,27,27,27, &   ! band 27
+!                  28,28,28,28,28,28,28,28,28,28,28,28,28,28,28,28, &   ! band 28
+!                  29,29,29,29,29,29,29,29,29,29,29,29,29,29,29,29 /)   ! band 29
+
+
+      wt(:) =  (/ 0.1527534276 , 0.1491729617 , 0.1420961469 , &
+                  0.1316886544 , 0.1181945205 , 0.1019300893 , &
+                  0.0832767040 , 0.0626720116 , 0.0424925000 , &
+                  0.0046269894 , 0.0038279891 , 0.0030260086 , &
+                  0.0022199750 , 0.0014140010 , 0.0005330000 , &
+                  0.0000750000  /)
+
+      end subroutine swcmbdat
+
+!***************************************************************************
+      subroutine swaerpr
+!***************************************************************************
+
+! Purpose: Define spectral aerosol properties for six ECMWF aerosol types
+! as used in the ECMWF IFS model (see module rrsw_aer.F90 for details)
+!
+! Original: Defined for rrtmg_sw 14 spectral bands, JJMorcrette, ECMWF Feb 2003
+! Revision: Reformatted for consistency with rrtmg_lw, MJIacono, AER, Jul 2006
+
+      use rrsw_aer_f, only : rsrtaua, rsrpiza, rsrasya
+
+      save
+
+      rsrtaua( 1, :) = (/ &
+        0.10849 , 0.66699 , 0.65255 , 0.11600 , 0.06529 , 0.04468 /)
+      rsrtaua( 2, :) = (/ &
+        0.10849 , 0.66699 , 0.65255 , 0.11600 , 0.06529 , 0.04468 /)
+      rsrtaua( 3, :) = (/ &
+        0.20543 , 0.84642 , 0.84958 , 0.21673 , 0.28270 , 0.10915 /)
+      rsrtaua( 4, :) = (/ &
+        0.20543 , 0.84642 , 0.84958 , 0.21673 , 0.28270 , 0.10915 /)
+      rsrtaua( 5, :) = (/ &
+        0.20543 , 0.84642 , 0.84958 , 0.21673 , 0.28270 , 0.10915 /)
+      rsrtaua( 6, :) = (/ &
+        0.20543 , 0.84642 , 0.84958 , 0.21673 , 0.28270 , 0.10915 /)
+      rsrtaua( 7, :) = (/ &
+        0.20543 , 0.84642 , 0.84958 , 0.21673 , 0.28270 , 0.10915 /)
+      rsrtaua( 8, :) = (/ &
+        0.52838 , 0.93285 , 0.93449 , 0.53078 , 0.67148 , 0.46608 /)
+      rsrtaua( 9, :) = (/ &
+        0.52838 , 0.93285 , 0.93449 , 0.53078 , 0.67148 , 0.46608 /)
+      rsrtaua(10, :) = (/ &
+        1.69446 , 1.11855 , 1.09212 , 1.72145 , 1.03858 , 1.12044 /)
+      rsrtaua(11, :) = (/ &
+        1.69446 , 1.11855 , 1.09212 , 1.72145 , 1.03858 , 1.12044 /)
+      rsrtaua(12, :) = (/ &
+        1.69446 , 1.11855 , 1.09212 , 1.72145 , 1.03858 , 1.12044 /)
+      rsrtaua(13, :) = (/ &
+        1.69446 , 1.11855 , 1.09212 , 1.72145 , 1.03858 , 1.12044 /)
+      rsrtaua(14, :) = (/ &
+        0.10849 , 0.66699 , 0.65255 , 0.11600 , 0.06529 , 0.04468 /)
+ 
+      rsrpiza( 1, :) = (/ &
+        .5230504 , .7868518 , .8531531 , .4048149 , .8748231 , .2355667 /)
+      rsrpiza( 2, :) = (/ &
+        .5230504 , .7868518 , .8531531 , .4048149 , .8748231 , .2355667 /)
+      rsrpiza( 3, :) = (/ &
+        .8287144 , .9949396 , .9279543 , .6765051 , .9467578 , .9955938 /)
+      rsrpiza( 4, :) = (/ &
+        .8287144 , .9949396 , .9279543 , .6765051 , .9467578 , .9955938 /)
+      rsrpiza( 5, :) = (/ &
+        .8287144 , .9949396 , .9279543 , .6765051 , .9467578 , .9955938 /)
+      rsrpiza( 6, :) = (/ &
+        .8287144 , .9949396 , .9279543 , .6765051 , .9467578 , .9955938 /)
+      rsrpiza( 7, :) = (/ &
+        .8287144 , .9949396 , .9279543 , .6765051 , .9467578 , .9955938 /)
+      rsrpiza( 8, :) = (/ &
+        .8970131 , .9984940 , .9245594 , .7768385 , .9532763 , .9999999 /)
+      rsrpiza( 9, :) = (/ &
+        .8970131 , .9984940 , .9245594 , .7768385 , .9532763 , .9999999 /)
+      rsrpiza(10, :) = (/ &
+        .9148907 , .9956173 , .7504584 , .8131335 , .9401905 , .9999999 /)
+      rsrpiza(11, :) = (/ &
+        .9148907 , .9956173 , .7504584 , .8131335 , .9401905 , .9999999 /)
+      rsrpiza(12, :) = (/ &
+        .9148907 , .9956173 , .7504584 , .8131335 , .9401905 , .9999999 /)
+      rsrpiza(13, :) = (/ &
+        .9148907 , .9956173 , .7504584 , .8131335 , .9401905 , .9999999 /)
+      rsrpiza(14, :) = (/ &
+        .5230504 , .7868518 , .8531531 , .4048149 , .8748231 , .2355667 /)
+
+      rsrasya( 1, :) = (/ &
+        0.700610 , 0.818871 , 0.702399 , 0.689886 , .4629866 , .1907639 /)
+      rsrasya( 2, :) = (/ &
+        0.700610 , 0.818871 , 0.702399 , 0.689886 , .4629866 , .1907639 /)
+      rsrasya( 3, :) = (/ &
+        0.636342 , 0.802467 , 0.691305 , 0.627497 , .6105750 , .4760794 /)
+      rsrasya( 4, :) = (/ &
+        0.636342 , 0.802467 , 0.691305 , 0.627497 , .6105750 , .4760794 /)
+      rsrasya( 5, :) = (/ &
+        0.636342 , 0.802467 , 0.691305 , 0.627497 , .6105750 , .4760794 /)
+      rsrasya( 6, :) = (/ &
+        0.636342 , 0.802467 , 0.691305 , 0.627497 , .6105750 , .4760794 /)
+      rsrasya( 7, :) = (/ &
+        0.636342 , 0.802467 , 0.691305 , 0.627497 , .6105750 , .4760794 /)
+      rsrasya( 8, :) = (/ &
+        0.668431 , 0.788530 , 0.698682 , 0.657422 , .6735182 , .6519706 /)
+      rsrasya( 9, :) = (/ &
+        0.668431 , 0.788530 , 0.698682 , 0.657422 , .6735182 , .6519706 /)
+      rsrasya(10, :) = (/ &
+        0.729019 , 0.803129 , 0.784592 , 0.712208 , .7008249 , .7270548 /)
+      rsrasya(11, :) = (/ &
+        0.729019 , 0.803129 , 0.784592 , 0.712208 , .7008249 , .7270548 /)
+      rsrasya(12, :) = (/ &
+        0.729019 , 0.803129 , 0.784592 , 0.712208 , .7008249 , .7270548 /)
+      rsrasya(13, :) = (/ &
+        0.729019 , 0.803129 , 0.784592 , 0.712208 , .7008249 , .7270548 /)
+      rsrasya(14, :) = (/ &
+        0.700610 , 0.818871 , 0.702399 , 0.689886 , .4629866 , .1907639 /)
+
+      end subroutine swaerpr
+ 
+!***************************************************************************
+      subroutine cmbgb16s
+!***************************************************************************
+!
+!  Original version:       MJIacono; July 1998
+!  Revision for RRTM_SW:   MJIacono; November 2002
+!  Revision for RRTMG_SW:  MJIacono; December 2003
+!  Revision for F90 reformatting:  MJIacono; July 2006
+!
+!  The subroutines CMBGB16->CMBGB29 input the absorption coefficient
+!  data for each band, which are defined for 16 g-points and 14 spectral
+!  bands. The data are combined with appropriate weighting following the
+!  g-point mapping arrays specified in RRTMG_SW_INIT.  Solar source 
+!  function data in array SFLUXREF are combined without weighting.  All
+!  g-point reduced data are put into new arrays for use in RRTMG_SW.
+!
+!  band 16:  2600-3250 cm-1 (low key- h2o,ch4; high key - ch4)
+!
+!-----------------------------------------------------------------------
+
+      use rrsw_kg16_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            absa, ka, absb, kb, selfref, forref, sfluxref
+
+! ------- Local -------
+      integer  :: jn, jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(1)
+                  sumk = 0.
+                  do ipr = 1, ngn(igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(1)
+               sumk = 0.
+               do ipr = 1, ngn(igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(1)
+            sumk = 0.
+            do ipr = 1, ngn(igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,3
+         iprsm = 0
+         do igc = 1,ngc(1)
+            sumk = 0.
+            do ipr = 1, ngn(igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(1)
+         sumf = 0.
+         do ipr = 1, ngn(igc)
+            iprsm = iprsm + 1
+            sumf = sumf + sfluxrefo(iprsm)
+         enddo
+         sfluxref(igc) = sumf
+      enddo
+
+      end subroutine cmbgb16s
+
+!***************************************************************************
+      subroutine cmbgb17
+!***************************************************************************
+!
+!     band 17:  3250-4000 cm-1 (low - h2o,co2; high - h2o,co2)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg17_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            absa, ka, absb, kb, selfref, forref, sfluxref
+
+! ------- Local -------
+      integer  :: jn, jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(2)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(1)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+16)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jn = 1,5
+         do jt = 1,5
+            do jp = 13,59
+               iprsm = 0
+               do igc = 1,ngc(2)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(1)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kbo(jn,jt,jp,iprsm)*rwgt(iprsm+16)
+                  enddo
+                  kb(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(2)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(1)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+16)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(2)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(1)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+16)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,5
+         iprsm = 0
+         do igc = 1,ngc(2)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(1)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + sfluxrefo(iprsm,jp)
+            enddo
+            sfluxref(igc,jp) = sumf
+         enddo
+      enddo
+
+      end subroutine cmbgb17
+
+!***************************************************************************
+      subroutine cmbgb18
+!***************************************************************************
+!
+!     band 18:  4000-4650 cm-1 (low - h2o,ch4; high - ch4)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg18_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            absa, ka, absb, kb, selfref, forref, sfluxref
+
+! ------- Local -------
+      integer  :: jn, jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(3)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(2)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+32)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(3)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(2)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+32)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(3)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(2)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+32)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,3
+         iprsm = 0
+         do igc = 1,ngc(3)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(2)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+32)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(3)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(2)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + sfluxrefo(iprsm,jp)
+            enddo
+            sfluxref(igc,jp) = sumf
+         enddo
+      enddo
+
+      end subroutine cmbgb18
+
+!***************************************************************************
+      subroutine cmbgb19
+!***************************************************************************
+!
+!     band 19:  4650-5150 cm-1 (low - h2o,co2; high - co2)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg19_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            absa, ka, absb, kb, selfref, forref, sfluxref
+
+! ------- Local -------
+      integer  :: jn, jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(4)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(3)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+48)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(4)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(3)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+48)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(4)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(3)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+48)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,3
+         iprsm = 0
+         do igc = 1,ngc(4)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(3)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+48)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(4)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(3)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + sfluxrefo(iprsm,jp)
+            enddo
+            sfluxref(igc,jp) = sumf
+         enddo
+      enddo
+
+      end subroutine cmbgb19
+
+!***************************************************************************
+      subroutine cmbgb20
+!***************************************************************************
+!
+!     band 20:  5150-6150 cm-1 (low - h2o; high - h2o)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg20_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, absch4o, &
+                            absa, ka, absb, kb, selfref, forref, sfluxref, absch4
+
+! ------- Local -------
+      integer  :: jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf1, sumf2
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(5)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(4)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+64)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(5)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(4)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+64)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(5)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(4)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+64)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(5)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(4)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+64)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(5)
+         sumf1 = 0.
+         sumf2 = 0.
+         do ipr = 1, ngn(ngs(4)+igc)
+            iprsm = iprsm + 1
+            sumf1 = sumf1 + sfluxrefo(iprsm)
+            sumf2 = sumf2 + absch4o(iprsm)*rwgt(iprsm+64)
+         enddo
+         sfluxref(igc) = sumf1
+         absch4(igc) = sumf2
+      enddo
+
+      end subroutine cmbgb20
+
+!***************************************************************************
+      subroutine cmbgb21
+!***************************************************************************
+!
+!     band 21:  6150-7700 cm-1 (low - h2o,co2; high - h2o,co2)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg21_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            absa, ka, absb, kb, selfref, forref, sfluxref
+
+! ------- Local -------
+      integer  :: jn, jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(6)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(5)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+80)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jn = 1,5
+         do jt = 1,5
+            do jp = 13,59
+               iprsm = 0
+               do igc = 1,ngc(6)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(5)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kbo(jn,jt,jp,iprsm)*rwgt(iprsm+80)
+                  enddo
+                  kb(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(6)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(5)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+80)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(6)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(5)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+80)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(6)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(5)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + sfluxrefo(iprsm,jp)
+            enddo
+            sfluxref(igc,jp) = sumf
+         enddo
+      enddo
+
+      end subroutine cmbgb21
+
+!***************************************************************************
+      subroutine cmbgb22
+!***************************************************************************
+!
+!     band 22:  7700-8050 cm-1 (low - h2o,o2; high - o2)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg22_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            absa, ka, absb, kb, selfref, forref, sfluxref
+
+! ------- Local -------
+      integer  :: jn, jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(7)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(6)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+96)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(7)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(6)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+96)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(7)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(6)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+96)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,3
+         iprsm = 0
+         do igc = 1,ngc(7)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(6)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+96)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(7)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(6)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + sfluxrefo(iprsm,jp)
+            enddo
+            sfluxref(igc,jp) = sumf
+         enddo
+      enddo
+
+      end subroutine cmbgb22
+
+!***************************************************************************
+      subroutine cmbgb23
+!***************************************************************************
+!
+!     band 23:  8050-12850 cm-1 (low - h2o; high - nothing)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg23_f, only : kao, selfrefo, forrefo, sfluxrefo, raylo, &
+                            absa, ka, selfref, forref, sfluxref, rayl
+
+! ------- Local -------
+      integer  :: jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf1, sumf2
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(8)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(7)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+112)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(8)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(7)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+112)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,3
+         iprsm = 0
+         do igc = 1,ngc(8)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(7)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+112)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(8)
+         sumf1 = 0.
+         sumf2 = 0.
+         do ipr = 1, ngn(ngs(7)+igc)
+            iprsm = iprsm + 1
+            sumf1 = sumf1 + sfluxrefo(iprsm)
+            sumf2 = sumf2 + raylo(iprsm)*rwgt(iprsm+112)
+         enddo
+         sfluxref(igc) = sumf1
+         rayl(igc) = sumf2
+      enddo
+
+      end subroutine cmbgb23
+
+!***************************************************************************
+      subroutine cmbgb24
+!***************************************************************************
+!
+!     band 24:  12850-16000 cm-1 (low - h2o,o2; high - o2)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg24_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            abso3ao, abso3bo, raylao, raylbo, &
+                            absa, ka, absb, kb, selfref, forref, sfluxref, &
+                            abso3a, abso3b, rayla, raylb
+
+! ------- Local -------
+      integer  :: jn, jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf1, sumf2, sumf3
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(9)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(8)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+128)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,5
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(9)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(8)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+128)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(9)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(8)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+128)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,3
+         iprsm = 0
+         do igc = 1,ngc(9)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(8)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+128)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(9)
+         sumf1 = 0.
+         sumf2 = 0.
+         sumf3 = 0.
+         do ipr = 1, ngn(ngs(8)+igc)
+            iprsm = iprsm + 1
+            sumf1 = sumf1 + raylbo(iprsm)*rwgt(iprsm+128)
+            sumf2 = sumf2 + abso3ao(iprsm)*rwgt(iprsm+128)
+            sumf3 = sumf3 + abso3bo(iprsm)*rwgt(iprsm+128)
+         enddo
+         raylb(igc) = sumf1
+         abso3a(igc) = sumf2
+         abso3b(igc) = sumf3
+      enddo
+
+      do jp = 1,9
+         iprsm = 0
+         do igc = 1,ngc(9)
+            sumf1 = 0.
+            sumf2 = 0.
+            do ipr = 1, ngn(ngs(8)+igc)
+               iprsm = iprsm + 1
+               sumf1 = sumf1 + sfluxrefo(iprsm,jp)
+               sumf2 = sumf2 + raylao(iprsm,jp)*rwgt(iprsm+128)
+            enddo
+            sfluxref(igc,jp) = sumf1
+            rayla(igc,jp) = sumf2
+         enddo
+      enddo
+
+      end subroutine cmbgb24
+
+!***************************************************************************
+      subroutine cmbgb25
+!***************************************************************************
+!
+!     band 25:  16000-22650 cm-1 (low - h2o; high - nothing)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg25_f, only : kao, sfluxrefo, &
+                            abso3ao, abso3bo, raylo, &
+                            absa, ka, sfluxref, &
+                            abso3a, abso3b, rayl
+
+! ------- Local -------
+      integer  :: jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf1, sumf2, sumf3, sumf4
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(10)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(9)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+144)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(10)
+         sumf1 = 0.
+         sumf2 = 0.
+         sumf3 = 0.
+         sumf4 = 0.
+         do ipr = 1, ngn(ngs(9)+igc)
+            iprsm = iprsm + 1
+            sumf1 = sumf1 + sfluxrefo(iprsm)
+            sumf2 = sumf2 + abso3ao(iprsm)*rwgt(iprsm+144)
+            sumf3 = sumf3 + abso3bo(iprsm)*rwgt(iprsm+144)
+            sumf4 = sumf4 + raylo(iprsm)*rwgt(iprsm+144)
+         enddo
+         sfluxref(igc) = sumf1
+         abso3a(igc) = sumf2
+         abso3b(igc) = sumf3
+         rayl(igc) = sumf4
+      enddo
+
+      end subroutine cmbgb25
+
+!***************************************************************************
+      subroutine cmbgb26
+!***************************************************************************
+!
+!     band 26:  22650-29000 cm-1 (low - nothing; high - nothing)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg26_f, only : sfluxrefo, raylo, &
+                            sfluxref, rayl
+
+! ------- Local -------
+      integer  :: igc, ipr, iprsm
+      real  :: sumf1, sumf2
+
+
+      iprsm = 0
+      do igc = 1,ngc(11)
+         sumf1 = 0.
+         sumf2 = 0.
+         do ipr = 1, ngn(ngs(10)+igc)
+            iprsm = iprsm + 1
+            sumf1 = sumf1 + raylo(iprsm)*rwgt(iprsm+160)
+            sumf2 = sumf2 + sfluxrefo(iprsm)
+         enddo
+         rayl(igc) = sumf1
+         sfluxref(igc) = sumf2
+      enddo
+
+      end subroutine cmbgb26
+
+!***************************************************************************
+      subroutine cmbgb27
+!***************************************************************************
+!
+!     band 27:  29000-38000 cm-1 (low - o3; high - o3)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg27_f, only : kao, kbo, sfluxrefo, raylo, &
+                            absa, ka, absb, kb, sfluxref, rayl
+
+! ------- Local -------
+      integer  :: jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf1, sumf2
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(12)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(11)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+176)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(12)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(11)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+176)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(12)
+         sumf1 = 0.
+         sumf2 = 0.
+         do ipr = 1, ngn(ngs(11)+igc)
+            iprsm = iprsm + 1
+            sumf1 = sumf1 + sfluxrefo(iprsm)
+            sumf2 = sumf2 + raylo(iprsm)*rwgt(iprsm+176)
+         enddo
+         sfluxref(igc) = sumf1
+         rayl(igc) = sumf2
+      enddo
+
+      end subroutine cmbgb27
+
+!***************************************************************************
+      subroutine cmbgb28
+!***************************************************************************
+!
+!     band 28:  38000-50000 cm-1 (low - o3,o2; high - o3,o2)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg28_f, only : kao, kbo, sfluxrefo, &
+                            absa, ka, absb, kb, sfluxref
+
+! ------- Local -------
+      integer  :: jn, jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf
+
+
+      do jn = 1,9
+         do jt = 1,5
+            do jp = 1,13
+               iprsm = 0
+               do igc = 1,ngc(13)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(12)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kao(jn,jt,jp,iprsm)*rwgt(iprsm+192)
+                  enddo
+                  ka(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jn = 1,5
+         do jt = 1,5
+            do jp = 13,59
+               iprsm = 0
+               do igc = 1,ngc(13)
+                  sumk = 0.
+                  do ipr = 1, ngn(ngs(12)+igc)
+                     iprsm = iprsm + 1
+                     sumk = sumk + kbo(jn,jt,jp,iprsm)*rwgt(iprsm+192)
+                  enddo
+                  kb(jn,jt,jp,igc) = sumk
+               enddo
+            enddo
+         enddo
+      enddo
+
+      do jp = 1,5
+         iprsm = 0
+         do igc = 1,ngc(13)
+            sumf = 0.
+            do ipr = 1, ngn(ngs(12)+igc)
+               iprsm = iprsm + 1
+               sumf = sumf + sfluxrefo(iprsm,jp)
+            enddo
+            sfluxref(igc,jp) = sumf
+         enddo
+      enddo
+
+      end subroutine cmbgb28
+
+!***************************************************************************
+      subroutine cmbgb29
+!***************************************************************************
+!
+!     band 29:  820-2600 cm-1 (low - h2o; high - co2)
+!-----------------------------------------------------------------------
+
+      use rrsw_kg29_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            absh2oo, absco2o, &
+                            absa, ka, absb, kb, selfref, forref, sfluxref, &
+                            absh2o, absco2
+
+! ------- Local -------
+      integer  :: jt, jp, igc, ipr, iprsm
+      real  :: sumk, sumf1, sumf2, sumf3
+
+
+      do jt = 1,5
+         do jp = 1,13
+            iprsm = 0
+            do igc = 1,ngc(14)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(13)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kao(jt,jp,iprsm)*rwgt(iprsm+208)
+               enddo
+               ka(jt,jp,igc) = sumk
+            enddo
+         enddo
+         do jp = 13,59
+            iprsm = 0
+            do igc = 1,ngc(14)
+               sumk = 0.
+               do ipr = 1, ngn(ngs(13)+igc)
+                  iprsm = iprsm + 1
+                  sumk = sumk + kbo(jt,jp,iprsm)*rwgt(iprsm+208)
+               enddo
+               kb(jt,jp,igc) = sumk
+            enddo
+         enddo
+      enddo
+
+      do jt = 1,10
+         iprsm = 0
+         do igc = 1,ngc(14)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(13)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + selfrefo(jt,iprsm)*rwgt(iprsm+208)
+            enddo
+            selfref(jt,igc) = sumk
+         enddo
+      enddo
+
+      do jt = 1,4
+         iprsm = 0
+         do igc = 1,ngc(14)
+            sumk = 0.
+            do ipr = 1, ngn(ngs(13)+igc)
+               iprsm = iprsm + 1
+               sumk = sumk + forrefo(jt,iprsm)*rwgt(iprsm+208)
+            enddo
+            forref(jt,igc) = sumk
+         enddo
+      enddo
+
+      iprsm = 0
+      do igc = 1,ngc(14)
+         sumf1 = 0.
+         sumf2 = 0.
+         sumf3 = 0.
+         do ipr = 1, ngn(ngs(13)+igc)
+            iprsm = iprsm + 1
+            sumf1 = sumf1 + sfluxrefo(iprsm)
+            sumf2 = sumf2 + absco2o(iprsm)*rwgt(iprsm+208)
+            sumf3 = sumf3 + absh2oo(iprsm)*rwgt(iprsm+208)
+         enddo
+         sfluxref(igc) = sumf1
+         absco2(igc) = sumf2
+         absh2o(igc) = sumf3
+      enddo
+
+      end subroutine cmbgb29
+
+!***********************************************************************
+      subroutine swcldpr
+!***********************************************************************
+
+! Purpose: Define cloud extinction coefficient, single scattering albedo
+!          and asymmetry parameter data.
+!
+
+! ------- Modules -------
+
+      use rrsw_cld_f, only : extliq1, ssaliq1, asyliq1, &
+                           extice2, ssaice2, asyice2, &
+                           extice3, ssaice3, asyice3, fdlice3, &
+                           abari, bbari, cbari, dbari, ebari, fbari
+
+      save
+
+!-----------------------------------------------------------------------
+!
+! Explanation of the method for each value of INFLAG.  A value of
+!  0 for INFLAG do not distingish being liquid and ice clouds.
+!  INFLAG = 2 does distinguish between liquid and ice clouds, and
+!    requires further user input to specify the method to be used to 
+!    compute the aborption due to each.
+!  INFLAG = 0:  For each cloudy layer, the cloud fraction, the cloud optical
+!    depth, the cloud single-scattering albedo, and the
+!    moments of the phase function (0:NSTREAM).  Note
+!    that these values are delta-m scaled within this
+!    subroutine.
+
+!  INFLAG = 2:  For each cloudy layer, the cloud fraction, cloud 
+!    water path (g/m2), and cloud ice fraction are input.
+!  ICEFLAG = 2:  The ice effective radius (microns) is input and the
+!    optical properties due to ice clouds are computed from
+!    the optical properties stored in the RT code, STREAMER v3.0 
+!    (Reference: Key. J., Streamer User's Guide, Cooperative 
+!    Institute for Meteorological Satellite Studies, 2001, 96 pp.).
+!    Valid range of values for re are between 5.0 and
+!    131.0 micron.
+!    This version uses Ebert and Curry, JGR, (1992) method for 
+!    ice particles larger than 131.0 microns. 
+!  ICEFLAG = 3:  The ice generalized effective size (dge) is input
+!    and the optical depths, single-scattering albedo,
+!    and phase function moments are calculated as in
+!    Q. Fu, J. Climate, (1996). Q. Fu provided high resolution
+!    tables which were appropriately averaged for the
+!    bands in RRTM_SW.  Linear interpolation is used to
+!    get the coefficients from the stored tables.
+!    Valid range of values for dge are between 5.0 and
+!    140.0 micron. 
+!    This version uses Ebert and Curry, JGR, (1992) method for 
+!    ice particles larger than 140.0 microns. 
+!  LIQFLAG = 1:  The water droplet effective radius (microns) is input 
+!    and the optical depths due to water clouds are computed 
+!    as in Hu and Stamnes, J., Clim., 6, 728-742, (1993) with
+!    modified coefficients derived from Mie scattering calculations. 
+!    The values for absorption coefficients appropriate for
+!    the spectral bands in RRTM/RRTMG have been obtained for a 
+!    range of effective radii by an averaging procedure 
+!    based on the work of J. Pinto (private communication).
+!    Linear interpolation is used to get the absorption 
+!    coefficients for the input effective radius.
+!    ..Updated tables suggested by Peter Blossey (Univ. Washington) 
+!    and came from RRTMG_SW_v3.9 from AER, Inc.
+!
+!     ------------------------------------------------------------------
+
+! Everything below is for INFLAG = 2.
+
+! Coefficients for Ebert and Curry method
+      abari(:) = (/ &
+        & 3.448e-03 ,3.448e-03 ,3.448e-03 ,3.448e-03 ,3.448e-03  /)
+      bbari(:) = (/ &
+        & 2.431e+00 ,2.431e+00 ,2.431e+00 ,2.431e+00 ,2.431e+00  /)
+      cbari(:) = (/ &
+        & 1.000e-05 ,1.100e-04 ,1.240e-02 ,3.779e-02 ,4.666e-01  /)
+      dbari(:) = (/ &
+        & 0.000e+00 ,1.405e-05 ,6.867e-04 ,1.284e-03 ,2.050e-05  /)
+      ebari(:) = (/ &
+        & 7.661e-01 ,7.730e-01 ,7.865e-01 ,8.172e-01 ,9.595e-01  /)
+      fbari(:) = (/ &
+        & 5.851e-04 ,5.665e-04 ,7.204e-04 ,7.463e-04 ,1.076e-04  /)
+
+! LIQFLAG==1 extinction coefficients, single scattering albedos, and asymmetry parameters
+!   Derived from on Mie scattering computations; based on Hu & Stamnes coefficients
+
+! Extinction coefficient
+!     BAND  16
+      extliq1(:, 16) = (/ &
+        & 9.004493E-01,6.366723E-01,4.542354E-01,3.468253E-01,2.816431E-01,&
+        & 2.383415E-01,2.070854E-01,1.831854E-01,1.642115E-01,1.487539E-01,&
+        & 1.359169E-01,1.250900E-01,1.158354E-01,1.078400E-01,1.008646E-01,&
+        & 9.472307E-02,8.928000E-02,8.442308E-02,8.005924E-02,7.612231E-02,&
+        & 7.255153E-02,6.929539E-02,6.631769E-02,6.358153E-02,6.106231E-02,&
+        & 5.873077E-02,5.656924E-02,5.455769E-02,5.267846E-02,5.091923E-02,&
+        & 4.926692E-02,4.771154E-02,4.623923E-02,4.484385E-02,4.351539E-02,&
+        & 4.224615E-02,4.103385E-02,3.986538E-02,3.874077E-02,3.765462E-02,&
+        & 3.660077E-02,3.557384E-02,3.457615E-02,3.360308E-02,3.265000E-02,&
+        & 3.171770E-02,3.080538E-02,2.990846E-02,2.903000E-02,2.816461E-02,&
+        & 2.731539E-02,2.648231E-02,2.566308E-02,2.485923E-02,2.407000E-02,&
+        & 2.329615E-02,2.253769E-02,2.179615E-02 /)
+!     BAND  17
+      extliq1(:, 17) = (/ &
+       & 6.741200e-01,5.390739e-01,4.198767e-01,3.332553e-01,2.735633e-01,&
+       & 2.317727e-01,2.012760e-01,1.780400e-01,1.596927e-01,1.447980e-01,&
+       & 1.324480e-01,1.220347e-01,1.131327e-01,1.054313e-01,9.870534e-02,&
+       & 9.278200e-02,8.752599e-02,8.282933e-02,7.860600e-02,7.479133e-02,&
+       & 7.132800e-02,6.816733e-02,6.527401e-02,6.261266e-02,6.015934e-02,&
+       & 5.788867e-02,5.578134e-02,5.381667e-02,5.198133e-02,5.026067e-02,&
+       & 4.864466e-02,4.712267e-02,4.568066e-02,4.431200e-02,4.300867e-02,&
+       & 4.176600e-02,4.057400e-02,3.942534e-02,3.832066e-02,3.725068e-02,&
+       & 3.621400e-02,3.520533e-02,3.422333e-02,3.326400e-02,3.232467e-02,&
+       & 3.140535e-02,3.050400e-02,2.962000e-02,2.875267e-02,2.789800e-02,&
+       & 2.705934e-02,2.623667e-02,2.542667e-02,2.463200e-02,2.385267e-02,&
+       & 2.308667e-02,2.233667e-02,2.160067e-02 /)
+!     BAND  18
+      extliq1(:, 18) = (/ &
+       & 9.250861e-01,6.245692e-01,4.347038e-01,3.320208e-01,2.714869e-01,&
+       & 2.309516e-01,2.012592e-01,1.783315e-01,1.600369e-01,1.451000e-01,&
+       & 1.326838e-01,1.222069e-01,1.132554e-01,1.055146e-01,9.876000e-02,&
+       & 9.281386e-02,8.754000e-02,8.283078e-02,7.860077e-02,7.477769e-02,&
+       & 7.130847e-02,6.814461e-02,6.524615e-02,6.258462e-02,6.012847e-02,&
+       & 5.785462e-02,5.574231e-02,5.378000e-02,5.194461e-02,5.022462e-02,&
+       & 4.860846e-02,4.708462e-02,4.564154e-02,4.427462e-02,4.297231e-02,&
+       & 4.172769e-02,4.053693e-02,3.939000e-02,3.828462e-02,3.721692e-02,&
+       & 3.618000e-02,3.517077e-02,3.418923e-02,3.323077e-02,3.229154e-02,&
+       & 3.137154e-02,3.047154e-02,2.959077e-02,2.872308e-02,2.786846e-02,&
+       & 2.703077e-02,2.620923e-02,2.540077e-02,2.460615e-02,2.382693e-02,&
+       & 2.306231e-02,2.231231e-02,2.157923e-02 /)
+!     BAND  19
+      extliq1(:, 19) = (/ &
+       & 9.298960e-01,5.776460e-01,4.083450e-01,3.211160e-01,2.666390e-01,&
+       & 2.281990e-01,1.993250e-01,1.768080e-01,1.587810e-01,1.440390e-01,&
+       & 1.317720e-01,1.214150e-01,1.125540e-01,1.048890e-01,9.819600e-02,&
+       & 9.230201e-02,8.706900e-02,8.239698e-02,7.819500e-02,7.439899e-02,&
+       & 7.095300e-02,6.780700e-02,6.492900e-02,6.228600e-02,5.984600e-02,&
+       & 5.758599e-02,5.549099e-02,5.353801e-02,5.171400e-02,5.000500e-02,&
+       & 4.840000e-02,4.688500e-02,4.545100e-02,4.409300e-02,4.279700e-02,&
+       & 4.156100e-02,4.037700e-02,3.923800e-02,3.813800e-02,3.707600e-02,&
+       & 3.604500e-02,3.504300e-02,3.406500e-02,3.310800e-02,3.217700e-02,&
+       & 3.126600e-02,3.036800e-02,2.948900e-02,2.862400e-02,2.777500e-02,&
+       & 2.694200e-02,2.612300e-02,2.531700e-02,2.452800e-02,2.375100e-02,&
+       & 2.299100e-02,2.224300e-02,2.151201e-02 /)
+!     BAND  20
+      extliq1(:, 20) = (/ &
+       & 8.780964e-01,5.407031e-01,3.961100e-01,3.166645e-01,2.640455e-01,&
+       & 2.261070e-01,1.974820e-01,1.751775e-01,1.573415e-01,1.427725e-01,&
+       & 1.306535e-01,1.204195e-01,1.116650e-01,1.040915e-01,9.747550e-02,&
+       & 9.164800e-02,8.647649e-02,8.185501e-02,7.770200e-02,7.394749e-02,&
+       & 7.053800e-02,6.742700e-02,6.457999e-02,6.196149e-02,5.954450e-02,&
+       & 5.730650e-02,5.522949e-02,5.329450e-02,5.148500e-02,4.979000e-02,&
+       & 4.819600e-02,4.669301e-02,4.527050e-02,4.391899e-02,4.263500e-02,&
+       & 4.140500e-02,4.022850e-02,3.909500e-02,3.800199e-02,3.694600e-02,&
+       & 3.592000e-02,3.492250e-02,3.395050e-02,3.300150e-02,3.207250e-02,&
+       & 3.116250e-02,3.027100e-02,2.939500e-02,2.853500e-02,2.768900e-02,&
+       & 2.686000e-02,2.604350e-02,2.524150e-02,2.445350e-02,2.368049e-02,&
+       & 2.292150e-02,2.217800e-02,2.144800e-02 /)
+!     BAND  21
+      extliq1(:, 21) = (/ &
+       & 7.937480e-01,5.123036e-01,3.858181e-01,3.099622e-01,2.586829e-01,&
+       & 2.217587e-01,1.939755e-01,1.723397e-01,1.550258e-01,1.408600e-01,&
+       & 1.290545e-01,1.190661e-01,1.105039e-01,1.030848e-01,9.659387e-02,&
+       & 9.086775e-02,8.577807e-02,8.122452e-02,7.712711e-02,7.342193e-02,&
+       & 7.005387e-02,6.697840e-02,6.416000e-02,6.156903e-02,5.917484e-02,&
+       & 5.695807e-02,5.489968e-02,5.298097e-02,5.118806e-02,4.950645e-02,&
+       & 4.792710e-02,4.643581e-02,4.502484e-02,4.368547e-02,4.241001e-02,&
+       & 4.118936e-02,4.002193e-02,3.889711e-02,3.781322e-02,3.676387e-02,&
+       & 3.574549e-02,3.475548e-02,3.379033e-02,3.284678e-02,3.192420e-02,&
+       & 3.102032e-02,3.013484e-02,2.926258e-02,2.840839e-02,2.756742e-02,&
+       & 2.674258e-02,2.593064e-02,2.513258e-02,2.435000e-02,2.358064e-02,&
+       & 2.282581e-02,2.208548e-02,2.135936e-02 /)
+!     BAND  22
+      extliq1(:, 22) = (/ &
+       & 7.533129e-01,5.033129e-01,3.811271e-01,3.062757e-01,2.558729e-01,&
+       & 2.196828e-01,1.924372e-01,1.711714e-01,1.541086e-01,1.401114e-01,&
+       & 1.284257e-01,1.185200e-01,1.100243e-01,1.026529e-01,9.620142e-02,&
+       & 9.050714e-02,8.544428e-02,8.091714e-02,7.684000e-02,7.315429e-02,&
+       & 6.980143e-02,6.673999e-02,6.394000e-02,6.136000e-02,5.897715e-02,&
+       & 5.677000e-02,5.472285e-02,5.281286e-02,5.102858e-02,4.935429e-02,&
+       & 4.778000e-02,4.629714e-02,4.489142e-02,4.355857e-02,4.228715e-02,&
+       & 4.107285e-02,3.990857e-02,3.879000e-02,3.770999e-02,3.666429e-02,&
+       & 3.565000e-02,3.466286e-02,3.370143e-02,3.276143e-02,3.184143e-02,&
+       & 3.094000e-02,3.005714e-02,2.919000e-02,2.833714e-02,2.750000e-02,&
+       & 2.667714e-02,2.586714e-02,2.507143e-02,2.429143e-02,2.352428e-02,&
+       & 2.277143e-02,2.203429e-02,2.130857e-02 /)
+!     BAND  23
+      extliq1(:, 23) = (/ &
+       & 7.079894e-01,4.878198e-01,3.719852e-01,3.001873e-01,2.514795e-01,&
+       & 2.163013e-01,1.897100e-01,1.689033e-01,1.521793e-01,1.384449e-01,&
+       & 1.269666e-01,1.172326e-01,1.088745e-01,1.016224e-01,9.527085e-02,&
+       & 8.966240e-02,8.467543e-02,8.021144e-02,7.619344e-02,7.255676e-02,&
+       & 6.924996e-02,6.623030e-02,6.346261e-02,6.091499e-02,5.856325e-02,&
+       & 5.638385e-02,5.435930e-02,5.247156e-02,5.070699e-02,4.905230e-02,&
+       & 4.749499e-02,4.602611e-02,4.463581e-02,4.331543e-02,4.205647e-02,&
+       & 4.085241e-02,3.969978e-02,3.859033e-02,3.751877e-02,3.648168e-02,&
+       & 3.547468e-02,3.449553e-02,3.354072e-02,3.260732e-02,3.169438e-02,&
+       & 3.079969e-02,2.992146e-02,2.905875e-02,2.821201e-02,2.737873e-02,&
+       & 2.656052e-02,2.575586e-02,2.496511e-02,2.418783e-02,2.342500e-02,&
+       & 2.267646e-02,2.194177e-02,2.122146e-02 /)
+!     BAND  24
+      extliq1(:, 24) = (/ &
+       & 6.850164e-01,4.762468e-01,3.642001e-01,2.946012e-01,2.472001e-01,&
+       & 2.128588e-01,1.868537e-01,1.664893e-01,1.501142e-01,1.366620e-01,&
+       & 1.254147e-01,1.158721e-01,1.076732e-01,1.005530e-01,9.431306e-02,&
+       & 8.879891e-02,8.389232e-02,7.949714e-02,7.553857e-02,7.195474e-02,&
+       & 6.869413e-02,6.571444e-02,6.298286e-02,6.046779e-02,5.814474e-02,&
+       & 5.599141e-02,5.399114e-02,5.212443e-02,5.037870e-02,4.874321e-02,&
+       & 4.720219e-02,4.574813e-02,4.437160e-02,4.306460e-02,4.181810e-02,&
+       & 4.062603e-02,3.948252e-02,3.838256e-02,3.732049e-02,3.629192e-02,&
+       & 3.529301e-02,3.432190e-02,3.337412e-02,3.244842e-02,3.154175e-02,&
+       & 3.065253e-02,2.978063e-02,2.892367e-02,2.808221e-02,2.725478e-02,&
+       & 2.644174e-02,2.564175e-02,2.485508e-02,2.408303e-02,2.332365e-02,&
+       & 2.257890e-02,2.184824e-02,2.113224e-02 /)
+!     BAND  25
+      extliq1(:, 25) = (/ &
+       & 6.673017e-01,4.664520e-01,3.579398e-01,2.902234e-01,2.439904e-01,&
+       & 2.104149e-01,1.849277e-01,1.649234e-01,1.488087e-01,1.355515e-01,&
+       & 1.244562e-01,1.150329e-01,1.069321e-01,9.989310e-02,9.372070e-02,&
+       & 8.826450e-02,8.340622e-02,7.905378e-02,7.513109e-02,7.157859e-02,&
+       & 6.834588e-02,6.539114e-02,6.268150e-02,6.018621e-02,5.788098e-02,&
+       & 5.574351e-02,5.375699e-02,5.190412e-02,5.017099e-02,4.854497e-02,&
+       & 4.701490e-02,4.557030e-02,4.420249e-02,4.290304e-02,4.166427e-02,&
+       & 4.047820e-02,3.934232e-02,3.824778e-02,3.719236e-02,3.616931e-02,&
+       & 3.517597e-02,3.420856e-02,3.326566e-02,3.234346e-02,3.144122e-02,&
+       & 3.055684e-02,2.968798e-02,2.883519e-02,2.799635e-02,2.717228e-02,&
+       & 2.636182e-02,2.556424e-02,2.478114e-02,2.401086e-02,2.325657e-02,&
+       & 2.251506e-02,2.178594e-02,2.107301e-02 /)
+!     BAND  26
+      extliq1(:, 26) = (/ &
+       & 6.552414e-01,4.599454e-01,3.538626e-01,2.873547e-01,2.418033e-01,&
+       & 2.086660e-01,1.834885e-01,1.637142e-01,1.477767e-01,1.346583e-01,&
+       & 1.236734e-01,1.143412e-01,1.063148e-01,9.933905e-02,9.322026e-02,&
+       & 8.780979e-02,8.299230e-02,7.867554e-02,7.478450e-02,7.126053e-02,&
+       & 6.805276e-02,6.512143e-02,6.243211e-02,5.995541e-02,5.766712e-02,&
+       & 5.554484e-02,5.357246e-02,5.173222e-02,5.001069e-02,4.839505e-02,&
+       & 4.687471e-02,4.543861e-02,4.407857e-02,4.278577e-02,4.155331e-02,&
+       & 4.037322e-02,3.924302e-02,3.815376e-02,3.710172e-02,3.608296e-02,&
+       & 3.509330e-02,3.412980e-02,3.319009e-02,3.227106e-02,3.137157e-02,&
+       & 3.048950e-02,2.962365e-02,2.877297e-02,2.793726e-02,2.711500e-02,&
+       & 2.630666e-02,2.551206e-02,2.473052e-02,2.396287e-02,2.320861e-02,&
+       & 2.246810e-02,2.174162e-02,2.102927e-02 /)
+!     BAND  27
+      extliq1(:, 27) = (/ &
+       & 6.430901e-01,4.532134e-01,3.496132e-01,2.844655e-01,2.397347e-01,&
+       & 2.071236e-01,1.822976e-01,1.627640e-01,1.469961e-01,1.340006e-01,&
+       & 1.231069e-01,1.138441e-01,1.058706e-01,9.893678e-02,9.285166e-02,&
+       & 8.746871e-02,8.267411e-02,7.837656e-02,7.450257e-02,7.099318e-02,&
+       & 6.779929e-02,6.487987e-02,6.220168e-02,5.973530e-02,5.745636e-02,&
+       & 5.534344e-02,5.337986e-02,5.154797e-02,4.983404e-02,4.822582e-02,&
+       & 4.671228e-02,4.528321e-02,4.392997e-02,4.264325e-02,4.141647e-02,&
+       & 4.024259e-02,3.911767e-02,3.803309e-02,3.698782e-02,3.597140e-02,&
+       & 3.498774e-02,3.402852e-02,3.309340e-02,3.217818e-02,3.128292e-02,&
+       & 3.040486e-02,2.954230e-02,2.869545e-02,2.786261e-02,2.704372e-02,&
+       & 2.623813e-02,2.544668e-02,2.466788e-02,2.390313e-02,2.315136e-02,&
+       & 2.241391e-02,2.168921e-02,2.097903e-02 /)
+!     BAND  28
+      extliq1(:, 28) = (/ &
+       & 6.367074e-01,4.495768e-01,3.471263e-01,2.826149e-01,2.382868e-01,&
+       & 2.059640e-01,1.813562e-01,1.619881e-01,1.463436e-01,1.334402e-01,&
+       & 1.226166e-01,1.134096e-01,1.054829e-01,9.858838e-02,9.253790e-02,&
+       & 8.718582e-02,8.241830e-02,7.814482e-02,7.429212e-02,7.080165e-02,&
+       & 6.762385e-02,6.471838e-02,6.205388e-02,5.959726e-02,5.732871e-02,&
+       & 5.522402e-02,5.326793e-02,5.144230e-02,4.973440e-02,4.813188e-02,&
+       & 4.662283e-02,4.519798e-02,4.384833e-02,4.256541e-02,4.134253e-02,&
+       & 4.017136e-02,3.904911e-02,3.796779e-02,3.692364e-02,3.591182e-02,&
+       & 3.492930e-02,3.397230e-02,3.303920e-02,3.212572e-02,3.123278e-02,&
+       & 3.035519e-02,2.949493e-02,2.864985e-02,2.781840e-02,2.700197e-02,&
+       & 2.619682e-02,2.540674e-02,2.462966e-02,2.386613e-02,2.311602e-02,&
+       & 2.237846e-02,2.165660e-02,2.094756e-02 /)
+!     BAND  29
+      extliq1(:, 29) = (/ &
+       & 4.298416e-01,4.391639e-01,3.975030e-01,3.443028e-01,2.957345e-01,&
+       & 2.556461e-01,2.234755e-01,1.976636e-01,1.767428e-01,1.595611e-01,&
+       & 1.452636e-01,1.332156e-01,1.229481e-01,1.141059e-01,1.064208e-01,&
+       & 9.968527e-02,9.373833e-02,8.845221e-02,8.372112e-02,7.946667e-02,&
+       & 7.561807e-02,7.212029e-02,6.893166e-02,6.600944e-02,6.332277e-02,&
+       & 6.084277e-02,5.854721e-02,5.641361e-02,5.442639e-02,5.256750e-02,&
+       & 5.082499e-02,4.918556e-02,4.763694e-02,4.617222e-02,4.477861e-02,&
+       & 4.344861e-02,4.217999e-02,4.096111e-02,3.978638e-02,3.865361e-02,&
+       & 3.755473e-02,3.649028e-02,3.545361e-02,3.444361e-02,3.345666e-02,&
+       & 3.249167e-02,3.154722e-02,3.062083e-02,2.971250e-02,2.882083e-02,&
+       & 2.794611e-02,2.708778e-02,2.624500e-02,2.541750e-02,2.460528e-02,&
+       & 2.381194e-02,2.303250e-02,2.226833e-02 /)
+
+! Single scattering albedo     
+!     BAND  16
+      ssaliq1(:, 16) = (/ &
+       & 8.362119e-01,8.098460e-01,7.762291e-01,7.486042e-01,7.294172e-01,&
+       & 7.161000e-01,7.060656e-01,6.978387e-01,6.907193e-01,6.843551e-01,&
+       & 6.785668e-01,6.732450e-01,6.683191e-01,6.637264e-01,6.594307e-01,&
+       & 6.554033e-01,6.516115e-01,6.480295e-01,6.446429e-01,6.414306e-01,&
+       & 6.383783e-01,6.354750e-01,6.327068e-01,6.300665e-01,6.275376e-01,&
+       & 6.251245e-01,6.228136e-01,6.205944e-01,6.184720e-01,6.164330e-01,&
+       & 6.144742e-01,6.125962e-01,6.108004e-01,6.090740e-01,6.074200e-01,&
+       & 6.058381e-01,6.043209e-01,6.028681e-01,6.014836e-01,6.001626e-01,&
+       & 5.988957e-01,5.976864e-01,5.965390e-01,5.954379e-01,5.943972e-01,&
+       & 5.934019e-01,5.924624e-01,5.915579e-01,5.907025e-01,5.898913e-01,&
+       & 5.891213e-01,5.883815e-01,5.876851e-01,5.870158e-01,5.863868e-01,&
+       & 5.857821e-01,5.852111e-01,5.846579e-01 /)
+!     BAND  17
+      ssaliq1(:, 17) = (/ &
+       & 6.995459e-01,7.158012e-01,7.076001e-01,6.927244e-01,6.786434e-01,&
+       & 6.673545e-01,6.585859e-01,6.516314e-01,6.459010e-01,6.410225e-01,&
+       & 6.367574e-01,6.329554e-01,6.295119e-01,6.263595e-01,6.234462e-01,&
+       & 6.207274e-01,6.181755e-01,6.157678e-01,6.134880e-01,6.113173e-01,&
+       & 6.092495e-01,6.072689e-01,6.053717e-01,6.035507e-01,6.018001e-01,&
+       & 6.001134e-01,5.984951e-01,5.969294e-01,5.954256e-01,5.939698e-01,&
+       & 5.925716e-01,5.912265e-01,5.899270e-01,5.886771e-01,5.874746e-01,&
+       & 5.863185e-01,5.852077e-01,5.841460e-01,5.831249e-01,5.821474e-01,&
+       & 5.812078e-01,5.803173e-01,5.794616e-01,5.786443e-01,5.778617e-01,&
+       & 5.771236e-01,5.764191e-01,5.757400e-01,5.750971e-01,5.744842e-01,&
+       & 5.739012e-01,5.733482e-01,5.728175e-01,5.723214e-01,5.718383e-01,&
+       & 5.713827e-01,5.709471e-01,5.705330e-01 /)
+!     BAND  18
+      ssaliq1(:, 18) = (/ &
+       & 9.929711e-01,9.896942e-01,9.852408e-01,9.806820e-01,9.764512e-01,&
+       & 9.725375e-01,9.688677e-01,9.653832e-01,9.620552e-01,9.588522e-01,&
+       & 9.557475e-01,9.527265e-01,9.497731e-01,9.468756e-01,9.440270e-01,&
+       & 9.412230e-01,9.384592e-01,9.357287e-01,9.330369e-01,9.303778e-01,&
+       & 9.277502e-01,9.251546e-01,9.225907e-01,9.200553e-01,9.175521e-01,&
+       & 9.150773e-01,9.126352e-01,9.102260e-01,9.078485e-01,9.055057e-01,&
+       & 9.031978e-01,9.009306e-01,8.987010e-01,8.965177e-01,8.943774e-01,&
+       & 8.922869e-01,8.902430e-01,8.882551e-01,8.863182e-01,8.844373e-01,&
+       & 8.826143e-01,8.808499e-01,8.791413e-01,8.774940e-01,8.759019e-01,&
+       & 8.743650e-01,8.728941e-01,8.714712e-01,8.701065e-01,8.688008e-01,&
+       & 8.675409e-01,8.663295e-01,8.651714e-01,8.640637e-01,8.629943e-01,&
+       & 8.619762e-01,8.609995e-01,8.600581e-01 /)
+!     BAND  19
+      ssaliq1(:, 19) = (/ &
+       & 9.910612e-01,9.854226e-01,9.795008e-01,9.742920e-01,9.695996e-01,&
+       & 9.652274e-01,9.610648e-01,9.570521e-01,9.531397e-01,9.493086e-01,&
+       & 9.455413e-01,9.418362e-01,9.381902e-01,9.346016e-01,9.310718e-01,&
+       & 9.275957e-01,9.241757e-01,9.208038e-01,9.174802e-01,9.142058e-01,&
+       & 9.109753e-01,9.077895e-01,9.046433e-01,9.015409e-01,8.984784e-01,&
+       & 8.954572e-01,8.924748e-01,8.895367e-01,8.866395e-01,8.837864e-01,&
+       & 8.809819e-01,8.782267e-01,8.755231e-01,8.728712e-01,8.702802e-01,&
+       & 8.677443e-01,8.652733e-01,8.628678e-01,8.605300e-01,8.582593e-01,&
+       & 8.560596e-01,8.539352e-01,8.518782e-01,8.498915e-01,8.479790e-01,&
+       & 8.461384e-01,8.443645e-01,8.426613e-01,8.410229e-01,8.394495e-01,&
+       & 8.379428e-01,8.364967e-01,8.351117e-01,8.337820e-01,8.325091e-01,&
+       & 8.312874e-01,8.301169e-01,8.289985e-01 /)
+!     BAND  20
+      ssaliq1(:, 20) = (/ &
+       & 9.969802e-01,9.950445e-01,9.931448e-01,9.914272e-01,9.898652e-01,&
+       & 9.884250e-01,9.870637e-01,9.857482e-01,9.844558e-01,9.831755e-01,&
+       & 9.819068e-01,9.806477e-01,9.794000e-01,9.781666e-01,9.769461e-01,&
+       & 9.757386e-01,9.745459e-01,9.733650e-01,9.721953e-01,9.710398e-01,&
+       & 9.698936e-01,9.687583e-01,9.676334e-01,9.665192e-01,9.654132e-01,&
+       & 9.643208e-01,9.632374e-01,9.621625e-01,9.611003e-01,9.600518e-01,&
+       & 9.590144e-01,9.579922e-01,9.569864e-01,9.559948e-01,9.550239e-01,&
+       & 9.540698e-01,9.531382e-01,9.522280e-01,9.513409e-01,9.504772e-01,&
+       & 9.496360e-01,9.488220e-01,9.480327e-01,9.472693e-01,9.465333e-01,&
+       & 9.458211e-01,9.451344e-01,9.444732e-01,9.438372e-01,9.432268e-01,&
+       & 9.426391e-01,9.420757e-01,9.415308e-01,9.410102e-01,9.405115e-01,&
+       & 9.400326e-01,9.395716e-01,9.391313e-01 /)
+!     BAND  21
+      ssaliq1(:, 21) = (/ &
+       & 9.980034e-01,9.968572e-01,9.958696e-01,9.949747e-01,9.941241e-01,&
+       & 9.933043e-01,9.924971e-01,9.916978e-01,9.909023e-01,9.901046e-01,&
+       & 9.893087e-01,9.885146e-01,9.877195e-01,9.869283e-01,9.861379e-01,&
+       & 9.853523e-01,9.845715e-01,9.837945e-01,9.830217e-01,9.822567e-01,&
+       & 9.814935e-01,9.807356e-01,9.799815e-01,9.792332e-01,9.784845e-01,&
+       & 9.777424e-01,9.770042e-01,9.762695e-01,9.755416e-01,9.748152e-01,&
+       & 9.740974e-01,9.733873e-01,9.726813e-01,9.719861e-01,9.713010e-01,&
+       & 9.706262e-01,9.699647e-01,9.693144e-01,9.686794e-01,9.680596e-01,&
+       & 9.674540e-01,9.668657e-01,9.662926e-01,9.657390e-01,9.652019e-01,&
+       & 9.646820e-01,9.641784e-01,9.636945e-01,9.632260e-01,9.627743e-01,&
+       & 9.623418e-01,9.619227e-01,9.615194e-01,9.611341e-01,9.607629e-01,&
+       & 9.604057e-01,9.600622e-01,9.597322e-01 /)
+!     BAND  22
+      ssaliq1(:, 22) = (/ &
+       & 9.988219e-01,9.981767e-01,9.976168e-01,9.971066e-01,9.966195e-01,&
+       & 9.961566e-01,9.956995e-01,9.952481e-01,9.947982e-01,9.943495e-01,&
+       & 9.938955e-01,9.934368e-01,9.929825e-01,9.925239e-01,9.920653e-01,&
+       & 9.916096e-01,9.911552e-01,9.907067e-01,9.902594e-01,9.898178e-01,&
+       & 9.893791e-01,9.889453e-01,9.885122e-01,9.880837e-01,9.876567e-01,&
+       & 9.872331e-01,9.868121e-01,9.863938e-01,9.859790e-01,9.855650e-01,&
+       & 9.851548e-01,9.847491e-01,9.843496e-01,9.839521e-01,9.835606e-01,&
+       & 9.831771e-01,9.827975e-01,9.824292e-01,9.820653e-01,9.817124e-01,&
+       & 9.813644e-01,9.810291e-01,9.807020e-01,9.803864e-01,9.800782e-01,&
+       & 9.797821e-01,9.794958e-01,9.792179e-01,9.789509e-01,9.786940e-01,&
+       & 9.784460e-01,9.782090e-01,9.779789e-01,9.777553e-01,9.775425e-01,&
+       & 9.773387e-01,9.771420e-01,9.769529e-01 /)
+!     BAND  23
+      ssaliq1(:, 23) = (/ &
+       & 9.998902e-01,9.998395e-01,9.997915e-01,9.997442e-01,9.997016e-01,&
+       & 9.996600e-01,9.996200e-01,9.995806e-01,9.995411e-01,9.995005e-01,&
+       & 9.994589e-01,9.994178e-01,9.993766e-01,9.993359e-01,9.992948e-01,&
+       & 9.992533e-01,9.992120e-01,9.991723e-01,9.991313e-01,9.990906e-01,&
+       & 9.990510e-01,9.990113e-01,9.989716e-01,9.989323e-01,9.988923e-01,&
+       & 9.988532e-01,9.988140e-01,9.987761e-01,9.987373e-01,9.986989e-01,&
+       & 9.986597e-01,9.986239e-01,9.985861e-01,9.985485e-01,9.985123e-01,&
+       & 9.984762e-01,9.984415e-01,9.984065e-01,9.983722e-01,9.983398e-01,&
+       & 9.983078e-01,9.982758e-01,9.982461e-01,9.982157e-01,9.981872e-01,&
+       & 9.981595e-01,9.981324e-01,9.981068e-01,9.980811e-01,9.980580e-01,&
+       & 9.980344e-01,9.980111e-01,9.979908e-01,9.979690e-01,9.979492e-01,&
+       & 9.979316e-01,9.979116e-01,9.978948e-01 /)
+!     BAND  24
+      ssaliq1(:, 24) = (/ &
+       & 9.999978e-01,9.999948e-01,9.999915e-01,9.999905e-01,9.999896e-01,&
+       & 9.999887e-01,9.999888e-01,9.999888e-01,9.999870e-01,9.999854e-01,&
+       & 9.999855e-01,9.999856e-01,9.999839e-01,9.999834e-01,9.999829e-01,&
+       & 9.999809e-01,9.999816e-01,9.999793e-01,9.999782e-01,9.999779e-01,&
+       & 9.999772e-01,9.999764e-01,9.999756e-01,9.999744e-01,9.999744e-01,&
+       & 9.999736e-01,9.999729e-01,9.999716e-01,9.999706e-01,9.999692e-01,&
+       & 9.999690e-01,9.999675e-01,9.999673e-01,9.999660e-01,9.999654e-01,&
+       & 9.999647e-01,9.999647e-01,9.999625e-01,9.999620e-01,9.999614e-01,&
+       & 9.999613e-01,9.999607e-01,9.999604e-01,9.999594e-01,9.999589e-01,&
+       & 9.999586e-01,9.999567e-01,9.999550e-01,9.999557e-01,9.999542e-01,&
+       & 9.999546e-01,9.999539e-01,9.999536e-01,9.999526e-01,9.999523e-01,&
+       & 9.999508e-01,9.999534e-01,9.999507e-01 /)
+!     BAND  25
+      ssaliq1(:, 25) = (/ &
+       & 1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,&
+       & 1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,&
+       & 1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,&
+       & 1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,9.999995e-01,&
+       & 9.999995e-01,9.999990e-01,9.999991e-01,9.999991e-01,9.999990e-01,&
+       & 9.999989e-01,9.999988e-01,9.999988e-01,9.999986e-01,9.999988e-01,&
+       & 9.999986e-01,9.999987e-01,9.999986e-01,9.999985e-01,9.999985e-01,&
+       & 9.999985e-01,9.999985e-01,9.999983e-01,9.999983e-01,9.999981e-01,&
+       & 9.999981e-01,9.999986e-01,9.999985e-01,9.999983e-01,9.999984e-01,&
+       & 9.999982e-01,9.999983e-01,9.999982e-01,9.999980e-01,9.999981e-01,&
+       & 9.999978e-01,9.999979e-01,9.999985e-01,9.999985e-01,9.999983e-01,&
+       & 9.999983e-01,9.999983e-01,9.999983e-01 /)
+!     BAND  26
+      ssaliq1(:, 26) = (/ &
+       & 1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,&
+       & 1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,&
+       & 1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,&
+       & 1.000000e+00,1.000000e+00,1.000000e+00,1.000000e+00,9.999991e-01,&
+       & 9.999990e-01,9.999992e-01,9.999995e-01,9.999986e-01,9.999994e-01,&
+       & 9.999985e-01,9.999980e-01,9.999984e-01,9.999983e-01,9.999979e-01,&
+       & 9.999969e-01,9.999977e-01,9.999971e-01,9.999969e-01,9.999969e-01,&
+       & 9.999965e-01,9.999970e-01,9.999985e-01,9.999973e-01,9.999961e-01,&
+       & 9.999968e-01,9.999952e-01,9.999970e-01,9.999974e-01,9.999965e-01,&
+       & 9.999969e-01,9.999970e-01,9.999970e-01,9.999960e-01,9.999923e-01,&
+       & 9.999958e-01,9.999937e-01,9.999960e-01,9.999953e-01,9.999946e-01,&
+       & 9.999946e-01,9.999957e-01,9.999951e-01 /)
+!     BAND  27
+      ssaliq1(:, 27) = (/ &
+       & 1.000000e+00,1.000000e+00,9.999983e-01,9.999979e-01,9.999965e-01,&
+       & 9.999949e-01,9.999948e-01,9.999918e-01,9.999917e-01,9.999923e-01,&
+       & 9.999908e-01,9.999889e-01,9.999902e-01,9.999895e-01,9.999881e-01,&
+       & 9.999882e-01,9.999876e-01,9.999866e-01,9.999866e-01,9.999858e-01,&
+       & 9.999860e-01,9.999852e-01,9.999836e-01,9.999831e-01,9.999818e-01,&
+       & 9.999808e-01,9.999816e-01,9.999800e-01,9.999783e-01,9.999780e-01,&
+       & 9.999763e-01,9.999746e-01,9.999731e-01,9.999713e-01,9.999762e-01,&
+       & 9.999740e-01,9.999670e-01,9.999703e-01,9.999687e-01,9.999666e-01,&
+       & 9.999683e-01,9.999667e-01,9.999611e-01,9.999635e-01,9.999600e-01,&
+       & 9.999635e-01,9.999594e-01,9.999601e-01,9.999586e-01,9.999559e-01,&
+       & 9.999569e-01,9.999558e-01,9.999523e-01,9.999535e-01,9.999529e-01,&
+       & 9.999553e-01,9.999495e-01,9.999490e-01 /)
+!     BAND  28
+      ssaliq1(:, 28) = (/ &
+       & 9.999920e-01,9.999873e-01,9.999855e-01,9.999832e-01,9.999807e-01,&
+       & 9.999778e-01,9.999754e-01,9.999721e-01,9.999692e-01,9.999651e-01,&
+       & 9.999621e-01,9.999607e-01,9.999567e-01,9.999546e-01,9.999521e-01,&
+       & 9.999491e-01,9.999457e-01,9.999439e-01,9.999403e-01,9.999374e-01,&
+       & 9.999353e-01,9.999315e-01,9.999282e-01,9.999244e-01,9.999234e-01,&
+       & 9.999189e-01,9.999130e-01,9.999117e-01,9.999073e-01,9.999020e-01,&
+       & 9.998993e-01,9.998987e-01,9.998922e-01,9.998893e-01,9.998869e-01,&
+       & 9.998805e-01,9.998778e-01,9.998751e-01,9.998708e-01,9.998676e-01,&
+       & 9.998624e-01,9.998642e-01,9.998582e-01,9.998547e-01,9.998546e-01,&
+       & 9.998477e-01,9.998487e-01,9.998466e-01,9.998403e-01,9.998412e-01,&
+       & 9.998406e-01,9.998342e-01,9.998326e-01,9.998333e-01,9.998328e-01,&
+       & 9.998290e-01,9.998276e-01,9.998249e-01 /)
+!     BAND  29
+      ssaliq1(:, 29) = (/ &
+       & 8.383753e-01,8.461471e-01,8.373325e-01,8.212889e-01,8.023834e-01,&
+       & 7.829501e-01,7.641777e-01,7.466000e-01,7.304023e-01,7.155998e-01,&
+       & 7.021259e-01,6.898840e-01,6.787615e-01,6.686479e-01,6.594414e-01,&
+       & 6.510417e-01,6.433668e-01,6.363335e-01,6.298788e-01,6.239398e-01,&
+       & 6.184633e-01,6.134055e-01,6.087228e-01,6.043786e-01,6.003439e-01,&
+       & 5.965910e-01,5.930917e-01,5.898280e-01,5.867798e-01,5.839264e-01,&
+       & 5.812576e-01,5.787592e-01,5.764163e-01,5.742189e-01,5.721598e-01,&
+       & 5.702286e-01,5.684182e-01,5.667176e-01,5.651237e-01,5.636253e-01,&
+       & 5.622228e-01,5.609074e-01,5.596713e-01,5.585089e-01,5.574223e-01,&
+       & 5.564002e-01,5.554411e-01,5.545397e-01,5.536914e-01,5.528967e-01,&
+       & 5.521495e-01,5.514457e-01,5.507818e-01,5.501623e-01,5.495750e-01,&
+       & 5.490192e-01,5.484980e-01,5.480046e-01 /)
+
+! Asymmetry parameter
+!     BAND  16
+      asyliq1(:, 16) = (/ &
+       & 8.038165e-01,8.014154e-01,7.942381e-01,7.970521e-01,8.086621e-01,&
+       & 8.233392e-01,8.374127e-01,8.495742e-01,8.596945e-01,8.680497e-01,&
+       & 8.750005e-01,8.808589e-01,8.858749e-01,8.902403e-01,8.940939e-01,&
+       & 8.975379e-01,9.006450e-01,9.034741e-01,9.060659e-01,9.084561e-01,&
+       & 9.106675e-01,9.127198e-01,9.146332e-01,9.164194e-01,9.180970e-01,&
+       & 9.196658e-01,9.211421e-01,9.225352e-01,9.238443e-01,9.250841e-01,&
+       & 9.262541e-01,9.273620e-01,9.284081e-01,9.294002e-01,9.303395e-01,&
+       & 9.312285e-01,9.320715e-01,9.328716e-01,9.336271e-01,9.343427e-01,&
+       & 9.350219e-01,9.356647e-01,9.362728e-01,9.368495e-01,9.373956e-01,&
+       & 9.379113e-01,9.383987e-01,9.388608e-01,9.392986e-01,9.397132e-01,&
+       & 9.401063e-01,9.404776e-01,9.408299e-01,9.411641e-01,9.414800e-01,&
+       & 9.417787e-01,9.420633e-01,9.423364e-01 /)
+!     BAND  17
+      asyliq1(:, 17) = (/ &
+       & 8.941000e-01,9.054049e-01,9.049510e-01,9.027216e-01,9.021636e-01,&
+       & 9.037878e-01,9.069852e-01,9.109817e-01,9.152013e-01,9.193040e-01,&
+       & 9.231177e-01,9.265712e-01,9.296606e-01,9.324048e-01,9.348419e-01,&
+       & 9.370131e-01,9.389529e-01,9.406954e-01,9.422727e-01,9.437088e-01,&
+       & 9.450221e-01,9.462308e-01,9.473488e-01,9.483830e-01,9.493492e-01,&
+       & 9.502541e-01,9.510999e-01,9.518971e-01,9.526455e-01,9.533554e-01,&
+       & 9.540249e-01,9.546571e-01,9.552551e-01,9.558258e-01,9.563603e-01,&
+       & 9.568713e-01,9.573569e-01,9.578141e-01,9.582485e-01,9.586604e-01,&
+       & 9.590525e-01,9.594218e-01,9.597710e-01,9.601052e-01,9.604181e-01,&
+       & 9.607159e-01,9.609979e-01,9.612655e-01,9.615184e-01,9.617564e-01,&
+       & 9.619860e-01,9.622009e-01,9.624031e-01,9.625957e-01,9.627792e-01,&
+       & 9.629530e-01,9.631171e-01,9.632746e-01 /)
+!     BAND  18
+      asyliq1(:, 18) = (/ &
+       & 8.574638e-01,8.351383e-01,8.142977e-01,8.083068e-01,8.129284e-01,&
+       & 8.215827e-01,8.307238e-01,8.389963e-01,8.460481e-01,8.519273e-01,&
+       & 8.568153e-01,8.609116e-01,8.643892e-01,8.673941e-01,8.700248e-01,&
+       & 8.723707e-01,8.744902e-01,8.764240e-01,8.782057e-01,8.798593e-01,&
+       & 8.814063e-01,8.828573e-01,8.842261e-01,8.855196e-01,8.867497e-01,&
+       & 8.879164e-01,8.890316e-01,8.900941e-01,8.911118e-01,8.920832e-01,&
+       & 8.930156e-01,8.939091e-01,8.947663e-01,8.955888e-01,8.963786e-01,&
+       & 8.971350e-01,8.978617e-01,8.985590e-01,8.992243e-01,8.998631e-01,&
+       & 9.004753e-01,9.010602e-01,9.016192e-01,9.021542e-01,9.026644e-01,&
+       & 9.031535e-01,9.036194e-01,9.040656e-01,9.044894e-01,9.048933e-01,&
+       & 9.052789e-01,9.056481e-01,9.060004e-01,9.063343e-01,9.066544e-01,&
+       & 9.069604e-01,9.072512e-01,9.075290e-01 /)
+!     BAND  19
+      asyliq1(:, 19) = (/ &
+       & 8.349569e-01,8.034579e-01,7.932136e-01,8.010156e-01,8.137083e-01,&
+       & 8.255339e-01,8.351938e-01,8.428286e-01,8.488944e-01,8.538187e-01,&
+       & 8.579255e-01,8.614473e-01,8.645338e-01,8.672908e-01,8.697947e-01,&
+       & 8.720843e-01,8.742015e-01,8.761718e-01,8.780160e-01,8.797479e-01,&
+       & 8.813810e-01,8.829250e-01,8.843907e-01,8.857822e-01,8.871059e-01,&
+       & 8.883724e-01,8.895810e-01,8.907384e-01,8.918456e-01,8.929083e-01,&
+       & 8.939284e-01,8.949060e-01,8.958463e-01,8.967486e-01,8.976129e-01,&
+       & 8.984463e-01,8.992439e-01,9.000094e-01,9.007438e-01,9.014496e-01,&
+       & 9.021235e-01,9.027699e-01,9.033859e-01,9.039772e-01,9.045419e-01,&
+       & 9.050819e-01,9.055975e-01,9.060907e-01,9.065607e-01,9.070093e-01,&
+       & 9.074389e-01,9.078475e-01,9.082388e-01,9.086117e-01,9.089678e-01,&
+       & 9.093081e-01,9.096307e-01,9.099410e-01 /)
+!     BAND  20
+      asyliq1(:, 20) = (/ &
+       & 8.109692e-01,7.846657e-01,7.881928e-01,8.009509e-01,8.131208e-01,&
+       & 8.230400e-01,8.309448e-01,8.372920e-01,8.424837e-01,8.468166e-01,&
+       & 8.504947e-01,8.536642e-01,8.564256e-01,8.588513e-01,8.610011e-01,&
+       & 8.629122e-01,8.646262e-01,8.661720e-01,8.675752e-01,8.688582e-01,&
+       & 8.700379e-01,8.711300e-01,8.721485e-01,8.731027e-01,8.740010e-01,&
+       & 8.748499e-01,8.756564e-01,8.764239e-01,8.771542e-01,8.778523e-01,&
+       & 8.785211e-01,8.791601e-01,8.797725e-01,8.803589e-01,8.809173e-01,&
+       & 8.814552e-01,8.819705e-01,8.824611e-01,8.829311e-01,8.833791e-01,&
+       & 8.838078e-01,8.842148e-01,8.846044e-01,8.849756e-01,8.853291e-01,&
+       & 8.856645e-01,8.859841e-01,8.862904e-01,8.865801e-01,8.868551e-01,&
+       & 8.871182e-01,8.873673e-01,8.876059e-01,8.878307e-01,8.880462e-01,&
+       & 8.882501e-01,8.884453e-01,8.886339e-01 /)
+!     BAND  21
+      asyliq1(:, 21) = (/ &
+       & 7.838510e-01,7.803151e-01,7.980477e-01,8.144160e-01,8.261784e-01,&
+       & 8.344240e-01,8.404278e-01,8.450391e-01,8.487593e-01,8.518741e-01,&
+       & 8.545484e-01,8.568890e-01,8.589560e-01,8.607983e-01,8.624504e-01,&
+       & 8.639408e-01,8.652945e-01,8.665301e-01,8.676634e-01,8.687121e-01,&
+       & 8.696855e-01,8.705933e-01,8.714448e-01,8.722454e-01,8.730014e-01,&
+       & 8.737180e-01,8.743982e-01,8.750436e-01,8.756598e-01,8.762481e-01,&
+       & 8.768089e-01,8.773427e-01,8.778532e-01,8.783434e-01,8.788089e-01,&
+       & 8.792530e-01,8.796784e-01,8.800845e-01,8.804716e-01,8.808411e-01,&
+       & 8.811923e-01,8.815276e-01,8.818472e-01,8.821504e-01,8.824408e-01,&
+       & 8.827155e-01,8.829777e-01,8.832269e-01,8.834631e-01,8.836892e-01,&
+       & 8.839034e-01,8.841075e-01,8.843021e-01,8.844866e-01,8.846631e-01,&
+       & 8.848304e-01,8.849910e-01,8.851425e-01 /)
+!     BAND  22
+      asyliq1(:, 22) = (/ &
+       & 7.760783e-01,7.890215e-01,8.090192e-01,8.230252e-01,8.321369e-01,&
+       & 8.384258e-01,8.431529e-01,8.469558e-01,8.501499e-01,8.528899e-01,&
+       & 8.552899e-01,8.573956e-01,8.592570e-01,8.609098e-01,8.623897e-01,&
+       & 8.637169e-01,8.649184e-01,8.660097e-01,8.670096e-01,8.679338e-01,&
+       & 8.687896e-01,8.695880e-01,8.703365e-01,8.710422e-01,8.717092e-01,&
+       & 8.723378e-01,8.729363e-01,8.735063e-01,8.740475e-01,8.745661e-01,&
+       & 8.750560e-01,8.755275e-01,8.759731e-01,8.764000e-01,8.768071e-01,&
+       & 8.771942e-01,8.775628e-01,8.779126e-01,8.782483e-01,8.785626e-01,&
+       & 8.788610e-01,8.791482e-01,8.794180e-01,8.796765e-01,8.799207e-01,&
+       & 8.801522e-01,8.803707e-01,8.805777e-01,8.807749e-01,8.809605e-01,&
+       & 8.811362e-01,8.813047e-01,8.814647e-01,8.816131e-01,8.817588e-01,&
+       & 8.818930e-01,8.820230e-01,8.821445e-01 /)
+!     BAND  23
+      asyliq1(:, 23) = (/ &
+       & 7.847907e-01,8.099917e-01,8.257428e-01,8.350423e-01,8.411971e-01,&
+       & 8.457241e-01,8.493010e-01,8.522565e-01,8.547660e-01,8.569311e-01,&
+       & 8.588181e-01,8.604729e-01,8.619296e-01,8.632208e-01,8.643725e-01,&
+       & 8.654050e-01,8.663363e-01,8.671835e-01,8.679590e-01,8.686707e-01,&
+       & 8.693308e-01,8.699433e-01,8.705147e-01,8.710490e-01,8.715497e-01,&
+       & 8.720219e-01,8.724669e-01,8.728849e-01,8.732806e-01,8.736550e-01,&
+       & 8.740099e-01,8.743435e-01,8.746601e-01,8.749610e-01,8.752449e-01,&
+       & 8.755143e-01,8.757688e-01,8.760095e-01,8.762375e-01,8.764532e-01,&
+       & 8.766579e-01,8.768506e-01,8.770323e-01,8.772049e-01,8.773690e-01,&
+       & 8.775226e-01,8.776679e-01,8.778062e-01,8.779360e-01,8.780587e-01,&
+       & 8.781747e-01,8.782852e-01,8.783892e-01,8.784891e-01,8.785824e-01,&
+       & 8.786705e-01,8.787546e-01,8.788336e-01 /)
+!     BAND  24
+      asyliq1(:, 24) = (/ &
+       & 8.054324e-01,8.266282e-01,8.378075e-01,8.449848e-01,8.502166e-01,&
+       & 8.542268e-01,8.573477e-01,8.598022e-01,8.617689e-01,8.633859e-01,&
+       & 8.647536e-01,8.659354e-01,8.669807e-01,8.679143e-01,8.687577e-01,&
+       & 8.695222e-01,8.702207e-01,8.708591e-01,8.714446e-01,8.719836e-01,&
+       & 8.724812e-01,8.729426e-01,8.733689e-01,8.737665e-01,8.741373e-01,&
+       & 8.744834e-01,8.748070e-01,8.751131e-01,8.754011e-01,8.756676e-01,&
+       & 8.759219e-01,8.761599e-01,8.763857e-01,8.765984e-01,8.767999e-01,&
+       & 8.769889e-01,8.771669e-01,8.773373e-01,8.774969e-01,8.776469e-01,&
+       & 8.777894e-01,8.779237e-01,8.780505e-01,8.781703e-01,8.782820e-01,&
+       & 8.783886e-01,8.784894e-01,8.785844e-01,8.786736e-01,8.787584e-01,&
+       & 8.788379e-01,8.789130e-01,8.789849e-01,8.790506e-01,8.791141e-01,&
+       & 8.791750e-01,8.792324e-01,8.792867e-01 /)
+!     BAND  25
+      asyliq1(:, 25) = (/ &
+       & 8.249534e-01,8.391988e-01,8.474107e-01,8.526860e-01,8.563983e-01,&
+       & 8.592389e-01,8.615144e-01,8.633790e-01,8.649325e-01,8.662504e-01,&
+       & 8.673841e-01,8.683741e-01,8.692495e-01,8.700309e-01,8.707328e-01,&
+       & 8.713650e-01,8.719432e-01,8.724676e-01,8.729498e-01,8.733922e-01,&
+       & 8.737981e-01,8.741745e-01,8.745225e-01,8.748467e-01,8.751512e-01,&
+       & 8.754315e-01,8.756962e-01,8.759450e-01,8.761774e-01,8.763945e-01,&
+       & 8.766021e-01,8.767970e-01,8.769803e-01,8.771511e-01,8.773151e-01,&
+       & 8.774689e-01,8.776147e-01,8.777533e-01,8.778831e-01,8.780050e-01,&
+       & 8.781197e-01,8.782301e-01,8.783323e-01,8.784312e-01,8.785222e-01,&
+       & 8.786096e-01,8.786916e-01,8.787688e-01,8.788411e-01,8.789122e-01,&
+       & 8.789762e-01,8.790373e-01,8.790954e-01,8.791514e-01,8.792018e-01,&
+       & 8.792517e-01,8.792990e-01,8.793429e-01 /)
+!     BAND  26
+      asyliq1(:, 26) = (/ &
+       & 8.323091e-01,8.429776e-01,8.498123e-01,8.546929e-01,8.584295e-01,&
+       & 8.613489e-01,8.636324e-01,8.654303e-01,8.668675e-01,8.680404e-01,&
+       & 8.690174e-01,8.698495e-01,8.705666e-01,8.711961e-01,8.717556e-01,&
+       & 8.722546e-01,8.727063e-01,8.731170e-01,8.734933e-01,8.738382e-01,&
+       & 8.741590e-01,8.744525e-01,8.747295e-01,8.749843e-01,8.752210e-01,&
+       & 8.754437e-01,8.756524e-01,8.758472e-01,8.760288e-01,8.762030e-01,&
+       & 8.763603e-01,8.765122e-01,8.766539e-01,8.767894e-01,8.769130e-01,&
+       & 8.770310e-01,8.771422e-01,8.772437e-01,8.773419e-01,8.774355e-01,&
+       & 8.775221e-01,8.776047e-01,8.776802e-01,8.777539e-01,8.778216e-01,&
+       & 8.778859e-01,8.779473e-01,8.780031e-01,8.780562e-01,8.781097e-01,&
+       & 8.781570e-01,8.782021e-01,8.782463e-01,8.782845e-01,8.783235e-01,&
+       & 8.783610e-01,8.783953e-01,8.784273e-01 /)
+!     BAND  27
+      asyliq1(:, 27) = (/ &
+       & 8.396448e-01,8.480172e-01,8.535934e-01,8.574145e-01,8.600835e-01,&
+       & 8.620347e-01,8.635500e-01,8.648003e-01,8.658758e-01,8.668248e-01,&
+       & 8.676697e-01,8.684220e-01,8.690893e-01,8.696807e-01,8.702046e-01,&
+       & 8.706676e-01,8.710798e-01,8.714478e-01,8.717778e-01,8.720747e-01,&
+       & 8.723431e-01,8.725889e-01,8.728144e-01,8.730201e-01,8.732129e-01,&
+       & 8.733907e-01,8.735541e-01,8.737100e-01,8.738533e-01,8.739882e-01,&
+       & 8.741164e-01,8.742362e-01,8.743485e-01,8.744530e-01,8.745512e-01,&
+       & 8.746471e-01,8.747373e-01,8.748186e-01,8.748973e-01,8.749732e-01,&
+       & 8.750443e-01,8.751105e-01,8.751747e-01,8.752344e-01,8.752902e-01,&
+       & 8.753412e-01,8.753917e-01,8.754393e-01,8.754843e-01,8.755282e-01,&
+       & 8.755662e-01,8.756039e-01,8.756408e-01,8.756722e-01,8.757072e-01,&
+       & 8.757352e-01,8.757653e-01,8.757932e-01 /)
+!     BAND  28
+      asyliq1(:, 28) = (/ &
+       & 8.374590e-01,8.465669e-01,8.518701e-01,8.547627e-01,8.565745e-01,&
+       & 8.579065e-01,8.589717e-01,8.598632e-01,8.606363e-01,8.613268e-01,&
+       & 8.619560e-01,8.625340e-01,8.630689e-01,8.635601e-01,8.640084e-01,&
+       & 8.644180e-01,8.647885e-01,8.651220e-01,8.654218e-01,8.656908e-01,&
+       & 8.659294e-01,8.661422e-01,8.663334e-01,8.665037e-01,8.666543e-01,&
+       & 8.667913e-01,8.669156e-01,8.670242e-01,8.671249e-01,8.672161e-01,&
+       & 8.672993e-01,8.673733e-01,8.674457e-01,8.675103e-01,8.675713e-01,&
+       & 8.676267e-01,8.676798e-01,8.677286e-01,8.677745e-01,8.678178e-01,&
+       & 8.678601e-01,8.678986e-01,8.679351e-01,8.679693e-01,8.680013e-01,&
+       & 8.680334e-01,8.680624e-01,8.680915e-01,8.681178e-01,8.681428e-01,&
+       & 8.681654e-01,8.681899e-01,8.682103e-01,8.682317e-01,8.682498e-01,&
+       & 8.682677e-01,8.682861e-01,8.683041e-01 /)
+!     BAND  29
+      asyliq1(:, 29) = (/ &
+       & 7.877069e-01,8.244281e-01,8.367971e-01,8.409074e-01,8.429859e-01,&
+       & 8.454386e-01,8.489350e-01,8.534141e-01,8.585814e-01,8.641267e-01,&
+       & 8.697999e-01,8.754223e-01,8.808785e-01,8.860944e-01,8.910354e-01,&
+       & 8.956837e-01,9.000392e-01,9.041091e-01,9.079071e-01,9.114479e-01,&
+       & 9.147462e-01,9.178234e-01,9.206903e-01,9.233663e-01,9.258668e-01,&
+       & 9.282006e-01,9.303847e-01,9.324288e-01,9.343418e-01,9.361356e-01,&
+       & 9.378176e-01,9.393939e-01,9.408736e-01,9.422622e-01,9.435670e-01,&
+       & 9.447900e-01,9.459395e-01,9.470199e-01,9.480335e-01,9.489852e-01,&
+       & 9.498782e-01,9.507168e-01,9.515044e-01,9.522470e-01,9.529409e-01,&
+       & 9.535946e-01,9.542071e-01,9.547838e-01,9.553256e-01,9.558351e-01,&
+       & 9.563139e-01,9.567660e-01,9.571915e-01,9.575901e-01,9.579685e-01,&
+       & 9.583239e-01,9.586602e-01,9.589766e-01 /)
+
+
+! Spherical Ice Particle Parameterization
+! extinction units (ext coef/iwc): [(m^-1)/(g m^-3)]
+      extice2(:, 16) = (/ &
+! band 16
+        & 4.101824e-01 ,2.435514e-01 ,1.713697e-01 ,1.314865e-01 ,1.063406e-01 ,&
+        & 8.910701e-02 ,7.659480e-02 ,6.711784e-02 ,5.970353e-02 ,5.375249e-02 ,&
+        & 4.887577e-02 ,4.481025e-02 ,4.137171e-02 ,3.842744e-02 ,3.587948e-02 ,&
+        & 3.365396e-02 ,3.169419e-02 ,2.995593e-02 ,2.840419e-02 ,2.701091e-02 ,&
+        & 2.575336e-02 ,2.461293e-02 ,2.357423e-02 ,2.262443e-02 ,2.175276e-02 ,&
+        & 2.095012e-02 ,2.020875e-02 ,1.952199e-02 ,1.888412e-02 ,1.829018e-02 ,&
+        & 1.773586e-02 ,1.721738e-02 ,1.673144e-02 ,1.627510e-02 ,1.584579e-02 ,&
+        & 1.544122e-02 ,1.505934e-02 ,1.469833e-02 ,1.435654e-02 ,1.403251e-02 ,&
+        & 1.372492e-02 ,1.343255e-02 ,1.315433e-02  /)
+      extice2(:, 17) = (/ &
+! band 17
+        & 3.836650e-01 ,2.304055e-01 ,1.637265e-01 ,1.266681e-01 ,1.031602e-01 ,&
+        & 8.695191e-02 ,7.511544e-02 ,6.610009e-02 ,5.900909e-02 ,5.328833e-02 ,&
+        & 4.857728e-02 ,4.463133e-02 ,4.127880e-02 ,3.839567e-02 ,3.589013e-02 ,&
+        & 3.369280e-02 ,3.175027e-02 ,3.002079e-02 ,2.847121e-02 ,2.707493e-02 ,&
+        & 2.581031e-02 ,2.465962e-02 ,2.360815e-02 ,2.264363e-02 ,2.175571e-02 ,&
+        & 2.093563e-02 ,2.017592e-02 ,1.947015e-02 ,1.881278e-02 ,1.819901e-02 ,&
+        & 1.762463e-02 ,1.708598e-02 ,1.657982e-02 ,1.610330e-02 ,1.565390e-02 ,&
+        & 1.522937e-02 ,1.482768e-02 ,1.444706e-02 ,1.408588e-02 ,1.374270e-02 ,&
+        & 1.341619e-02 ,1.310517e-02 ,1.280857e-02  /)
+      extice2(:, 18) = (/ &
+! band 18
+        & 4.152673e-01 ,2.436816e-01 ,1.702243e-01 ,1.299704e-01 ,1.047528e-01 ,&
+        & 8.756039e-02 ,7.513327e-02 ,6.575690e-02 ,5.844616e-02 ,5.259609e-02 ,&
+        & 4.781531e-02 ,4.383980e-02 ,4.048517e-02 ,3.761891e-02 ,3.514342e-02 ,&
+        & 3.298525e-02 ,3.108814e-02 ,2.940825e-02 ,2.791096e-02 ,2.656858e-02 ,&
+        & 2.535869e-02 ,2.426297e-02 ,2.326627e-02 ,2.235602e-02 ,2.152164e-02 ,&
+        & 2.075420e-02 ,2.004613e-02 ,1.939091e-02 ,1.878296e-02 ,1.821744e-02 ,&
+        & 1.769015e-02 ,1.719741e-02 ,1.673600e-02 ,1.630308e-02 ,1.589615e-02 ,&
+        & 1.551298e-02 ,1.515159e-02 ,1.481021e-02 ,1.448726e-02 ,1.418131e-02 ,&
+        & 1.389109e-02 ,1.361544e-02 ,1.335330e-02  /)
+      extice2(:, 19) = (/ &
+! band 19
+        & 3.873250e-01 ,2.331609e-01 ,1.655002e-01 ,1.277753e-01 ,1.038247e-01 ,&
+        & 8.731780e-02 ,7.527638e-02 ,6.611873e-02 ,5.892850e-02 ,5.313885e-02 ,&
+        & 4.838068e-02 ,4.440356e-02 ,4.103167e-02 ,3.813804e-02 ,3.562870e-02 ,&
+        & 3.343269e-02 ,3.149539e-02 ,2.977414e-02 ,2.823510e-02 ,2.685112e-02 ,&
+        & 2.560015e-02 ,2.446411e-02 ,2.342805e-02 ,2.247948e-02 ,2.160789e-02 ,&
+        & 2.080438e-02 ,2.006139e-02 ,1.937238e-02 ,1.873177e-02 ,1.813469e-02 ,&
+        & 1.757689e-02 ,1.705468e-02 ,1.656479e-02 ,1.610435e-02 ,1.567081e-02 ,&
+        & 1.526192e-02 ,1.487565e-02 ,1.451020e-02 ,1.416396e-02 ,1.383546e-02 ,&
+        & 1.352339e-02 ,1.322657e-02 ,1.294392e-02  /)
+      extice2(:, 20) = (/ &
+! band 20
+        & 3.784280e-01 ,2.291396e-01 ,1.632551e-01 ,1.263775e-01 ,1.028944e-01 ,&
+        & 8.666975e-02 ,7.480952e-02 ,6.577335e-02 ,5.866714e-02 ,5.293694e-02 ,&
+        & 4.822153e-02 ,4.427547e-02 ,4.092626e-02 ,3.804918e-02 ,3.555184e-02 ,&
+        & 3.336440e-02 ,3.143307e-02 ,2.971577e-02 ,2.817912e-02 ,2.679632e-02 ,&
+        & 2.554558e-02 ,2.440903e-02 ,2.337187e-02 ,2.242173e-02 ,2.154821e-02 ,&
+        & 2.074249e-02 ,1.999706e-02 ,1.930546e-02 ,1.866212e-02 ,1.806221e-02 ,&
+        & 1.750152e-02 ,1.697637e-02 ,1.648352e-02 ,1.602010e-02 ,1.558358e-02 ,&
+        & 1.517172e-02 ,1.478250e-02 ,1.441413e-02 ,1.406498e-02 ,1.373362e-02 ,&
+        & 1.341872e-02 ,1.311911e-02 ,1.283371e-02  /)
+      extice2(:, 21) = (/ &
+! band 21
+        & 3.719909e-01 ,2.259490e-01 ,1.613144e-01 ,1.250648e-01 ,1.019462e-01 ,&
+        & 8.595358e-02 ,7.425064e-02 ,6.532618e-02 ,5.830218e-02 ,5.263421e-02 ,&
+        & 4.796697e-02 ,4.405891e-02 ,4.074013e-02 ,3.788776e-02 ,3.541071e-02 ,&
+        & 3.324008e-02 ,3.132280e-02 ,2.961733e-02 ,2.809071e-02 ,2.671645e-02 ,&
+        & 2.547302e-02 ,2.434276e-02 ,2.331102e-02 ,2.236558e-02 ,2.149614e-02 ,&
+        & 2.069397e-02 ,1.995163e-02 ,1.926272e-02 ,1.862174e-02 ,1.802389e-02 ,&
+        & 1.746500e-02 ,1.694142e-02 ,1.644994e-02 ,1.598772e-02 ,1.555225e-02 ,&
+        & 1.514129e-02 ,1.475286e-02 ,1.438515e-02 ,1.403659e-02 ,1.370572e-02 ,&
+        & 1.339124e-02 ,1.309197e-02 ,1.280685e-02  /)
+      extice2(:, 22) = (/ &
+! band 22
+        & 3.713158e-01 ,2.253816e-01 ,1.608461e-01 ,1.246718e-01 ,1.016109e-01 ,&
+        & 8.566332e-02 ,7.399666e-02 ,6.510199e-02 ,5.810290e-02 ,5.245608e-02 ,&
+        & 4.780702e-02 ,4.391478e-02 ,4.060989e-02 ,3.776982e-02 ,3.530374e-02 ,&
+        & 3.314296e-02 ,3.123458e-02 ,2.953719e-02 ,2.801794e-02 ,2.665043e-02 ,&
+        & 2.541321e-02 ,2.428868e-02 ,2.326224e-02 ,2.232173e-02 ,2.145688e-02 ,&
+        & 2.065899e-02 ,1.992067e-02 ,1.923552e-02 ,1.859808e-02 ,1.800356e-02 ,&
+        & 1.744782e-02 ,1.692721e-02 ,1.643855e-02 ,1.597900e-02 ,1.554606e-02 ,&
+        & 1.513751e-02 ,1.475137e-02 ,1.438586e-02 ,1.403938e-02 ,1.371050e-02 ,&
+        & 1.339793e-02 ,1.310050e-02 ,1.281713e-02  /)
+      extice2(:, 23) = (/ &
+! band 23
+        & 3.605883e-01 ,2.204388e-01 ,1.580431e-01 ,1.229033e-01 ,1.004203e-01 ,&
+        & 8.482616e-02 ,7.338941e-02 ,6.465105e-02 ,5.776176e-02 ,5.219398e-02 ,&
+        & 4.760288e-02 ,4.375369e-02 ,4.048111e-02 ,3.766539e-02 ,3.521771e-02 ,&
+        & 3.307079e-02 ,3.117277e-02 ,2.948303e-02 ,2.796929e-02 ,2.660560e-02 ,&
+        & 2.537086e-02 ,2.424772e-02 ,2.322182e-02 ,2.228114e-02 ,2.141556e-02 ,&
+        & 2.061649e-02 ,1.987661e-02 ,1.918962e-02 ,1.855009e-02 ,1.795330e-02 ,&
+        & 1.739514e-02 ,1.687199e-02 ,1.638069e-02 ,1.591845e-02 ,1.548276e-02 ,&
+        & 1.507143e-02 ,1.468249e-02 ,1.431416e-02 ,1.396486e-02 ,1.363318e-02 ,&
+        & 1.331781e-02 ,1.301759e-02 ,1.273147e-02  /)
+      extice2(:, 24) = (/ &
+! band 24
+        & 3.527890e-01 ,2.168469e-01 ,1.560090e-01 ,1.216216e-01 ,9.955787e-02 ,&
+        & 8.421942e-02 ,7.294827e-02 ,6.432192e-02 ,5.751081e-02 ,5.199888e-02 ,&
+        & 4.744835e-02 ,4.362899e-02 ,4.037847e-02 ,3.757910e-02 ,3.514351e-02 ,&
+        & 3.300546e-02 ,3.111382e-02 ,2.942853e-02 ,2.791775e-02 ,2.655584e-02 ,&
+        & 2.532195e-02 ,2.419892e-02 ,2.317255e-02 ,2.223092e-02 ,2.136402e-02 ,&
+        & 2.056334e-02 ,1.982160e-02 ,1.913258e-02 ,1.849087e-02 ,1.789178e-02 ,&
+        & 1.733124e-02 ,1.680565e-02 ,1.631187e-02 ,1.584711e-02 ,1.540889e-02 ,&
+        & 1.499502e-02 ,1.460354e-02 ,1.423269e-02 ,1.388088e-02 ,1.354670e-02 ,&
+        & 1.322887e-02 ,1.292620e-02 ,1.263767e-02  /)
+      extice2(:, 25) = (/ &
+! band 25
+        & 3.477874e-01 ,2.143515e-01 ,1.544887e-01 ,1.205942e-01 ,9.881779e-02 ,&
+        & 8.366261e-02 ,7.251586e-02 ,6.397790e-02 ,5.723183e-02 ,5.176908e-02 ,&
+        & 4.725658e-02 ,4.346715e-02 ,4.024055e-02 ,3.746055e-02 ,3.504080e-02 ,&
+        & 3.291583e-02 ,3.103507e-02 ,2.935891e-02 ,2.785582e-02 ,2.650042e-02 ,&
+        & 2.527206e-02 ,2.415376e-02 ,2.313142e-02 ,2.219326e-02 ,2.132934e-02 ,&
+        & 2.053122e-02 ,1.979169e-02 ,1.910456e-02 ,1.846448e-02 ,1.786680e-02 ,&
+        & 1.730745e-02 ,1.678289e-02 ,1.628998e-02 ,1.582595e-02 ,1.538835e-02 ,&
+        & 1.497499e-02 ,1.458393e-02 ,1.421341e-02 ,1.386187e-02 ,1.352788e-02 ,&
+        & 1.321019e-02 ,1.290762e-02 ,1.261913e-02  /)
+      extice2(:, 26) = (/ &
+! band 26
+        & 3.453721e-01 ,2.130744e-01 ,1.536698e-01 ,1.200140e-01 ,9.838078e-02 ,&
+        & 8.331940e-02 ,7.223803e-02 ,6.374775e-02 ,5.703770e-02 ,5.160290e-02 ,&
+        & 4.711259e-02 ,4.334110e-02 ,4.012923e-02 ,3.736150e-02 ,3.495208e-02 ,&
+        & 3.283589e-02 ,3.096267e-02 ,2.929302e-02 ,2.779560e-02 ,2.644517e-02 ,&
+        & 2.522119e-02 ,2.410677e-02 ,2.308788e-02 ,2.215281e-02 ,2.129165e-02 ,&
+        & 2.049602e-02 ,1.975874e-02 ,1.907365e-02 ,1.843542e-02 ,1.783943e-02 ,&
+        & 1.728162e-02 ,1.675847e-02 ,1.626685e-02 ,1.580401e-02 ,1.536750e-02 ,&
+        & 1.495515e-02 ,1.456502e-02 ,1.419537e-02 ,1.384463e-02 ,1.351139e-02 ,&
+        & 1.319438e-02 ,1.289246e-02 ,1.260456e-02  /)
+      extice2(:, 27) = (/ &
+! band 27
+        & 3.417883e-01 ,2.113379e-01 ,1.526395e-01 ,1.193347e-01 ,9.790253e-02 ,&
+        & 8.296715e-02 ,7.196979e-02 ,6.353806e-02 ,5.687024e-02 ,5.146670e-02 ,&
+        & 4.700001e-02 ,4.324667e-02 ,4.004894e-02 ,3.729233e-02 ,3.489172e-02 ,&
+        & 3.278257e-02 ,3.091499e-02 ,2.924987e-02 ,2.775609e-02 ,2.640859e-02 ,&
+        & 2.518695e-02 ,2.407439e-02 ,2.305697e-02 ,2.212303e-02 ,2.126273e-02 ,&
+        & 2.046774e-02 ,1.973090e-02 ,1.904610e-02 ,1.840801e-02 ,1.781204e-02 ,&
+        & 1.725417e-02 ,1.673086e-02 ,1.623902e-02 ,1.577590e-02 ,1.533906e-02 ,&
+        & 1.492634e-02 ,1.453580e-02 ,1.416571e-02 ,1.381450e-02 ,1.348078e-02 ,&
+        & 1.316327e-02 ,1.286082e-02 ,1.257240e-02  /)
+      extice2(:, 28) = (/ &
+! band 28
+        & 3.416111e-01 ,2.114124e-01 ,1.527734e-01 ,1.194809e-01 ,9.804612e-02 ,&
+        & 8.310287e-02 ,7.209595e-02 ,6.365442e-02 ,5.697710e-02 ,5.156460e-02 ,&
+        & 4.708957e-02 ,4.332850e-02 ,4.012361e-02 ,3.736037e-02 ,3.495364e-02 ,&
+        & 3.283879e-02 ,3.096593e-02 ,2.929589e-02 ,2.779751e-02 ,2.644571e-02 ,&
+        & 2.522004e-02 ,2.410369e-02 ,2.308271e-02 ,2.214542e-02 ,2.128195e-02 ,&
+        & 2.048396e-02 ,1.974429e-02 ,1.905679e-02 ,1.841614e-02 ,1.781774e-02 ,&
+        & 1.725754e-02 ,1.673203e-02 ,1.623807e-02 ,1.577293e-02 ,1.533416e-02 ,&
+        & 1.491958e-02 ,1.452727e-02 ,1.415547e-02 ,1.380262e-02 ,1.346732e-02 ,&
+        & 1.314830e-02 ,1.284439e-02 ,1.255456e-02  /)
+      extice2(:, 29) = (/ &
+! band 29
+        & 4.196611e-01 ,2.493642e-01 ,1.761261e-01 ,1.357197e-01 ,1.102161e-01 ,&
+        & 9.269376e-02 ,7.992985e-02 ,7.022538e-02 ,6.260168e-02 ,5.645603e-02 ,&
+        & 5.139732e-02 ,4.716088e-02 ,4.356133e-02 ,4.046498e-02 ,3.777303e-02 ,&
+        & 3.541094e-02 ,3.332137e-02 ,3.145954e-02 ,2.978998e-02 ,2.828419e-02 ,&
+        & 2.691905e-02 ,2.567559e-02 ,2.453811e-02 ,2.349350e-02 ,2.253072e-02 ,&
+        & 2.164042e-02 ,2.081464e-02 ,2.004652e-02 ,1.933015e-02 ,1.866041e-02 ,&
+        & 1.803283e-02 ,1.744348e-02 ,1.688894e-02 ,1.636616e-02 ,1.587244e-02 ,&
+        & 1.540539e-02 ,1.496287e-02 ,1.454295e-02 ,1.414392e-02 ,1.376423e-02 ,&
+        & 1.340247e-02 ,1.305739e-02 ,1.272784e-02  /)
+
+! single-scattering albedo: unitless
+      ssaice2(:, 16) = (/ &
+! band 16
+        & 6.630615e-01 ,6.451169e-01 ,6.333696e-01 ,6.246927e-01 ,6.178420e-01 ,&
+        & 6.121976e-01 ,6.074069e-01 ,6.032505e-01 ,5.995830e-01 ,5.963030e-01 ,&
+        & 5.933372e-01 ,5.906311e-01 ,5.881427e-01 ,5.858395e-01 ,5.836955e-01 ,&
+        & 5.816896e-01 ,5.798046e-01 ,5.780264e-01 ,5.763429e-01 ,5.747441e-01 ,&
+        & 5.732213e-01 ,5.717672e-01 ,5.703754e-01 ,5.690403e-01 ,5.677571e-01 ,&
+        & 5.665215e-01 ,5.653297e-01 ,5.641782e-01 ,5.630643e-01 ,5.619850e-01 ,&
+        & 5.609381e-01 ,5.599214e-01 ,5.589328e-01 ,5.579707e-01 ,5.570333e-01 ,&
+        & 5.561193e-01 ,5.552272e-01 ,5.543558e-01 ,5.535041e-01 ,5.526708e-01 ,&
+        & 5.518551e-01 ,5.510561e-01 ,5.502729e-01  /)
+      ssaice2(:, 17) = (/ &
+! band 17
+        & 7.689749e-01 ,7.398171e-01 ,7.205819e-01 ,7.065690e-01 ,6.956928e-01 ,&
+        & 6.868989e-01 ,6.795813e-01 ,6.733606e-01 ,6.679838e-01 ,6.632742e-01 ,&
+        & 6.591036e-01 ,6.553766e-01 ,6.520197e-01 ,6.489757e-01 ,6.461991e-01 ,&
+        & 6.436531e-01 ,6.413075e-01 ,6.391375e-01 ,6.371221e-01 ,6.352438e-01 ,&
+        & 6.334876e-01 ,6.318406e-01 ,6.302918e-01 ,6.288315e-01 ,6.274512e-01 ,&
+        & 6.261436e-01 ,6.249022e-01 ,6.237211e-01 ,6.225953e-01 ,6.215201e-01 ,&
+        & 6.204914e-01 ,6.195055e-01 ,6.185592e-01 ,6.176492e-01 ,6.167730e-01 ,&
+        & 6.159280e-01 ,6.151120e-01 ,6.143228e-01 ,6.135587e-01 ,6.128177e-01 ,&
+        & 6.120984e-01 ,6.113993e-01 ,6.107189e-01  /)
+      ssaice2(:, 18) = (/ &
+! band 18
+        & 9.956167e-01 ,9.814770e-01 ,9.716104e-01 ,9.639746e-01 ,9.577179e-01 ,&
+        & 9.524010e-01 ,9.477672e-01 ,9.436527e-01 ,9.399467e-01 ,9.365708e-01 ,&
+        & 9.334672e-01 ,9.305921e-01 ,9.279118e-01 ,9.253993e-01 ,9.230330e-01 ,&
+        & 9.207954e-01 ,9.186719e-01 ,9.166501e-01 ,9.147199e-01 ,9.128722e-01 ,&
+        & 9.110997e-01 ,9.093956e-01 ,9.077544e-01 ,9.061708e-01 ,9.046406e-01 ,&
+        & 9.031598e-01 ,9.017248e-01 ,9.003326e-01 ,8.989804e-01 ,8.976655e-01 ,&
+        & 8.963857e-01 ,8.951389e-01 ,8.939233e-01 ,8.927370e-01 ,8.915785e-01 ,&
+        & 8.904464e-01 ,8.893392e-01 ,8.882559e-01 ,8.871951e-01 ,8.861559e-01 ,&
+        & 8.851373e-01 ,8.841383e-01 ,8.831581e-01  /)
+      ssaice2(:, 19) = (/ &
+! band 19
+        & 9.723177e-01 ,9.452119e-01 ,9.267592e-01 ,9.127393e-01 ,9.014238e-01 ,&
+        & 8.919334e-01 ,8.837584e-01 ,8.765773e-01 ,8.701736e-01 ,8.643950e-01 ,&
+        & 8.591299e-01 ,8.542942e-01 ,8.498230e-01 ,8.456651e-01 ,8.417794e-01 ,&
+        & 8.381324e-01 ,8.346964e-01 ,8.314484e-01 ,8.283687e-01 ,8.254408e-01 ,&
+        & 8.226505e-01 ,8.199854e-01 ,8.174348e-01 ,8.149891e-01 ,8.126403e-01 ,&
+        & 8.103808e-01 ,8.082041e-01 ,8.061044e-01 ,8.040765e-01 ,8.021156e-01 ,&
+        & 8.002174e-01 ,7.983781e-01 ,7.965941e-01 ,7.948622e-01 ,7.931795e-01 ,&
+        & 7.915432e-01 ,7.899508e-01 ,7.884002e-01 ,7.868891e-01 ,7.854156e-01 ,&
+        & 7.839779e-01 ,7.825742e-01 ,7.812031e-01  /)
+      ssaice2(:, 20) = (/ &
+! band 20
+        & 9.933294e-01 ,9.860917e-01 ,9.811564e-01 ,9.774008e-01 ,9.743652e-01 ,&
+        & 9.718155e-01 ,9.696159e-01 ,9.676810e-01 ,9.659531e-01 ,9.643915e-01 ,&
+        & 9.629667e-01 ,9.616561e-01 ,9.604426e-01 ,9.593125e-01 ,9.582548e-01 ,&
+        & 9.572607e-01 ,9.563227e-01 ,9.554347e-01 ,9.545915e-01 ,9.537888e-01 ,&
+        & 9.530226e-01 ,9.522898e-01 ,9.515874e-01 ,9.509130e-01 ,9.502643e-01 ,&
+        & 9.496394e-01 ,9.490366e-01 ,9.484542e-01 ,9.478910e-01 ,9.473456e-01 ,&
+        & 9.468169e-01 ,9.463039e-01 ,9.458056e-01 ,9.453212e-01 ,9.448499e-01 ,&
+        & 9.443910e-01 ,9.439438e-01 ,9.435077e-01 ,9.430821e-01 ,9.426666e-01 ,&
+        & 9.422607e-01 ,9.418638e-01 ,9.414756e-01  /)
+      ssaice2(:, 21) = (/ &
+! band 21
+        & 9.900787e-01 ,9.828880e-01 ,9.779258e-01 ,9.741173e-01 ,9.710184e-01 ,&
+        & 9.684012e-01 ,9.661332e-01 ,9.641301e-01 ,9.623352e-01 ,9.607083e-01 ,&
+        & 9.592198e-01 ,9.578474e-01 ,9.565739e-01 ,9.553856e-01 ,9.542715e-01 ,&
+        & 9.532226e-01 ,9.522314e-01 ,9.512919e-01 ,9.503986e-01 ,9.495472e-01 ,&
+        & 9.487337e-01 ,9.479549e-01 ,9.472077e-01 ,9.464897e-01 ,9.457985e-01 ,&
+        & 9.451322e-01 ,9.444890e-01 ,9.438673e-01 ,9.432656e-01 ,9.426826e-01 ,&
+        & 9.421173e-01 ,9.415684e-01 ,9.410351e-01 ,9.405164e-01 ,9.400115e-01 ,&
+        & 9.395198e-01 ,9.390404e-01 ,9.385728e-01 ,9.381164e-01 ,9.376707e-01 ,&
+        & 9.372350e-01 ,9.368091e-01 ,9.363923e-01  /)
+      ssaice2(:, 22) = (/ &
+! band 22
+        & 9.986793e-01 ,9.985239e-01 ,9.983911e-01 ,9.982715e-01 ,9.981606e-01 ,&
+        & 9.980562e-01 ,9.979567e-01 ,9.978613e-01 ,9.977691e-01 ,9.976798e-01 ,&
+        & 9.975929e-01 ,9.975081e-01 ,9.974251e-01 ,9.973438e-01 ,9.972640e-01 ,&
+        & 9.971855e-01 ,9.971083e-01 ,9.970322e-01 ,9.969571e-01 ,9.968830e-01 ,&
+        & 9.968099e-01 ,9.967375e-01 ,9.966660e-01 ,9.965951e-01 ,9.965250e-01 ,&
+        & 9.964555e-01 ,9.963867e-01 ,9.963185e-01 ,9.962508e-01 ,9.961836e-01 ,&
+        & 9.961170e-01 ,9.960508e-01 ,9.959851e-01 ,9.959198e-01 ,9.958550e-01 ,&
+        & 9.957906e-01 ,9.957266e-01 ,9.956629e-01 ,9.955997e-01 ,9.955367e-01 ,&
+        & 9.954742e-01 ,9.954119e-01 ,9.953500e-01  /)
+      ssaice2(:, 23) = (/ &
+! band 23
+        & 9.997944e-01 ,9.997791e-01 ,9.997664e-01 ,9.997547e-01 ,9.997436e-01 ,&
+        & 9.997327e-01 ,9.997219e-01 ,9.997110e-01 ,9.996999e-01 ,9.996886e-01 ,&
+        & 9.996771e-01 ,9.996653e-01 ,9.996533e-01 ,9.996409e-01 ,9.996282e-01 ,&
+        & 9.996152e-01 ,9.996019e-01 ,9.995883e-01 ,9.995743e-01 ,9.995599e-01 ,&
+        & 9.995453e-01 ,9.995302e-01 ,9.995149e-01 ,9.994992e-01 ,9.994831e-01 ,&
+        & 9.994667e-01 ,9.994500e-01 ,9.994329e-01 ,9.994154e-01 ,9.993976e-01 ,&
+        & 9.993795e-01 ,9.993610e-01 ,9.993422e-01 ,9.993230e-01 ,9.993035e-01 ,&
+        & 9.992837e-01 ,9.992635e-01 ,9.992429e-01 ,9.992221e-01 ,9.992008e-01 ,&
+        & 9.991793e-01 ,9.991574e-01 ,9.991352e-01  /)
+      ssaice2(:, 24) = (/ &
+! band 24
+        & 9.999949e-01 ,9.999947e-01 ,9.999943e-01 ,9.999939e-01 ,9.999934e-01 ,&
+        & 9.999927e-01 ,9.999920e-01 ,9.999913e-01 ,9.999904e-01 ,9.999895e-01 ,&
+        & 9.999885e-01 ,9.999874e-01 ,9.999863e-01 ,9.999851e-01 ,9.999838e-01 ,&
+        & 9.999824e-01 ,9.999810e-01 ,9.999795e-01 ,9.999780e-01 ,9.999764e-01 ,&
+        & 9.999747e-01 ,9.999729e-01 ,9.999711e-01 ,9.999692e-01 ,9.999673e-01 ,&
+        & 9.999653e-01 ,9.999632e-01 ,9.999611e-01 ,9.999589e-01 ,9.999566e-01 ,&
+        & 9.999543e-01 ,9.999519e-01 ,9.999495e-01 ,9.999470e-01 ,9.999444e-01 ,&
+        & 9.999418e-01 ,9.999392e-01 ,9.999364e-01 ,9.999336e-01 ,9.999308e-01 ,&
+        & 9.999279e-01 ,9.999249e-01 ,9.999219e-01  /)
+      ssaice2(:, 25) = (/ &
+! band 25
+        & 9.999997e-01 ,9.999997e-01 ,9.999997e-01 ,9.999996e-01 ,9.999996e-01 ,&
+        & 9.999995e-01 ,9.999994e-01 ,9.999993e-01 ,9.999993e-01 ,9.999992e-01 ,&
+        & 9.999991e-01 ,9.999989e-01 ,9.999988e-01 ,9.999987e-01 ,9.999986e-01 ,&
+        & 9.999984e-01 ,9.999983e-01 ,9.999981e-01 ,9.999980e-01 ,9.999978e-01 ,&
+        & 9.999976e-01 ,9.999974e-01 ,9.999972e-01 ,9.999971e-01 ,9.999969e-01 ,&
+        & 9.999966e-01 ,9.999964e-01 ,9.999962e-01 ,9.999960e-01 ,9.999957e-01 ,&
+        & 9.999955e-01 ,9.999953e-01 ,9.999950e-01 ,9.999947e-01 ,9.999945e-01 ,&
+        & 9.999942e-01 ,9.999939e-01 ,9.999936e-01 ,9.999934e-01 ,9.999931e-01 ,&
+        & 9.999928e-01 ,9.999925e-01 ,9.999921e-01  /)
+      ssaice2(:, 26) = (/ &
+! band 26
+        & 9.999997e-01 ,9.999996e-01 ,9.999996e-01 ,9.999995e-01 ,9.999994e-01 ,&
+        & 9.999993e-01 ,9.999992e-01 ,9.999991e-01 ,9.999990e-01 ,9.999989e-01 ,&
+        & 9.999987e-01 ,9.999986e-01 ,9.999984e-01 ,9.999982e-01 ,9.999980e-01 ,&
+        & 9.999978e-01 ,9.999976e-01 ,9.999974e-01 ,9.999972e-01 ,9.999970e-01 ,&
+        & 9.999967e-01 ,9.999965e-01 ,9.999962e-01 ,9.999959e-01 ,9.999956e-01 ,&
+        & 9.999954e-01 ,9.999951e-01 ,9.999947e-01 ,9.999944e-01 ,9.999941e-01 ,&
+        & 9.999938e-01 ,9.999934e-01 ,9.999931e-01 ,9.999927e-01 ,9.999923e-01 ,&
+        & 9.999920e-01 ,9.999916e-01 ,9.999912e-01 ,9.999908e-01 ,9.999904e-01 ,&
+        & 9.999899e-01 ,9.999895e-01 ,9.999891e-01  /)
+      ssaice2(:, 27) = (/ &
+! band 27
+        & 9.999987e-01 ,9.999987e-01 ,9.999985e-01 ,9.999984e-01 ,9.999982e-01 ,&
+        & 9.999980e-01 ,9.999978e-01 ,9.999976e-01 ,9.999973e-01 ,9.999970e-01 ,&
+        & 9.999967e-01 ,9.999964e-01 ,9.999960e-01 ,9.999956e-01 ,9.999952e-01 ,&
+        & 9.999948e-01 ,9.999944e-01 ,9.999939e-01 ,9.999934e-01 ,9.999929e-01 ,&
+        & 9.999924e-01 ,9.999918e-01 ,9.999913e-01 ,9.999907e-01 ,9.999901e-01 ,&
+        & 9.999894e-01 ,9.999888e-01 ,9.999881e-01 ,9.999874e-01 ,9.999867e-01 ,&
+        & 9.999860e-01 ,9.999853e-01 ,9.999845e-01 ,9.999837e-01 ,9.999829e-01 ,&
+        & 9.999821e-01 ,9.999813e-01 ,9.999804e-01 ,9.999796e-01 ,9.999787e-01 ,&
+        & 9.999778e-01 ,9.999768e-01 ,9.999759e-01  /)
+      ssaice2(:, 28) = (/ &
+! band 28
+        & 9.999989e-01 ,9.999989e-01 ,9.999987e-01 ,9.999986e-01 ,9.999984e-01 ,&
+        & 9.999982e-01 ,9.999980e-01 ,9.999978e-01 ,9.999975e-01 ,9.999972e-01 ,&
+        & 9.999969e-01 ,9.999966e-01 ,9.999962e-01 ,9.999958e-01 ,9.999954e-01 ,&
+        & 9.999950e-01 ,9.999945e-01 ,9.999941e-01 ,9.999936e-01 ,9.999931e-01 ,&
+        & 9.999925e-01 ,9.999920e-01 ,9.999914e-01 ,9.999908e-01 ,9.999902e-01 ,&
+        & 9.999896e-01 ,9.999889e-01 ,9.999883e-01 ,9.999876e-01 ,9.999869e-01 ,&
+        & 9.999861e-01 ,9.999854e-01 ,9.999846e-01 ,9.999838e-01 ,9.999830e-01 ,&
+        & 9.999822e-01 ,9.999814e-01 ,9.999805e-01 ,9.999796e-01 ,9.999787e-01 ,&
+        & 9.999778e-01 ,9.999769e-01 ,9.999759e-01  /)
+      ssaice2(:, 29) = (/ &
+! band 29
+        & 7.042143e-01 ,6.691161e-01 ,6.463240e-01 ,6.296590e-01 ,6.166381e-01 ,&
+        & 6.060183e-01 ,5.970908e-01 ,5.894144e-01 ,5.826968e-01 ,5.767343e-01 ,&
+        & 5.713804e-01 ,5.665256e-01 ,5.620867e-01 ,5.579987e-01 ,5.542101e-01 ,&
+        & 5.506794e-01 ,5.473727e-01 ,5.442620e-01 ,5.413239e-01 ,5.385389e-01 ,&
+        & 5.358901e-01 ,5.333633e-01 ,5.309460e-01 ,5.286277e-01 ,5.263988e-01 ,&
+        & 5.242512e-01 ,5.221777e-01 ,5.201719e-01 ,5.182280e-01 ,5.163410e-01 ,&
+        & 5.145062e-01 ,5.127197e-01 ,5.109776e-01 ,5.092766e-01 ,5.076137e-01 ,&
+        & 5.059860e-01 ,5.043911e-01 ,5.028266e-01 ,5.012904e-01 ,4.997805e-01 ,&
+        & 4.982951e-01 ,4.968326e-01 ,4.953913e-01  /)
+
+! asymmetry factor: unitless
+      asyice2(:, 16) = (/ &
+! band 16
+        & 7.946655e-01 ,8.547685e-01 ,8.806016e-01 ,8.949880e-01 ,9.041676e-01 ,&
+        & 9.105399e-01 ,9.152249e-01 ,9.188160e-01 ,9.216573e-01 ,9.239620e-01 ,&
+        & 9.258695e-01 ,9.274745e-01 ,9.288441e-01 ,9.300267e-01 ,9.310584e-01 ,&
+        & 9.319665e-01 ,9.327721e-01 ,9.334918e-01 ,9.341387e-01 ,9.347236e-01 ,&
+        & 9.352551e-01 ,9.357402e-01 ,9.361850e-01 ,9.365942e-01 ,9.369722e-01 ,&
+        & 9.373225e-01 ,9.376481e-01 ,9.379516e-01 ,9.382352e-01 ,9.385010e-01 ,&
+        & 9.387505e-01 ,9.389854e-01 ,9.392070e-01 ,9.394163e-01 ,9.396145e-01 ,&
+        & 9.398024e-01 ,9.399809e-01 ,9.401508e-01 ,9.403126e-01 ,9.404670e-01 ,&
+        & 9.406144e-01 ,9.407555e-01 ,9.408906e-01  /)
+      asyice2(:, 17) = (/ &
+! band 17
+        & 9.078091e-01 ,9.195850e-01 ,9.267250e-01 ,9.317083e-01 ,9.354632e-01 ,&
+        & 9.384323e-01 ,9.408597e-01 ,9.428935e-01 ,9.446301e-01 ,9.461351e-01 ,&
+        & 9.474555e-01 ,9.486259e-01 ,9.496722e-01 ,9.506146e-01 ,9.514688e-01 ,&
+        & 9.522476e-01 ,9.529612e-01 ,9.536181e-01 ,9.542251e-01 ,9.547883e-01 ,&
+        & 9.553124e-01 ,9.558019e-01 ,9.562601e-01 ,9.566904e-01 ,9.570953e-01 ,&
+        & 9.574773e-01 ,9.578385e-01 ,9.581806e-01 ,9.585054e-01 ,9.588142e-01 ,&
+        & 9.591083e-01 ,9.593888e-01 ,9.596569e-01 ,9.599135e-01 ,9.601593e-01 ,&
+        & 9.603952e-01 ,9.606219e-01 ,9.608399e-01 ,9.610499e-01 ,9.612523e-01 ,&
+        & 9.614477e-01 ,9.616365e-01 ,9.618192e-01  /)
+      asyice2(:, 18) = (/ &
+! band 18
+        & 8.322045e-01 ,8.528693e-01 ,8.648167e-01 ,8.729163e-01 ,8.789054e-01 ,&
+        & 8.835845e-01 ,8.873819e-01 ,8.905511e-01 ,8.932532e-01 ,8.955965e-01 ,&
+        & 8.976567e-01 ,8.994887e-01 ,9.011334e-01 ,9.026221e-01 ,9.039791e-01 ,&
+        & 9.052237e-01 ,9.063715e-01 ,9.074349e-01 ,9.084245e-01 ,9.093489e-01 ,&
+        & 9.102154e-01 ,9.110303e-01 ,9.117987e-01 ,9.125253e-01 ,9.132140e-01 ,&
+        & 9.138682e-01 ,9.144910e-01 ,9.150850e-01 ,9.156524e-01 ,9.161955e-01 ,&
+        & 9.167160e-01 ,9.172157e-01 ,9.176959e-01 ,9.181581e-01 ,9.186034e-01 ,&
+        & 9.190330e-01 ,9.194478e-01 ,9.198488e-01 ,9.202368e-01 ,9.206126e-01 ,&
+        & 9.209768e-01 ,9.213301e-01 ,9.216731e-01  /)
+      asyice2(:, 19) = (/ &
+! band 19
+        & 8.116560e-01 ,8.488278e-01 ,8.674331e-01 ,8.788148e-01 ,8.865810e-01 ,&
+        & 8.922595e-01 ,8.966149e-01 ,9.000747e-01 ,9.028980e-01 ,9.052513e-01 ,&
+        & 9.072468e-01 ,9.089632e-01 ,9.104574e-01 ,9.117713e-01 ,9.129371e-01 ,&
+        & 9.139793e-01 ,9.149174e-01 ,9.157668e-01 ,9.165400e-01 ,9.172473e-01 ,&
+        & 9.178970e-01 ,9.184962e-01 ,9.190508e-01 ,9.195658e-01 ,9.200455e-01 ,&
+        & 9.204935e-01 ,9.209130e-01 ,9.213067e-01 ,9.216771e-01 ,9.220262e-01 ,&
+        & 9.223560e-01 ,9.226680e-01 ,9.229636e-01 ,9.232443e-01 ,9.235112e-01 ,&
+        & 9.237652e-01 ,9.240074e-01 ,9.242385e-01 ,9.244594e-01 ,9.246708e-01 ,&
+        & 9.248733e-01 ,9.250674e-01 ,9.252536e-01  /)
+      asyice2(:, 20) = (/ &
+! band 20
+        & 8.047113e-01 ,8.402864e-01 ,8.570332e-01 ,8.668455e-01 ,8.733206e-01 ,&
+        & 8.779272e-01 ,8.813796e-01 ,8.840676e-01 ,8.862225e-01 ,8.879904e-01 ,&
+        & 8.894682e-01 ,8.907228e-01 ,8.918019e-01 ,8.927404e-01 ,8.935645e-01 ,&
+        & 8.942943e-01 ,8.949452e-01 ,8.955296e-01 ,8.960574e-01 ,8.965366e-01 ,&
+        & 8.969736e-01 ,8.973740e-01 ,8.977422e-01 ,8.980820e-01 ,8.983966e-01 ,&
+        & 8.986889e-01 ,8.989611e-01 ,8.992153e-01 ,8.994533e-01 ,8.996766e-01 ,&
+        & 8.998865e-01 ,9.000843e-01 ,9.002709e-01 ,9.004474e-01 ,9.006146e-01 ,&
+        & 9.007731e-01 ,9.009237e-01 ,9.010670e-01 ,9.012034e-01 ,9.013336e-01 ,&
+        & 9.014579e-01 ,9.015767e-01 ,9.016904e-01  /)
+      asyice2(:, 21) = (/ &
+! band 21
+        & 8.179122e-01 ,8.480726e-01 ,8.621945e-01 ,8.704354e-01 ,8.758555e-01 ,&
+        & 8.797007e-01 ,8.825750e-01 ,8.848078e-01 ,8.865939e-01 ,8.880564e-01 ,&
+        & 8.892765e-01 ,8.903105e-01 ,8.911982e-01 ,8.919689e-01 ,8.926446e-01 ,&
+        & 8.932419e-01 ,8.937738e-01 ,8.942506e-01 ,8.946806e-01 ,8.950702e-01 ,&
+        & 8.954251e-01 ,8.957497e-01 ,8.960477e-01 ,8.963223e-01 ,8.965762e-01 ,&
+        & 8.968116e-01 ,8.970306e-01 ,8.972347e-01 ,8.974255e-01 ,8.976042e-01 ,&
+        & 8.977720e-01 ,8.979298e-01 ,8.980784e-01 ,8.982188e-01 ,8.983515e-01 ,&
+        & 8.984771e-01 ,8.985963e-01 ,8.987095e-01 ,8.988171e-01 ,8.989195e-01 ,&
+        & 8.990172e-01 ,8.991104e-01 ,8.991994e-01  /)
+      asyice2(:, 22) = (/ &
+! band 22
+        & 8.169789e-01 ,8.455024e-01 ,8.586925e-01 ,8.663283e-01 ,8.713217e-01 ,&
+        & 8.748488e-01 ,8.774765e-01 ,8.795122e-01 ,8.811370e-01 ,8.824649e-01 ,&
+        & 8.835711e-01 ,8.845073e-01 ,8.853103e-01 ,8.860068e-01 ,8.866170e-01 ,&
+        & 8.871560e-01 ,8.876358e-01 ,8.880658e-01 ,8.884533e-01 ,8.888044e-01 ,&
+        & 8.891242e-01 ,8.894166e-01 ,8.896851e-01 ,8.899324e-01 ,8.901612e-01 ,&
+        & 8.903733e-01 ,8.905706e-01 ,8.907545e-01 ,8.909265e-01 ,8.910876e-01 ,&
+        & 8.912388e-01 ,8.913812e-01 ,8.915153e-01 ,8.916419e-01 ,8.917617e-01 ,&
+        & 8.918752e-01 ,8.919829e-01 ,8.920851e-01 ,8.921824e-01 ,8.922751e-01 ,&
+        & 8.923635e-01 ,8.924478e-01 ,8.925284e-01  /)
+      asyice2(:, 23) = (/ &
+! band 23
+        & 8.387642e-01 ,8.569979e-01 ,8.658630e-01 ,8.711825e-01 ,8.747605e-01 ,&
+        & 8.773472e-01 ,8.793129e-01 ,8.808621e-01 ,8.821179e-01 ,8.831583e-01 ,&
+        & 8.840361e-01 ,8.847875e-01 ,8.854388e-01 ,8.860094e-01 ,8.865138e-01 ,&
+        & 8.869634e-01 ,8.873668e-01 ,8.877310e-01 ,8.880617e-01 ,8.883635e-01 ,&
+        & 8.886401e-01 ,8.888947e-01 ,8.891298e-01 ,8.893477e-01 ,8.895504e-01 ,&
+        & 8.897393e-01 ,8.899159e-01 ,8.900815e-01 ,8.902370e-01 ,8.903833e-01 ,&
+        & 8.905214e-01 ,8.906518e-01 ,8.907753e-01 ,8.908924e-01 ,8.910036e-01 ,&
+        & 8.911094e-01 ,8.912101e-01 ,8.913062e-01 ,8.913979e-01 ,8.914856e-01 ,&
+        & 8.915695e-01 ,8.916498e-01 ,8.917269e-01  /)
+      asyice2(:, 24) = (/ &
+! band 24
+        & 8.522208e-01 ,8.648132e-01 ,8.711224e-01 ,8.749901e-01 ,8.776354e-01 ,&
+        & 8.795743e-01 ,8.810649e-01 ,8.822518e-01 ,8.832225e-01 ,8.840333e-01 ,&
+        & 8.847224e-01 ,8.853162e-01 ,8.858342e-01 ,8.862906e-01 ,8.866962e-01 ,&
+        & 8.870595e-01 ,8.873871e-01 ,8.876842e-01 ,8.879551e-01 ,8.882032e-01 ,&
+        & 8.884316e-01 ,8.886425e-01 ,8.888380e-01 ,8.890199e-01 ,8.891895e-01 ,&
+        & 8.893481e-01 ,8.894968e-01 ,8.896366e-01 ,8.897683e-01 ,8.898926e-01 ,&
+        & 8.900102e-01 ,8.901215e-01 ,8.902272e-01 ,8.903276e-01 ,8.904232e-01 ,&
+        & 8.905144e-01 ,8.906014e-01 ,8.906845e-01 ,8.907640e-01 ,8.908402e-01 ,&
+        & 8.909132e-01 ,8.909834e-01 ,8.910507e-01  /)
+      asyice2(:, 25) = (/ &
+! band 25
+        & 8.578202e-01 ,8.683033e-01 ,8.735431e-01 ,8.767488e-01 ,8.789378e-01 ,&
+        & 8.805399e-01 ,8.817701e-01 ,8.827485e-01 ,8.835480e-01 ,8.842152e-01 ,&
+        & 8.847817e-01 ,8.852696e-01 ,8.856949e-01 ,8.860694e-01 ,8.864020e-01 ,&
+        & 8.866997e-01 ,8.869681e-01 ,8.872113e-01 ,8.874330e-01 ,8.876360e-01 ,&
+        & 8.878227e-01 ,8.879951e-01 ,8.881548e-01 ,8.883033e-01 ,8.884418e-01 ,&
+        & 8.885712e-01 ,8.886926e-01 ,8.888066e-01 ,8.889139e-01 ,8.890152e-01 ,&
+        & 8.891110e-01 ,8.892017e-01 ,8.892877e-01 ,8.893695e-01 ,8.894473e-01 ,&
+        & 8.895214e-01 ,8.895921e-01 ,8.896597e-01 ,8.897243e-01 ,8.897862e-01 ,&
+        & 8.898456e-01 ,8.899025e-01 ,8.899572e-01  /)
+      asyice2(:, 26) = (/ &
+! band 26
+        & 8.625615e-01 ,8.713831e-01 ,8.755799e-01 ,8.780560e-01 ,8.796983e-01 ,&
+        & 8.808714e-01 ,8.817534e-01 ,8.824420e-01 ,8.829953e-01 ,8.834501e-01 ,&
+        & 8.838310e-01 ,8.841549e-01 ,8.844338e-01 ,8.846767e-01 ,8.848902e-01 ,&
+        & 8.850795e-01 ,8.852484e-01 ,8.854002e-01 ,8.855374e-01 ,8.856620e-01 ,&
+        & 8.857758e-01 ,8.858800e-01 ,8.859759e-01 ,8.860644e-01 ,8.861464e-01 ,&
+        & 8.862225e-01 ,8.862935e-01 ,8.863598e-01 ,8.864218e-01 ,8.864800e-01 ,&
+        & 8.865347e-01 ,8.865863e-01 ,8.866349e-01 ,8.866809e-01 ,8.867245e-01 ,&
+        & 8.867658e-01 ,8.868050e-01 ,8.868423e-01 ,8.868778e-01 ,8.869117e-01 ,&
+        & 8.869440e-01 ,8.869749e-01 ,8.870044e-01  /)
+      asyice2(:, 27) = (/ &
+! band 27
+        & 8.587495e-01 ,8.684764e-01 ,8.728189e-01 ,8.752872e-01 ,8.768846e-01 ,&
+        & 8.780060e-01 ,8.788386e-01 ,8.794824e-01 ,8.799960e-01 ,8.804159e-01 ,&
+        & 8.807660e-01 ,8.810626e-01 ,8.813175e-01 ,8.815390e-01 ,8.817335e-01 ,&
+        & 8.819057e-01 ,8.820593e-01 ,8.821973e-01 ,8.823220e-01 ,8.824353e-01 ,&
+        & 8.825387e-01 ,8.826336e-01 ,8.827209e-01 ,8.828016e-01 ,8.828764e-01 ,&
+        & 8.829459e-01 ,8.830108e-01 ,8.830715e-01 ,8.831283e-01 ,8.831817e-01 ,&
+        & 8.832320e-01 ,8.832795e-01 ,8.833244e-01 ,8.833668e-01 ,8.834071e-01 ,&
+        & 8.834454e-01 ,8.834817e-01 ,8.835164e-01 ,8.835495e-01 ,8.835811e-01 ,&
+        & 8.836113e-01 ,8.836402e-01 ,8.836679e-01  /)
+      asyice2(:, 28) = (/ &
+! band 28
+        & 8.561110e-01 ,8.678583e-01 ,8.727554e-01 ,8.753892e-01 ,8.770154e-01 ,&
+        & 8.781109e-01 ,8.788949e-01 ,8.794812e-01 ,8.799348e-01 ,8.802952e-01 ,&
+        & 8.805880e-01 ,8.808300e-01 ,8.810331e-01 ,8.812058e-01 ,8.813543e-01 ,&
+        & 8.814832e-01 ,8.815960e-01 ,8.816956e-01 ,8.817839e-01 ,8.818629e-01 ,&
+        & 8.819339e-01 ,8.819979e-01 ,8.820560e-01 ,8.821089e-01 ,8.821573e-01 ,&
+        & 8.822016e-01 ,8.822425e-01 ,8.822801e-01 ,8.823150e-01 ,8.823474e-01 ,&
+        & 8.823775e-01 ,8.824056e-01 ,8.824318e-01 ,8.824564e-01 ,8.824795e-01 ,&
+        & 8.825011e-01 ,8.825215e-01 ,8.825408e-01 ,8.825589e-01 ,8.825761e-01 ,&
+        & 8.825924e-01 ,8.826078e-01 ,8.826224e-01  /)
+      asyice2(:, 29) = (/ &
+! band 29
+        & 8.311124e-01 ,8.688197e-01 ,8.900274e-01 ,9.040696e-01 ,9.142334e-01 ,&
+        & 9.220181e-01 ,9.282195e-01 ,9.333048e-01 ,9.375689e-01 ,9.412085e-01 ,&
+        & 9.443604e-01 ,9.471230e-01 ,9.495694e-01 ,9.517549e-01 ,9.537224e-01 ,&
+        & 9.555057e-01 ,9.571316e-01 ,9.586222e-01 ,9.599952e-01 ,9.612656e-01 ,&
+        & 9.624458e-01 ,9.635461e-01 ,9.645756e-01 ,9.655418e-01 ,9.664513e-01 ,&
+        & 9.673098e-01 ,9.681222e-01 ,9.688928e-01 ,9.696256e-01 ,9.703237e-01 ,&
+        & 9.709903e-01 ,9.716280e-01 ,9.722391e-01 ,9.728258e-01 ,9.733901e-01 ,&
+        & 9.739336e-01 ,9.744579e-01 ,9.749645e-01 ,9.754546e-01 ,9.759294e-01 ,&
+        & 9.763901e-01 ,9.768376e-01 ,9.772727e-01  /)
+
+! Hexagonal Ice Particle Parameterization
+! extinction units (ext coef/iwc): [(m^-1)/(g m^-3)]
+      extice3(:, 16) = (/ &
+! band 16
+        & 5.194013e-01 ,3.215089e-01 ,2.327917e-01 ,1.824424e-01 ,1.499977e-01 ,&
+        & 1.273492e-01 ,1.106421e-01 ,9.780982e-02 ,8.764435e-02 ,7.939266e-02 ,&
+        & 7.256081e-02 ,6.681137e-02 ,6.190600e-02 ,5.767154e-02 ,5.397915e-02 ,&
+        & 5.073102e-02 ,4.785151e-02 ,4.528125e-02 ,4.297296e-02 ,4.088853e-02 ,&
+        & 3.899690e-02 ,3.727251e-02 ,3.569411e-02 ,3.424393e-02 ,3.290694e-02 ,&
+        & 3.167040e-02 ,3.052340e-02 ,2.945654e-02 ,2.846172e-02 ,2.753188e-02 ,&
+        & 2.666085e-02 ,2.584322e-02 ,2.507423e-02 ,2.434967e-02 ,2.366579e-02 ,&
+        & 2.301926e-02 ,2.240711e-02 ,2.182666e-02 ,2.127551e-02 ,2.075150e-02 ,&
+        & 2.025267e-02 ,1.977725e-02 ,1.932364e-02 ,1.889035e-02 ,1.847607e-02 ,&
+        & 1.807956e-02  /)
+      extice3(:, 17) = (/ &
+! band 17
+        & 4.901155e-01 ,3.065286e-01 ,2.230800e-01 ,1.753951e-01 ,1.445402e-01 ,&
+        & 1.229417e-01 ,1.069777e-01 ,9.469760e-02 ,8.495824e-02 ,7.704501e-02 ,&
+        & 7.048834e-02 ,6.496693e-02 ,6.025353e-02 ,5.618286e-02 ,5.263186e-02 ,&
+        & 4.950698e-02 ,4.673585e-02 ,4.426164e-02 ,4.203904e-02 ,4.003153e-02 ,&
+        & 3.820932e-02 ,3.654790e-02 ,3.502688e-02 ,3.362919e-02 ,3.234041e-02 ,&
+        & 3.114829e-02 ,3.004234e-02 ,2.901356e-02 ,2.805413e-02 ,2.715727e-02 ,&
+        & 2.631705e-02 ,2.552828e-02 ,2.478637e-02 ,2.408725e-02 ,2.342734e-02 ,&
+        & 2.280343e-02 ,2.221264e-02 ,2.165242e-02 ,2.112043e-02 ,2.061461e-02 ,&
+        & 2.013308e-02 ,1.967411e-02 ,1.923616e-02 ,1.881783e-02 ,1.841781e-02 ,&
+        & 1.803494e-02  /)
+      extice3(:, 18) = (/ &
+! band 18
+        & 5.056264e-01 ,3.160261e-01 ,2.298442e-01 ,1.805973e-01 ,1.487318e-01 ,&
+        & 1.264258e-01 ,1.099389e-01 ,9.725656e-02 ,8.719819e-02 ,7.902576e-02 ,&
+        & 7.225433e-02 ,6.655206e-02 ,6.168427e-02 ,5.748028e-02 ,5.381296e-02 ,&
+        & 5.058572e-02 ,4.772383e-02 ,4.516857e-02 ,4.287317e-02 ,4.079990e-02 ,&
+        & 3.891801e-02 ,3.720217e-02 ,3.563133e-02 ,3.418786e-02 ,3.285686e-02 ,&
+        & 3.162569e-02 ,3.048352e-02 ,2.942104e-02 ,2.843018e-02 ,2.750395e-02 ,&
+        & 2.663621e-02 ,2.582160e-02 ,2.505539e-02 ,2.433337e-02 ,2.365185e-02 ,&
+        & 2.300750e-02 ,2.239736e-02 ,2.181878e-02 ,2.126937e-02 ,2.074699e-02 ,&
+        & 2.024968e-02 ,1.977567e-02 ,1.932338e-02 ,1.889134e-02 ,1.847823e-02 ,&
+        & 1.808281e-02  /)
+      extice3(:, 19) = (/ &
+! band 19
+        & 4.881605e-01 ,3.055237e-01 ,2.225070e-01 ,1.750688e-01 ,1.443736e-01 ,&
+        & 1.228869e-01 ,1.070054e-01 ,9.478893e-02 ,8.509997e-02 ,7.722769e-02 ,&
+        & 7.070495e-02 ,6.521211e-02 ,6.052311e-02 ,5.647351e-02 ,5.294088e-02 ,&
+        & 4.983217e-02 ,4.707539e-02 ,4.461398e-02 ,4.240288e-02 ,4.040575e-02 ,&
+        & 3.859298e-02 ,3.694016e-02 ,3.542701e-02 ,3.403655e-02 ,3.275444e-02 ,&
+        & 3.156849e-02 ,3.046827e-02 ,2.944481e-02 ,2.849034e-02 ,2.759812e-02 ,&
+        & 2.676226e-02 ,2.597757e-02 ,2.523949e-02 ,2.454400e-02 ,2.388750e-02 ,&
+        & 2.326682e-02 ,2.267909e-02 ,2.212176e-02 ,2.159253e-02 ,2.108933e-02 ,&
+        & 2.061028e-02 ,2.015369e-02 ,1.971801e-02 ,1.930184e-02 ,1.890389e-02 ,&
+        & 1.852300e-02  /)
+      extice3(:, 20) = (/ &
+! band 20
+        & 5.103703e-01 ,3.188144e-01 ,2.317435e-01 ,1.819887e-01 ,1.497944e-01 ,&
+        & 1.272584e-01 ,1.106013e-01 ,9.778822e-02 ,8.762610e-02 ,7.936938e-02 ,&
+        & 7.252809e-02 ,6.676701e-02 ,6.184901e-02 ,5.760165e-02 ,5.389651e-02 ,&
+        & 5.063598e-02 ,4.774457e-02 ,4.516295e-02 ,4.284387e-02 ,4.074922e-02 ,&
+        & 3.884792e-02 ,3.711438e-02 ,3.552734e-02 ,3.406898e-02 ,3.272425e-02 ,&
+        & 3.148038e-02 ,3.032643e-02 ,2.925299e-02 ,2.825191e-02 ,2.731612e-02 ,&
+        & 2.643943e-02 ,2.561642e-02 ,2.484230e-02 ,2.411284e-02 ,2.342429e-02 ,&
+        & 2.277329e-02 ,2.215686e-02 ,2.157231e-02 ,2.101724e-02 ,2.048946e-02 ,&
+        & 1.998702e-02 ,1.950813e-02 ,1.905118e-02 ,1.861468e-02 ,1.819730e-02 ,&
+        & 1.779781e-02  /)
+      extice3(:, 21) = (/ &
+! band 21
+        & 5.031161e-01 ,3.144511e-01 ,2.286942e-01 ,1.796903e-01 ,1.479819e-01 ,&
+        & 1.257860e-01 ,1.093803e-01 ,9.676059e-02 ,8.675183e-02 ,7.861971e-02 ,&
+        & 7.188168e-02 ,6.620754e-02 ,6.136376e-02 ,5.718050e-02 ,5.353127e-02 ,&
+        & 5.031995e-02 ,4.747218e-02 ,4.492952e-02 ,4.264544e-02 ,4.058240e-02 ,&
+        & 3.870979e-02 ,3.700242e-02 ,3.543933e-02 ,3.400297e-02 ,3.267854e-02 ,&
+        & 3.145345e-02 ,3.031691e-02 ,2.925967e-02 ,2.827370e-02 ,2.735203e-02 ,&
+        & 2.648858e-02 ,2.567798e-02 ,2.491555e-02 ,2.419710e-02 ,2.351893e-02 ,&
+        & 2.287776e-02 ,2.227063e-02 ,2.169491e-02 ,2.114821e-02 ,2.062840e-02 ,&
+        & 2.013354e-02 ,1.966188e-02 ,1.921182e-02 ,1.878191e-02 ,1.837083e-02 ,&
+        & 1.797737e-02  /)
+      extice3(:, 22) = (/ &
+! band 22
+        & 4.949453e-01 ,3.095918e-01 ,2.253402e-01 ,1.771964e-01 ,1.460446e-01 ,&
+        & 1.242383e-01 ,1.081206e-01 ,9.572235e-02 ,8.588928e-02 ,7.789990e-02 ,&
+        & 7.128013e-02 ,6.570559e-02 ,6.094684e-02 ,5.683701e-02 ,5.325183e-02 ,&
+        & 5.009688e-02 ,4.729909e-02 ,4.480106e-02 ,4.255708e-02 ,4.053025e-02 ,&
+        & 3.869051e-02 ,3.701310e-02 ,3.547745e-02 ,3.406631e-02 ,3.276512e-02 ,&
+        & 3.156153e-02 ,3.044494e-02 ,2.940626e-02 ,2.843759e-02 ,2.753211e-02 ,&
+        & 2.668381e-02 ,2.588744e-02 ,2.513839e-02 ,2.443255e-02 ,2.376629e-02 ,&
+        & 2.313637e-02 ,2.253990e-02 ,2.197428e-02 ,2.143718e-02 ,2.092649e-02 ,&
+        & 2.044032e-02 ,1.997694e-02 ,1.953478e-02 ,1.911241e-02 ,1.870855e-02 ,&
+        & 1.832199e-02  /)
+      extice3(:, 23) = (/ &
+! band 23
+        & 5.052816e-01 ,3.157665e-01 ,2.296233e-01 ,1.803986e-01 ,1.485473e-01 ,&
+        & 1.262514e-01 ,1.097718e-01 ,9.709524e-02 ,8.704139e-02 ,7.887264e-02 ,&
+        & 7.210424e-02 ,6.640454e-02 ,6.153894e-02 ,5.733683e-02 ,5.367116e-02 ,&
+        & 5.044537e-02 ,4.758477e-02 ,4.503066e-02 ,4.273629e-02 ,4.066395e-02 ,&
+        & 3.878291e-02 ,3.706784e-02 ,3.549771e-02 ,3.405488e-02 ,3.272448e-02 ,&
+        & 3.149387e-02 ,3.035221e-02 ,2.929020e-02 ,2.829979e-02 ,2.737397e-02 ,&
+        & 2.650663e-02 ,2.569238e-02 ,2.492651e-02 ,2.420482e-02 ,2.352361e-02 ,&
+        & 2.287954e-02 ,2.226968e-02 ,2.169136e-02 ,2.114220e-02 ,2.062005e-02 ,&
+        & 2.012296e-02 ,1.964917e-02 ,1.919709e-02 ,1.876524e-02 ,1.835231e-02 ,&
+        & 1.795707e-02  /)
+      extice3(:, 24) = (/ &
+! band 24
+        & 5.042067e-01 ,3.151195e-01 ,2.291708e-01 ,1.800573e-01 ,1.482779e-01 ,&
+        & 1.260324e-01 ,1.095900e-01 ,9.694202e-02 ,8.691087e-02 ,7.876056e-02 ,&
+        & 7.200745e-02 ,6.632062e-02 ,6.146600e-02 ,5.727338e-02 ,5.361599e-02 ,&
+        & 5.039749e-02 ,4.754334e-02 ,4.499500e-02 ,4.270580e-02 ,4.063815e-02 ,&
+        & 3.876135e-02 ,3.705016e-02 ,3.548357e-02 ,3.404400e-02 ,3.271661e-02 ,&
+        & 3.148877e-02 ,3.034969e-02 ,2.929008e-02 ,2.830191e-02 ,2.737818e-02 ,&
+        & 2.651279e-02 ,2.570039e-02 ,2.493624e-02 ,2.421618e-02 ,2.353650e-02 ,&
+        & 2.289390e-02 ,2.228541e-02 ,2.170840e-02 ,2.116048e-02 ,2.063950e-02 ,&
+        & 2.014354e-02 ,1.967082e-02 ,1.921975e-02 ,1.878888e-02 ,1.837688e-02 ,&
+        & 1.798254e-02  /)
+      extice3(:, 25) = (/ &
+! band 25
+        & 5.022507e-01 ,3.139246e-01 ,2.283218e-01 ,1.794059e-01 ,1.477544e-01 ,&
+        & 1.255984e-01 ,1.092222e-01 ,9.662516e-02 ,8.663439e-02 ,7.851688e-02 ,&
+        & 7.179095e-02 ,6.612700e-02 ,6.129193e-02 ,5.711618e-02 ,5.347351e-02 ,&
+        & 5.026796e-02 ,4.742530e-02 ,4.488721e-02 ,4.260724e-02 ,4.054790e-02 ,&
+        & 3.867866e-02 ,3.697435e-02 ,3.541407e-02 ,3.398029e-02 ,3.265824e-02 ,&
+        & 3.143535e-02 ,3.030085e-02 ,2.924551e-02 ,2.826131e-02 ,2.734130e-02 ,&
+        & 2.647939e-02 ,2.567026e-02 ,2.490919e-02 ,2.419203e-02 ,2.351509e-02 ,&
+        & 2.287507e-02 ,2.226903e-02 ,2.169434e-02 ,2.114862e-02 ,2.062975e-02 ,&
+        & 2.013578e-02 ,1.966496e-02 ,1.921571e-02 ,1.878658e-02 ,1.837623e-02 ,&
+        & 1.798348e-02  /)
+      extice3(:, 26) = (/ &
+! band 26
+        & 5.068316e-01 ,3.166869e-01 ,2.302576e-01 ,1.808693e-01 ,1.489122e-01 ,&
+        & 1.265423e-01 ,1.100080e-01 ,9.728926e-02 ,8.720201e-02 ,7.900612e-02 ,&
+        & 7.221524e-02 ,6.649660e-02 ,6.161484e-02 ,5.739877e-02 ,5.372093e-02 ,&
+        & 5.048442e-02 ,4.761431e-02 ,4.505172e-02 ,4.274972e-02 ,4.067050e-02 ,&
+        & 3.878321e-02 ,3.706244e-02 ,3.548710e-02 ,3.403948e-02 ,3.270466e-02 ,&
+        & 3.146995e-02 ,3.032450e-02 ,2.925897e-02 ,2.826527e-02 ,2.733638e-02 ,&
+        & 2.646615e-02 ,2.564920e-02 ,2.488078e-02 ,2.415670e-02 ,2.347322e-02 ,&
+        & 2.282702e-02 ,2.221513e-02 ,2.163489e-02 ,2.108390e-02 ,2.056002e-02 ,&
+        & 2.006128e-02 ,1.958591e-02 ,1.913232e-02 ,1.869904e-02 ,1.828474e-02 ,&
+        & 1.788819e-02  /)
+      extice3(:, 27) = (/ &
+! band 27
+        & 5.077707e-01 ,3.172636e-01 ,2.306695e-01 ,1.811871e-01 ,1.491691e-01 ,&
+        & 1.267565e-01 ,1.101907e-01 ,9.744773e-02 ,8.734125e-02 ,7.912973e-02 ,&
+        & 7.232591e-02 ,6.659637e-02 ,6.170530e-02 ,5.748120e-02 ,5.379634e-02 ,&
+        & 5.055367e-02 ,4.767809e-02 ,4.511061e-02 ,4.280423e-02 ,4.072104e-02 ,&
+        & 3.883015e-02 ,3.710611e-02 ,3.552776e-02 ,3.407738e-02 ,3.274002e-02 ,&
+        & 3.150296e-02 ,3.035532e-02 ,2.928776e-02 ,2.829216e-02 ,2.736150e-02 ,&
+        & 2.648961e-02 ,2.567111e-02 ,2.490123e-02 ,2.417576e-02 ,2.349098e-02 ,&
+        & 2.284354e-02 ,2.223049e-02 ,2.164914e-02 ,2.109711e-02 ,2.057222e-02 ,&
+        & 2.007253e-02 ,1.959626e-02 ,1.914181e-02 ,1.870770e-02 ,1.829261e-02 ,&
+        & 1.789531e-02  /)
+      extice3(:, 28) = (/ &
+! band 28
+        & 5.062281e-01 ,3.163402e-01 ,2.300275e-01 ,1.807060e-01 ,1.487921e-01 ,&
+        & 1.264523e-01 ,1.099403e-01 ,9.723879e-02 ,8.716516e-02 ,7.898034e-02 ,&
+        & 7.219863e-02 ,6.648771e-02 ,6.161254e-02 ,5.740217e-02 ,5.372929e-02 ,&
+        & 5.049716e-02 ,4.763092e-02 ,4.507179e-02 ,4.277290e-02 ,4.069649e-02 ,&
+        & 3.881175e-02 ,3.709331e-02 ,3.552008e-02 ,3.407442e-02 ,3.274141e-02 ,&
+        & 3.150837e-02 ,3.036447e-02 ,2.930037e-02 ,2.830801e-02 ,2.738037e-02 ,&
+        & 2.651132e-02 ,2.569547e-02 ,2.492810e-02 ,2.420499e-02 ,2.352243e-02 ,&
+        & 2.287710e-02 ,2.226604e-02 ,2.168658e-02 ,2.113634e-02 ,2.061316e-02 ,&
+        & 2.011510e-02 ,1.964038e-02 ,1.918740e-02 ,1.875471e-02 ,1.834096e-02 ,&
+        & 1.794495e-02  /)
+      extice3(:, 29) = (/ &
+! band 29
+        & 1.338834e-01 ,1.924912e-01 ,1.755523e-01 ,1.534793e-01 ,1.343937e-01 ,&
+        & 1.187883e-01 ,1.060654e-01 ,9.559106e-02 ,8.685880e-02 ,7.948698e-02 ,&
+        & 7.319086e-02 ,6.775669e-02 ,6.302215e-02 ,5.886236e-02 ,5.517996e-02 ,&
+        & 5.189810e-02 ,4.895539e-02 ,4.630225e-02 ,4.389823e-02 ,4.171002e-02 ,&
+        & 3.970998e-02 ,3.787493e-02 ,3.618537e-02 ,3.462471e-02 ,3.317880e-02 ,&
+        & 3.183547e-02 ,3.058421e-02 ,2.941590e-02 ,2.832256e-02 ,2.729724e-02 ,&
+        & 2.633377e-02 ,2.542675e-02 ,2.457136e-02 ,2.376332e-02 ,2.299882e-02 ,&
+        & 2.227443e-02 ,2.158707e-02 ,2.093400e-02 ,2.031270e-02 ,1.972091e-02 ,&
+        & 1.915659e-02 ,1.861787e-02 ,1.810304e-02 ,1.761055e-02 ,1.713899e-02 ,&
+        & 1.668704e-02  /)
+
+! single-scattering albedo: unitless
+      ssaice3(:, 16) = (/ &
+! band 16
+        & 6.749442e-01 ,6.649947e-01 ,6.565828e-01 ,6.489928e-01 ,6.420046e-01 ,&
+        & 6.355231e-01 ,6.294964e-01 ,6.238901e-01 ,6.186783e-01 ,6.138395e-01 ,&
+        & 6.093543e-01 ,6.052049e-01 ,6.013742e-01 ,5.978457e-01 ,5.946030e-01 ,&
+        & 5.916302e-01 ,5.889115e-01 ,5.864310e-01 ,5.841731e-01 ,5.821221e-01 ,&
+        & 5.802624e-01 ,5.785785e-01 ,5.770549e-01 ,5.756759e-01 ,5.744262e-01 ,&
+        & 5.732901e-01 ,5.722524e-01 ,5.712974e-01 ,5.704097e-01 ,5.695739e-01 ,&
+        & 5.687747e-01 ,5.679964e-01 ,5.672238e-01 ,5.664415e-01 ,5.656340e-01 ,&
+        & 5.647860e-01 ,5.638821e-01 ,5.629070e-01 ,5.618452e-01 ,5.606815e-01 ,&
+        & 5.594006e-01 ,5.579870e-01 ,5.564255e-01 ,5.547008e-01 ,5.527976e-01 ,&
+        & 5.507005e-01  /)
+      ssaice3(:, 17) = (/ &
+! band 17
+        & 7.628550e-01 ,7.567297e-01 ,7.508463e-01 ,7.451972e-01 ,7.397745e-01 ,&
+        & 7.345705e-01 ,7.295775e-01 ,7.247881e-01 ,7.201945e-01 ,7.157894e-01 ,&
+        & 7.115652e-01 ,7.075145e-01 ,7.036300e-01 ,6.999044e-01 ,6.963304e-01 ,&
+        & 6.929007e-01 ,6.896083e-01 ,6.864460e-01 ,6.834067e-01 ,6.804833e-01 ,&
+        & 6.776690e-01 ,6.749567e-01 ,6.723397e-01 ,6.698109e-01 ,6.673637e-01 ,&
+        & 6.649913e-01 ,6.626870e-01 ,6.604441e-01 ,6.582561e-01 ,6.561163e-01 ,&
+        & 6.540182e-01 ,6.519554e-01 ,6.499215e-01 ,6.479099e-01 ,6.459145e-01 ,&
+        & 6.439289e-01 ,6.419468e-01 ,6.399621e-01 ,6.379686e-01 ,6.359601e-01 ,&
+        & 6.339306e-01 ,6.318740e-01 ,6.297845e-01 ,6.276559e-01 ,6.254825e-01 ,&
+        & 6.232583e-01  /)
+      ssaice3(:, 18) = (/ &
+! band 18
+        & 9.924147e-01 ,9.882792e-01 ,9.842257e-01 ,9.802522e-01 ,9.763566e-01 ,&
+        & 9.725367e-01 ,9.687905e-01 ,9.651157e-01 ,9.615104e-01 ,9.579725e-01 ,&
+        & 9.544997e-01 ,9.510901e-01 ,9.477416e-01 ,9.444520e-01 ,9.412194e-01 ,&
+        & 9.380415e-01 ,9.349165e-01 ,9.318421e-01 ,9.288164e-01 ,9.258373e-01 ,&
+        & 9.229027e-01 ,9.200106e-01 ,9.171589e-01 ,9.143457e-01 ,9.115688e-01 ,&
+        & 9.088263e-01 ,9.061161e-01 ,9.034362e-01 ,9.007846e-01 ,8.981592e-01 ,&
+        & 8.955581e-01 ,8.929792e-01 ,8.904206e-01 ,8.878803e-01 ,8.853562e-01 ,&
+        & 8.828464e-01 ,8.803488e-01 ,8.778616e-01 ,8.753827e-01 ,8.729102e-01 ,&
+        & 8.704421e-01 ,8.679764e-01 ,8.655112e-01 ,8.630445e-01 ,8.605744e-01 ,&
+        & 8.580989e-01  /)
+      ssaice3(:, 19) = (/ &
+! band 19
+        & 9.629413e-01 ,9.517182e-01 ,9.409209e-01 ,9.305366e-01 ,9.205529e-01 ,&
+        & 9.109569e-01 ,9.017362e-01 ,8.928780e-01 ,8.843699e-01 ,8.761992e-01 ,&
+        & 8.683536e-01 ,8.608204e-01 ,8.535873e-01 ,8.466417e-01 ,8.399712e-01 ,&
+        & 8.335635e-01 ,8.274062e-01 ,8.214868e-01 ,8.157932e-01 ,8.103129e-01 ,&
+        & 8.050336e-01 ,7.999432e-01 ,7.950294e-01 ,7.902798e-01 ,7.856825e-01 ,&
+        & 7.812250e-01 ,7.768954e-01 ,7.726815e-01 ,7.685711e-01 ,7.645522e-01 ,&
+        & 7.606126e-01 ,7.567404e-01 ,7.529234e-01 ,7.491498e-01 ,7.454074e-01 ,&
+        & 7.416844e-01 ,7.379688e-01 ,7.342485e-01 ,7.305118e-01 ,7.267468e-01 ,&
+        & 7.229415e-01 ,7.190841e-01 ,7.151628e-01 ,7.111657e-01 ,7.070811e-01 ,&
+        & 7.028972e-01  /)
+      ssaice3(:, 20) = (/ &
+! band 20
+        & 9.942270e-01 ,9.909206e-01 ,9.876775e-01 ,9.844960e-01 ,9.813746e-01 ,&
+        & 9.783114e-01 ,9.753049e-01 ,9.723535e-01 ,9.694553e-01 ,9.666088e-01 ,&
+        & 9.638123e-01 ,9.610641e-01 ,9.583626e-01 ,9.557060e-01 ,9.530928e-01 ,&
+        & 9.505211e-01 ,9.479895e-01 ,9.454961e-01 ,9.430393e-01 ,9.406174e-01 ,&
+        & 9.382288e-01 ,9.358717e-01 ,9.335446e-01 ,9.312456e-01 ,9.289731e-01 ,&
+        & 9.267255e-01 ,9.245010e-01 ,9.222980e-01 ,9.201147e-01 ,9.179496e-01 ,&
+        & 9.158008e-01 ,9.136667e-01 ,9.115457e-01 ,9.094359e-01 ,9.073358e-01 ,&
+        & 9.052436e-01 ,9.031577e-01 ,9.010763e-01 ,8.989977e-01 ,8.969203e-01 ,&
+        & 8.948423e-01 ,8.927620e-01 ,8.906778e-01 ,8.885879e-01 ,8.864907e-01 ,&
+        & 8.843843e-01  /)
+      ssaice3(:, 21) = (/ &
+! band 21
+        & 9.934014e-01 ,9.899331e-01 ,9.865537e-01 ,9.832610e-01 ,9.800523e-01 ,&
+        & 9.769254e-01 ,9.738777e-01 ,9.709069e-01 ,9.680106e-01 ,9.651862e-01 ,&
+        & 9.624315e-01 ,9.597439e-01 ,9.571212e-01 ,9.545608e-01 ,9.520605e-01 ,&
+        & 9.496177e-01 ,9.472301e-01 ,9.448954e-01 ,9.426111e-01 ,9.403749e-01 ,&
+        & 9.381843e-01 ,9.360370e-01 ,9.339307e-01 ,9.318629e-01 ,9.298313e-01 ,&
+        & 9.278336e-01 ,9.258673e-01 ,9.239302e-01 ,9.220198e-01 ,9.201338e-01 ,&
+        & 9.182700e-01 ,9.164258e-01 ,9.145991e-01 ,9.127874e-01 ,9.109884e-01 ,&
+        & 9.091999e-01 ,9.074194e-01 ,9.056447e-01 ,9.038735e-01 ,9.021033e-01 ,&
+        & 9.003320e-01 ,8.985572e-01 ,8.967766e-01 ,8.949879e-01 ,8.931888e-01 ,&
+        & 8.913770e-01  /)
+      ssaice3(:, 22) = (/ &
+! band 22
+        & 9.994833e-01 ,9.992055e-01 ,9.989278e-01 ,9.986500e-01 ,9.983724e-01 ,&
+        & 9.980947e-01 ,9.978172e-01 ,9.975397e-01 ,9.972623e-01 ,9.969849e-01 ,&
+        & 9.967077e-01 ,9.964305e-01 ,9.961535e-01 ,9.958765e-01 ,9.955997e-01 ,&
+        & 9.953230e-01 ,9.950464e-01 ,9.947699e-01 ,9.944936e-01 ,9.942174e-01 ,&
+        & 9.939414e-01 ,9.936656e-01 ,9.933899e-01 ,9.931144e-01 ,9.928390e-01 ,&
+        & 9.925639e-01 ,9.922889e-01 ,9.920141e-01 ,9.917396e-01 ,9.914652e-01 ,&
+        & 9.911911e-01 ,9.909171e-01 ,9.906434e-01 ,9.903700e-01 ,9.900967e-01 ,&
+        & 9.898237e-01 ,9.895510e-01 ,9.892784e-01 ,9.890062e-01 ,9.887342e-01 ,&
+        & 9.884625e-01 ,9.881911e-01 ,9.879199e-01 ,9.876490e-01 ,9.873784e-01 ,&
+        & 9.871081e-01  /)
+      ssaice3(:, 23) = (/ &
+! band 23
+        & 9.999343e-01 ,9.998917e-01 ,9.998492e-01 ,9.998067e-01 ,9.997642e-01 ,&
+        & 9.997218e-01 ,9.996795e-01 ,9.996372e-01 ,9.995949e-01 ,9.995528e-01 ,&
+        & 9.995106e-01 ,9.994686e-01 ,9.994265e-01 ,9.993845e-01 ,9.993426e-01 ,&
+        & 9.993007e-01 ,9.992589e-01 ,9.992171e-01 ,9.991754e-01 ,9.991337e-01 ,&
+        & 9.990921e-01 ,9.990505e-01 ,9.990089e-01 ,9.989674e-01 ,9.989260e-01 ,&
+        & 9.988846e-01 ,9.988432e-01 ,9.988019e-01 ,9.987606e-01 ,9.987194e-01 ,&
+        & 9.986782e-01 ,9.986370e-01 ,9.985959e-01 ,9.985549e-01 ,9.985139e-01 ,&
+        & 9.984729e-01 ,9.984319e-01 ,9.983910e-01 ,9.983502e-01 ,9.983094e-01 ,&
+        & 9.982686e-01 ,9.982279e-01 ,9.981872e-01 ,9.981465e-01 ,9.981059e-01 ,&
+        & 9.980653e-01  /)
+      ssaice3(:, 24) = (/ &
+! band 24
+        & 9.999978e-01 ,9.999965e-01 ,9.999952e-01 ,9.999939e-01 ,9.999926e-01 ,&
+        & 9.999913e-01 ,9.999900e-01 ,9.999887e-01 ,9.999873e-01 ,9.999860e-01 ,&
+        & 9.999847e-01 ,9.999834e-01 ,9.999821e-01 ,9.999808e-01 ,9.999795e-01 ,&
+        & 9.999782e-01 ,9.999769e-01 ,9.999756e-01 ,9.999743e-01 ,9.999730e-01 ,&
+        & 9.999717e-01 ,9.999704e-01 ,9.999691e-01 ,9.999678e-01 ,9.999665e-01 ,&
+        & 9.999652e-01 ,9.999639e-01 ,9.999626e-01 ,9.999613e-01 ,9.999600e-01 ,&
+        & 9.999587e-01 ,9.999574e-01 ,9.999561e-01 ,9.999548e-01 ,9.999535e-01 ,&
+        & 9.999522e-01 ,9.999509e-01 ,9.999496e-01 ,9.999483e-01 ,9.999470e-01 ,&
+        & 9.999457e-01 ,9.999444e-01 ,9.999431e-01 ,9.999418e-01 ,9.999405e-01 ,&
+        & 9.999392e-01  /)
+      ssaice3(:, 25) = (/ &
+! band 25
+        & 9.999994e-01 ,9.999993e-01 ,9.999991e-01 ,9.999990e-01 ,9.999989e-01 ,&
+        & 9.999987e-01 ,9.999986e-01 ,9.999984e-01 ,9.999983e-01 ,9.999982e-01 ,&
+        & 9.999980e-01 ,9.999979e-01 ,9.999977e-01 ,9.999976e-01 ,9.999975e-01 ,&
+        & 9.999973e-01 ,9.999972e-01 ,9.999970e-01 ,9.999969e-01 ,9.999967e-01 ,&
+        & 9.999966e-01 ,9.999965e-01 ,9.999963e-01 ,9.999962e-01 ,9.999960e-01 ,&
+        & 9.999959e-01 ,9.999957e-01 ,9.999956e-01 ,9.999954e-01 ,9.999953e-01 ,&
+        & 9.999952e-01 ,9.999950e-01 ,9.999949e-01 ,9.999947e-01 ,9.999946e-01 ,&
+        & 9.999944e-01 ,9.999943e-01 ,9.999941e-01 ,9.999940e-01 ,9.999939e-01 ,&
+        & 9.999937e-01 ,9.999936e-01 ,9.999934e-01 ,9.999933e-01 ,9.999931e-01 ,&
+        & 9.999930e-01  /)
+      ssaice3(:, 26) = (/ &
+! band 26
+        & 9.999997e-01 ,9.999995e-01 ,9.999992e-01 ,9.999990e-01 ,9.999987e-01 ,&
+        & 9.999985e-01 ,9.999983e-01 ,9.999980e-01 ,9.999978e-01 ,9.999976e-01 ,&
+        & 9.999973e-01 ,9.999971e-01 ,9.999969e-01 ,9.999967e-01 ,9.999965e-01 ,&
+        & 9.999963e-01 ,9.999960e-01 ,9.999958e-01 ,9.999956e-01 ,9.999954e-01 ,&
+        & 9.999952e-01 ,9.999950e-01 ,9.999948e-01 ,9.999946e-01 ,9.999944e-01 ,&
+        & 9.999942e-01 ,9.999939e-01 ,9.999937e-01 ,9.999935e-01 ,9.999933e-01 ,&
+        & 9.999931e-01 ,9.999929e-01 ,9.999927e-01 ,9.999925e-01 ,9.999923e-01 ,&
+        & 9.999920e-01 ,9.999918e-01 ,9.999916e-01 ,9.999914e-01 ,9.999911e-01 ,&
+        & 9.999909e-01 ,9.999907e-01 ,9.999905e-01 ,9.999902e-01 ,9.999900e-01 ,&
+        & 9.999897e-01  /)
+      ssaice3(:, 27) = (/ &
+! band 27
+        & 9.999991e-01 ,9.999985e-01 ,9.999980e-01 ,9.999974e-01 ,9.999968e-01 ,&
+        & 9.999963e-01 ,9.999957e-01 ,9.999951e-01 ,9.999946e-01 ,9.999940e-01 ,&
+        & 9.999934e-01 ,9.999929e-01 ,9.999923e-01 ,9.999918e-01 ,9.999912e-01 ,&
+        & 9.999907e-01 ,9.999901e-01 ,9.999896e-01 ,9.999891e-01 ,9.999885e-01 ,&
+        & 9.999880e-01 ,9.999874e-01 ,9.999869e-01 ,9.999863e-01 ,9.999858e-01 ,&
+        & 9.999853e-01 ,9.999847e-01 ,9.999842e-01 ,9.999836e-01 ,9.999831e-01 ,&
+        & 9.999826e-01 ,9.999820e-01 ,9.999815e-01 ,9.999809e-01 ,9.999804e-01 ,&
+        & 9.999798e-01 ,9.999793e-01 ,9.999787e-01 ,9.999782e-01 ,9.999776e-01 ,&
+        & 9.999770e-01 ,9.999765e-01 ,9.999759e-01 ,9.999754e-01 ,9.999748e-01 ,&
+        & 9.999742e-01  /)
+      ssaice3(:, 28) = (/ &
+! band 28
+        & 9.999975e-01 ,9.999961e-01 ,9.999946e-01 ,9.999931e-01 ,9.999917e-01 ,&
+        & 9.999903e-01 ,9.999888e-01 ,9.999874e-01 ,9.999859e-01 ,9.999845e-01 ,&
+        & 9.999831e-01 ,9.999816e-01 ,9.999802e-01 ,9.999788e-01 ,9.999774e-01 ,&
+        & 9.999759e-01 ,9.999745e-01 ,9.999731e-01 ,9.999717e-01 ,9.999702e-01 ,&
+        & 9.999688e-01 ,9.999674e-01 ,9.999660e-01 ,9.999646e-01 ,9.999631e-01 ,&
+        & 9.999617e-01 ,9.999603e-01 ,9.999589e-01 ,9.999574e-01 ,9.999560e-01 ,&
+        & 9.999546e-01 ,9.999532e-01 ,9.999517e-01 ,9.999503e-01 ,9.999489e-01 ,&
+        & 9.999474e-01 ,9.999460e-01 ,9.999446e-01 ,9.999431e-01 ,9.999417e-01 ,&
+        & 9.999403e-01 ,9.999388e-01 ,9.999374e-01 ,9.999359e-01 ,9.999345e-01 ,&
+        & 9.999330e-01  /)
+      ssaice3(:, 29) = (/ &
+! band 29
+        & 4.526500e-01 ,5.287890e-01 ,5.410487e-01 ,5.459865e-01 ,5.485149e-01 ,&
+        & 5.498914e-01 ,5.505895e-01 ,5.508310e-01 ,5.507364e-01 ,5.503793e-01 ,&
+        & 5.498090e-01 ,5.490612e-01 ,5.481637e-01 ,5.471395e-01 ,5.460083e-01 ,&
+        & 5.447878e-01 ,5.434946e-01 ,5.421442e-01 ,5.407514e-01 ,5.393309e-01 ,&
+        & 5.378970e-01 ,5.364641e-01 ,5.350464e-01 ,5.336582e-01 ,5.323140e-01 ,&
+        & 5.310283e-01 ,5.298158e-01 ,5.286914e-01 ,5.276704e-01 ,5.267680e-01 ,&
+        & 5.260000e-01 ,5.253823e-01 ,5.249311e-01 ,5.246629e-01 ,5.245946e-01 ,&
+        & 5.247434e-01 ,5.251268e-01 ,5.257626e-01 ,5.266693e-01 ,5.278653e-01 ,&
+        & 5.293698e-01 ,5.312022e-01 ,5.333823e-01 ,5.359305e-01 ,5.388676e-01 ,&
+        & 5.422146e-01  /)
+
+! asymmetry factor: unitless
+      asyice3(:, 16) = (/ &
+! band 16
+        & 8.340752e-01 ,8.435170e-01 ,8.517487e-01 ,8.592064e-01 ,8.660387e-01 ,&
+        & 8.723204e-01 ,8.780997e-01 ,8.834137e-01 ,8.882934e-01 ,8.927662e-01 ,&
+        & 8.968577e-01 ,9.005914e-01 ,9.039899e-01 ,9.070745e-01 ,9.098659e-01 ,&
+        & 9.123836e-01 ,9.146466e-01 ,9.166734e-01 ,9.184817e-01 ,9.200886e-01 ,&
+        & 9.215109e-01 ,9.227648e-01 ,9.238661e-01 ,9.248304e-01 ,9.256727e-01 ,&
+        & 9.264078e-01 ,9.270505e-01 ,9.276150e-01 ,9.281156e-01 ,9.285662e-01 ,&
+        & 9.289806e-01 ,9.293726e-01 ,9.297557e-01 ,9.301435e-01 ,9.305491e-01 ,&
+        & 9.309859e-01 ,9.314671e-01 ,9.320055e-01 ,9.326140e-01 ,9.333053e-01 ,&
+        & 9.340919e-01 ,9.349861e-01 ,9.360000e-01 ,9.371451e-01 ,9.384329e-01 ,&
+        & 9.398744e-01  /)
+      asyice3(:, 17) = (/ &
+! band 17
+        & 8.728160e-01 ,8.777333e-01 ,8.823754e-01 ,8.867535e-01 ,8.908785e-01 ,&
+        & 8.947611e-01 ,8.984118e-01 ,9.018408e-01 ,9.050582e-01 ,9.080739e-01 ,&
+        & 9.108976e-01 ,9.135388e-01 ,9.160068e-01 ,9.183106e-01 ,9.204595e-01 ,&
+        & 9.224620e-01 ,9.243271e-01 ,9.260632e-01 ,9.276788e-01 ,9.291822e-01 ,&
+        & 9.305817e-01 ,9.318853e-01 ,9.331012e-01 ,9.342372e-01 ,9.353013e-01 ,&
+        & 9.363013e-01 ,9.372450e-01 ,9.381400e-01 ,9.389939e-01 ,9.398145e-01 ,&
+        & 9.406092e-01 ,9.413856e-01 ,9.421511e-01 ,9.429131e-01 ,9.436790e-01 ,&
+        & 9.444561e-01 ,9.452517e-01 ,9.460729e-01 ,9.469270e-01 ,9.478209e-01 ,&
+        & 9.487617e-01 ,9.497562e-01 ,9.508112e-01 ,9.519335e-01 ,9.531294e-01 ,&
+        & 9.544055e-01  /)
+      asyice3(:, 18) = (/ &
+! band 18
+        & 7.897566e-01 ,7.948704e-01 ,7.998041e-01 ,8.045623e-01 ,8.091495e-01 ,&
+        & 8.135702e-01 ,8.178290e-01 ,8.219305e-01 ,8.258790e-01 ,8.296792e-01 ,&
+        & 8.333355e-01 ,8.368524e-01 ,8.402343e-01 ,8.434856e-01 ,8.466108e-01 ,&
+        & 8.496143e-01 ,8.525004e-01 ,8.552737e-01 ,8.579384e-01 ,8.604990e-01 ,&
+        & 8.629597e-01 ,8.653250e-01 ,8.675992e-01 ,8.697867e-01 ,8.718916e-01 ,&
+        & 8.739185e-01 ,8.758715e-01 ,8.777551e-01 ,8.795734e-01 ,8.813308e-01 ,&
+        & 8.830315e-01 ,8.846799e-01 ,8.862802e-01 ,8.878366e-01 ,8.893534e-01 ,&
+        & 8.908350e-01 ,8.922854e-01 ,8.937090e-01 ,8.951099e-01 ,8.964925e-01 ,&
+        & 8.978609e-01 ,8.992192e-01 ,9.005718e-01 ,9.019229e-01 ,9.032765e-01 ,&
+        & 9.046369e-01  /)
+      asyice3(:, 19) = (/ &
+! band 19
+        & 7.812615e-01 ,7.887764e-01 ,7.959664e-01 ,8.028413e-01 ,8.094109e-01 ,&
+        & 8.156849e-01 ,8.216730e-01 ,8.273846e-01 ,8.328294e-01 ,8.380166e-01 ,&
+        & 8.429556e-01 ,8.476556e-01 ,8.521258e-01 ,8.563753e-01 ,8.604131e-01 ,&
+        & 8.642481e-01 ,8.678893e-01 ,8.713455e-01 ,8.746254e-01 ,8.777378e-01 ,&
+        & 8.806914e-01 ,8.834948e-01 ,8.861566e-01 ,8.886854e-01 ,8.910897e-01 ,&
+        & 8.933779e-01 ,8.955586e-01 ,8.976402e-01 ,8.996311e-01 ,9.015398e-01 ,&
+        & 9.033745e-01 ,9.051436e-01 ,9.068555e-01 ,9.085185e-01 ,9.101410e-01 ,&
+        & 9.117311e-01 ,9.132972e-01 ,9.148476e-01 ,9.163905e-01 ,9.179340e-01 ,&
+        & 9.194864e-01 ,9.210559e-01 ,9.226505e-01 ,9.242784e-01 ,9.259476e-01 ,&
+        & 9.276661e-01  /)
+      asyice3(:, 20) = (/ &
+! band 20
+        & 7.640720e-01 ,7.691119e-01 ,7.739941e-01 ,7.787222e-01 ,7.832998e-01 ,&
+        & 7.877304e-01 ,7.920177e-01 ,7.961652e-01 ,8.001765e-01 ,8.040551e-01 ,&
+        & 8.078044e-01 ,8.114280e-01 ,8.149294e-01 ,8.183119e-01 ,8.215791e-01 ,&
+        & 8.247344e-01 ,8.277812e-01 ,8.307229e-01 ,8.335629e-01 ,8.363046e-01 ,&
+        & 8.389514e-01 ,8.415067e-01 ,8.439738e-01 ,8.463560e-01 ,8.486568e-01 ,&
+        & 8.508795e-01 ,8.530274e-01 ,8.551039e-01 ,8.571122e-01 ,8.590558e-01 ,&
+        & 8.609378e-01 ,8.627618e-01 ,8.645309e-01 ,8.662485e-01 ,8.679178e-01 ,&
+        & 8.695423e-01 ,8.711251e-01 ,8.726697e-01 ,8.741792e-01 ,8.756571e-01 ,&
+        & 8.771065e-01 ,8.785307e-01 ,8.799331e-01 ,8.813169e-01 ,8.826854e-01 ,&
+        & 8.840419e-01  /)
+      asyice3(:, 21) = (/ &
+! band 21
+        & 7.602598e-01 ,7.651572e-01 ,7.699014e-01 ,7.744962e-01 ,7.789452e-01 ,&
+        & 7.832522e-01 ,7.874205e-01 ,7.914538e-01 ,7.953555e-01 ,7.991290e-01 ,&
+        & 8.027777e-01 ,8.063049e-01 ,8.097140e-01 ,8.130081e-01 ,8.161906e-01 ,&
+        & 8.192645e-01 ,8.222331e-01 ,8.250993e-01 ,8.278664e-01 ,8.305374e-01 ,&
+        & 8.331153e-01 ,8.356030e-01 ,8.380037e-01 ,8.403201e-01 ,8.425553e-01 ,&
+        & 8.447121e-01 ,8.467935e-01 ,8.488022e-01 ,8.507412e-01 ,8.526132e-01 ,&
+        & 8.544210e-01 ,8.561675e-01 ,8.578554e-01 ,8.594875e-01 ,8.610665e-01 ,&
+        & 8.625951e-01 ,8.640760e-01 ,8.655119e-01 ,8.669055e-01 ,8.682594e-01 ,&
+        & 8.695763e-01 ,8.708587e-01 ,8.721094e-01 ,8.733308e-01 ,8.745255e-01 ,&
+        & 8.756961e-01  /)
+      asyice3(:, 22) = (/ &
+! band 22
+        & 7.568957e-01 ,7.606995e-01 ,7.644072e-01 ,7.680204e-01 ,7.715402e-01 ,&
+        & 7.749682e-01 ,7.783057e-01 ,7.815541e-01 ,7.847148e-01 ,7.877892e-01 ,&
+        & 7.907786e-01 ,7.936846e-01 ,7.965084e-01 ,7.992515e-01 ,8.019153e-01 ,&
+        & 8.045011e-01 ,8.070103e-01 ,8.094444e-01 ,8.118048e-01 ,8.140927e-01 ,&
+        & 8.163097e-01 ,8.184571e-01 ,8.205364e-01 ,8.225488e-01 ,8.244958e-01 ,&
+        & 8.263789e-01 ,8.281993e-01 ,8.299586e-01 ,8.316580e-01 ,8.332991e-01 ,&
+        & 8.348831e-01 ,8.364115e-01 ,8.378857e-01 ,8.393071e-01 ,8.406770e-01 ,&
+        & 8.419969e-01 ,8.432682e-01 ,8.444923e-01 ,8.456706e-01 ,8.468044e-01 ,&
+        & 8.478952e-01 ,8.489444e-01 ,8.499533e-01 ,8.509234e-01 ,8.518561e-01 ,&
+        & 8.527528e-01  /)
+      asyice3(:, 23) = (/ &
+! band 23
+        & 7.575066e-01 ,7.606912e-01 ,7.638236e-01 ,7.669035e-01 ,7.699306e-01 ,&
+        & 7.729046e-01 ,7.758254e-01 ,7.786926e-01 ,7.815060e-01 ,7.842654e-01 ,&
+        & 7.869705e-01 ,7.896211e-01 ,7.922168e-01 ,7.947574e-01 ,7.972428e-01 ,&
+        & 7.996726e-01 ,8.020466e-01 ,8.043646e-01 ,8.066262e-01 ,8.088313e-01 ,&
+        & 8.109796e-01 ,8.130709e-01 ,8.151049e-01 ,8.170814e-01 ,8.190001e-01 ,&
+        & 8.208608e-01 ,8.226632e-01 ,8.244071e-01 ,8.260924e-01 ,8.277186e-01 ,&
+        & 8.292856e-01 ,8.307932e-01 ,8.322411e-01 ,8.336291e-01 ,8.349570e-01 ,&
+        & 8.362244e-01 ,8.374312e-01 ,8.385772e-01 ,8.396621e-01 ,8.406856e-01 ,&
+        & 8.416476e-01 ,8.425479e-01 ,8.433861e-01 ,8.441620e-01 ,8.448755e-01 ,&
+        & 8.455263e-01  /)
+      asyice3(:, 24) = (/ &
+! band 24
+        & 7.568829e-01 ,7.597947e-01 ,7.626745e-01 ,7.655212e-01 ,7.683337e-01 ,&
+        & 7.711111e-01 ,7.738523e-01 ,7.765565e-01 ,7.792225e-01 ,7.818494e-01 ,&
+        & 7.844362e-01 ,7.869819e-01 ,7.894854e-01 ,7.919459e-01 ,7.943623e-01 ,&
+        & 7.967337e-01 ,7.990590e-01 ,8.013373e-01 ,8.035676e-01 ,8.057488e-01 ,&
+        & 8.078802e-01 ,8.099605e-01 ,8.119890e-01 ,8.139645e-01 ,8.158862e-01 ,&
+        & 8.177530e-01 ,8.195641e-01 ,8.213183e-01 ,8.230149e-01 ,8.246527e-01 ,&
+        & 8.262308e-01 ,8.277483e-01 ,8.292042e-01 ,8.305976e-01 ,8.319275e-01 ,&
+        & 8.331929e-01 ,8.343929e-01 ,8.355265e-01 ,8.365928e-01 ,8.375909e-01 ,&
+        & 8.385197e-01 ,8.393784e-01 ,8.401659e-01 ,8.408815e-01 ,8.415240e-01 ,&
+        & 8.420926e-01  /)
+      asyice3(:, 25) = (/ &
+! band 25
+        & 7.548616e-01 ,7.575454e-01 ,7.602153e-01 ,7.628696e-01 ,7.655067e-01 ,&
+        & 7.681249e-01 ,7.707225e-01 ,7.732978e-01 ,7.758492e-01 ,7.783750e-01 ,&
+        & 7.808735e-01 ,7.833430e-01 ,7.857819e-01 ,7.881886e-01 ,7.905612e-01 ,&
+        & 7.928983e-01 ,7.951980e-01 ,7.974588e-01 ,7.996789e-01 ,8.018567e-01 ,&
+        & 8.039905e-01 ,8.060787e-01 ,8.081196e-01 ,8.101115e-01 ,8.120527e-01 ,&
+        & 8.139416e-01 ,8.157764e-01 ,8.175557e-01 ,8.192776e-01 ,8.209405e-01 ,&
+        & 8.225427e-01 ,8.240826e-01 ,8.255585e-01 ,8.269688e-01 ,8.283117e-01 ,&
+        & 8.295856e-01 ,8.307889e-01 ,8.319198e-01 ,8.329767e-01 ,8.339579e-01 ,&
+        & 8.348619e-01 ,8.356868e-01 ,8.364311e-01 ,8.370930e-01 ,8.376710e-01 ,&
+        & 8.381633e-01  /)
+      asyice3(:, 26) = (/ &
+! band 26
+        & 7.491854e-01 ,7.518523e-01 ,7.545089e-01 ,7.571534e-01 ,7.597839e-01 ,&
+        & 7.623987e-01 ,7.649959e-01 ,7.675737e-01 ,7.701303e-01 ,7.726639e-01 ,&
+        & 7.751727e-01 ,7.776548e-01 ,7.801084e-01 ,7.825318e-01 ,7.849230e-01 ,&
+        & 7.872804e-01 ,7.896020e-01 ,7.918862e-01 ,7.941309e-01 ,7.963345e-01 ,&
+        & 7.984951e-01 ,8.006109e-01 ,8.026802e-01 ,8.047009e-01 ,8.066715e-01 ,&
+        & 8.085900e-01 ,8.104546e-01 ,8.122636e-01 ,8.140150e-01 ,8.157072e-01 ,&
+        & 8.173382e-01 ,8.189063e-01 ,8.204096e-01 ,8.218464e-01 ,8.232148e-01 ,&
+        & 8.245130e-01 ,8.257391e-01 ,8.268915e-01 ,8.279682e-01 ,8.289675e-01 ,&
+        & 8.298875e-01 ,8.307264e-01 ,8.314824e-01 ,8.321537e-01 ,8.327385e-01 ,&
+        & 8.332350e-01  /)
+      asyice3(:, 27) = (/ &
+! band 27
+        & 7.397086e-01 ,7.424069e-01 ,7.450955e-01 ,7.477725e-01 ,7.504362e-01 ,&
+        & 7.530846e-01 ,7.557159e-01 ,7.583283e-01 ,7.609199e-01 ,7.634888e-01 ,&
+        & 7.660332e-01 ,7.685512e-01 ,7.710411e-01 ,7.735009e-01 ,7.759288e-01 ,&
+        & 7.783229e-01 ,7.806814e-01 ,7.830024e-01 ,7.852841e-01 ,7.875246e-01 ,&
+        & 7.897221e-01 ,7.918748e-01 ,7.939807e-01 ,7.960380e-01 ,7.980449e-01 ,&
+        & 7.999995e-01 ,8.019000e-01 ,8.037445e-01 ,8.055311e-01 ,8.072581e-01 ,&
+        & 8.089235e-01 ,8.105255e-01 ,8.120623e-01 ,8.135319e-01 ,8.149326e-01 ,&
+        & 8.162626e-01 ,8.175198e-01 ,8.187025e-01 ,8.198089e-01 ,8.208371e-01 ,&
+        & 8.217852e-01 ,8.226514e-01 ,8.234338e-01 ,8.241306e-01 ,8.247399e-01 ,&
+        & 8.252599e-01  /)
+      asyice3(:, 28) = (/ &
+! band 28
+        & 7.224533e-01 ,7.251681e-01 ,7.278728e-01 ,7.305654e-01 ,7.332444e-01 ,&
+        & 7.359078e-01 ,7.385539e-01 ,7.411808e-01 ,7.437869e-01 ,7.463702e-01 ,&
+        & 7.489291e-01 ,7.514616e-01 ,7.539661e-01 ,7.564408e-01 ,7.588837e-01 ,&
+        & 7.612933e-01 ,7.636676e-01 ,7.660049e-01 ,7.683034e-01 ,7.705612e-01 ,&
+        & 7.727767e-01 ,7.749480e-01 ,7.770733e-01 ,7.791509e-01 ,7.811789e-01 ,&
+        & 7.831556e-01 ,7.850791e-01 ,7.869478e-01 ,7.887597e-01 ,7.905131e-01 ,&
+        & 7.922062e-01 ,7.938372e-01 ,7.954044e-01 ,7.969059e-01 ,7.983399e-01 ,&
+        & 7.997047e-01 ,8.009985e-01 ,8.022195e-01 ,8.033658e-01 ,8.044357e-01 ,&
+        & 8.054275e-01 ,8.063392e-01 ,8.071692e-01 ,8.079157e-01 ,8.085768e-01 ,&
+        & 8.091507e-01  /)
+      asyice3(:, 29) = (/ &
+! band 29
+        & 8.850026e-01 ,9.005489e-01 ,9.069242e-01 ,9.121799e-01 ,9.168987e-01 ,&
+        & 9.212259e-01 ,9.252176e-01 ,9.289028e-01 ,9.323000e-01 ,9.354235e-01 ,&
+        & 9.382858e-01 ,9.408985e-01 ,9.432734e-01 ,9.454218e-01 ,9.473557e-01 ,&
+        & 9.490871e-01 ,9.506282e-01 ,9.519917e-01 ,9.531904e-01 ,9.542374e-01 ,&
+        & 9.551461e-01 ,9.559298e-01 ,9.566023e-01 ,9.571775e-01 ,9.576692e-01 ,&
+        & 9.580916e-01 ,9.584589e-01 ,9.587853e-01 ,9.590851e-01 ,9.593729e-01 ,&
+        & 9.596632e-01 ,9.599705e-01 ,9.603096e-01 ,9.606954e-01 ,9.611427e-01 ,&
+        & 9.616667e-01 ,9.622826e-01 ,9.630060e-01 ,9.638524e-01 ,9.648379e-01 ,&
+        & 9.659788e-01 ,9.672916e-01 ,9.687933e-01 ,9.705014e-01 ,9.724337e-01 ,&
+        & 9.746084e-01  /)
+
+! fdelta: unitless
+      fdlice3(:, 16) = (/ &
+! band 16
+        & 4.959277e-02 ,4.685292e-02 ,4.426104e-02 ,4.181231e-02 ,3.950191e-02 ,&
+        & 3.732500e-02 ,3.527675e-02 ,3.335235e-02 ,3.154697e-02 ,2.985578e-02 ,&
+        & 2.827395e-02 ,2.679666e-02 ,2.541909e-02 ,2.413640e-02 ,2.294378e-02 ,&
+        & 2.183639e-02 ,2.080940e-02 ,1.985801e-02 ,1.897736e-02 ,1.816265e-02 ,&
+        & 1.740905e-02 ,1.671172e-02 ,1.606585e-02 ,1.546661e-02 ,1.490917e-02 ,&
+        & 1.438870e-02 ,1.390038e-02 ,1.343939e-02 ,1.300089e-02 ,1.258006e-02 ,&
+        & 1.217208e-02 ,1.177212e-02 ,1.137536e-02 ,1.097696e-02 ,1.057210e-02 ,&
+        & 1.015596e-02 ,9.723704e-03 ,9.270516e-03 ,8.791565e-03 ,8.282026e-03 ,&
+        & 7.737072e-03 ,7.151879e-03 ,6.521619e-03 ,5.841467e-03 ,5.106597e-03 ,&
+        & 4.312183e-03  /)
+      fdlice3(:, 17) = (/ &
+! band 17
+        & 5.071224e-02 ,5.000217e-02 ,4.933872e-02 ,4.871992e-02 ,4.814380e-02 ,&
+        & 4.760839e-02 ,4.711170e-02 ,4.665177e-02 ,4.622662e-02 ,4.583426e-02 ,&
+        & 4.547274e-02 ,4.514007e-02 ,4.483428e-02 ,4.455340e-02 ,4.429544e-02 ,&
+        & 4.405844e-02 ,4.384041e-02 ,4.363939e-02 ,4.345340e-02 ,4.328047e-02 ,&
+        & 4.311861e-02 ,4.296586e-02 ,4.282024e-02 ,4.267977e-02 ,4.254248e-02 ,&
+        & 4.240640e-02 ,4.226955e-02 ,4.212995e-02 ,4.198564e-02 ,4.183462e-02 ,&
+        & 4.167494e-02 ,4.150462e-02 ,4.132167e-02 ,4.112413e-02 ,4.091003e-02 ,&
+        & 4.067737e-02 ,4.042420e-02 ,4.014854e-02 ,3.984840e-02 ,3.952183e-02 ,&
+        & 3.916683e-02 ,3.878144e-02 ,3.836368e-02 ,3.791158e-02 ,3.742316e-02 ,&
+        & 3.689645e-02  /)
+      fdlice3(:, 18) = (/ &
+! band 18
+        & 1.062938e-01 ,1.065234e-01 ,1.067822e-01 ,1.070682e-01 ,1.073793e-01 ,&
+        & 1.077137e-01 ,1.080693e-01 ,1.084442e-01 ,1.088364e-01 ,1.092439e-01 ,&
+        & 1.096647e-01 ,1.100970e-01 ,1.105387e-01 ,1.109878e-01 ,1.114423e-01 ,&
+        & 1.119004e-01 ,1.123599e-01 ,1.128190e-01 ,1.132757e-01 ,1.137279e-01 ,&
+        & 1.141738e-01 ,1.146113e-01 ,1.150385e-01 ,1.154534e-01 ,1.158540e-01 ,&
+        & 1.162383e-01 ,1.166045e-01 ,1.169504e-01 ,1.172741e-01 ,1.175738e-01 ,&
+        & 1.178472e-01 ,1.180926e-01 ,1.183080e-01 ,1.184913e-01 ,1.186405e-01 ,&
+        & 1.187538e-01 ,1.188291e-01 ,1.188645e-01 ,1.188580e-01 ,1.188076e-01 ,&
+        & 1.187113e-01 ,1.185672e-01 ,1.183733e-01 ,1.181277e-01 ,1.178282e-01 ,&
+        & 1.174731e-01  /)
+      fdlice3(:, 19) = (/ &
+! band 19
+        & 1.076195e-01 ,1.065195e-01 ,1.054696e-01 ,1.044673e-01 ,1.035099e-01 ,&
+        & 1.025951e-01 ,1.017203e-01 ,1.008831e-01 ,1.000808e-01 ,9.931116e-02 ,&
+        & 9.857151e-02 ,9.785939e-02 ,9.717230e-02 ,9.650774e-02 ,9.586322e-02 ,&
+        & 9.523623e-02 ,9.462427e-02 ,9.402484e-02 ,9.343544e-02 ,9.285358e-02 ,&
+        & 9.227675e-02 ,9.170245e-02 ,9.112818e-02 ,9.055144e-02 ,8.996974e-02 ,&
+        & 8.938056e-02 ,8.878142e-02 ,8.816981e-02 ,8.754323e-02 ,8.689919e-02 ,&
+        & 8.623517e-02 ,8.554869e-02 ,8.483724e-02 ,8.409832e-02 ,8.332943e-02 ,&
+        & 8.252807e-02 ,8.169175e-02 ,8.081795e-02 ,7.990419e-02 ,7.894796e-02 ,&
+        & 7.794676e-02 ,7.689809e-02 ,7.579945e-02 ,7.464834e-02 ,7.344227e-02 ,&
+        & 7.217872e-02  /)
+      fdlice3(:, 20) = (/ &
+! band 20
+        & 1.119014e-01 ,1.122706e-01 ,1.126690e-01 ,1.130947e-01 ,1.135456e-01 ,&
+        & 1.140199e-01 ,1.145154e-01 ,1.150302e-01 ,1.155623e-01 ,1.161096e-01 ,&
+        & 1.166703e-01 ,1.172422e-01 ,1.178233e-01 ,1.184118e-01 ,1.190055e-01 ,&
+        & 1.196025e-01 ,1.202008e-01 ,1.207983e-01 ,1.213931e-01 ,1.219832e-01 ,&
+        & 1.225665e-01 ,1.231411e-01 ,1.237050e-01 ,1.242561e-01 ,1.247926e-01 ,&
+        & 1.253122e-01 ,1.258132e-01 ,1.262934e-01 ,1.267509e-01 ,1.271836e-01 ,&
+        & 1.275896e-01 ,1.279669e-01 ,1.283134e-01 ,1.286272e-01 ,1.289063e-01 ,&
+        & 1.291486e-01 ,1.293522e-01 ,1.295150e-01 ,1.296351e-01 ,1.297104e-01 ,&
+        & 1.297390e-01 ,1.297189e-01 ,1.296480e-01 ,1.295244e-01 ,1.293460e-01 ,&
+        & 1.291109e-01  /)
+      fdlice3(:, 21) = (/ &
+! band 21
+        & 1.133298e-01 ,1.136777e-01 ,1.140556e-01 ,1.144615e-01 ,1.148934e-01 ,&
+        & 1.153492e-01 ,1.158269e-01 ,1.163243e-01 ,1.168396e-01 ,1.173706e-01 ,&
+        & 1.179152e-01 ,1.184715e-01 ,1.190374e-01 ,1.196108e-01 ,1.201897e-01 ,&
+        & 1.207720e-01 ,1.213558e-01 ,1.219389e-01 ,1.225194e-01 ,1.230951e-01 ,&
+        & 1.236640e-01 ,1.242241e-01 ,1.247733e-01 ,1.253096e-01 ,1.258309e-01 ,&
+        & 1.263352e-01 ,1.268205e-01 ,1.272847e-01 ,1.277257e-01 ,1.281415e-01 ,&
+        & 1.285300e-01 ,1.288893e-01 ,1.292173e-01 ,1.295118e-01 ,1.297710e-01 ,&
+        & 1.299927e-01 ,1.301748e-01 ,1.303154e-01 ,1.304124e-01 ,1.304637e-01 ,&
+        & 1.304673e-01 ,1.304212e-01 ,1.303233e-01 ,1.301715e-01 ,1.299638e-01 ,&
+        & 1.296983e-01  /)
+      fdlice3(:, 22) = (/ &
+! band 22
+        & 1.145360e-01 ,1.153256e-01 ,1.161453e-01 ,1.169929e-01 ,1.178666e-01 ,&
+        & 1.187641e-01 ,1.196835e-01 ,1.206227e-01 ,1.215796e-01 ,1.225522e-01 ,&
+        & 1.235383e-01 ,1.245361e-01 ,1.255433e-01 ,1.265579e-01 ,1.275779e-01 ,&
+        & 1.286011e-01 ,1.296257e-01 ,1.306494e-01 ,1.316703e-01 ,1.326862e-01 ,&
+        & 1.336951e-01 ,1.346950e-01 ,1.356838e-01 ,1.366594e-01 ,1.376198e-01 ,&
+        & 1.385629e-01 ,1.394866e-01 ,1.403889e-01 ,1.412678e-01 ,1.421212e-01 ,&
+        & 1.429469e-01 ,1.437430e-01 ,1.445074e-01 ,1.452381e-01 ,1.459329e-01 ,&
+        & 1.465899e-01 ,1.472069e-01 ,1.477819e-01 ,1.483128e-01 ,1.487976e-01 ,&
+        & 1.492343e-01 ,1.496207e-01 ,1.499548e-01 ,1.502346e-01 ,1.504579e-01 ,&
+        & 1.506227e-01  /)
+      fdlice3(:, 23) = (/ &
+! band 23
+        & 1.153263e-01 ,1.161445e-01 ,1.169932e-01 ,1.178703e-01 ,1.187738e-01 ,&
+        & 1.197016e-01 ,1.206516e-01 ,1.216217e-01 ,1.226099e-01 ,1.236141e-01 ,&
+        & 1.246322e-01 ,1.256621e-01 ,1.267017e-01 ,1.277491e-01 ,1.288020e-01 ,&
+        & 1.298584e-01 ,1.309163e-01 ,1.319736e-01 ,1.330281e-01 ,1.340778e-01 ,&
+        & 1.351207e-01 ,1.361546e-01 ,1.371775e-01 ,1.381873e-01 ,1.391820e-01 ,&
+        & 1.401593e-01 ,1.411174e-01 ,1.420540e-01 ,1.429671e-01 ,1.438547e-01 ,&
+        & 1.447146e-01 ,1.455449e-01 ,1.463433e-01 ,1.471078e-01 ,1.478364e-01 ,&
+        & 1.485270e-01 ,1.491774e-01 ,1.497857e-01 ,1.503497e-01 ,1.508674e-01 ,&
+        & 1.513367e-01 ,1.517554e-01 ,1.521216e-01 ,1.524332e-01 ,1.526880e-01 ,&
+        & 1.528840e-01  /)
+      fdlice3(:, 24) = (/ &
+! band 24
+        & 1.160842e-01 ,1.169118e-01 ,1.177697e-01 ,1.186556e-01 ,1.195676e-01 ,&
+        & 1.205036e-01 ,1.214616e-01 ,1.224394e-01 ,1.234349e-01 ,1.244463e-01 ,&
+        & 1.254712e-01 ,1.265078e-01 ,1.275539e-01 ,1.286075e-01 ,1.296664e-01 ,&
+        & 1.307287e-01 ,1.317923e-01 ,1.328550e-01 ,1.339149e-01 ,1.349699e-01 ,&
+        & 1.360179e-01 ,1.370567e-01 ,1.380845e-01 ,1.390991e-01 ,1.400984e-01 ,&
+        & 1.410803e-01 ,1.420429e-01 ,1.429840e-01 ,1.439016e-01 ,1.447936e-01 ,&
+        & 1.456579e-01 ,1.464925e-01 ,1.472953e-01 ,1.480642e-01 ,1.487972e-01 ,&
+        & 1.494923e-01 ,1.501472e-01 ,1.507601e-01 ,1.513287e-01 ,1.518511e-01 ,&
+        & 1.523252e-01 ,1.527489e-01 ,1.531201e-01 ,1.534368e-01 ,1.536969e-01 ,&
+        & 1.538984e-01  /)
+      fdlice3(:, 25) = (/ &
+! band 25
+        & 1.168725e-01 ,1.177088e-01 ,1.185747e-01 ,1.194680e-01 ,1.203867e-01 ,&
+        & 1.213288e-01 ,1.222923e-01 ,1.232750e-01 ,1.242750e-01 ,1.252903e-01 ,&
+        & 1.263187e-01 ,1.273583e-01 ,1.284069e-01 ,1.294626e-01 ,1.305233e-01 ,&
+        & 1.315870e-01 ,1.326517e-01 ,1.337152e-01 ,1.347756e-01 ,1.358308e-01 ,&
+        & 1.368788e-01 ,1.379175e-01 ,1.389449e-01 ,1.399590e-01 ,1.409577e-01 ,&
+        & 1.419389e-01 ,1.429007e-01 ,1.438410e-01 ,1.447577e-01 ,1.456488e-01 ,&
+        & 1.465123e-01 ,1.473461e-01 ,1.481483e-01 ,1.489166e-01 ,1.496492e-01 ,&
+        & 1.503439e-01 ,1.509988e-01 ,1.516118e-01 ,1.521808e-01 ,1.527038e-01 ,&
+        & 1.531788e-01 ,1.536037e-01 ,1.539764e-01 ,1.542951e-01 ,1.545575e-01 ,&
+        & 1.547617e-01  /)
+      fdlice3(:, 26) = (/ &
+!band 26
+        & 1.180509e-01 ,1.189025e-01 ,1.197820e-01 ,1.206875e-01 ,1.216171e-01 ,&
+        & 1.225687e-01 ,1.235404e-01 ,1.245303e-01 ,1.255363e-01 ,1.265564e-01 ,&
+        & 1.275888e-01 ,1.286313e-01 ,1.296821e-01 ,1.307392e-01 ,1.318006e-01 ,&
+        & 1.328643e-01 ,1.339284e-01 ,1.349908e-01 ,1.360497e-01 ,1.371029e-01 ,&
+        & 1.381486e-01 ,1.391848e-01 ,1.402095e-01 ,1.412208e-01 ,1.422165e-01 ,&
+        & 1.431949e-01 ,1.441539e-01 ,1.450915e-01 ,1.460058e-01 ,1.468947e-01 ,&
+        & 1.477564e-01 ,1.485888e-01 ,1.493900e-01 ,1.501580e-01 ,1.508907e-01 ,&
+        & 1.515864e-01 ,1.522428e-01 ,1.528582e-01 ,1.534305e-01 ,1.539578e-01 ,&
+        & 1.544380e-01 ,1.548692e-01 ,1.552494e-01 ,1.555767e-01 ,1.558490e-01 ,&
+        & 1.560645e-01  /)
+      fdlice3(:, 27) = (/ &
+! band 27
+        & 1.200480e-01 ,1.209267e-01 ,1.218304e-01 ,1.227575e-01 ,1.237059e-01 ,&
+        & 1.246739e-01 ,1.256595e-01 ,1.266610e-01 ,1.276765e-01 ,1.287041e-01 ,&
+        & 1.297420e-01 ,1.307883e-01 ,1.318412e-01 ,1.328988e-01 ,1.339593e-01 ,&
+        & 1.350207e-01 ,1.360813e-01 ,1.371393e-01 ,1.381926e-01 ,1.392396e-01 ,&
+        & 1.402783e-01 ,1.413069e-01 ,1.423235e-01 ,1.433263e-01 ,1.443134e-01 ,&
+        & 1.452830e-01 ,1.462332e-01 ,1.471622e-01 ,1.480681e-01 ,1.489490e-01 ,&
+        & 1.498032e-01 ,1.506286e-01 ,1.514236e-01 ,1.521863e-01 ,1.529147e-01 ,&
+        & 1.536070e-01 ,1.542614e-01 ,1.548761e-01 ,1.554491e-01 ,1.559787e-01 ,&
+        & 1.564629e-01 ,1.568999e-01 ,1.572879e-01 ,1.576249e-01 ,1.579093e-01 ,&
+        & 1.581390e-01  /)
+      fdlice3(:, 28) = (/ &
+! band 28
+        & 1.247813e-01 ,1.256496e-01 ,1.265417e-01 ,1.274560e-01 ,1.283905e-01 ,&
+        & 1.293436e-01 ,1.303135e-01 ,1.312983e-01 ,1.322964e-01 ,1.333060e-01 ,&
+        & 1.343252e-01 ,1.353523e-01 ,1.363855e-01 ,1.374231e-01 ,1.384632e-01 ,&
+        & 1.395042e-01 ,1.405441e-01 ,1.415813e-01 ,1.426140e-01 ,1.436404e-01 ,&
+        & 1.446587e-01 ,1.456672e-01 ,1.466640e-01 ,1.476475e-01 ,1.486157e-01 ,&
+        & 1.495671e-01 ,1.504997e-01 ,1.514117e-01 ,1.523016e-01 ,1.531673e-01 ,&
+        & 1.540073e-01 ,1.548197e-01 ,1.556026e-01 ,1.563545e-01 ,1.570734e-01 ,&
+        & 1.577576e-01 ,1.584054e-01 ,1.590149e-01 ,1.595843e-01 ,1.601120e-01 ,&
+        & 1.605962e-01 ,1.610349e-01 ,1.614266e-01 ,1.617693e-01 ,1.620614e-01 ,&
+        & 1.623011e-01  /)
+      fdlice3(:, 29) = (/ &
+! band 29
+        & 1.006055e-01 ,9.549582e-02 ,9.063960e-02 ,8.602900e-02 ,8.165612e-02 ,&
+        & 7.751308e-02 ,7.359199e-02 ,6.988496e-02 ,6.638412e-02 ,6.308156e-02 ,&
+        & 5.996942e-02 ,5.703979e-02 ,5.428481e-02 ,5.169657e-02 ,4.926719e-02 ,&
+        & 4.698880e-02 ,4.485349e-02 ,4.285339e-02 ,4.098061e-02 ,3.922727e-02 ,&
+        & 3.758547e-02 ,3.604733e-02 ,3.460497e-02 ,3.325051e-02 ,3.197604e-02 ,&
+        & 3.077369e-02 ,2.963558e-02 ,2.855381e-02 ,2.752050e-02 ,2.652776e-02 ,&
+        & 2.556772e-02 ,2.463247e-02 ,2.371415e-02 ,2.280485e-02 ,2.189670e-02 ,&
+        & 2.098180e-02 ,2.005228e-02 ,1.910024e-02 ,1.811781e-02 ,1.709709e-02 ,&
+        & 1.603020e-02 ,1.490925e-02 ,1.372635e-02 ,1.247363e-02 ,1.114319e-02 ,&
+        & 9.727157e-03  /)
+
+      end subroutine swcldpr
+
+      end module rrtmg_sw_init_f
+
+      module rrtmg_sw_spcvmc_f
+
+! ------- Modules -------
+
+      use parrrsw_f, only : nbndsw, ngptsw, mxmol, jpband, mxlay
+      use rrsw_tbl_f, only : tblint, bpade, od_lo, exp_tbl
+      use rrsw_vsn_f, only : hvrspc, hnamspc
+      use rrsw_wvn_f, only : ngc, ngs, ngb
+      
+      use rrtmg_sw_taumol_f, only: taumol_sw
+     
+      implicit none
+
+      contains
+
+! ---------------------------------------------------------------------------
+      subroutine spcvmc_sw &
+            (cc,tncol, ncol, nlayers, istart, iend, icpr, idelm, iout, &
+             pavel, tavel, pz, tz, tbound, palbd, palbp, &
+             pcldfmc, ptaucmc, pasycmc, pomgcmc, ptaormc, &
+             ptaua, pasya, pomga, prmu0, coldry,  adjflux, &
+             laytrop, layswtch, laylow, jp, jt, jt1, &
+             co2mult, colch4, colco2, colh2o, colmol, coln2o, colo2, colo3, &
+             fac00, fac01, fac10, fac11, &
+             selffac, selffrac, indself, forfac, forfrac, indfor, &
+             pbbfd, pbbfu, pbbcd, pbbcu, puvfd, puvcd, pnifd, pnicd, &
+             pbbfddir, pbbcddir, puvfddir, puvcddir, pnifddir, pnicddir, &
+             zgco,zomco,zrdnd,zref,zrefo,zrefd,zrefdo,ztauo,zdbt,ztdbt, &
+             ztra,ztrao,ztrad,ztrado,zfd,zfu,ztaug, ztaur, zsflxzen)
+! ---------------------------------------------------------------------------
+!
+! Purpose: Contains spectral loop to compute the shortwave radiative fluxes, 
+!          using the two-stream method of H. Barker and McICA, the Monte-Carlo
+!          Independent Column Approximation, for the representation of 
+!          sub-grid cloud variability (i.e. cloud overlap).
+!
+! Interface:  *spcvmc_sw* is called from *rrtmg_sw.F90* or rrtmg_sw.1col.F90*
+!
+! Method:
+!    Adapted from two-stream model of H. Barker;
+!    Two-stream model options (selected with kmodts in rrtmg_sw_reftra.F90):
+!        1: Eddington, 2: PIFM, Zdunkowski et al., 3: discret ordinates
+!
+! Modifications:
+!
+! Original: H. Barker
+! Revision: Merge with RRTMG_SW: J.-J.Morcrette, ECMWF, Feb 2003
+! Revision: Add adjustment for Earth/Sun distance : MJIacono, AER, Oct 2003
+! Revision: Bug fix for use of PALBP and PALBD: MJIacono, AER, Nov 2003
+! Revision: Bug fix to apply delta scaling to clear sky: AER, Dec 2004
+! Revision: Code modified so that delta scaling is not done in cloudy profiles
+!           if routine cldprop is used; delta scaling can be applied by swithcing
+!           code below if cldprop is not used to get cloud properties. 
+!           AER, Jan 2005
+! Revision: Modified to use McICA: MJIacono, AER, Nov 2005
+! Revision: Uniform formatting for RRTMG: MJIacono, AER, Jul 2006 
+! Revision: Use exponential lookup table for transmittance: MJIacono, AER, 
+!           Aug 2007 
+!
+! ------------------------------------------------------------------
+
+! ------- Declarations ------
+
+! ------- Input -------
+
+      integer , intent(in) :: tncol, ncol,cc
+      integer , intent(in) :: nlayers
+      integer , intent(in) :: istart
+      integer , intent(in) :: iend
+      integer , intent(in) :: icpr
+      integer , intent(in) :: idelm   ! delta-m scaling flag
+                                              ! [0 = direct and diffuse fluxes are unscaled]
+                                              ! [1 = direct and diffuse fluxes are scaled]
+      integer , intent(in) :: iout
+      integer , intent(in) :: laytrop(:)
+      integer , intent(in) :: layswtch(:)
+      integer , intent(in) :: laylow(:)
+
+      integer , intent(in) :: indfor(:,:) 
+      integer , intent(in) :: indself(:,:) 
+      integer , intent(in) :: jp(:,:) 
+      integer , intent(in) :: jt(:,:) 
+      integer , intent(in) :: jt1(:,:) 
+                                                          !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: pavel(:,:)                     ! layer pressure (hPa, mb) 
+                                                          !   Dimensions: (ncol,nlayers)
+      real , intent(in) :: tavel(:,:)                     ! layer temperature (K)
+                                                          !   Dimensions: (ncol,nlayers)
+      real , intent(in) :: pz(:,0:)                       ! level (interface) pressure (hPa, mb)
+                                                          !   Dimensions: (ncol,0:nlayers)
+      real , intent(in) :: tz(:,0:)                       ! level temperatures (hPa, mb)
+                                                          !   Dimensions: (ncol,0:nlayers)
+      real , intent(in) :: tbound(:)                      ! surface temperature (K)
+                                                          !   Dimensions: (ncol)
+      real , intent(in) :: coldry(:,:)                    ! dry air column density (mol/cm2)
+                                                          !   Dimensions: (ncol,nlayers)
+      real , intent(in) :: colmol(:,:) 
+                                                          !   Dimensions: (ncol,nlayers)
+      real , intent(in) :: adjflux(:)                     ! Earth/Sun distance adjustment
+                                                          !   Dimensions: (jpband)
+
+      real , intent(in) :: palbd(:,:)                     ! surface albedo (diffuse)
+                                                          !   Dimensions: (ncol,nbndsw)
+      real , intent(in) :: palbp(:,:)                     ! surface albedo (direct)
+                                                          !   Dimensions: (ncol,nbndsw)
+      real , intent(in) :: prmu0(:)                       ! cosine of solar zenith angle
+                                                          !   Dimensions: (ncol)
+
+      real , intent(in) :: pcldfmc(:,:,:)                 ! cloud fraction [mcica]
+      real , intent(in) :: ptaucmc(:,:,:)                 ! cloud optical depth [mcica]
+      real , intent(in) :: pasycmc(:,:,:)                 ! cloud asymmetry parameter [mcica]
+      real , intent(in) :: pomgcmc(:,:,:)                 ! cloud single scattering albedo [mcica]
+      real , intent(in) :: ptaormc(:,:,:)                 ! cloud optical depth, non-delta scaled [mcica]
+                                                          !   Dimensions: (ncol,nlayers,ngptsw)
+   
+      real , intent(in) :: ptaua(:,:,:)                   ! aerosol optical depth
+      real , intent(in) :: pasya(:,:,:)                   ! aerosol asymmetry parameter
+      real , intent(in) :: pomga(:,:,:)                   ! aerosol single scattering albedo
+                                                          !   Dimensions: (ncol,nlayers,nbndsw)
+                                                               
+      real , intent(in) :: colh2o(:,:) 
+      real , intent(in) :: colco2(:,:) 
+      real , intent(in) :: colch4(:,:) 
+      real , intent(in) :: co2mult(:,:) 
+      real , intent(in) :: colo3(:,:) 
+      real , intent(in) :: colo2(:,:) 
+      real , intent(in) :: coln2o(:,:) 
+                                                          !   Dimensions: (ncol,nlayers)
+
+      real , intent(in) :: forfac(:,:) 
+      real , intent(in) :: forfrac(:,:) 
+      real , intent(in) :: selffac(:,:) 
+      real , intent(in) :: selffrac(:,:) 
+      real , intent(in) :: fac00(:,:) 
+      real , intent(in) :: fac01(:,:) 
+      real , intent(in) :: fac10(:,:) 
+      real , intent(in) :: fac11(:,:) 
+                                                          !   Dimensions: (ncol,nlayers)
+                                                               
+      real, intent(inout)   :: zgco(tncol,ngptsw,nlayers+1), zomco(tncol,ngptsw,nlayers+1)  
+      real, intent(inout)   :: zrdnd(tncol,ngptsw,nlayers+1) 
+      real, intent(inout)   :: zref(tncol,ngptsw,nlayers+1)  , zrefo(tncol,ngptsw,nlayers+1)  
+      real, intent(inout)   :: zrefd(tncol,ngptsw,nlayers+1)  , zrefdo(tncol,ngptsw,nlayers+1)  
+      real, intent(inout)   :: ztauo(tncol,ngptsw,nlayers)  
+      real, intent(inout)   :: zdbt(tncol,ngptsw,nlayers+1)  ,ztdbt(tncol,ngptsw,nlayers+1)   
+      real, intent(inout)   :: ztra(tncol,ngptsw,nlayers+1)  , ztrao(tncol,ngptsw,nlayers+1)  
+      real, intent(inout)   :: ztrad(tncol,ngptsw,nlayers+1)  , ztrado(tncol,ngptsw,nlayers+1)  
+      real, intent(inout)   :: zfd(tncol,ngptsw,nlayers+1)  , zfu(tncol,ngptsw,nlayers+1)   
+      real :: zcd(tncol,ngptsw,nlayers+1)  , zcu(tncol,ngptsw,nlayers+1)   
+      real, intent(inout)  :: ztaur(tncol,nlayers,ngptsw), ztaug(tncol,nlayers,ngptsw) 
+      real, intent(inout)  :: zsflxzen(tncol,ngptsw)
+   
+
+! ------- Output -------
+                                                               !   All Dimensions: (ncol,nlayers+1)
+      real , intent(out) :: pbbcd(:,:) 
+      real , intent(out) :: pbbcu(:,:) 
+      real , intent(out) :: pbbfd(:,:) 
+      real , intent(out) :: pbbfu(:,:) 
+      real , intent(out) :: pbbfddir(:,:) 
+      real , intent(out) :: pbbcddir(:,:) 
+
+      real , intent(out) :: puvcd(:,:) 
+      real , intent(out) :: puvfd(:,:) 
+      real , intent(out) :: puvcddir(:,:) 
+      real , intent(out) :: puvfddir(:,:) 
+
+      real , intent(out) :: pnicd(:,:) 
+      real , intent(out) :: pnifd(:,:) 
+      real , intent(out) :: pnicddir(:,:) 
+      real , intent(out) :: pnifddir(:,:) 
+      
+! ------- Local -------
+  
+      integer   :: klev
+      integer  :: ibm, ikl, ikp, ikx
+      integer  :: iw, jb, jg, jl, jk
+
+      integer  :: itind
+
+      real  :: tblind, ze1
+      real  :: zclear, zcloud
+        
+      real  :: zincflx, ze2
+
+      real  :: zdbtmc, zdbtmo, zf, zgw, zreflect
+      real  :: zwf, tauorig, repclc
+
+      real :: zdbt_nodel(tncol,ngptsw,nlayers+1)
+      real :: zdbtc_nodel(tncol,ngptsw,nlayers+1)
+      real :: ztdbt_nodel(tncol,ngptsw,nlayers+1)
+      real :: ztdbtc_nodel(tncol,ngptsw,nlayers+1)
+
+
+! Arrays from rrtmg_sw_vrtqdr routine
+  
+      integer :: iplon
+
+! ------------------------------------------------------------------
+
+!!$acc update host(pomga, ptaua)
+!$acc data create(zcd,zcu,zdbt_nodel,zdbtc_nodel,ztdbt_nodel,ztdbtc_nodel)
+
+!print *, "aerosol values"
+!print *, pomga(1, :, :)
+!print *, ptaua(1, :, :)
+
+!$acc kernels     
+         pbbcd =0. 
+         pbbcu =0. 
+         pbbfd =0. 
+         pbbfu =0. 
+         pbbcddir =0. 
+         pbbfddir =0. 
+         puvcd =0. 
+         puvfd =0. 
+         puvcddir =0. 
+         puvfddir =0. 
+         pnicd =0. 
+         pnifd =0. 
+         pnicddir =0. 
+         pnifddir =0.
+         zsflxzen = 0.
+!         znirr=0.
+!         znirf=0.
+!         zparr=0.
+!         zparf=0.
+!         zuvrr=0.
+!         zuvrf=0.
+         klev = nlayers
+!$acc end kernels      
+
+#ifndef _OPENACC
+#  define ncol CHNK
+#endif
+
+         
+! Calculate the optical depths for gaseous absorption and Rayleigh scattering     
+      call taumol_sw(ncol,nlayers, &
+                     colh2o , colco2 , colch4 , colo2 , &
+                     colo3 , colmol , &
+                     laytrop , jp , jt , jt1 , &
+                     fac00 , fac01 , fac10 , fac11 , &
+                     selffac , selffrac , indself , forfac , forfrac ,&
+                     indfor , &
+                     zsflxzen , ztaug, ztaur)
+
+      
+      repclc = 1.e-12 
+
+#ifdef _OPENACC
+# define ILOOP_S_CPU
+# define ILOOP_E_CPU
+# define ILOOP_S_GPU do iplon = 1, ncol
+# define ILOOP_E_GPU enddo
+# define WLOOP_S_CPU
+# define WLOOP_E_CPU
+# define WLOOP_S_GPU do iw = 1, 112
+# define WLOOP_E_GPU enddo
+#else
+# define ILOOP_S_GPU
+# define ILOOP_E_GPU
+# define ILOOP_S_CPU do iplon = 1, ncol
+# define ILOOP_E_CPU enddo
+# define WLOOP_S_GPU
+# define WLOOP_E_GPU
+# define WLOOP_S_CPU do iw = 1, 112
+# define WLOOP_E_CPU enddo
+#endif
+
+   
+!$acc kernels 
+
+      ILOOP_S_GPU
+      WLOOP_S_CPU
+
+        WLOOP_S_GPU
+        ILOOP_S_CPU
+
+! Top of shortwave spectral band loop, jb = 16 -> 29; ibm = 1 -> 14
+
+          jb = ngb(iw)
+          ibm = jb-15
+          
+! Clear-sky    
+!   TOA direct beam    
+           
+          ztdbtc_nodel(iplon,iw,1)=1.0  !jm
+           
+! Cloudy-sky    
+!   Surface values
+          ztrao(iplon,iw,klev+1)   =0.0 
+          ztrado(iplon,iw,klev+1)  =0.0 
+          zrefo(iplon,iw,klev+1)   =palbp(iplon,ibm) 
+          zrefdo(iplon,iw,klev+1)  =palbd(iplon,ibm) 
+           
+! Total sky    
+!   TOA direct beam    
+          ztdbt(iplon,iw,1)  =1.0 
+          ztdbt_nodel(iplon,iw,1)=1.0
+
+    
+!   Surface values
+          zdbt(iplon,iw,klev+1)   =0.0 
+          ztra(iplon,iw,klev+1)   =0.0 
+          ztrad(iplon,iw,klev+1)  =0.0 
+          zref(iplon,iw,klev+1)   =palbp(iplon,ibm) 
+          zrefd(iplon,iw,klev+1)  =palbd(iplon,ibm) 
+    
+        enddo
+      enddo
+
+!$acc end kernels     
+
+
+!$acc kernels loop 
+
+       ILOOP_S_GPU
+!$acc loop private(zf, zwf, ibm, ikl, jb)
+         WLOOP_S_GPU
+            !$acc loop seq
+            do jk=1,klev
+
+               ikl=klev+1-jk
+       WLOOP_S_CPU
+               jb = ngb(iw)
+               ibm = jb-15
+         ILOOP_S_CPU
+               ! Clear-sky optical parameters including aerosols
+               ztauo(iplon,iw,jk)   = ztaur(iplon,ikl,iw)  + ztaug(iplon,ikl,iw) + ptaua(iplon,ikl,ibm)      
+
+#ifndef _OPENACC
+! Use exponential lookup table for transmittance, or expansion of
+! exponential for low tau
+               zclear = 1.0  - pcldfmc(iplon,ikl,iw)
+               zcloud =  pcldfmc(iplon,ikl,iw)
+
+               ze1 = ztauo(iplon,iw,jk) / prmu0(iplon)  ! ztauo corresponds to ztauc at this point in _sw.F version
+               if (ze1 .le. od_lo) then
+                  zdbtmc = 1. - ze1 + 0.5 * ze1 * ze1
+               else
+                  tblind = ze1 / (bpade + ze1)
+                  itind = tblint * tblind + 0.5
+                  zdbtmc = exp_tbl(itind)
+               endif
+
+               zdbtc_nodel(iplon,iw,jk) = zdbtmc
+               ztdbtc_nodel(iplon,iw,jk+1) = zdbtc_nodel(iplon,iw,jk) * ztdbtc_nodel(iplon,iw,jk)
+
+               tauorig = ztauo(iplon,iw,jk) + ptaormc(iplon,ikl,iw)    ! ztauo corresponds to ztauc at this point in _sw.F version
+               ze1 = tauorig / prmu0(iplon)
+               if (ze1 .le. od_lo) then
+                  zdbtmo = 1. - ze1 + 0.5 * ze1 * ze1
+               else
+                  tblind = ze1 / (bpade + ze1)
+                  itind = tblint * tblind + 0.5
+                  zdbtmo = exp_tbl(itind)
+               endif
+
+               zdbt_nodel(iplon,iw,jk) = zclear*zdbtmc + zcloud*zdbtmo
+               ztdbt_nodel(iplon,iw,jk+1) = zdbt_nodel(iplon,iw,jk) * ztdbt_nodel(iplon,iw,jk)
+
+#endif
+
+               zomco(iplon,iw,jk)   = ztaur(iplon,ikl,iw) + ptaua(iplon,ikl,ibm) * pomga(iplon,ikl,ibm)
+               zgco(iplon,iw,jk) = pasya(iplon,ikl,ibm) * pomga(iplon,ikl,ibm) * ptaua(iplon,ikl,ibm) / zomco(iplon,iw,jk)   
+               zomco(iplon,iw,jk)   = zomco(iplon,iw,jk) / ztauo(iplon,iw,jk)
+               
+               zf = zgco(iplon, iw, jk)
+               zf = zf * zf
+               zwf = zomco(iplon, iw, jk) * zf
+
+               ztauo(iplon, iw, jk) = (1.0 - zwf) * ztauo(iplon, iw, jk)
+               zomco(iplon, iw, jk) = (zomco(iplon, iw, jk) - zwf) / (1.0 - zwf)
+               zgco(iplon, iw, jk) = (zgco(iplon, iw, jk) - zf) / (1.0 - zf)
+               
+           end do    
+        end do
+      end do
+!$acc end kernels               
+
+
+! Clear sky reflectivities
+      call reftra_sw (ncol, nlayers, &
+                      pcldfmc, zgco, prmu0, ztauo, zomco, &
+                      zrefo, zrefdo, ztrao, ztrado, 1)
+                        
+
+!$acc kernels loop    
+       ILOOP_S_GPU
+
+! Combine clear and cloudy reflectivies and optical depths     
+
+!$acc loop
+       WLOOP_S_GPU
+            
+!$acc loop seq
+            do jk=1,klev
+
+       WLOOP_S_CPU
+       ILOOP_S_CPU
+! Combine clear and cloudy contributions for total sky
+               !ikl = klev+1-jk 
+
+! Direct beam transmittance        
+
+               ze1 = (ztauo(iplon,iw,jk))  / prmu0(iplon)      
+#ifdef _OPENACC
+               zdbtmc = exp(-ze1)
+#else
+               ze1 = ztauo(iplon,iw,jk) / prmu0(iplon)
+               if (ze1 .le. od_lo) then
+                  zdbtmc = 1. - ze1 + 0.5 * ze1 * ze1
+               else
+                  tblind = ze1 / (bpade + ze1)
+                  itind = tblint * tblind + 0.5
+                  zdbtmc = exp_tbl(itind)
+               endif
+#endif
+               zdbt(iplon,iw,jk)   = zdbtmc
+               ztdbt(iplon,iw,jk+1)   = zdbt(iplon,iw,jk)  *ztdbt(iplon,iw,jk)  
+
+           end do          
+        end do
+      end do
+!$acc end kernels
+
+! compute the fluxes from the optical depths and reflectivities
+
+                 
+! Vertical quadrature for clear-sky fluxes
+
+!$acc kernels 
+       ILOOP_S_GPU
+        WLOOP_S_GPU
+       WLOOP_S_CPU
+          jb = ngb(iw)
+          ibm = jb-15
+        ILOOP_S_CPU
+
+! Top of shortwave spectral band loop, jb = 16 -> 29; ibm = 1 -> 14
+
+
+          zgco(iplon,iw,klev+1)   =palbp(iplon,ibm) 
+          zomco(iplon,iw,klev+1)  =palbd(iplon,ibm) 
+    
+        end do
+      end do
+!$acc end kernels  
+
+
+            call vrtqdr_sw(ncol, klev, &
+                           zrefo  , zrefdo  , ztrao  , ztrado  , &
+                           zdbt , zrdnd  , zgco, zomco, ztdbt  , &
+                           zcd , zcu  , ztra)
+            
+! perform band integration for clear cases      
+!$acc kernels loop
+       ILOOP_S_GPU
+    
+!$acc loop    
+        do ikl=1,klev+1
+            
+      !$acc loop seq
+          do iw = 1, 112
+             jb = ngb(iw)
+      
+             jk=klev+2-ikl
+             ibm = jb-15
+!DIR$ SIMD
+          ILOOP_S_CPU
+             zincflx = adjflux(jb)  * zsflxzen(iplon,iw)   * prmu0(iplon)           
+
+! Accumulate spectral fluxes over whole spectrum  
+              
+             pbbcu(iplon,ikl)  = pbbcu(iplon,ikl)  + zincflx*zcu(iplon,iw,jk)  
+             pbbcd(iplon,ikl)  = pbbcd(iplon,ikl)  + zincflx*zcd(iplon,iw,jk)  
+             pbbcddir(iplon,ikl)  = pbbcddir(iplon,ikl)  + zincflx*ztdbtc_nodel(iplon,iw,jk)  
+              
+
+! Accumulate direct fluxes for UV/visible bands
+             if (ibm >= 10 .and. ibm <= 13) then
+                puvcd(iplon,ikl)  = puvcd(iplon,ikl)  + zincflx*zcd(iplon,iw,jk)  
+                puvcddir(iplon,ikl)  = puvcddir(iplon,ikl)  + zincflx*ztdbtc_nodel(iplon,iw,jk)  
+                 
+! Accumulate direct fluxes for near-IR bands
+             else if (ibm == 14 .or. ibm <= 9) then  
+                pnicd(iplon,ikl)  = pnicd(iplon,ikl)  + zincflx*zcd(iplon,iw,jk)  
+                pnicddir(iplon,ikl)  = pnicddir(iplon,ikl)  + zincflx*ztdbtc_nodel(iplon,iw,jk)  
+                 
+             endif
+
+          enddo          
+
+! End loop on jb, spectral band
+        enddo
+
+! End of longitude loop    
+      enddo               
+!$acc end kernels
+
+
+
+      if (cc==2) then
+
+!$acc kernels 
+        ILOOP_S_GPU
+          WLOOP_S_GPU
+            do jk=1,klev
+
+               ikl=klev+1-jk
+          WLOOP_S_CPU
+               jb = ngb(iw)
+               ibm = jb-15
+!DIR$ SIMD
+           ILOOP_S_CPU
+               ! since the cloudy cases are now computed in a separate partition from the clear cases, we must
+               ! recompute the needed clear sky prerequisites.
+               ze1 = ztaur(iplon,ikl,iw) + ptaua(iplon,ikl,ibm) * pomga(iplon, ikl, ibm) 
+               ze2 = pasya(iplon, ikl, ibm) * pomga(iplon, ikl, ibm) * ptaua(iplon, ikl, ibm) / ze1
+               ze1 = ze1/ (ztaur(iplon,ikl,iw)  + ztaug(iplon,ikl,iw) + ptaua(iplon,ikl,ibm)  )
+               
+               ! compute delta scaled coefficients
+               zf = ze2*ze2
+               zwf = ze1*zf
+               ze1 = (ze1 - zwf) / (1.0 - zwf)
+               ze2 = (ze2 - zf) / (1.0 - zf)
+
+               ! direct calculation of delta scaled values
+               zomco(iplon,iw,jk)   = (ztauo(iplon,iw,jk) * ze1  + ptaucmc(iplon,ikl,iw)  * pomgcmc(iplon,ikl,iw))
+               
+               zgco(iplon, iw, jk) =  (ptaucmc(iplon,ikl,iw)  * pomgcmc(iplon,ikl,iw)  * pasycmc(iplon,ikl,iw) ) + &
+                                      (ztauo(iplon, iw, jk) * ze1 * ze2)
+               
+               ztauo(iplon,iw,jk)   = ztauo(iplon,iw,jk) + ptaucmc(iplon,ikl,iw) 
+
+               zgco(iplon,iw,jk)   = zgco(iplon, iw, jk) / zomco(iplon, iw, jk)
+               zomco(iplon,iw,jk)  = zomco(iplon,iw,jk) / ztauo(iplon,iw,jk)
+             
+            end do    
+          end do
+        end do
+!$acc end kernels
+
+
+! Total sky reflectivities      
+        call reftra_sw (ncol, nlayers, &
+                        pcldfmc, zgco, prmu0, ztauo, zomco, &
+                        zref, zrefd, ztra, ztrad, 0)
+            
+
+        klev = nlayers
+
+
+!$acc kernels loop    
+        ILOOP_S_GPU
+
+!$acc loop
+          WLOOP_S_GPU
+            
+!$acc loop seq
+            do jk=1,klev
+
+! Combine clear and cloudy contributions for total sky
+               ikl = klev+1-jk 
+          WLOOP_S_CPU
+            ILOOP_S_CPU
+               zclear = 1.0  - pcldfmc(iplon,ikl,iw) 
+               zcloud = pcldfmc(iplon,ikl,iw) 
+
+               zref(iplon,iw,jk)   = zclear*zrefo(iplon,iw,jk)   + zcloud*zref(iplon,iw,jk)  
+               zrefd(iplon,iw,jk)  = zclear*zrefdo(iplon,iw,jk)   + zcloud*zrefd(iplon,iw,jk)  
+               ztra(iplon,iw,jk)   = zclear*ztrao(iplon,iw,jk)   + zcloud*ztra(iplon,iw,jk)  
+               ztrad(iplon,iw,jk)  = zclear*ztrado(iplon,iw,jk)   + zcloud*ztrad(iplon,iw,jk)  
+
+! Clear + Cloud
+
+               ze1 = ztauo(iplon,iw,jk )   / prmu0(iplon)   
+#ifdef _OPENACC
+               zdbtmo = exp(-ze1)            
+#else
+              if (ze1 .le. od_lo) then
+                  zdbtmo = 1. - ze1 + 0.5 * ze1 * ze1
+               else
+                  tblind = ze1 / (bpade + ze1)
+                  itind = tblint * tblind + 0.5
+                  zdbtmo = exp_tbl(itind)
+               endif
+#endif
+               ze1 = (ztauo(iplon,iw,jk) - ptaucmc(iplon,ikl,iw))  / prmu0(iplon)           
+#ifdef _OPENACC
+               zdbtmc = exp(-ze1)
+#else
+               if (ze1 .le. od_lo) then
+                  zdbtmc = 1. - ze1 + 0.5 * ze1 * ze1
+               else
+                  tblind = ze1 / (bpade + ze1)
+                  itind = tblint * tblind + 0.5
+                  zdbtmc = exp_tbl(itind)
+               endif
+#endif
+            
+               zdbt(iplon,iw,jk)   = zclear*zdbtmc + zcloud*zdbtmo
+               ztdbt(iplon,iw,jk+1)   = zdbt(iplon,iw,jk)  *ztdbt(iplon,iw,jk)  
+
+            enddo          
+          end do
+        end do
+!$acc end kernels
+
+!$acc kernels
+        zrdnd = 0.0
+        zgco = 0.0
+        zomco = 0.0
+        zfd = 0.0
+        zfu = 0.0
+!$acc end kernels
+
+
+!$acc kernels 
+        ILOOP_S_GPU
+          WLOOP_S_GPU
+
+! Top of shortwave spectral band loop, jb = 16 -> 29; ibm = 1 -> 14
+
+        WLOOP_S_CPU
+            jb = ngb(iw)
+            ibm = jb-15
+          ILOOP_S_CPU
+
+            zgco(iplon,iw,klev+1)   =palbp(iplon,ibm) 
+            zomco(iplon,iw,klev+1)  =palbd(iplon,ibm) 
+    
+          end do
+        end do
+!$acc end kernels  
+
+
+! Vertical quadrature for cloudy fluxes
+
+
+        call vrtqdr_sw(ncol, klev, &
+                       zref  , zrefd  , ztra  , ztrad , &
+                       zdbt , zrdnd  , zgco, zomco , ztdbt  , &
+                       zfd , zfu  ,  ztrao)
+
+! Upwelling and downwelling fluxes at levels
+!   Two-stream calculations go from top to bottom; 
+!   layer indexing is reversed to go bottom to top for output arrays
+
+        klev = nlayers
+        repclc = 1.e-12 
+
+!$acc kernels loop
+        ILOOP_S_GPU
+    
+!$acc loop    
+          do ikl=1,klev+1
+!$acc loop seq
+          WLOOP_S_GPU
+          WLOOP_S_CPU
+               jb = ngb(iw)
+               jk=klev+2-ikl
+               ibm = jb-15
+            ILOOP_S_CPU
+               zincflx = adjflux(jb)  * zsflxzen(iplon,iw)   * prmu0(iplon)           
+
+! Accumulate spectral fluxes over whole spectrum  
+               pbbfu(iplon,ikl)  = pbbfu(iplon,ikl)  + zincflx*zfu(iplon,iw,jk)  
+               pbbfd(iplon,ikl)  = pbbfd(iplon,ikl)  + zincflx*zfd(iplon,iw,jk)              
+               pbbfddir(iplon,ikl)  = pbbfddir(iplon,ikl)  + zincflx*ztdbt_nodel(iplon,iw,jk)  
+
+! Accumulate direct fluxes for UV/visible bands
+               if (ibm >= 10 .and. ibm <= 13) then
+                 
+                  puvfd(iplon,ikl)  = puvfd(iplon,ikl)  + zincflx*zfd(iplon,iw,jk)  
+                  puvfddir(iplon,ikl)  = puvfddir(iplon,ikl)  + zincflx*ztdbt_nodel(iplon,iw,jk)  
+                 
+                 
+! Accumulate direct fluxes for near-IR bands
+               else if (ibm == 14 .or. ibm <= 9) then  
+                
+                  pnifd(iplon,ikl)  = pnifd(iplon,ikl)  + zincflx*zfd(iplon,iw,jk)  
+                  pnifddir(iplon,ikl)  = pnifddir(iplon,ikl)  + zincflx*ztdbt_nodel(iplon,iw,jk)  
+                   
+                 
+               endif
+
+            enddo          
+
+! End loop on jb, spectral band
+          enddo
+
+! End of longitude loop    
+        enddo               
+!$acc end kernels
+
+
+      else      ! cc = 1
+!$acc kernels
+         pbbfd = pbbcd
+         pbbfu = pbbcu
+         puvfd = puvcd
+         puvfddir = puvcddir
+         pnifd = pnicd
+         pnifddir = pnicddir
+!$acc end kernels    
+      end if    ! if cc=2, else, endif
+
+
+!$acc kernels
+      ILOOP_S_GPU
+         WLOOP_S_GPU
+      WLOOP_S_CPU
+            jb = ngb(iw)
+            ibm = jb - 15
+         ILOOP_S_CPU
+            zincflx = adjflux(jb)  * zsflxzen(iplon,iw)   * prmu0(iplon)    
+            
+         end do
+      end do
+!$acc end kernels
+
+!$acc end data
+# undef ILOOP_S_GPU
+# undef ILOOP_E_GPU
+# undef ILOOP_S_CPU
+# undef ILOOP_E_CPU
+# undef WLOOP_S_GPU
+# undef WLOOP_E_GPU
+# undef WLOOP_S_CPU
+# undef WLOOP_E_CPU
+#ifndef _OPENACC
+#  undef ncol
+#endif
+         
+! !!!!!!!!!!!!!!!!!!!!!
+!  END CLEAR  !!!!!!!!!
+! !!!!!!!!!!!!!!!!!!!!!
+
+      end subroutine spcvmc_sw
+             
+! --------------------------------------------------------------------
+      subroutine reftra_sw(ncol, nlayers, pcldfmc, pgg, prmuzl, ptau, pw, &
+                           pref, prefd, ptra, ptrad, ac)
+! --------------------------------------------------------------------
+  
+! Purpose: computes the reflectivity and transmissivity of a clear or 
+!   cloudy layer using a choice of various approximations.
+!
+! Interface:  *rrtmg_sw_reftra* is called by *rrtmg_sw_spcvrt*
+!
+! Description:
+! explicit arguments :
+! --------------------
+! inputs
+! ------ 
+!      lrtchk  = .t. for all layers in clear profile
+!      lrtchk  = .t. for cloudy layers in cloud profile 
+!              = .f. for clear layers in cloud profile
+!      pgg     = assymetry factor
+!      prmuz   = cosine solar zenith angle
+!      ptau    = optical thickness
+!      pw      = single scattering albedo
+!
+! outputs
+! -------
+!      pref    : collimated beam reflectivity
+!      prefd   : diffuse beam reflectivity 
+!      ptra    : collimated beam transmissivity
+!      ptrad   : diffuse beam transmissivity
+!
+!
+! Method:
+! -------
+!      standard delta-eddington, p.i.f.m., or d.o.m. layer calculations.
+!      kmodts  = 1 eddington (joseph et al., 1976)
+!              = 2 pifm (zdunkowski et al., 1980)
+!              = 3 discrete ordinates (liou, 1973)
+!
+! ac = 1 -- clear
+! ac = 0 -- total (clear and cloudy)
+!
+! Modifications:
+! --------------
+! Original: J-JMorcrette, ECMWF, Feb 2003
+! Revised for F90 reformatting: MJIacono, AER, Jul 2006
+! Revised to add exponential lookup table: MJIacono, AER, Aug 2007
+!
+! ------------------------------------------------------------------
+
+! ------- Declarations ------
+
+! ------- Input -------
+
+      integer , intent(in) :: nlayers
+      integer , intent(in) :: ncol
+
+      real,  intent(in) :: pcldfmc(:,:,:)                      ! Logical flag for reflectivity and
+                                                               ! and transmissivity calculation; 
+                                                               !   Dimensions: (ncol,nlayers,ngptsw)
+
+      real , intent(in) :: pgg(:,:,:)               ! asymmetry parameter
+      real , intent(in) :: ptau(:,:,:)              ! optical depth
+      real , intent(in) :: pw(:,:,:)                ! single scattering albedo 
+                                                               !   Dimensions: (ncol,nlayers,ngptsw)
+
+      real ,  intent(in) :: prmuzl(:)                          ! cosine of solar zenith angle
+                                                               !   Dimensions: (ncol)
+      integer, intent(in) :: ac
+
+! ------- Output -------
+
+      real , intent(out) :: pref(:,:,:)             ! direct beam reflectivity
+      real , intent(out) :: prefd(:,:,:)            ! diffuse beam reflectivity
+      real , intent(out) :: ptra(:,:,:)             ! direct beam transmissivity
+      real , intent(out) :: ptrad(:,:,:)            ! diffuse beam transmissivity
+                                                               !   Dimensions: (ncol,nlayers,ngptsw)
+
+! ------- Local -------
+
+      integer  :: jk, jl, kmodts
+      integer  :: itind, iplon, iw
+
+      real  :: tblind
+      real  :: za, za1, za2
+      real  :: zbeta, zdend, zdenr, zdent
+      real  :: ze1, ze2, zem1, zem2, zemm, zep1, zep2
+      real  :: zg, zg3, zgamma1, zgamma2, zgamma3, zgamma4, zgt
+      real  :: zr1, zr2, zr3, zr4, zr5
+      real  :: zrk, zrk2, zrkg, zrm1, zrp, zrp1, zrpp
+      real  :: zsr3, zt1, zt2, zt3, zt4, zt5, zto1
+      real  :: zw, zwcrit, zwo, prmuz
+
+      real , parameter :: eps = 1.e-08 
+
+!     ------------------------------------------------------------------
+
+! Initialize
+
+      zsr3=sqrt(3. )
+      zwcrit=0.9999995 
+      kmodts=2
+      
+!$acc kernels loop
+      do iplon=1,ncol
+!$acc loop
+        do iw=1,112
+!$acc loop private(zgamma1, zgamma2, zgamma3, zgamma4)
+          do jk=1, nlayers
+             prmuz = prmuzl(iplon)
+             if ((.not.(pcldfmc(iplon,nlayers+1-jk,iw))  > 1.e-12) .and. ac==0  ) then
+               pref(iplon,iw,jk)   =0. 
+               ptra(iplon,iw,jk)   =1. 
+               prefd(iplon,iw,jk)  =0. 
+               ptrad(iplon,iw,jk)  =1. 
+             else
+               zto1=ptau(iplon,iw,jk)  
+               zw  =pw(iplon,iw,jk)  
+               zg  =pgg(iplon,iw,jk)    
+
+! General two-stream expressions
+
+               zg3= 3.  * zg
+           
+               zgamma1= (8.  - zw * (5.  + zg3)) * 0.25 
+               zgamma2=  3.  *(zw * (1.  - zg )) * 0.25 
+               zgamma3= (2.  - zg3 * prmuz ) * 0.25 
+       
+               zgamma4= 1.  - zgamma3
+    
+! Recompute original s.s.a. to test for conservative solution
+
+               zwo= zw / (1.  - (1.  - zw) * (zg / (1.  - zg))**2)
+    
+               if (zwo >= zwcrit) then
+! Conservative scattering
+
+                  za  = zgamma1 * prmuz 
+                  za1 = za - zgamma3
+                  zgt = zgamma1 * zto1
+        
+! Homogeneous reflectance and transmittance,
+! collimated beam
+
+                  ze1 = min ( zto1 / prmuz , 500. )
+
+
+                  ze2 = exp(-ze1)
+                  pref(iplon,iw,jk)   = (zgt - za1 * (1.  - ze2)) / (1.  + zgt)
+                  ptra(iplon,iw,jk)   = 1.  - pref(iplon,iw,jk)  
+
+! isotropic incidence
+
+                  prefd(iplon,iw,jk)   = zgt / (1.  + zgt)
+                  ptrad(iplon,iw,jk)   = 1.  - prefd(iplon,iw,jk)          
+
+! This is applied for consistency between total (delta-scaled) and direct (unscaled) 
+! calculations at very low optical depths (tau < 1.e-4) when the exponential lookup
+! table returns a transmittance of 1.0.
+                  if (ze2 .eq. 1.0 ) then 
+                     pref(iplon,iw,jk)   = 0.0 
+                     ptra(iplon,iw,jk)   = 1.0 
+                     prefd(iplon,iw,jk)   = 0.0 
+                     ptrad(iplon,iw,jk)   = 1.0 
+                  endif
+
+               else
+! Non-conservative scattering
+
+                  za1 = zgamma1 * zgamma4 + zgamma2 * zgamma3
+                  za2 = zgamma1 * zgamma3 + zgamma2 * zgamma4
+                  zrk = sqrt ( zgamma1**2 - zgamma2**2)
+                  zrp = zrk * prmuz               
+                  zrp1 = 1.  + zrp
+                  zrm1 = 1.  - zrp
+                  zrk2 = 2.  * zrk
+                  zrpp = 1.  - zrp*zrp
+                  zrkg = zrk + zgamma1
+                  zr1  = zrm1 * (za2 + zrk * zgamma3)
+                  zr2  = zrp1 * (za2 - zrk * zgamma3)
+                  zr3  = zrk2 * (zgamma3 - za2 * prmuz )
+                  zr4  = zrpp * zrkg
+                  zr5  = zrpp * (zrk - zgamma1)
+                  zt1  = zrp1 * (za1 + zrk * zgamma4)
+                  zt2  = zrm1 * (za1 - zrk * zgamma4)
+                  zt3  = zrk2 * (zgamma4 + za1 * prmuz )
+                  zt4  = zr4
+                  zt5  = zr5
+
+! mji - reformulated code to avoid potential floating point exceptions
+!               zbeta = - zr5 / zr4
+                  zbeta = (zgamma1 - zrk) / zrkg
+!!
+        
+! Homogeneous reflectance and transmittance
+
+                  ze1 = min ( zrk * zto1, 5. )
+                  ze2 = min ( zto1 / prmuz , 5. )
+           
+! Use exponential lookup table for transmittance, or expansion of 
+! exponential for low tau
+                  if (ze1 .le. od_lo) then 
+                     zem1 = 1.  - ze1 + 0.5  * ze1 * ze1
+                     zep1 = 1.  / zem1
+                  else
+                     zem1 = exp(-ze1)
+                     zep1 = 1.  / zem1
+                  endif
+                  if (ze2 .le. od_lo) then 
+                     zem2 = 1.  - ze2 + 0.5  * ze2 * ze2
+                     zep2 = 1.  / zem2
+                  else
+                     zem2 = exp(-ze2)
+                     zep2 = 1.  / zem2
+                  endif
+
+                  zdenr = zr4*zep1 + zr5*zem1
+                  zdent = zt4*zep1 + zt5*zem1
+                  if (zdenr .ge. -eps .and. zdenr .le. eps) then
+                     pref(iplon,iw,jk)   = eps
+                     ptra(iplon,iw,jk)   = zem2
+                  else 
+                     pref(iplon,iw,jk)   = zw * (zr1*zep1 - zr2*zem1 - zr3*zem2) / zdenr
+                     ptra(iplon,iw,jk)   = zem2 - zem2 * zw * (zt1*zep1 - zt2*zem1 - zt3*zep2) / zdent
+                  endif
+
+! diffuse beam
+
+                  zemm = zem1*zem1
+                  zdend = 1.  / ( (1.  - zbeta*zemm ) * zrkg)
+                  prefd(iplon,iw,jk)   =  zgamma2 * (1.  - zemm) * zdend
+                  ptrad(iplon,iw,jk)   =  zrk2*zem1*zdend
+
+               endif
+
+            endif         
+
+          end do  
+        end do
+      end do
+!$acc end kernels
+
+      end subroutine reftra_sw
+                           
+! --------------------------------------------------------------------------
+      subroutine vrtqdr_sw(ncol, klev, &
+                           pref, prefd, ptra, ptrad, &
+                           pdbt, prdnd, prup, prupd, ptdbt, &
+                           pfd, pfu, ztdn)
+! --------------------------------------------------------------------------
+ 
+! Purpose: This routine performs the vertical quadrature integration
+!
+! Interface:  *vrtqdr_sw* is called from *spcvrt_sw* and *spcvmc_sw*
+!
+! Modifications.
+! 
+! Original: H. Barker
+! Revision: Integrated with rrtmg_sw, J.-J. Morcrette, ECMWF, Oct 2002
+! Revision: Reformatted for consistency with rrtmg_lw: MJIacono, AER, Jul 2006
+!
+!-----------------------------------------------------------------------
+
+! ------- Declarations -------
+
+! Input
+
+      integer , intent (in) :: klev                           ! number of model layers
+      integer , intent (in) :: ncol
+    
+
+#ifdef _OPENACC
+      real , intent(in) :: pref(:,:,:)             ! direct beam reflectivity
+      real , intent(in) :: prefd(:,:,:)            ! diffuse beam reflectivity
+      real , intent(in) :: ptra(:,:,:)             ! direct beam transmissivity
+      real , intent(in) :: ptrad(:,:,:)            ! diffuse beam transmissivity
+      real , intent(in) :: pdbt(:,:,:)  
+      real , intent(in) :: ptdbt(:,:,:)  
+      real , intent(out) :: prdnd(:,:,:)  
+      real , intent(inout) :: prup(:,:,:)  
+      real , intent(inout) :: prupd(:,:,:)  
+      real, intent(inout) :: ztdn(:,:,:)
+                                                              !   Dimensions: (ncol,nlayers,ngptsw)
+                                                              
+! Output
+      real , intent(out) :: pfd(:,:,:)            ! downwelling flux (W/m2)
+                                                              ! unadjusted for earth/sun distance or zenith angle
+      real , intent(inout) :: pfu(:,:,:)          ! upwelling flux (W/m2)
+                                                              ! unadjusted for earth/sun distance or zenith angle
+                                                              !   Dimensions: (ncol,nlayers,ngptsw)
+#else
+      real , intent(in) :: pref(CHNK,112,klev+1)             ! direct beam reflectivity
+      real , intent(in) :: prefd(CHNK,112,klev+1)            ! diffuse beam reflectivity
+      real , intent(in) :: ptra(CHNK,112,klev+1)             ! direct beam transmissivity
+      real , intent(in) :: ptrad(CHNK,112,klev+1)            ! diffuse beam transmissivity
+      real , intent(in) :: pdbt(CHNK,112,klev+1)
+      real , intent(in) :: ptdbt(CHNK,112,klev+1)
+      real , intent(out) :: prdnd(CHNK,112,klev+1)
+      real , intent(inout) :: prup(CHNK,112,klev+1)
+      real , intent(inout)  :: prupd(CHNK,112,klev+1)
+      real, intent(inout) :: ztdn(CHNK,112,klev+1)
+                                                              !   Dimensions: (ncol,nlayers,ngptsw)
+
+! Output
+      real , intent(out) :: pfd(CHNK,112,klev+1)            ! downwelling flux (W/m2)
+                                                              ! unadjusted for earth/sun distance or zenith angle
+      real , intent(inout) :: pfu(CHNK,112,klev+1)          ! upwelling flux (W/m2)
+                                                              ! unadjusted for earth/sun distance or zenith angle
+                                                              !   Dimensions: (ncol,nlayers,ngptsw)
+#endif
+
+! Local
+
+      integer  :: ikp, ikx, jk, iplon, iw
+
+#ifdef _OPENACC
+
+      real  :: zreflect, zreflectj
+
+# define ILOOP_S_CPU 
+# define ILOOP_E_CPU
+# define ILOOP_S_GPU do iplon = 1, ncol
+# define ILOOP_E_GPU enddo
+# define WLOOP_S_CPU 
+# define WLOOP_E_CPU 
+# define WLOOP_S_GPU do iw = 1, 112
+# define WLOOP_E_GPU enddo
+
+#else
+
+!      real, dimension(CHNK)  :: zreflect, zreflectj
+      real  :: zreflect, zreflectj
+
+# define ncol CHNK
+
+# define ILOOP_S_GPU 
+# define ILOOP_E_GPU 
+# define ILOOP_S_CPU do iplon = 1, ncol
+# define ILOOP_E_CPU enddo
+# define WLOOP_S_GPU 
+# define WLOOP_E_GPU 
+# define WLOOP_S_CPU do iw = 1, 112
+# define WLOOP_E_CPU enddo
+
+!# define zreflect ZREFLECT(iplon)
+!# define zreflectj ZREFLECTJ(iplon)
+
+#endif
+     
+! Definitions
+!
+! pref(jk)   direct reflectance
+! prefd(jk)  diffuse reflectance
+! ptra(jk)   direct transmittance
+! ptrad(jk)  diffuse transmittance
+!
+! pdbt(jk)   layer mean direct beam transmittance
+! ptdbt(jk)  total direct beam transmittance at levels
+!
+!-----------------------------------------------------------------------------
+                   
+! Link lowest layer with surface
+! this kernel has a lot of dependencies
+
+!               CHNK       hardcode      klev+1
+! pref            8         112          52
+! prefd            8         112          52
+! ptra            8         112          52
+! ptrad            8         112          52
+! pdbt            8         112          52
+! ptdbt            8         112          52
+! prdnd            8         112          52
+! prup            8         112          52
+! prupd            8         112          52
+! ztdn            8         112          52
+! pfd            8         112          52
+! pfu            8         112          52
+!DIR$ ASSUME_ALIGNED pref:64,prefd:64,ptra:64,ptrad:64
+!DIR$ ASSUME_ALIGNED pdbt:64,ptdbt:64,prdnd:64,prup:64,prupd:64,ztdn:64,pfd:64,pfu:64
+
+#if 0
+write(0,*)'pref ',shape( pref)             ! direct beam reflectivity
+write(0,*)'prefd ',shape( prefd)            ! diffuse beam reflectivity
+write(0,*)'ptra ',shape( ptra)             ! direct beam transmissivity
+write(0,*)'ptrad ',shape( ptrad)            ! diffuse beam transmissivity
+write(0,*)'pdbt ',shape( pdbt)
+write(0,*)'ptdbt ',shape( ptdbt)
+write(0,*)'prdnd ',shape( prdnd)
+write(0,*)'prup ',shape( prup)
+write(0,*)'prupd ',shape( prupd)
+write(0,*)'ztdn ',shape( ztdn)
+write(0,*)'pfd ',shape( pfd)            ! downwelling flux (W/m2)
+write(0,*)'pfu ',shape( pfu)          ! upwelling flux (W/m2)
+#endif
+
+
+
+!$acc kernels loop
+      ILOOP_S_GPU
+
+!$acc loop private(zreflect)
+        WLOOP_S_GPU
+         WLOOP_S_CPU
+!DIR$ VECTOR ALIGNED
+           ILOOP_S_CPU
+            zreflect = 1.  / (1.  - prefd(iplon,iw,klev+1)   * prefd(iplon,iw,klev)  )
+            prup(iplon,iw,klev)   = pref(iplon,iw,klev)   + (ptrad(iplon,iw,klev)   * &
+                 ((ptra(iplon,iw,klev)   - pdbt(iplon,iw,klev)  ) * prefd(iplon,iw,klev+1)   + &
+                   pdbt(iplon,iw,klev)   * pref(iplon,iw,klev+1)  )) * zreflect
+            prupd(iplon,iw,klev)   = prefd(iplon,iw,klev)   + ptrad(iplon,iw,klev)   * ptrad(iplon,iw,klev)   * &
+                    prefd(iplon,iw,klev+1)   * zreflect
+           ILOOP_E_CPU
+         WLOOP_E_GPU
+        WLOOP_E_CPU
+      ILOOP_E_GPU
+!$acc end kernels
+      
+! Pass from bottom to top 
+!$acc kernels loop
+      ILOOP_S_GPU
+
+!$acc loop    
+       WLOOP_S_GPU
+
+!$acc loop seq 
+            do jk = 1,klev-1
+               ikp = klev+1-jk                       
+               ikx = ikp-1
+         WLOOP_S_CPU
+!DIR$ VECTOR ALIGNED
+           ILOOP_S_CPU
+               zreflectj = 1.  / (1.  -prupd(iplon,iw,ikp)   * prefd(iplon,iw,ikx)  )
+               prup(iplon,iw,ikx)   = pref(iplon,iw,ikx)   + (ptrad(iplon,iw,ikx)   * &
+                   ((ptra(iplon,iw,ikx)   - pdbt(iplon,iw,ikx)  ) * prupd(iplon,iw,ikp)   + &
+                     pdbt(iplon,iw,ikx)   * prup(iplon,iw,ikp)  )) * zreflectj
+               prupd(iplon,iw,ikx)   = prefd(iplon,iw,ikx)   + ptrad(iplon,iw,ikx)   * ptrad(iplon,iw,ikx)   * &
+                      prupd(iplon,iw,ikp)   * zreflectj
+           ILOOP_E_CPU
+         WLOOP_E_CPU
+            end do
+       WLOOP_E_GPU
+      ILOOP_E_GPU
+!$acc end kernels
+
+!$acc kernels loop
+      ILOOP_S_GPU
+!$acc loop
+        WLOOP_S_GPU
+         WLOOP_S_CPU
+
+! Upper boundary conditions
+!DIR$ VECTOR ALIGNED
+           ILOOP_S_CPU
+            ztdn(iplon, iw, 1) = 1. 
+            prdnd(iplon,iw,1)   = 0. 
+            ztdn(iplon, iw, 2) = ptra(iplon,iw,1)  
+            prdnd(iplon,iw,2)   = prefd(iplon,iw,1)  
+           ILOOP_E_CPU
+         WLOOP_E_GPU
+        WLOOP_E_CPU
+      ILOOP_E_GPU
+!$acc end kernels      
+      
+!$acc kernels loop
+      ILOOP_S_GPU
+!$acc loop
+       WLOOP_S_GPU
+
+! Pass from top to bottom
+!$acc loop seq
+            do jk = 2,klev
+               ikp = jk+1
+         WLOOP_S_CPU
+!DIR$ VECTOR ALIGNED
+           ILOOP_S_CPU
+               zreflect = 1.  / (1.  - prefd(iplon,iw,jk)   * prdnd(iplon,iw,jk)  )
+               ztdn(iplon, iw, ikp) = ptdbt(iplon,iw,jk)   * ptra(iplon,iw,jk)   + &
+                    (ptrad(iplon,iw,jk)   * ((ztdn(iplon, iw, jk) - ptdbt(iplon,iw,jk)  ) + &
+                     ptdbt(iplon,iw,jk)   * pref(iplon,iw,jk)   * prdnd(iplon,iw,jk)  )) * zreflect
+               prdnd(iplon,iw,ikp)   = prefd(iplon,iw,jk)   + ptrad(iplon,iw,jk)   * ptrad(iplon,iw,jk)   * &
+                      prdnd(iplon,iw,jk)   * zreflect
+           ILOOP_E_CPU
+         WLOOP_E_CPU
+            end do
+       WLOOP_E_GPU
+      ILOOP_E_GPU
+!$acc end kernels
+    
+! Up and down-welling fluxes at levels
+
+!$acc kernels loop
+      ILOOP_S_GPU
+!$acc loop
+       WLOOP_S_GPU
+!$acc loop 
+            do jk = 1,klev+1
+         WLOOP_S_CPU
+!DIR$ VECTOR ALIGNED
+           ILOOP_S_CPU
+               zreflect = 1.  / (1.  - prdnd(iplon,iw,jk)   * prupd(iplon,iw,jk)  )
+               pfu(iplon,iw,jk)   = (ptdbt(iplon,iw,jk)   * prup(iplon,iw,jk)   + &
+                      (ztdn(iplon, iw, jk) - ptdbt(iplon,iw,jk)  ) * prupd(iplon,iw,jk)  ) * zreflect
+               pfd(iplon,iw,jk)   = ptdbt(iplon,iw,jk)   + (ztdn(iplon, iw, jk) - ptdbt(iplon,iw,jk)  + &
+                      ptdbt(iplon,iw,jk)   * prup(iplon,iw,jk)   * prdnd(iplon,iw,jk)  ) * zreflect
+           ILOOP_E_CPU
+         WLOOP_E_CPU
+            end do
+       WLOOP_E_GPU
+      ILOOP_E_GPU
+!$acc end kernels
+      
+      end subroutine vrtqdr_sw
+
+      end module rrtmg_sw_spcvmc_f
+# undef ILOOP_S_GPU 
+# undef ILOOP_E_GPU 
+# undef ILOOP_S_CPU
+# undef ILOOP_E_CPU
+# undef WLOOP_S_GPU 
+# undef WLOOP_E_GPU 
+# undef WLOOP_S_CPU
+# undef WLOOP_E_CPU
+# undef zreflect
+# undef zreflectj
+# undef ncol
+
+      module rrtmg_sw_rad_f
+!
+! ****************************************************************************
+! *                                                                          *
+! *                             RRTMG_SW                                     *
+! *                                                                          *
+! *                                                                          *
+! *                                                                          *
+! *                 a rapid radiative transfer model                         *
+! *                  for the solar spectral region                           *
+! *           for application to general circulation models                  *
+! *                                                                          *
+! *                                                                          *
+! *           Atmospheric and Environmental Research, Inc.                   *
+! *                       131 Hartwell Avenue                                *
+! *                       Lexington, MA 02421                                *
+! *                                                                          *
+! *                                                                          *
+! *                          Eli J. Mlawer                                   *
+! *                       Jennifer S. Delamere                               *
+! *                        Michael J. Iacono                                 *
+! *                        Shepard A. Clough                                 *
+! *                       David M. Berthiaume                                *
+! *                                                                          *
+! *                                                                          *
+! *                                                                          *
+! *                                                                          *
+! *                                                                          *
+! *                      email:  miacono@aer.com                             *
+! *                      email:  emlawer@aer.com                             *
+! *                      email:  jdelamer@aer.com                            *
+! *                                                                          *
+! *       The authors wish to acknowledge the contributions of the           *
+! *       following people:  Steven J. Taubman, Patrick D. Brown,            *
+! *       Ronald E. Farren, Luke Chen, Robert Bergstrom.                     *
+! *                                                                          *
+! ****************************************************************************
+    
+! --------- Modules ---------
+
+      use rrsw_vsn_f
+      use mcica_subcol_gen_sw_f, only: mcica_sw
+      use rrtmg_sw_cldprmc_f, only: cldprmc_sw
+      use rrtmg_sw_setcoef_f, only: setcoef_sw
+      use rrtmg_sw_spcvmc_f, only: spcvmc_sw
+
+      implicit none
+
+      public :: rrtmg_sw,  earth_sun
+
+      INTEGER, PARAMETER :: debug_level_swf=100
+
+      contains
+    
+      subroutine rrtmg_sw &
+            (rpart   ,ncol    ,nlay    ,icld    ,iaer   , &
+             play    ,plev    ,tlay    ,tlev    ,tsfc   , &
+             h2ovmr  ,o3vmr   ,co2vmr  ,ch4vmr  ,n2ovmr ,o2vmr , &
+             asdir   ,asdif   ,aldir   ,aldif   , &
+             coszen  ,adjes   ,dyofyr  ,scon    , &
+             inflgsw ,iceflgsw,liqflgsw,cld     , &
+             tauc    ,ssac    ,asmc    ,fsfc    , &
+             ciwp    ,clwp    ,cswp    ,rei     ,rel    ,res   , &
+             tauaer  ,ssaaer  ,asmaer  ,ecaer   , &
+             swuflx  ,swdflx  ,swhr    ,swuflxc ,swdflxc,swhrc , &
+! --------- Add the following four compenants for ssib shortwave down radiation ---!
+! -------------------      by Zhenxin 2011-06-20      --------------------------------!
+             sibvisdir, sibvisdif, sibnirdir, sibnirdif,         &
+! ----------------------  End,  Zhenxin 2011-06-20    --------------------------------!
+             swdkdir,   swdkdif                                  & ! jararias, 2013/08/10
+                                )
+
+
+      use parrrsw_f, only : nbndsw, ngptsw, naerec, nstr, nmol, mxmol, &
+                          jpband, jpb1, jpb2, rrsw_scon
+      use rrsw_aer_f, only : rsrtaua, rsrpiza, rsrasya
+      use rrsw_con_f, only : heatfac, oneminus, pi,  grav, avogad
+      use rrsw_wvn_f, only : wavenum1, wavenum2
+      use rrsw_cld_f, only : extliq1, ssaliq1, asyliq1, &
+                           extice2, ssaice2, asyice2, &
+                           extice3, ssaice3, asyice3, fdlice3, &
+                           abari, bbari, cbari, dbari, ebari, fbari
+      use rrsw_wvn_f, only : wavenum2, ngb
+      use rrsw_ref_f, only : preflog, tref
+
+!#ifdef _OPENACC
+!      use cudafor
+!#endif 
+
+
+! ------- Declarations
+
+      integer , intent(in) :: rpart           ! The number of columns in each partition
+      integer , intent(in) :: ncol            ! Number of horizontal columns     
+      integer , intent(in) :: nlay            ! Number of model layers
+      integer , intent(inout) :: icld         ! Cloud overlap method
+                                              !    0: Clear only
+                                              !    1: Random
+                                              !    2: Maximum/random
+                                              !    3: Maximum
+      integer , intent(in) :: iaer            ! Aerosol option flag
+      real , intent(in) :: play(:,:)          ! Layer pressures (hPa, mb)
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: plev(:,:)          ! Interface pressures (hPa, mb)
+                                              !    Dimensions: (ncol,nlay+1)
+      real , intent(in) :: tlay(:,:)          ! Layer temperatures (K)
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: tlev(:,:)          ! Interface temperatures (K)
+                                              !    Dimensions: (ncol,nlay+1)
+      real , intent(in) :: tsfc(:)            ! Surface temperature (K)
+                                              !    Dimensions: (ncol)
+      real , intent(in) :: h2ovmr(:,:)        ! H2O volume mixing ratio
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: o3vmr(:,:)         ! O3 volume mixing ratio
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: co2vmr(:,:)        ! CO2 volume mixing ratio
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: ch4vmr(:,:)        ! Methane volume mixing ratio
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: n2ovmr(:,:)        ! Nitrous oxide volume mixing ratio
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: o2vmr(:,:)         ! Oxygen volume mixing ratio
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: asdir(:)           ! UV/vis surface albedo direct rad
+                                              !    Dimensions: (ncol)
+      real , intent(in) :: aldir(:)           ! Near-IR surface albedo direct rad
+                                              !    Dimensions: (ncol)
+      real , intent(in) :: asdif(:)           ! UV/vis surface albedo: diffuse rad
+                                              !    Dimensions: (ncol)
+      real , intent(in) :: aldif(:)           ! Near-IR surface albedo: diffuse rad
+                                              !    Dimensions: (ncol)
+
+      integer , intent(in) :: dyofyr          ! Day of the year (used to get Earth/Sun
+                                              !  distance if adjflx not provided)
+      real , intent(in) :: adjes              ! Flux adjustment for Earth/Sun distance
+      real , intent(in) :: coszen(:)          ! Cosine of solar zenith angle
+                                              !    Dimensions: (ncol)
+      real , intent(in) :: scon               ! Solar constant (W/m2)
+
+      integer , intent(in) :: inflgsw         ! Flag for cloud optical properties
+      integer , intent(in) :: iceflgsw        ! Flag for ice particle specification
+      integer , intent(in) :: liqflgsw        ! Flag for liquid droplet specification
+
+      real , intent(in) :: cld(:,:)           ! Cloud fraction
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: tauc(:,:,:)        ! In-cloud optical depth
+                                              !    Dimensions: (ncol,nlay,nbndlw)
+      real , intent(in) :: ssac(:,:,:)        ! In-cloud single scattering albedo
+                                              !    Dimensions: (ncol,nlay,nbndlw)
+      real , intent(in) :: asmc(:,:,:)        ! In-cloud asymmetry parameter
+                                              !    Dimensions: (ncol,nlay,nbndlw)
+      real , intent(in) :: fsfc(:,:,:)        ! In-cloud forward scattering fraction
+                                              !    Dimensions: (ncol,nlay,nbndlw)
+      real , intent(in) :: ciwp(:,:)          ! In-cloud ice water path (g/m2)
+                                              !    Dimensions: (ncol, nlay)
+      real , intent(in) :: clwp(:,:)          ! In-cloud liquid water path (g/m2)
+                                              !    Dimensions: (ncol, nlay)
+      real , intent(in) :: cswp(:,:)          ! In-cloud snow water path (g/m2)
+                                              !    Dimensions: (ncol, nlay)
+      real , intent(in) :: rei(:,:)           ! Cloud ice effective radius (microns)
+                                              !    Dimensions: (ncol, nlay)
+                                              ! specific definition of rei depends on setting of iceflglw:
+                                              ! iceflglw = 0: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                              !               r_ec must be >= 10.0 microns
+                                              ! iceflglw = 1: ice effective radius, r_ec, (Ebert and Curry, 1992),
+                                              !               r_ec range is limited to 13.0 to 130.0 microns
+                                              ! iceflglw = 2: ice effective radius, r_k, (Key, Streamer Ref. Manual, 1996)
+                                              !               r_k range is limited to 5.0 to 131.0 microns
+                                              ! iceflglw = 3: generalized effective size, dge, (Fu, 1996),
+                                              !               dge range is limited to 5.0 to 140.0 microns
+                                              !               [dge = 1.0315 * r_ec]
+      real , intent(in) :: rel(:,:)           ! Cloud water drop effective radius (microns)
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: res(:,:)           ! Cloud snow effective radius (microns)
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(in) :: tauaer(:,:,:)      ! Aerosol optical depth (iaer=10 only)
+                                              !    Dimensions: (ncol,nlay,nbndsw)
+                                              ! (non-delta scaled)      
+      real , intent(in) :: ssaaer(:,:,:)      ! Aerosol single scattering albedo (iaer=10 only)
+                                              !    Dimensions: (ncol,nlay,nbndsw)
+                                              ! (non-delta scaled)      
+      real , intent(in) :: asmaer(:,:,:)      ! Aerosol asymmetry parameter (iaer=10 only)
+                                              !    Dimensions: (ncol,nlay,nbndsw)
+                                              ! (non-delta scaled)      
+      real , intent(in) :: ecaer(:,:,:)       ! Aerosol optical depth at 0.55 micron (iaer=6 only)
+                                              !    Dimensions: (ncol,nlay,naerec)
+                                              ! (non-delta scaled)      
+                                              
+! ----- Output -----
+
+      real , intent(out) :: swuflx(:,:)       ! Total sky shortwave upward flux (W/m2)
+                                              !    Dimensions: (ncol,nlay+1)
+      real , intent(out) :: swdflx(:,:)       ! Total sky shortwave downward flux (W/m2)
+                                              !    Dimensions: (ncol,nlay+1)
+      real , intent(out) :: swhr(:,:)         ! Total sky shortwave radiative heating rate (K/d)
+                                              !    Dimensions: (ncol,nlay)
+      real , intent(out) :: swuflxc(:,:)      ! Clear sky shortwave upward flux (W/m2)
+                                              !    Dimensions: (ncol,nlay+1)
+      real , intent(out) :: swdflxc(:,:)      ! Clear sky shortwave downward flux (W/m2)
+                                              !    Dimensions: (ncol,nlay+1)
+      real , intent(out) :: swhrc(:,:)        ! Clear sky shortwave radiative heating rate (K/d)
+                                              !    Dimensions: (ncol,nlay)
+
+      real, intent(out) :: sibvisdir(:,:)      ! visible direct downward flux  (W/m2)
+                                               !    Dimensions: (ncol,nlay+1) Zhenxin (2011/06/20)
+      real, intent(out) :: sibvisdif(:,:)      ! visible diffusion downward flux  (W/m2)
+                                               !    Dimensions: (ncol,nlay+1) Zhenxin (2011/06/20)
+      real, intent(out) :: sibnirdir(:,:)      ! Near IR direct downward flux  (W/m2)
+                                               !    Dimensions: (ncol,nlay+1)  Zhenxin (2011/06/20)
+      real, intent(out) :: sibnirdif(:,:)      ! Near IR diffusion downward flux  (W/m2)
+                                               !    Dimensions: (ncol,nlay+1) Zhenxin (2011/06/20)
+      real, intent(out) :: swdkdir(:,:)        ! Total shortwave downward direct flux (W/m2)
+                                               !    Dimensions: (ncol,nlay+1) jararias, 2013/08/10
+      real, intent(out) :: swdkdif(:,:)        ! Total shortwave downward diffuse flux (W/m2)
+                                               !    Dimensions: (ncol,nlay+1) jararias, 2013/08/10
+
+      integer :: npart, pncol, ns
+      CHARACTER(LEN=256) :: message
+
+! mji - time
+      real :: t1, t2
+      
+#ifdef _OPENACC
+!      type(cudadeviceprop) :: prop
+!      real :: gmem
+      integer :: err
+      integer :: munits
+#endif
+
+      if (rpart > 0) then
+         pncol = rpart
+      else
+
+#ifdef _OPENACC
+ 
+!      err = cudaGetDeviceProperties( prop, 0)
+!      gmem = prop%totalGlobalMem / (1024.0 * 1024.0)
+!      print *, "Total GPU global memory is ", gmem , "MB"
+      
+      ! dmb 2013
+      ! Here 
+      ! The optimal partition size is determined by the following conditions
+      ! 1. Powers of 2 are the most efficient.
+      ! 2. The second to largest power of 2 that can fit on 
+      !    the GPU is most efficient.
+      ! 3. Having a small remainder for the final partiion is inefficient.
+      
+!      if (gmem > 5000) then
+         pncol = 4096
+!      else if (gmem > 3000) then
+!         pncol = 2048
+!      else if (gmem > 1000) then
+!          pncol = 1024
+!      else 
+!          pncol = 512
+!      end if  
+         
+      ! the smallest allowed partition size is 32
+      do err = 1, 6
+          if (pncol > ncol .and. pncol>32) then 
+              pncol = pncol/2
+          end if
+      end do
+      
+      ! if we have a very large number of columns, account for the 
+      ! static ncol memory requirement 
+      if (ncol>29000 .and. pncol>4000) then
+          pncol = pncol/2
+      end if
+
+#else
+      pncol = 2
+      pncol = 4
+!jm      pncol = CHNK  redundant, since this is passed in
+      
+#endif    
+          
+      end if
+
+      WRITE(message,*)'RRTMG_SWF: Number of columns is               ',ncol
+      call wrf_debug( debug_level_swf, message)
+      WRITE(message,*)'RRTMG_SWF: Number of columns per partition is ',pncol
+      call wrf_debug( debug_level_swf, message)
+      ns = ceiling( real(ncol) / real(pncol) )
+      WRITE(message,*)'RRTMG_SWF: Number of partitions is            ',ns
+      call wrf_debug( debug_level_swf, message)
+
+      call cpu_time(t1)
+                                                      
+      call rrtmg_sw_sub &
+            (pncol   ,ncol    ,nlay    ,icld    ,iaer   , &
+             play    ,plev    ,tlay    ,tlev    ,tsfc   , &
+             h2ovmr  ,o3vmr   ,co2vmr  ,ch4vmr  ,n2ovmr ,o2vmr , &
+             asdir   ,asdif   ,aldir   ,aldif   , &
+             coszen  ,adjes   ,dyofyr  ,scon    , &
+             inflgsw ,iceflgsw,liqflgsw,cld     , &
+             tauc    ,ssac    ,asmc    ,fsfc    , &
+             ciwp    ,clwp    ,cswp    ,rei     ,rel    ,res   , &
+             tauaer  ,ssaaer  ,asmaer  ,ecaer   , &
+             swuflx  ,swdflx  ,swhr    ,swuflxc ,swdflxc ,swhrc, &
+             sibvisdir, sibvisdif, sibnirdir, sibnirdif,         &
+             swdkdir  , swdkdif                                  & ! jararias, 2013/08/10
+                                )
+      call cpu_time(t2)
+      WRITE(message,*)'------------------------------------------------'
+      call wrf_debug( debug_level_swf, message)
+      WRITE(message,*)'TOTAL RRTMG_SWF RUN TIME IS   ', t2-t1
+      call wrf_debug( debug_level_swf, message)
+      WRITE(message,*)'------------------------------------------------'
+      call wrf_debug( debug_level_swf, message)
+                                                      
+      end subroutine rrtmg_sw                                                     
+
+
+      subroutine rrtmg_sw_sub &
+            (ncol    ,gncol   ,nlay    ,icld    ,iaer    , &
+             gplay   ,gplev   ,gtlay   ,gtlev   ,gtsfc   , &
+             gh2ovmr ,go3vmr  ,gco2vmr ,gch4vmr ,gn2ovmr ,go2vmr , &
+             gasdir  ,gasdif  ,galdir  ,galdif  , &
+             gcoszen ,adjes   ,dyofyr  ,scon    , &
+             inflgsw ,iceflgsw,liqflgsw,gcld    , &
+             gtauc   ,gssac   ,gasmc   ,gfsfc   , &
+             gciwp   ,gclwp   ,gcswp   ,grei    ,grel    ,gres   , &
+             gtauaer ,gssaaer ,gasmaer ,gecaer  , &
+             swuflx  ,swdflx  ,swhr    ,swuflxc ,swdflxc ,swhrc, &
+             sibvisdir, sibvisdif, sibnirdir, sibnirdif,         &
+             swdkdir  , swdkdif                                  & ! jararias, 2013/08/10
+                                )
+      use parrrsw_f, only : nbndsw, ngptsw, naerec, nstr, nmol, mxmol, &
+                          jpband, jpb1, jpb2, rrsw_scon
+      use rrsw_aer_f, only : rsrtaua, rsrpiza, rsrasya
+      use rrsw_con_f, only : heatfac, oneminus, pi,  grav, avogad
+      use rrsw_wvn_f, only : wavenum1, wavenum2
+      use rrsw_cld_f, only : extliq1, ssaliq1, asyliq1, &
+                           extice2, ssaice2, asyice2, &
+                           extice3, ssaice3, asyice3, fdlice3, &
+                           abari, bbari, cbari, dbari, ebari, fbari
+      use rrsw_wvn_f, only : wavenum2, ngb, icxa, nspa, nspb
+      use rrsw_ref_f, only : preflog, tref
+      use rrsw_kg16_f, kao16 => kao, kbo16 => kbo, selfrefo16 => selfrefo, forrefo16 => forrefo, sfluxrefo16 => sfluxrefo
+      use rrsw_kg16_f, ka16 => ka, kb16 => kb, selfref16 => selfref, forref16 => forref, sfluxref16 => sfluxref
+
+      use rrsw_kg17_f, kao17 => kao, kbo17 => kbo, selfrefo17 => selfrefo, forrefo17 => forrefo, sfluxrefo17 => sfluxrefo
+      use rrsw_kg17_f, ka17 => ka, kb17 => kb, selfref17 => selfref, forref17 => forref, sfluxref17 => sfluxref
+
+      use rrsw_kg18_f, kao18 => kao, kbo18 => kbo, selfrefo18 => selfrefo, forrefo18 => forrefo, sfluxrefo18 => sfluxrefo
+      use rrsw_kg18_f, ka18 => ka, kb18 => kb, selfref18 => selfref, forref18 => forref, sfluxref18 => sfluxref
+
+      use rrsw_kg19_f, kao19 => kao, kbo19 => kbo, selfrefo19 => selfrefo, forrefo19 => forrefo, sfluxrefo19 => sfluxrefo
+      use rrsw_kg19_f, ka19 => ka, kb19 => kb, selfref19 => selfref, forref19 => forref, sfluxref19 => sfluxref
+
+      use rrsw_kg20_f, kao20 => kao, kbo20 => kbo, selfrefo20 => selfrefo, forrefo20 => forrefo, &
+          sfluxrefo20 => sfluxrefo, absch4o20 => absch4o
+      use rrsw_kg20_f, ka20 => ka, kb20 => kb, selfref20 => selfref, forref20 => forref, &
+          sfluxref20 => sfluxref, absch420 => absch4
+
+      use rrsw_kg21_f, kao21 => kao, kbo21 => kbo, selfrefo21 => selfrefo, forrefo21 => forrefo, sfluxrefo21 => sfluxrefo
+      use rrsw_kg21_f, ka21 => ka, kb21 => kb, selfref21 => selfref, forref21 => forref, sfluxref21 => sfluxref
+
+      use rrsw_kg22_f, kao22 => kao, kbo22 => kbo, selfrefo22 => selfrefo, forrefo22 => forrefo, sfluxrefo22 => sfluxrefo
+      use rrsw_kg22_f, ka22 => ka, kb22 => kb, selfref22 => selfref, forref22 => forref, sfluxref22 => sfluxref
+
+      use rrsw_kg23_f, kao23 => kao, selfrefo23 => selfrefo, forrefo23 => forrefo, sfluxrefo23 => sfluxrefo, raylo23 => raylo
+      use rrsw_kg23_f, ka23 => ka, selfref23 => selfref, forref23 => forref, sfluxref23 => sfluxref, rayl23 => rayl
+
+      use rrsw_kg24_f, kao24 => kao, kbo24 => kbo, selfrefo24 => selfrefo, forrefo24 => forrefo, sfluxrefo24 => sfluxrefo
+      use rrsw_kg24_f, abso3ao24 => abso3ao, abso3bo24 => abso3bo, raylao24 => raylao, raylbo24 => raylbo
+      use rrsw_kg24_f, ka24 => ka, kb24 => kb, selfref24 => selfref, forref24 => forref, sfluxref24 => sfluxref
+      use rrsw_kg24_f, abso3a24 => abso3a, abso3b24 => abso3b, rayla24 => rayla, raylb24 => raylb
+
+      use rrsw_kg25_f, kao25 => kao, sfluxrefo25=>sfluxrefo
+      use rrsw_kg25_f, abso3ao25 => abso3ao, abso3bo25 => abso3bo, raylo25 => raylo
+      use rrsw_kg25_f, ka25 => ka, sfluxref25=>sfluxref
+      use rrsw_kg25_f, abso3a25 => abso3a, abso3b25 => abso3b, rayl25 => rayl
+     
+      use rrsw_kg26_f, sfluxrefo26 => sfluxrefo
+      use rrsw_kg26_f, sfluxref26 => sfluxref
+
+      use rrsw_kg27_f, kao27 => kao, kbo27 => kbo, sfluxrefo27 => sfluxrefo, rayl27=>rayl
+      use rrsw_kg27_f, ka27 => ka, kb27 => kb, sfluxref27 => sfluxref, raylo27=>raylo
+
+      use rrsw_kg28_f, kao28 => kao, kbo28 => kbo, sfluxrefo28 => sfluxrefo
+      use rrsw_kg28_f, ka28 => ka, kb28 => kb, sfluxref28 => sfluxref
+
+      use rrsw_kg29_f, kao29 => kao, kbo29 => kbo, selfrefo29 => selfrefo, forrefo29 => forrefo, sfluxrefo29 => sfluxrefo
+      use rrsw_kg29_f, absh2oo29 => absh2oo, absco2o29 => absco2o
+      use rrsw_kg29_f, ka29 => ka, kb29 => kb, selfref29 => selfref, forref29 => forref, sfluxref29 => sfluxref
+      use rrsw_kg29_f, absh2o29 => absh2o, absco229 => absco2
+
+! ------- Declarations
+
+      integer , intent(in) :: ncol
+      integer , intent(in) :: gncol                   ! Number of horizontal columns     
+      integer , intent(in) :: nlay                    ! Number of model layers
+      integer , intent(inout) :: icld                 ! Cloud overlap method
+                                                      !    0: Clear only
+                                                      !    1: Random
+                                                      !    2: Maximum/random
+                                                      !    3: Maximum
+      integer , intent(in) :: iaer
+      integer , intent(in) :: dyofyr                  ! Day of the year (used to get Earth/Sun
+                                                      !  distance if adjflx not provided)                                                      
+      real , intent(in) :: adjes                      ! Flux adjustment for Earth/Sun distance
+      real , intent(in) :: scon                       ! Solar constant (W/m2)
+
+      integer , intent(in) :: inflgsw                 ! Flag for cloud optical properties
+      integer , intent(in) :: iceflgsw                ! Flag for ice particle specification
+      integer , intent(in) :: liqflgsw                ! Flag for liquid droplet specification
+      
+      real , intent(in) :: gcld(gncol, nlay)          ! Cloud fraction
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: gtauc(gncol,nlay,nbndsw)   ! In-cloud optical depth
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+      real , intent(in) :: gssac(gncol,nlay,nbndsw)   ! In-cloud single scattering albedo
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+      real , intent(in) :: gasmc(gncol,nlay,nbndsw)   ! In-cloud asymmetry parameter
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+      real , intent(in) :: gfsfc(gncol,nlay,nbndsw)   ! In-cloud forward scattering fraction
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+      real , intent(in) :: gciwp(gncol, nlay)         ! In-cloud ice water path (g/m2)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: gclwp(gncol, nlay)         ! In-cloud liquid water path (g/m2)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: gcswp(gncol, nlay)         ! In-cloud snow water path (g/m2)
+                                                      !    Dimensions: (ncol,nlay)
+                                                      
+      real , intent(in) :: grei(gncol, nlay)          ! Cloud ice effective radius (microns)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: grel(gncol, nlay)          ! Cloud water drop effective radius (microns)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: gres(gncol, nlay)          ! Cloud snow drop effective radius (microns)
+                                                      !    Dimensions: (ncol,nlay)
+                                                      
+      
+      real , intent(in) :: gplay(gncol,nlay)          ! Layer pressures (hPa, mb)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: gplev(gncol,nlay+1)        ! Interface pressures (hPa, mb)
+                                                      !    Dimensions: (ncol,nlay+1)
+      real , intent(in) :: gtlay(gncol,nlay)          ! Layer temperatures (K)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: gtlev(gncol,nlay+1)        ! Interface temperatures (K)
+                                                      !    Dimensions: (ncol,nlay+1)
+      real , intent(in) :: gtsfc(gncol)               ! Surface temperature (K)
+                                                      !    Dimensions: (ncol)
+      real , intent(in) :: gh2ovmr(gncol,nlay)        ! H2O volume mixing ratio
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: go3vmr(gncol,nlay)         ! O3 volume mixing ratio
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: gco2vmr(gncol,nlay)        ! CO2 volume mixing ratio
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: gch4vmr(gncol,nlay)        ! Methane volume mixing ratio
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: gn2ovmr(gncol,nlay)        ! Nitrous oxide volume mixing ratio
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: go2vmr(gncol,nlay)         ! Oxygen volume mixing ratio
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(in) :: gasdir(gncol)              ! UV/vis surface albedo direct rad
+                                                      !    Dimensions: (ncol)
+      real , intent(in) :: galdir(gncol)              ! Near-IR surface albedo direct rad
+                                                      !    Dimensions: (ncol)
+      real , intent(in) :: gasdif(gncol)              ! UV/vis surface albedo: diffuse rad
+                                                      !    Dimensions: (ncol)
+      real , intent(in) :: galdif(gncol)              ! Near-IR surface albedo: diffuse rad
+                                                      !    Dimensions: (ncol)
+
+      
+      real , intent(in) :: gcoszen(gncol)             ! Cosine of solar zenith angle
+                                                      !    Dimensions: (ncol)
+    
+      real , intent(in) :: gtauaer(gncol,nlay,nbndsw) ! Aerosol optical depth (iaer=10 only)
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+                                                      ! (non-delta scaled)      
+      real , intent(in) :: gssaaer(gncol,nlay,nbndsw) ! Aerosol single scattering albedo (iaer=10 only)
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+                                                      ! (non-delta scaled)      
+      real , intent(in) :: gasmaer(gncol,nlay,nbndsw) ! Aerosol asymmetry parameter (iaer=10 only)
+                                                      !    Dimensions: (ncol,nlay,nbndsw)
+                                                      ! (non-delta scaled)      
+      real , intent(in) :: gecaer(:,:,:)              ! Aerosol optical depth at 0.55 micron (iaer=6 only)
+                                                      !    Dimensions: (ncol,nlay,naerec)
+                                                      ! (non-delta scaled)      
+!      integer , intent(in) :: normFlx                 ! Normalize fluxes flag
+                                                       ! 0 = no normalization
+                                                       ! 1 = normalize fluxes ( / (scon * coszen) )
+
+! ----- Output -----
+
+      real , intent(out) :: swuflx(:,:)               ! Total sky shortwave upward flux (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1)
+      real , intent(out) :: swdflx(:,:)               ! Total sky shortwave downward flux (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1)
+      real , intent(out) :: swhr(:,:)                 ! Total sky shortwave radiative heating rate (K/d)
+                                                      !    Dimensions: (ncol,nlay)
+      real , intent(out) :: swuflxc(:,:)              ! Clear sky shortwave upward flux (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1)
+      real , intent(out) :: swdflxc(:,:)              ! Clear sky shortwave downward flux (W/m2)
+                                                      !    Dimensions: (ncol,nlay+1)
+      real , intent(out) :: swhrc(:,:)                ! Clear sky shortwave radiative heating rate (K/d)
+                                                      !    Dimensions: (ncol,nlay)
+
+      real, intent(out) :: sibvisdir(:,:)              ! visible direct downward flux  (W/m2)
+                                                       !    Dimensions: (ncol,nlay+1) Zhenxin (2011/06/20)
+      real, intent(out) :: sibvisdif(:,:)              ! visible diffusion downward flux  (W/m2)
+                                                       !    Dimensions: (ncol,nlay+1) Zhenxin (2011/06/20)
+      real, intent(out) :: sibnirdir(:,:)              ! Near IR direct downward flux  (W/m2)
+                                                       !    Dimensions: (ncol,nlay+1)  Zhenxin (2011/06/20)
+      real, intent(out) :: sibnirdif(:,:)              ! Near IR diffusion downward flux  (W/m2)
+                                                       !    Dimensions: (ncol,nlay+1) Zhenxin (2011/06/20)
+      real, intent(out) :: swdkdir(:,:)                ! Total shortwave downward direct flux (W/m2)
+                                                       !    Dimensions: (ncol,nlay+1) jararias, 2013/08/10
+      real, intent(out) :: swdkdif(:,:)                ! Total shortwave downward diffuse flux (W/m2)
+                                                       !    Dimensions: (ncol,nlay+1) jararias, 2013/08/10
+
+! ----- Local -----
+
+! Control
+     
+      integer  :: istart                      ! beginning band of calculation
+      integer  :: iend                        ! ending band of calculation
+      integer  :: icpr                        ! cldprop/cldprmc use flag
+      integer  :: iout                        ! output option flag
+  
+      integer  :: idelm                       ! delta-m scaling flag
+                                              ! [0 = direct and diffuse fluxes are unscaled]
+                                              ! [1 = direct and diffuse fluxes are scaled]
+                                              ! (total downward fluxes are always delta scaled)
+      integer  :: isccos                      ! instrumental cosine response flag (inactive)
+      integer  :: iplon                       ! column loop index
+      integer  :: i                           ! layer loop index                       ! jk
+      integer  :: ib                          ! band loop index                        ! jsw
+      integer  :: ia, ig                      ! indices
+      integer  :: k                           ! layer loop index
+      integer  :: ims                         ! value for changing mcica permute seed
+      integer  :: imca                        ! flag for mcica [0=off, 1=on]
+
+      real  :: zepsec, zepzen                 ! epsilon
+      real  :: zdpgcp                         ! flux to heating conversion ratio
+
+#ifndef _OPENACC
+# define ncol CHNK
+#endif
+
+! Atmosphere
+
+      real  :: coldry(ncol,nlay+1)            ! dry air column amount
+      real  :: wkl(ncol,mxmol,nlay)           ! molecular amounts (mol/cm-2)
+
+      real  :: cossza(ncol)                   ! Cosine of solar zenith angle
+      real  :: adjflux(jpband)                ! adjustment for current Earth/Sun distance
+      
+                                              !  default value of 1368.22 Wm-2 at 1 AU
+      real  :: albdir(ncol,nbndsw)            ! surface albedo, direct          ! zalbp
+      real  :: albdif(ncol,nbndsw)            ! surface albedo, diffuse         ! zalbd
+      
+!      real  :: rdl(ncol), adl(ncol)
+
+! Atmosphere - setcoef
+      integer  :: laytrop(ncol)               ! tropopause layer index
+      integer  :: layswtch(ncol)              ! tropopause layer index
+      integer  :: laylow(ncol)                ! tropopause layer index
+      integer  :: jp(ncol,nlay+1)             ! 
+      integer  :: jt(ncol,nlay+1)             !
+      integer  :: jt1(ncol,nlay+1)            !
+
+      real  :: colh2o(ncol,nlay+1)            ! column amount (h2o)
+      real  :: colco2(ncol,nlay+1)            ! column amount (co2)
+      real  :: colo3(ncol,nlay+1)             ! column amount (o3)
+      real  :: coln2o(ncol,nlay+1)            ! column amount (n2o)
+      real  :: colch4(ncol,nlay+1)            ! column amount (ch4)
+      real  :: colo2(ncol,nlay+1)             ! column amount (o2)
+      real  :: colmol(ncol,nlay+1)            ! column amount
+      real  :: co2mult(ncol,nlay+1)           ! column amount 
+
+      integer  :: indself(ncol,nlay+1) 
+      integer  :: indfor(ncol,nlay+1) 
+      real  :: selffac(ncol,nlay+1) 
+      real  :: selffrac(ncol,nlay+1) 
+      real  :: forfac(ncol,nlay+1) 
+      real  :: forfrac(ncol,nlay+1) 
+
+      real  :: &                              !
+                         fac00(ncol,nlay+1) , fac01(ncol,nlay+1) , &
+                         fac10(ncol,nlay+1) , fac11(ncol,nlay+1)  
+      
+      real :: play(ncol,nlay)                 ! Layer pressures (hPa, mb)
+                                              !    Dimensions: (ncol,nlay)
+      real :: plev(ncol,nlay+1)               ! Interface pressures (hPa, mb)
+                                              !    Dimensions: (ncol,nlay+1)
+      real :: tlay(ncol,nlay)                 ! Layer temperatures (K)
+                                              !    Dimensions: (ncol,nlay)
+      real :: tlev(ncol,nlay+1)               ! Interface temperatures (K)
+                                              !    Dimensions: (ncol,nlay+1)
+      real :: tsfc(ncol)                      ! Surface temperature (K)
+                                              !    Dimensions: (ncol)
+      real :: coszen(ncol)   
+
+! Atmosphere/clouds - cldprop
+      integer  :: ncbands                     ! number of cloud spectral bands
+
+      real   :: cld(ncol,nlay)                ! Cloud fraction
+      real   :: tauc(ncol,nlay,nbndsw)        ! In-cloud optical depth
+      real   :: ssac(ncol,nlay,nbndsw)        ! In-cloud single scattering 
+      real   :: asmc(ncol,nlay,nbndsw)        ! In-cloud asymmetry parameter
+      real   :: fsfc(ncol,nlay,nbndsw)        ! In-cloud forward scattering fraction
+      real   :: ciwp(ncol,nlay)               ! In-cloud ice water path (g/m2)
+      real   :: clwp(ncol,nlay)               ! In-cloud liquid water path (g/m2)
+      real   :: cswp(ncol,nlay)               ! In-cloud snow water path (g/m2)
+      real   :: rei(ncol,nlay)                ! Cloud ice effective radius (microns)
+      real   :: rel(ncol,nlay)                ! Cloud water drop effective radius (microns)
+      real   :: res(ncol,nlay)                ! Cloud snow effective radius (microns)
+      
+      real  :: taucmc(ncol,nlay+1,ngptsw)     ! in-cloud optical depth [mcica]
+      real  :: taormc(ncol,nlay+1,ngptsw)     ! unscaled in-cloud optical depth [mcica]
+      real  :: ssacmc(ncol,nlay+1,ngptsw)     ! in-cloud single scattering albedo [mcica]
+      real  :: asmcmc(ncol,nlay+1,ngptsw)     ! in-cloud asymmetry parameter [mcica]
+      real  :: fsfcmc(ncol,nlay+1,ngptsw)     ! in-cloud forward scattering fraction [mcica]
+      
+      real :: cldfmcl(ncol,nlay+1,ngptsw)     ! cloud fraction [mcica]
+      real :: ciwpmcl(ncol,nlay+1,ngptsw)     ! in-cloud ice water path [mcica]
+      real :: clwpmcl(ncol,nlay+1,ngptsw)     ! in-cloud liquid water path [mcica]
+      real :: cswpmcl(ncol,nlay+1,ngptsw)     ! in-cloud liquid water path [mcica]
+                                                     
+! Atmosphere/clouds/aerosol - spcvrt,spcvmc
+      real  :: ztauc(ncol,nlay+1,nbndsw)      ! cloud optical depth
+      real  :: ztaucorig(ncol,nlay+1,nbndsw)  ! unscaled cloud optical depth
+      real  :: zasyc(ncol,nlay+1,nbndsw)      ! cloud asymmetry parameter 
+                                              !  (first moment of phase function)
+      real  :: zomgc(ncol,nlay+1,nbndsw)      ! cloud single scattering albedo
+   
+      real  :: taua(ncol, nlay+1, nbndsw)
+      real  :: asya(ncol, nlay+1, nbndsw)
+      real  :: omga(ncol, nlay+1, nbndsw)
+   
+      real  :: zbbfu(ncol,nlay+2)             ! temporary upward shortwave flux (w/m2)
+      real  :: zbbfd(ncol,nlay+2)             ! temporary downward shortwave flux (w/m2)
+      real  :: zbbcu(ncol,nlay+2)             ! temporary clear sky upward shortwave flux (w/m2)
+      real  :: zbbcd(ncol,nlay+2)             ! temporary clear sky downward shortwave flux (w/m2)
+      real  :: zbbfddir(ncol,nlay+2)          ! temporary downward direct shortwave flux (w/m2)
+      real  :: zbbcddir(ncol,nlay+2)          ! temporary clear sky downward direct shortwave flux (w/m2)
+      real  :: zuvfd(ncol,nlay+2)             ! temporary UV downward shortwave flux (w/m2)
+      real  :: zuvcd(ncol,nlay+2)             ! temporary clear sky UV downward shortwave flux (w/m2)
+      real  :: zuvfddir(ncol,nlay+2)          ! temporary UV downward direct shortwave flux (w/m2)
+      real  :: zuvcddir(ncol,nlay+2)          ! temporary clear sky UV downward direct shortwave flux (w/m2)
+      real  :: znifd(ncol,nlay+2)             ! temporary near-IR downward shortwave flux (w/m2)
+      real  :: znicd(ncol,nlay+2)             ! temporary clear sky near-IR downward shortwave flux (w/m2)
+      real  :: znifddir(ncol,nlay+2)          ! temporary near-IR downward direct shortwave flux (w/m2)
+      real  :: znicddir(ncol,nlay+2)          ! temporary clear sky near-IR downward direct shortwave flux (w/m2)
+
+! Optional output fields 
+      real  :: swnflx(ncol,nlay+2)            ! Total sky shortwave net flux (W/m2)
+      real  :: swnflxc(ncol,nlay+2)           ! Clear sky shortwave net flux (W/m2)
+      real  :: dirdflux(ncol,nlay+2)          ! Direct downward shortwave surface flux
+      real  :: difdflux(ncol,nlay+2)          ! Diffuse downward shortwave surface flux
+      real  :: uvdflx(ncol,nlay+2)            ! Total sky downward shortwave flux, UV/vis  
+      real  :: nidflx(ncol,nlay+2)            ! Total sky downward shortwave flux, near-IR 
+      real  :: dirdnuv(ncol,nlay+2)           ! Direct downward shortwave flux, UV/vis
+      real  :: difdnuv(ncol,nlay+2)           ! Diffuse downward shortwave flux, UV/vis
+      real  :: dirdnir(ncol,nlay+2)           ! Direct downward shortwave flux, near-IR
+      real  :: difdnir(ncol,nlay+2)           ! Diffuse downward shortwave flux, near-IR
+      
+      real :: zgco(ncol,ngptsw,nlay+1)  , zomco(ncol,ngptsw,nlay+1)  
+      real :: zrdnd(ncol,ngptsw,nlay+1) 
+      real :: zref(ncol,ngptsw,nlay+1)  , zrefo(ncol,ngptsw,nlay+1)  
+      real :: zrefd(ncol,ngptsw,nlay+1) , zrefdo(ncol,ngptsw,nlay+1)  
+      real :: ztauo(ncol,ngptsw,nlay)  
+      real :: zdbt(ncol,ngptsw,nlay+1)  , ztdbt(ncol,ngptsw,nlay+1)   
+      real :: ztra(ncol,ngptsw,nlay+1)  , ztrao(ncol,ngptsw,nlay+1)  
+      real :: ztrad(ncol,ngptsw,nlay+1) , ztrado(ncol,ngptsw,nlay+1)  
+      real :: zfd(ncol,ngptsw,nlay+1)   , zfu(ncol,ngptsw,nlay+1)  
+      real :: zsflxzen(ncol,ngptsw)
+      real :: ztaur(ncol,nlay,ngptsw)   , ztaug(ncol,nlay,ngptsw) 
+#ifndef _OPENACC
+# undef ncol
+#endif
+
+      integer :: npartc, npart, npartb, cldflag(gncol), profic(gncol), profi(gncol)
+
+      real , parameter :: amd = 28.9660       ! Effective molecular weight of dry air (g/mol)
+      real , parameter :: amw = 18.0160       ! Molecular weight of water vapor (g/mol)
+
+! Set molecular weight ratios (for converting mmr to vmr)
+!  e.g. h2ovmr = h2ommr * amdw)
+      real , parameter :: amdw = 1.607793   ! Molecular weight of dry air / water vapor
+      real , parameter :: amdc = 0.658114   ! Molecular weight of dry air / carbon dioxide
+      real , parameter :: amdo = 0.603428   ! Molecular weight of dry air / ozone
+      real , parameter :: amdm = 1.805423   ! Molecular weight of dry air / methane
+      real , parameter :: amdn = 0.658090   ! Molecular weight of dry air / nitrous oxide
+      real , parameter :: amdo2 = 0.905140  ! Molecular weight of dry air / oxygen
+
+      real , parameter :: sbc = 5.67e-08    ! Stefan-Boltzmann constant (W/m2K4)
+      integer ii,jj,kk,iw
+      integer  :: isp, l, ix, n, imol  ! Loop indices
+      real  :: amm, summol                      ! 
+      real  :: adjflx                           ! flux adjustment for Earth/Sun distance
+      integer :: prt
+      integer :: piplon
+      
+      integer :: ipart, cols, cole, colr, ncolc, ncolb
+      integer :: irng, cc, ncolst
+
+! Initializations
+      
+      zepsec = 1.e-06 
+      zepzen = 1.e-10 
+      oneminus = 1.0  - zepsec
+      pi = 2.  * asin(1. )
+      irng = 0
+
+      istart = jpb1
+      iend = jpb2
+      iout = 0
+      icpr = 1
+      ims = 2
+      
+      adjflx = adjes
+      if (dyofyr .gt. 0) then
+         adjflx = earth_sun(dyofyr)
+      endif
+  
+      do ib = jpb1, jpb2
+         adjflux(ib) = adjflx * scon / rrsw_scon
+      end do
+
+      if (icld.lt.0.or.icld.gt.3) icld = 2
+    
+      
+! determine cloud profile
+      cldflag=0
+      do iplon = 1, gncol
+        if (any(gcld(iplon,:) > 0)) cldflag(iplon)=1
+      end do
+
+
+! build profile separation
+      cols = 0
+      cole = 0
+
+      do iplon = 1, gncol
+        if (cldflag(iplon)==1) then
+            cole=cole+1
+            profi(cole) = iplon
+        else
+            cols=cols+1
+            profic(cols) = iplon
+        end if
+      end do
+        
+
+!$acc data copyout(swuflxc, swdflxc, swuflx, swdflx, swnflxc, swnflx, swhrc, swhr) &
+!$acc create(laytrop, layswtch, laylow, jp, jt, jt1, &
+!$acc co2mult, colch4, colco2, colh2o, colmol, coln2o, &
+!$acc colo2, colo3, fac00, fac01, fac10, fac11, &
+!$acc selffac, selffrac, indself, forfac, forfrac, indfor, &
+!$acc zbbfu, zbbfd, zbbcu, zbbcd,zbbfddir, zbbcddir, zuvfd, zuvcd, zuvfddir, &
+!$acc zuvcddir, znifd, znicd, znifddir,znicddir, &
+!$acc cldfmcl, ciwpmcl, clwpmcl, cswpmcl, &
+!$acc taormc, taucmc, ssacmc, asmcmc, fsfcmc) &
+!$acc create(zref,zrefo,zrefd,zrefdo,&
+!$acc ztauo,ztdbt,&
+!$acc ztra,ztrao,ztrad,ztrado,&
+!$acc zfd,zfu,zdbt,zgco,&
+!$acc zomco,zrdnd,ztaug, ztaur,zsflxzen)&
+!$acc create(ciwp, clwp, cswp, cld, tauc, ssac, asmc, fsfc, rei, rel, res) &
+!$acc create(play, tlay, plev, tlev, tsfc, cldflag, coszen) &
+!$acc create(coldry, wkl) &
+!$acc create(extliq1, ssaliq1, asyliq1, extice2, ssaice2, asyice2) &
+!$acc create(extice3, ssaice3, asyice3, fdlice3, abari, bbari, cbari, dbari, ebari, fbari) &
+!$acc create(taua, asya, omga,gtauaer,gssaaer,gasmaer) &
+!$acc copyin(wavenum2, ngb) &
+!$acc copyin(tref, preflog, albdif, albdir, cossza)&
+!$acc copyin(icxa, adjflux, nspa, nspb)&
+!$acc copyin(kao16,kbo16,selfrefo16,forrefo16,sfluxrefo16)&
+!$acc copyin(ka16,kb16,selfref16,forref16,sfluxref16)&
+!$acc copyin(kao17,kbo17,selfrefo17,forrefo17,sfluxrefo17)&
+!$acc copyin(ka17,kb17,selfref17,forref17,sfluxref17)&
+!$acc copyin(kao18,kbo18,selfrefo18,forrefo18,sfluxrefo18)&
+!$acc copyin(ka18,kb18,selfref18,forref18,sfluxref18)&
+!$acc copyin(kao19,kbo19,selfrefo19,forrefo19,sfluxrefo19)&
+!$acc copyin(ka19,kb19,selfref19,forref19,sfluxref19)&
+!$acc copyin(kao20,kbo20,selfrefo20,forrefo20,sfluxrefo20,absch4o20)&
+!$acc copyin(ka20,kb20,selfref20,forref20,sfluxref20,absch420)&
+!$acc copyin(kao21,kbo21,selfrefo21,forrefo21,sfluxrefo21)&
+!$acc copyin(ka21,kb21,selfref21,forref21,sfluxref21)&
+!$acc copyin(kao22,kbo22,selfrefo22,forrefo22,sfluxrefo22)&
+!$acc copyin(ka22,kb22,selfref22,forref22,sfluxref22)&
+!$acc copyin(kao23,selfrefo23,forrefo23,sfluxrefo23,raylo23)&
+!$acc copyin(ka23,selfref23,forref23,sfluxref23,rayl23)&
+!$acc copyin(kao24,kbo24,selfrefo24,forrefo24,sfluxrefo24,abso3ao24,abso3bo24,raylao24,raylbo24)&
+!$acc copyin(ka24,kb24,selfref24,forref24,sfluxref24,abso3a24,abso3b24,rayla24,raylb24)&
+!$acc copyin(kao25,sfluxrefo25,abso3ao25,abso3bo25,raylo25)&
+!$acc copyin(ka25,sfluxref25,abso3a25,abso3b25,rayl25)&
+!$acc copyin(sfluxrefo26)&
+!$acc copyin(sfluxref26)&
+!$acc copyin(kao27,kbo27,sfluxrefo27, raylo27)&
+!$acc copyin(ka27,kb27,sfluxref27, rayl27)&
+!$acc copyin(kao28,kbo28,sfluxrefo28)&
+!$acc copyin(ka28,kb28,sfluxref28) present(gtauc, gssac, gasmc, gfsfc)&
+!$acc copyin(kao29,kbo29,selfrefo29,forrefo29,sfluxrefo29,absh2oo29,absco2o29)&
+!$acc copyin(ka29,kb29,selfref29,forref29,sfluxref29,absh2o29,absco229)&
+!$acc present(gh2ovmr, gco2vmr, go3vmr, gn2ovmr, gch4vmr, go2vmr)&
+!$acc present(gcld, gciwp, gclwp, gcswp, grei, grel, gres, gplay, gplev, gtlay, gtlev, gtsfc)&
+!$acc copyin(gasdir, galdir, gasdif, galdif,profi,profic,gcoszen)&
+!$acc copyout(sibvisdir,sibvisdif,sibnirdir,sibnirdif,swdkdir,swdkdif)
+
+!$acc update device(extliq1, ssaliq1, asyliq1, extice2, ssaice2, asyice2) &
+!$acc device(extice3, ssaice3, asyice3, fdlice3, abari, bbari, cbari, dbari, ebari, fbari) &
+!$acc device(preflog)
+
+
+      ncolc = cols
+      ncolb = cole
+
+      npartc = ceiling( real(ncolc) / real(ncol) )
+      npartb = ceiling( real(ncolb) / real(ncol) )
+
+
+!$acc kernels    
+      cldfmcl = 0.0
+      ciwpmcl = 0.0
+      clwpmcl = 0.0     
+      cswpmcl = 0.0     
+!$acc end kernels
+  
+      idelm = 1
+      
+!$acc kernels
+      taua = 0.0
+      asya = 0.0
+      omga = 1.0
+!$acc end kernels
+
+
+! PARTITION LOOP ----------------------------------------------------------------------------
+      do cc = 1, 2
+
+        if (cc==1) then 
+         
+          npart = npartc
+          ncolst = ncolc
+
+        else
+        
+          npart = npartb
+          ncolst = ncolb
+         
+        end if
+     
+        do ipart = 0,npart-1
+!jm call unsetdebug
+!jm if (ipart.eq.IDEBUG-1) then
+!jm write(0,*)'setting setdebug ipart = ',ipart+1,' npart ',npart
+!jm call setdebug
+!jm endif
+          cols = ipart * ncol + 1
+          cole = (ipart + 1) * ncol
+          if (cole>ncolst) cole=ncolst
+          colr = cole - cols + 1
+
+!$acc kernels            
+          taormc = 0.0 
+          taucmc = 0.0
+          ssacmc = 1.0
+          asmcmc = 0.0
+          fsfcmc = 0.0
+!$acc end kernels            
+ 
+! Clear cases
+          if (cc==1) then    
+!$acc kernels loop private(piplon)
+             do iplon = 1, colr
+               piplon = profic(iplon + cols - 1)
+     
+               do ib=1,8
+                 albdir(iplon,ib)  = galdir(piplon)
+                 albdif(iplon,ib)  = galdif(piplon)
+               enddo
+               albdir(iplon,nbndsw)  = galdir(piplon)
+               albdif(iplon,nbndsw)  = galdif(piplon)
+!  UV/visible bands 25-28 (10-13), 16000-50000 cm-1, 0.200-0.625 micron
+     
+               do ib=10,13
+                 albdir(iplon,ib)  = gasdir(piplon)
+                 albdif(iplon,ib)  = gasdif(piplon)
+               enddo
+
+!  Transition band 9, 12850-16000 cm-1, 0.625-0.778 micron, Take average
+               albdir(iplon, 9) = (gasdir(piplon)+galdir(piplon))/2.
+               albdif(iplon, 9) = (gasdif(piplon)+galdif(piplon))/2.
+             end do
+!$acc end kernels      
+
+!$acc kernels 
+             do iplon = 1, colr
+               piplon = profic(iplon + cols - 1)
+               play(iplon,:) = gplay(piplon, 1:nlay)
+               plev(iplon,:) = gplev(piplon, 1:nlay+1)
+               tlay(iplon,:) = gtlay(piplon, 1:nlay)
+               tlev(iplon,:) = gtlev(piplon, 1:nlay+1)
+               tsfc(iplon)   = gtsfc(piplon)
+             end do
+!$acc end kernels
+
+             if (iaer==10) then
+!$acc kernels
+               do iw=1,nbndsw
+               do kk=1,nlay
+               do iplon = 1, colr
+                 piplon = profic(iplon + cols - 1)
+                 taua(iplon, kk, iw) = gtauaer(piplon, kk, iw)
+                 asya(iplon, kk, iw) = gasmaer(piplon, kk, iw)
+                 omga(iplon, kk, iw) = gssaaer(piplon, kk, iw)
+               end do
+               end do
+               end do
+!$acc end kernels
+             end if
+
+!$acc kernels
+             do iplon = 1, colr
+               piplon = profic(iplon + cols - 1)
+               wkl(iplon,1,:) = gh2ovmr(piplon,1:nlay)
+               wkl(iplon,2,:) = gco2vmr(piplon,1:nlay)
+               wkl(iplon,3,:) = go3vmr(piplon,1:nlay)
+               wkl(iplon,4,:) = gn2ovmr(piplon,1:nlay)
+               wkl(iplon,5,:) = 0.0
+               wkl(iplon,6,:) = gch4vmr(piplon,1:nlay)
+               wkl(iplon,7,:) = go2vmr(piplon,1:nlay)   
+               coszen(iplon)  = gcoszen(piplon)
+             end do
+!$acc end kernels
+
+!************** cloudy cases ***************
+          else   
+          
+!$acc kernels loop private(piplon)
+            do iplon = 1, colr
+              piplon = profi(iplon + cols - 1)
+
+              do ib=1,8
+                albdir(iplon,ib)  = galdir(piplon)
+                albdif(iplon,ib)  = galdif(piplon)
+              enddo
+              albdir(iplon,nbndsw)  = galdir(piplon)
+              albdif(iplon,nbndsw)  = galdif(piplon)
+
+!  UV/visible bands 25-28 (10-13), 16000-50000 cm-1, 0.200-0.625 micron
+              do ib=10,13
+                 albdir(iplon,ib)  = gasdir(piplon)
+                 albdif(iplon,ib)  = gasdif(piplon)
+              enddo
+
+!  Transition band 9, 12850-16000 cm-1, 0.625-0.778 micron, Take average
+              albdir(iplon, 9) = (gasdir(piplon)+galdir(piplon))/2.
+              albdif(iplon, 9) = (gasdif(piplon)+galdif(piplon))/2.
+            end do
+!$acc end kernels               
+          
+!$acc kernels 
+            do iplon = 1, colr
+              piplon = profi(iplon + cols - 1)
+              play(iplon,:) = gplay(piplon, 1:nlay)
+              plev(iplon,:) = gplev(piplon, 1:nlay+1)
+              tlay(iplon,:) = gtlay(piplon, 1:nlay)
+              tlev(iplon,:) = gtlev(piplon, 1:nlay+1)
+              tsfc(iplon) = gtsfc(piplon)
+              cld(iplon,:) = gcld(piplon, 1:nlay)
+              ciwp(iplon,:) = gciwp(piplon, 1:nlay)
+              clwp(iplon,:) = gclwp(piplon, 1:nlay)
+              cswp(iplon,:) = gcswp(piplon, 1:nlay)
+              rei(iplon,:) = grei(piplon, 1:nlay) 
+              rel(iplon,:) = grel(piplon, 1:nlay)
+              res(iplon,:) = gres(piplon, 1:nlay)
+            end do
+
+!$acc end kernels
+            if (iaer==10) then
+
+!$acc kernels    
+              do iw=1,nbndsw
+              do kk=1,nlay
+              do iplon = 1, colr
+                piplon = profi(iplon + cols - 1)
+                taua(iplon, kk, iw) = gtauaer(piplon, kk, iw)
+                asya(iplon, kk, iw) = gasmaer(piplon, kk, iw)
+                omga(iplon, kk, iw) = gssaaer(piplon, kk, iw)
+              end do
+              end do
+              end do
+!$acc end kernels
+            end if
+
+
+! Copy the direct cloud optical properties over to the temp arrays
+! and then onto the GPU
+! We are on the CPU here
+
+!$acc kernels 
+            do iw=1,nbndsw
+            do kk=1,nlay
+            do iplon = 1, colr
+              piplon = profi(iplon + cols - 1)
+              tauc(iplon, kk, iw) = gtauc(piplon, kk, iw)
+              ssac(iplon, kk, iw) = gssac(piplon, kk, iw)
+              asmc(iplon, kk, iw) = gasmc(piplon, kk, iw)
+              fsfc(iplon, kk, iw) = gfsfc(piplon, kk, iw)
+            end do
+            end do
+            end do
+!$acc end kernels
+
+!$acc kernels
+            do iplon = 1, colr
+              piplon = profi(iplon + cols - 1)
+              wkl(iplon,1,:) = gh2ovmr(piplon,1:nlay)
+              wkl(iplon,2,:) = gco2vmr(piplon,1:nlay)
+              wkl(iplon,3,:) = go3vmr(piplon,1:nlay)
+              wkl(iplon,4,:) = gn2ovmr(piplon,1:nlay)
+              wkl(iplon,5,:) = 0.0
+              wkl(iplon,6,:) = gch4vmr(piplon,1:nlay)
+              wkl(iplon,7,:) = go2vmr(piplon,1:nlay)  
+              coszen(iplon)  = gcoszen(piplon)
+            end do
+!$acc end kernels
+          end if    ! if-else-endif cc=1 (clear and cloudy cases)
+
+!$acc kernels
+          cossza = max(zepzen,coszen)
+!$acc end kernels  
+
+!$acc kernels
+          do iplon = 1,colr
+            do l = 1,nlay
+              coldry(iplon, l) = (plev(iplon, l)-plev(iplon, l+1)) * 1.e3  * avogad / &
+                 (1.e2  * grav * ((1.  - wkl(iplon, 1,l)) * amd + wkl(iplon, 1,l) * amw) * &
+                 (1.  + wkl(iplon, 1,l)))
+            end do
+          end do
+!$acc end kernels
+
+!$acc kernels
+          do iplon = 1,colr
+            do l = 1,nlay
+              do imol = 1, nmol
+                wkl(iplon,imol,l) = coldry(iplon,l) * wkl(iplon,imol,l)
+              end do
+            end do
+          end do
+!$acc end kernels
+
+#ifndef _OPENACC
+! Use Tom Henderson's technique to pad out and vector remainder
+! with valid data so that we can have a static loop range over 
+! columns without having to test for short vectors.
+      IF ( colr < CHNK ) THEN
+
+        DO jj = 1,ngptsw
+        DO kk = 1,nlay+1
+        DO ii = colr+1, CHNK
+           taormc(ii,kk,jj) = taormc(colr,kk,jj)
+           taucmc(ii,kk,jj) = taucmc(colr,kk,jj)
+           ssacmc(ii,kk,jj) = ssacmc(colr,kk,jj)
+           asmcmc(ii,kk,jj) = asmcmc(colr,kk,jj)
+           fsfcmc(ii,kk,jj) = fsfcmc(colr,kk,jj)
+        ENDDO
+        ENDDO
+        ENDDO
+        DO ib = 1,13
+        DO ii = colr+1, CHNK
+           albdir(ii,ib) = albdir(colr,ib)
+           albdif(ii,ib) = albdif(colr,ib)
+        ENDDO
+        ENDDO
+        DO kk = 1,nlay+1
+        DO ii = colr+1, CHNK
+           plev(ii,kk) = plev(colr,kk)
+           tlev(ii,kk) = tlev(colr,kk)
+           coldry(ii,kk) = coldry(colr,kk)
+        ENDDO
+        ENDDO
+        DO kk = 1,nlay
+        DO ii = colr+1, CHNK
+           play(ii,kk) = play(colr,kk)
+           tlay(ii,kk) = tlay(colr,kk)
+           cld(ii,kk)  = cld(colr,kk)
+           ciwp(ii,kk) = ciwp(colr,kk)
+           clwp(ii,kk) = clwp(colr,kk)
+           cswp(ii,kk) = cswp(colr,kk)
+           rei(ii,kk) = rei(colr,kk)
+           rel(ii,kk) = rel(colr,kk)
+           res(ii,kk) = res(colr,kk)
+        ENDDO
+        ENDDO
+        DO ii = colr+1, CHNK
+           tsfc(ii) = tsfc(colr)
+        ENDDO
+        IF ( iaer==10 ) THEN
+         DO jj = 1,nbndsw
+         DO kk = 1,nlay+1
+         DO ii = colr+1, CHNK
+           taua(ii,kk,jj) = taua(colr,kk,jj)
+           asya(ii,kk,jj) = asya(colr,kk,jj)
+           omga(ii,kk,jj) = omga(colr,kk,jj)
+         ENDDO
+         ENDDO
+         ENDDO
+        ENDIF
+        DO jj = 1,nbndsw
+        DO kk = 1,nlay
+        DO ii = colr+1, CHNK
+           tauc(ii,kk,jj) = tauc(colr,kk,jj)
+           ssac(ii,kk,jj) = ssac(colr,kk,jj)
+           asmc(ii,kk,jj) = asmc(colr,kk,jj)
+           fsfc(ii,kk,jj) = fsfc(colr,kk,jj)
+        ENDDO
+        ENDDO
+        ENDDO
+        DO kk = 1,nlay
+        DO jj = 1,mxmol
+        DO ii = colr+1, CHNK
+           wkl(ii,jj,kk) = wkl(colr,jj,kk)
+        ENDDO
+        ENDDO
+        ENDDO
+        DO ii = colr+1, CHNK
+           coszen(ii) = coszen(colr)
+        ENDDO
+
+      ENDIF
+#endif
+
+#ifndef _OPENACC
+#  define colr CHNK
+#endif
+
+          if (cc==2) then   ! call mcica for cloudy cases
+            call mcica_sw(colr, nlay, 112, icld, irng, play, &
+                          cld, ciwp, clwp, cswp, tauc, ssac, asmc, fsfc, &
+                          cldfmcl, ciwpmcl, clwpmcl, cswpmcl, &
+                          taucmc, ssacmc, asmcmc, fsfcmc, 1 ) 
+          end if   
+
+          if (cc==2) then   ! call cldprmc for cloudy cases
+            call cldprmc_sw(colr, nlay, inflgsw, iceflgsw, liqflgsw,  &
+                            cldfmcl, ciwpmcl, clwpmcl, cswpmcl, rei, rel, res, &
+                            taormc, taucmc, ssacmc, asmcmc, fsfcmc)
+          end if
+
+          call setcoef_sw(colr, nlay, play , tlay , plev , tlev , tsfc , &
+                          coldry , wkl , &
+                          laytrop, layswtch, laylow, jp , jt , jt1 , &
+                          co2mult , colch4 , colco2 , colh2o , colmol , coln2o , &
+                          colo2 , colo3 , fac00 , fac01 , fac10 , fac11 , &
+                          selffac , selffrac , indself , forfac , forfrac , indfor )
+
+          call spcvmc_sw(cc, ncol, colr, nlay, istart, iend, icpr, idelm, iout, &
+                         play, tlay, plev, tlev, &
+                         tsfc, albdif, albdir, &
+                         cldfmcl, taucmc, asmcmc, ssacmc, taormc, &
+                         taua, asya, omga, cossza, coldry, adjflux, &	 
+                         laytrop, layswtch, laylow, jp, jt, jt1, &
+                         co2mult, colch4, colco2, colh2o, colmol, &
+                         coln2o, colo2, colo3, &
+                         fac00, fac01, fac10, fac11, &
+                         selffac, selffrac, indself, forfac, forfrac, indfor, &
+                         zbbfd, zbbfu, zbbcd, zbbcu, zuvfd, &
+                         zuvcd, znifd, znicd, &
+                         zbbfddir, zbbcddir, zuvfddir, zuvcddir, znifddir, znicddir,&
+                         zgco,zomco,zrdnd,zref,zrefo,zrefd,zrefdo,ztauo,zdbt,ztdbt,&
+                         ztra,ztrao,ztrad,ztrado,zfd,zfu,ztaug, ztaur, zsflxzen)
+
+#ifndef _OPENACC
+#  undef colr
+#endif
+   
+! Transfer up and down, clear and total sky fluxes to output arrays.
+! Vertical indexing goes from bottom to top; reverse here for GCM if necessary.
+
+          if (cc==1) then   ! clear
+!$acc kernels loop independent
+            do iplon = 1, colr
+              piplon = profic(iplon + cols - 1)
+        
+              do i = 1, nlay+1
+                swuflxc(piplon,i) = zbbcu(iplon,i) 
+                swdflxc(piplon,i) = zbbcd(iplon,i) 
+                swuflx(piplon,i) = zbbfu(iplon,i) 
+                swdflx(piplon,i) = zbbfd(iplon,i) 
+
+!  All-sky downwward direct and diffuse fluxes
+                swdkdir(piplon,i) = zbbfddir(iplon,i)
+                swdkdif(piplon,i) = zbbfd(iplon,i) - zbbfddir(iplon,i)
+!  UV/visible downward direct/diffuse fluxes
+                sibvisdir(piplon,i) = zuvfddir(iplon,i)
+                sibvisdif(piplon,i) = zuvfd(iplon,i) - zuvfddir(iplon,i)
+!  Near-IR downward direct/diffuse fluxes
+                sibnirdir(piplon,i) = znifddir(iplon,i)
+                sibnirdif(piplon,i) = znifd(iplon,i) - znifddir(iplon,i)
+              enddo
+
+!  Total and clear sky net fluxes
+
+              do i = 1, nlay+1
+                swnflxc(iplon,i)  = swdflxc(piplon,i) - swuflxc(piplon,i)
+                swnflx(iplon,i)  = swdflx(piplon,i) - swuflx(piplon,i)
+              enddo
+
+!  Total and clear sky heating rates
+
+              do i = 1, nlay
+                zdpgcp = heatfac / (plev(iplon, i) - plev(iplon, i+1))
+                swhrc(piplon,i) = (swnflxc(iplon,i+1)  - swnflxc(iplon,i) ) * zdpgcp
+                swhr(piplon,i) = (swnflx(iplon,i+1)  - swnflx(iplon,i) ) * zdpgcp
+              enddo
+              swhrc(piplon,nlay) = 0. 
+              swhr(piplon,nlay) = 0. 
+       
+! End longitude loop
+            enddo
+!$acc end kernels 
+
+          else     ! cc = 2, cloudy
+!$acc kernels loop independent
+            do iplon = 1, colr
+              piplon = profi(iplon + cols - 1)
+
+              do i = 1, nlay+1
+                swuflxc(piplon,i) = zbbcu(iplon,i) 
+                swdflxc(piplon,i) = zbbcd(iplon,i) 
+                swuflx(piplon,i) = zbbfu(iplon,i) 
+                swdflx(piplon,i) = zbbfd(iplon,i) 
+
+!  All-sky downwward direct and diffuse fluxes
+                swdkdir(piplon,i) = zbbfddir(iplon,i)
+                swdkdif(piplon,i) = zbbfd(iplon,i) - zbbfddir(iplon,i)
+!  UV/visible downward direct/diffuse fluxes
+                sibvisdir(piplon,i) = zuvfddir(iplon,i)
+                sibvisdif(piplon,i) = zuvfd(iplon,i) - zuvfddir(iplon,i)
+!  Near-IR downward direct/diffuse fluxes
+                sibnirdir(piplon,i) = znifddir(iplon,i)
+                sibnirdif(piplon,i) = znifd(iplon,i) - znifddir(iplon,i)
+              enddo
+
+!  Total and clear sky net fluxes
+
+              do i = 1, nlay+1
+                swnflxc(iplon,i)  = swdflxc(piplon,i) - swuflxc(piplon,i)
+                swnflx(iplon,i)  = swdflx(piplon,i) - swuflx(piplon,i)
+              enddo
+
+!  Total and clear sky heating rates
+
+              do i = 1, nlay
+                zdpgcp = heatfac / (plev(iplon, i) - plev(iplon, i+1))
+                swhrc(piplon,i) = (swnflxc(iplon,i+1)  - swnflxc(iplon,i) ) * zdpgcp
+                swhr(piplon,i) = (swnflx(iplon,i+1)  - swnflx(iplon,i) ) * zdpgcp
+              enddo
+              swhrc(piplon,nlay) = 0. 
+              swhr(piplon,nlay) = 0. 
+         
+! End longitude loop
+            enddo
+!$acc end kernels 
+
+          end if   ! if-else-endif clear-cloudy
+
+! End partition loops
+        end do
+        
+      end do
+
+!$acc end data
+
+      end subroutine rrtmg_sw_sub
+
+!*************************************************************************
+      real  function earth_sun(idn)
+!*************************************************************************
+!
+!  Purpose: Function to calculate the correction factor of Earth's orbit
+!  for current day of the year
+
+!  idn        : Day of the year
+!  earth_sun  : square of the ratio of mean to actual Earth-Sun distance
+
+! ------- Modules -------
+
+      use rrsw_con_f, only : pi
+
+      integer , intent(in) :: idn
+
+      real  :: gamma
+
+      gamma = 2. *pi*(idn-1)/365. 
+
+! Use Iqbal's equation 1.2.1
+
+      earth_sun = 1.000110  + .034221  * cos(gamma) + .001289  * sin(gamma) + &
+                   .000719  * cos(2. *gamma) + .000077  * sin(2. *gamma)
+
+      end function earth_sun
+
+      end module rrtmg_sw_rad_f
+
+!------------------------------------------------------------------
+      MODULE module_ra_rrtmg_swf
+
+      use module_model_constants, only : cp
+      USE module_wrf_error
+!     USE module_dm
+
+      use parrrsw_f, only : nbndsw, ngptsw, naerec
+      use rrtmg_sw_init_f, only: rrtmg_sw_ini
+      use rrtmg_sw_rad_f, only: rrtmg_sw
+!     use mcica_subcol_gen_sw, only: mcica_subcol_sw
+
+      use module_ra_rrtmg_lwf, only : inirad_1, o3data, relcalc, reicalc, retab
+!                               mcica_random_numbers, randomNumberSequence, &
+!                               new_RandomNumberSequence, getRandomReal
+
+      CONTAINS
+
+!------------------------------------------------------------------
+      SUBROUTINE RRTMG_SWRAD_FAST(                                &
+                       rthratensw,                                &
+                       swupt, swuptc, swdnt, swdntc,              &
+                       swupb, swupbc, swdnb, swdnbc,              &
+!                      swupflx, swupflxc, swdnflx, swdnflxc,      &
+                       swcf, gsw,                                 &
+                       xtime, gmt, xlat, xlong,                   &
+                       radt, degrad, declin,                      &
+                       coszr, julday, solcon,                     &
+                       albedo, t3d, t8w, tsk,                     &
+                       p3d, p8w, pi3d, rho3d,                     &
+                       dz8w, cldfra3d, lradius, iradius,          & 
+                       is_cammgmp_used, r, g,                     &
+                       re_cloud,re_ice,re_snow,                   &
+                       has_reqc,has_reqi,has_reqs,                &
+                       icloud, warm_rain,                         &
+                       f_ice_phy, f_rain_phy,                     &
+                       xland, xice, snow,                         &
+                       qv3d, qc3d, qr3d,                          &
+                       qi3d, qs3d, qg3d,                          &
+                       o3input, o33d,                             &
+                       aer_opt, aerod, no_src,                    &
+                       alswvisdir, alswvisdif,                    &  !Zhenxin ssib alb comp (06/20/2011)
+                       alswnirdir, alswnirdif,                    &  !Zhenxin ssib alb comp (06/20/2011)
+                       swvisdir, swvisdif,                        &  !Zhenxin ssib swr comp (06/20/2011)
+                       swnirdir, swnirdif,                        &  !Zhenxin ssib swi comp (06/20/2011)
+                       sf_surface_physics,                        &  !Zhenxin
+                       f_qv, f_qc, f_qr, f_qi, f_qs, f_qg,        &
+                       tauaer300,tauaer400,tauaer600,tauaer999,   & ! czhao 
+                       gaer300,gaer400,gaer600,gaer999,           & ! czhao 
+                       waer300,waer400,waer600,waer999,           & ! czhao 
+                       aer_ra_feedback,                           &
+!jdfcz                 progn,prescribe,                           &
+                       progn,                                     &
+                       qndrop3d,f_qndrop,                         & !czhao
+                       ids,ide, jds,jde, kds,kde,                 & 
+                       ims,ime, jms,jme, kms,kme,                 &
+                       its,ite, jts,jte, kts,kte,                 &
+                       swupflx, swupflxc, swdnflx, swdnflxc,      &
+                       tauaer3d_sw,ssaaer3d_sw,asyaer3d_sw,       & ! jararias 2013/11
+                       swddir, swddni, swddif,                    & ! jararias 2013/08
+                       xcoszen,julian                             & ! jararias 2013/08
+                                                                  )
+!------------------------------------------------------------------
+      IMPLICIT NONE
+!------------------------------------------------------------------
+   LOGICAL, INTENT(IN )      ::        warm_rain
+   LOGICAL, INTENT(IN )      ::   is_CAMMGMP_used ! Added for CAM5 RRTMG<->CAMMGMP
+!
+   INTEGER, INTENT(IN )      ::        ids,ide, jds,jde, kds,kde, &
+                                       ims,ime, jms,jme, kms,kme, &
+                                       its,ite, jts,jte, kts,kte
+
+   INTEGER, INTENT(IN )      ::        ICLOUD
+!
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
+         INTENT(IN   ) ::                                   dz8w, &
+                                                             t3d, &
+                                                             t8w, &
+                                                             p3d, &
+                                                             p8w, &
+                                                            pi3d, &
+                                                           rho3d
+
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
+         INTENT(INOUT)  ::                            RTHRATENSW
+
+   REAL, DIMENSION( ims:ime, jms:jme )                          , &
+         INTENT(INOUT)  ::                                   GSW, &
+                                                            SWCF, &
+                                                           COSZR
+
+   INTEGER, INTENT(IN  )     ::                           JULDAY
+   REAL, INTENT(IN    )      ::                      RADT,DEGRAD, &
+                                         XTIME,DECLIN,SOLCON,GMT
+
+   REAL, DIMENSION( ims:ime, jms:jme )                          , &
+         INTENT(IN   )  ::                                  XLAT, &
+                                                           XLONG, &
+                                                           XLAND, &
+                                                            XICE, &
+                                                            SNOW, &
+                                                             TSK, &
+                                                          ALBEDO
+!
+!!! -------------------  Zhenxin (2011-06/20) ------------------
+   REAL, DIMENSION( ims:ime, jms:jme )                          , &
+         OPTIONAL                                               , &
+         INTENT(IN)     ::                            ALSWVISDIR, &     ! ssib albedo of sw and lw
+                                                      ALSWVISDIF, &
+                                                      ALSWNIRDIR, &
+                                                      ALSWNIRDIF
+
+   REAL, DIMENSION( ims:ime, jms:jme )                          , &
+         OPTIONAL                                               , &
+         INTENT(OUT)    ::                              SWVISDIR, &
+                                                        SWVISDIF, &
+                                                        SWNIRDIR, &
+                                                        SWNIRDIF        ! ssib sw dir and diff rad
+   INTEGER, INTENT(IN) :: sf_surface_physics                            ! ssib para
+
+!  ----------------------- end Zhenxin --------------------------
+!
+
+! ------------------------ jararias 2013/08/10 -----------------
+   real, dimension(ims:ime,jms:jme), intent(out) :: &
+         swddir,  &  ! All-sky broadband surface direct horiz irradiance
+         swddni,  &  ! All-sky broadband surface direct normal irradiance
+         swddif      ! All-sky broadband surface diffuse irradiance
+   real, optional, intent(in) :: &
+         julian      ! julian day (1-366)
+   real, dimension(ims:ime,jms:jme), optional, intent(in) :: &
+         xcoszen     ! cosine of the solar zenith angle
+   real, dimension(ims:ime,kms:kme,jms:jme,nbndsw), optional,     &
+        intent(in)                                :: tauaer3d_sw, &
+                                                     ssaaer3d_sw, &
+                                                     asyaer3d_sw
+! ------------------------ jararias end snippet -----------------
+
+
+   REAL, INTENT(IN  )   ::                                   R,G
+!
+! Optional
+!
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
+         OPTIONAL                                               , &
+         INTENT(IN   ) ::                                         &
+                                                        CLDFRA3D, &
+                                                         LRADIUS, &
+                                                         IRADIUS, &
+                                                            QV3D, &
+                                                            QC3D, &
+                                                            QR3D, &
+                                                            QI3D, &
+                                                            QS3D, &
+                                                            QG3D, &
+                                                        QNDROP3D
+
+!..Added by G. Thompson to couple cloud physics effective radii.
+   REAL, DIMENSION(ims:ime, kms:kme, jms:jme), INTENT(IN)::       &
+                                                        RE_CLOUD, &
+                                                          RE_ICE, &
+                                                         RE_SNOW
+   INTEGER, INTENT(IN):: has_reqc, has_reqi, has_reqs
+
+   real pi,third,relconst,lwpmin,rhoh2o
+
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
+         OPTIONAL                                               , &
+         INTENT(IN   ) ::                                         &
+                                                       F_ICE_PHY, &
+                                                      F_RAIN_PHY
+
+   LOGICAL, OPTIONAL, INTENT(IN)   ::                             &
+                          F_QV,F_QC,F_QR,F_QI,F_QS,F_QG,F_QNDROP
+
+! Optional
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme ), OPTIONAL ,       &
+       INTENT(IN    ) :: tauaer300,tauaer400,tauaer600,tauaer999, & ! czhao 
+                                 gaer300,gaer400,gaer600,gaer999, & ! czhao 
+                                 waer300,waer400,waer600,waer999    ! czhao 
+
+   INTEGER,    INTENT(IN  ), OPTIONAL   ::       aer_ra_feedback
+!jdfcz   INTEGER,    INTENT(IN  ), OPTIONAL   ::       progn,prescribe
+   INTEGER,    INTENT(IN  ), OPTIONAL   ::       progn
+!  Ozone
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme )                 , &
+         OPTIONAL                                               , &
+         INTENT(IN   ) :: O33D
+   INTEGER, OPTIONAL, INTENT(IN ) :: o3input
+!  EC aerosol: no_src = naerec = 6
+   INTEGER,           INTENT(IN ) :: no_src
+   REAL, DIMENSION( ims:ime, kms:kme, jms:jme, 1:no_src )       , &
+         OPTIONAL                                               , &
+         INTENT(IN   ) :: aerod
+   INTEGER, OPTIONAL, INTENT(IN ) :: aer_opt
+
+!wavelength corresponding to wavenum1 and wavenum2 (cm-1)
+   real, save :: wavemin(nbndsw) ! Min wavelength (um) of 14 intervals
+   data wavemin /3.077,2.500,2.150,1.942,1.626,1.299, &
+   1.242,0.778,0.625,0.442,0.345,0.263,0.200,3.846/
+   real, save :: wavemax(nbndsw) ! Max wavelength (um) of interval
+   data wavemax/3.846,3.077,2.500,2.150,1.942,1.626, &
+   1.299,1.242,0.778,0.625,0.442,0.345,0.263,12.195/
+   real wavemid(nbndsw) ! Mid wavelength (um) of interval
+   real, parameter :: thresh=1.e-9
+   real ang,slope
+   character(len=200) :: msg
+
+! Top of atmosphere and surface shortwave fluxes (W m-2)
+   REAL, DIMENSION( ims:ime, jms:jme ),                           &
+         OPTIONAL, INTENT(INOUT) ::                               &
+                                       SWUPT,SWUPTC,SWDNT,SWDNTC, &
+                                       SWUPB,SWUPBC,SWDNB,SWDNBC
+
+! Layer shortwave fluxes (including extra layer above model top)
+! Vertical ordering is from bottom to top (W m-2)
+   REAL, DIMENSION( ims:ime, kms:kme+2, jms:jme ),                &
+         OPTIONAL, INTENT(OUT) ::                                 &
+                               SWUPFLX,SWUPFLXC,SWDNFLX,SWDNFLXC
+
+!  LOCAL VARS
+ 
+   REAL, DIMENSION( kts:kte+1 ) ::                          Pw1D, &
+                                                            Tw1D
+
+   REAL, DIMENSION( kts:kte ) ::                          TTEN1D, &
+                                                        CLDFRA1D, &
+                                                            DZ1D, &
+                                                             P1D, &
+                                                             T1D, &
+                                                            QV1D, &
+                                                            QC1D, &
+                                                            QR1D, &
+                                                            QI1D, &
+                                                            QS1D, &
+                                                            QG1D, &
+                                                            O31D, &
+                                                        qndrop1d 
+
+! Added local arrays for RRTMG
+    integer ::                                              ncol, &
+                                                            nlay, &
+                                                            icld, &
+                                                            iaer, &
+                                                         inflgsw, &
+                                                        iceflgsw, &
+                                                        liqflgsw
+! Dimension with extra layer from model top to TOA
+    real, dimension( (jte-jts+1)*(ite-its+1), kts:kte+2 )  ::                  plev, &
+                                                            tlev
+    real, dimension( (jte-jts+1)*(ite-its+1), kts:kte+1 )  ::                  play, &
+                                                            tlay, &
+                                                          h2ovmr, &
+                                                           o3vmr, &
+                                                          co2vmr, &
+                                                           o2vmr, &
+                                                          ch4vmr, &
+                                                          n2ovmr
+    real, dimension( (jte-jts+1)*(ite-its+1), kts:kte+1 )  ::                   o3mmr
+! Surface albedo (for UV/visible and near-IR spectral regions,
+! and for direct and diffuse radiation)
+    real, dimension( (jte-jts+1)*(ite-its+1) )  ::                            asdir, &
+                                                           asdif, &
+                                                           aldir, &
+                                                           aldif
+! Dimension with extra layer from model top to TOA, 
+! though no clouds are allowed in extra layer
+    real, dimension( (jte-jts+1)*(ite-its+1), kts:kte+1 )  ::                clwpth, &
+                                                          ciwpth, &
+                                                          cswpth, &
+                                                             rel, &
+                                                             rei, &
+                                                             res, &
+                                                         cldfrac
+!                                                         cldfrac, &
+!                                                         relqmcl, &
+!                                                         reicmcl, &
+!                                                         resnmcl
+    real, dimension( (jte-jts+1)*(ite-its+1), kts:kte+1, nbndsw )  ::        taucld, &
+                                                          ssacld, &
+                                                          asmcld, &
+                                                          fsfcld
+!    real, dimension( ngptsw, (jte-jts+1)*(ite-its+1), kts:kte+1 )  ::       cldfmcl, &
+!                                                         clwpmcl, &
+!                                                         ciwpmcl, &
+!                                                         cswpmcl, &
+!                                                         taucmcl, &
+!                                                         ssacmcl, &
+!                                                         asmcmcl, &
+!                                                         fsfcmcl
+    real, dimension( (jte-jts+1)*(ite-its+1), kts:kte+1, nbndsw )  ::        tauaer, &
+                                                          ssaaer, &
+                                                          asmaer   
+    real, dimension( (jte-jts+1)*(ite-its+1), kts:kte+1, naerec )  ::         ecaer
+
+! Output arrays contain extra layer from model top to TOA
+    real, dimension( (jte-jts+1)*(ite-its+1), kts:kte+2 )  ::                swuflx, &
+                                                          swdflx, &
+                                                         swuflxc, &
+                                                         swdflxc, &
+                                                       sibvisdir, &  ! Zhenxin 2011-06-20
+                                                       sibvisdif, &
+                                                       sibnirdir, &
+                                                       sibnirdif     ! Zhenxin 2011-06-20
+
+    real, dimension( (jte-jts+1)*(ite-its+1), kts:kte+2 ) ::                swdkdir, &  ! jararias, 2013/08/10
+                                                         swdkdif     ! jararias, 2013/08/10
+
+    real, dimension( (jte-jts+1)*(ite-its+1), kts:kte+1 )  ::                  swhr, &
+                                                           swhrc
+
+    real, dimension ( (jte-jts+1)*(ite-its+1) ) ::                             tsfc, &
+                                                              ps, &
+                                                          coszen
+    real ::                                                   ro, &
+                                                              dz, &
+                                                           adjes, &
+                                                            scon, &  
+                                                snow_mass_factor
+    integer ::                                            dyofyr
+
+    integer:: idx_rei
+    real:: corr
+
+! Set trace gas volume mixing ratios, 2005 values, IPCC (2007)
+! carbon dioxide (379 ppmv)
+    real :: co2
+    data co2 / 379.e-6 / 
+! methane (1774 ppbv)
+    real :: ch4
+    data ch4 / 1774.e-9 / 
+! nitrous oxide (319 ppbv)
+    real :: n2o
+    data n2o / 319.e-9 / 
+! Set oxygen volume mixing ratio (for o2mmr=0.23143)
+    real :: o2
+    data o2 / 0.209488 /
+
+    integer :: iplon, irng, permuteseed
+    integer :: nb
+
+! For old lw cloud property specification
+! Cloud and precipitation absorption coefficients
+!    real :: abcw,abice,abrn,absn
+!    data abcw /0.144/
+!    data abice /0.0735/
+!    data abrn /0.330e-3/
+!    data absn /2.34e-3/
+
+! Molecular weights and ratios for converting mmr to vmr units
+!    real :: amd       ! Effective molecular weight of dry air (g/mol)  
+!    real :: amw       ! Molecular weight of water vapor (g/mol)        
+!    real :: amo       ! Molecular weight of ozone (g/mol)              
+!    real :: amo2      ! Molecular weight of oxygen (g/mol)              
+! Atomic weights for conversion from mass to volume mixing ratios                
+!    data amd   /  28.9660   /                                                  
+!    data amw   /  18.0160   /                                                  
+!    data amo   /  47.9998   /                                                  
+!    data amo2  /  31.9999   /
+                                                                                 
+    real :: amdw     ! Molecular weight of dry air / water vapor  
+    real :: amdo     ! Molecular weight of dry air / ozone
+    real :: amdo2    ! Molecular weight of dry air / oxygen
+    data amdw /  1.607793 /                                                    
+    data amdo /  0.603461 /
+    data amdo2 / 0.905190 /
+    
+!!
+    real, dimension((jte-jts+1)*(ite-its+1), 1:kte-kts+1 )  :: pdel          ! Layer pressure thickness (mb)
+
+    real, dimension((jte-jts+1)*(ite-its+1), 1:kte-kts+1) ::   cicewp, &     ! in-cloud cloud ice water path
+                                            cliqwp, &     ! in-cloud cloud liquid water path
+                                            csnowp, &     ! in-cloud snow water path
+                                             reliq, &     ! effective drop radius (microns)
+                                             reice        ! ice effective drop size (microns)
+    real, dimension((jte-jts+1)*(ite-its+1), 1:kte-kts+1):: recloud1d, &
+                                           reice1d, &
+                                          resnow1d
+    real :: gliqwp, gicewp, gsnowp, gravmks
+
+!
+!    REAL   ::  TSFC,GLW0,OLR0,EMISS0,FP
+    REAL   ::  FP
+
+!    real, dimension(1:ite-its+1 )          ::   clat     ! latitude in radians for columns
+    real :: coszrs                      ! Cosine of solar zenith angle for present latitude 
+    logical :: dorrsw                   ! Flag to allow shortwave calculation
+
+    real, dimension ((jte-jts+1)*(ite-its+1)) :: landfrac, landm, snowh, icefrac
+
+    integer :: pcols, pver
+    integer :: icol
+    integer :: rpart
+
+    REAL :: XT24, TLOCTM, HRANG, XXLAT
+    REAL :: qv1D_K
+
+    INTEGER :: i,j,K, na
+    LOGICAL :: predicate
+
+    REAL :: da, eot ! jararias, 14/08/2013
+
+    integer :: icnt
+    LOGICAL :: predicate,PRESENT_CLDFRA3D,present_o33d
+    LOGICAL :: PRESENT_F_QC,PRESENT_F_QR,PRESENT_F_QI,PRESENT_F_QS,PRESENT_F_QG
+    LOGICAL :: PRESENT_QC3D,PRESENT_QR3D,PRESENT_QI3D,PRESENT_QS3D,PRESENT_QG3D
+    LOGICAL :: PRESENT_QNDROP3D, PRESENT_progn,PRESENT_F_QNDROP,PRESENT_F_ICE_PHY
+
+!$acc routine(reicalc) seq
+!$acc routine(relcalc) seq
+
+! mji - write
+!    REAL, DIMENSION( ims:ime, jms:jme ) ::         SWDB, SWUT
+
+!------------------------------------------------------------------
+#if ( WRF_CHEM == 1 )
+      IF ( aer_ra_feedback == 1) then
+      IF ( .NOT. &
+      ( PRESENT(tauaer300) .AND. &
+        PRESENT(tauaer400) .AND. &
+        PRESENT(tauaer600) .AND. &
+        PRESENT(tauaer999) .AND. &
+        PRESENT(gaer300) .AND. &
+        PRESENT(gaer400) .AND. &
+        PRESENT(gaer600) .AND. &
+        PRESENT(gaer999) .AND. &
+        PRESENT(waer300) .AND. &
+        PRESENT(waer400) .AND. &
+        PRESENT(waer600) .AND. &
+        PRESENT(waer999) ) ) THEN
+      CALL wrf_error_fatal  &
+      ('Warning: missing fields required for aerosol radiation' )
+      ENDIF
+      ENDIF
+#endif
+
+! Initial value of number of columns per partition; 
+! Use 2 for CPU; for GPU set to 0 here to allow selection
+! of appropriate value in rrtmg_sw
+#ifdef _OPENACC
+      rpart = 0
+#else
+      rpart = CHNK
+#endif
+
+   PRESENT_CLDFRA3D = PRESENT( CLDFRA3D )
+   present_o33d = present(o33d)
+   PRESENT_F_QC = PRESENT(F_QC)
+   PRESENT_F_QR = PRESENT(F_QR)
+   PRESENT_F_QI = PRESENT(F_QI)
+   PRESENT_F_QS = PRESENT(F_QS)
+   PRESENT_F_QG = PRESENT(F_QG)
+   PRESENT_QC3D = PRESENT(QC3D)
+   PRESENT_QR3D = PRESENT(QR3D)
+   PRESENT_QI3D = PRESENT(QI3D)
+   PRESENT_QS3D = PRESENT(QS3D)
+   PRESENT_QG3D = PRESENT(QG3D)
+   PRESENT_F_QNDROP = PRESENT(F_QNDROP)
+   PRESENT_QNDROP3D = PRESENT(QNDROP3D)
+   PRESENT_progn    = PRESENT( progn )  
+   PRESENT_F_ICE_PHY = PRESENT(F_ICE_PHY)
+#ifndef _OPENACC
+   if(is_CAMMGMP_used) call wrf_error_fatal('is_CAMMGMP_used is not tested wit OpenACC')
+#endif
+
+!-----CALCULATE SHORT WAVE RADIATION
+!                                                              
+! All fields are ordered vertically from bottom to top
+! Pressures are in mb
+
+! jararias, 14/08/2013
+      if (present(xcoszen)) then
+         call wrf_debug(100,'coszen from radiation driver')
+      end if
+
+! Number of columns to process
+   ncol = (jte-jts+1)*(ite-its+1)
+
+   icnt = 0
+
+
+!$acc enter data create(coszr,coszen)
+! Cosine solar zenith angle for current time step
+!
+! xt24 is the fractional part of simulation days plus half of radt expressed in 
+! units of minutes
+! julian is in days
+! radt is in minutes
+! jararias, 14/08/2013
+     if (present(xcoszen)) then
+!$acc data copyin(xcoszen)
+!$acc kernels
+!$acc loop independent
+        do j = jts,jte
+!$acc loop independent
+        do i = its,ite
+           icol = i-its+1 + (j-jts)*(ite-its+1)
+           coszr(i,j)=xcoszen(i,j)
+           coszrs=xcoszen(i,j)
+! mji - count daytime points to not process fully nighttime scenes
+           if (coszrs .gt. 0.0) icnt = icnt + 1
+! Set cosine of solar zenith angle
+           coszen(icol) = coszrs
+        enddo
+        enddo
+!$acc end kernels
+!$acc end data
+     else
+!$acc kernels
+!$acc loop independent
+        do j = jts,jte
+!$acc loop independent
+        do i = its,ite
+           icol = i-its+1 + (j-jts)*(ite-its+1)
+!           da=6.2831853071795862*(julian-1)/365.
+!           eot=(0.000075+0.001868*cos(da)-0.032077*sin(da) &
+!              -0.014615*cos(2*da)-0.04089*sin(2*da))*(229.18)
+           xt24 = mod(xtime+radt*0.5,1440.)+eot
+           tloctm = gmt + xt24/60. + xlong(i,j)/15.
+           hrang = 15. * (tloctm-12.) * degrad
+           xxlat = xlat(i,j) * degrad
+           coszrs = sin(xxlat) * sin(declin) &
+                  + cos(xxlat) * cos(declin) * cos(hrang)
+           coszr(i,j) = coszrs
+! mji - count daytime points to not process fully nighttime scenes
+           if (coszrs .gt. 0.0) icnt = icnt + 1
+! Set cosine of solar zenith angle
+           coszen(icol) = coszrs
+        enddo
+        enddo
+!$acc end kernels
+     end if
+     write(msg,*) 'columns to be processed:', icnt
+     call wrf_debug(0,msg)
+     if(icnt.eq.0) goto 100
+
+
+!$acc data create(cldfrac,recloud1D,reice1D,resnow1D) &
+!$acc      create(plev,tlev,tsfc,play,pdel,tlay,&
+!$acc             o3vmr,o3mmr,h2ovmr,co2vmr,o2vmr,ch4vmr,n2ovmr) &
+!$acc      copyin(albedo) create(asdir,asdif,aldir,aldif) &
+!$acc      create(taucld,ssacld,asmcld,fsfcld,icefrac,landfrac,landm,snowh) &
+!$acc      create(clwpth,ciwpth,cswpth,rel,rei,res,cliqwp,cicewp,reliq,reice,csnowp,resnow1d) &
+!$acc      copyin(cldfra3d)  &
+!$acc      create(ecaer,tauaer,ssaaer,asmaer)
+!$acc enter data copyin(re_ice) if(has_reqi)
+!$acc enter data copyin(re_cloud) if(has_reqc)
+!$acc enter data copyin(re_snow) if(has_reqs)
+
+
+!$acc kernels
+   cldfrac(:,:) = 0.0
+
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent private(cldfra1d)
+      do i = its,ite
+         do k = kts, kte
+            cldfra1d(k) = 0.
+         enddo
+         IF (ICLOUD .ne. 0 .and. PRESENT_CLDFRA3D  ) THEN
+            DO K=kts,kte
+               CLDFRA1D(k)=CLDFRA3D(I,K,J)
+            ENDDO
+         ENDIF
+
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+         ! ARom: inflgsw is greater then 0 by default 
+         !if (inflgsw .ge. 0) then
+!$acc loop independent
+            do k = kts, kte
+               cldfrac(icol,k) = cldfra1d(k)
+            enddo
+         !endif
+      enddo
+   enddo 
+
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+               DO K=kts,kte
+                  recloud1D(icol,K) = 5.0
+                  reice1D(icol,K) = 10.0
+                  resnow1D(icol,K) = 10.
+               ENDDO
+      enddo
+   enddo 
+!$acc end kernels
+
+
+         IF (ICLOUD .ne. 0) THEN
+            IF ( has_reqc .ne. 0) THEN
+!$acc kernels
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+               DO K=kts,kte
+                  recloud1D(icol,K) = MAX(2.5, re_cloud(I,K,J)*1.E6)
+                  if (recloud1D(icol,K).LE.2.5.AND.cldfra3d(i,k,j).gt.0. &
+     &                            .AND. (XLAND(I,J)-1.5).GT.0.) then      !--- Ocean
+                     recloud1D(icol,K) = 10.5
+                  elseif (recloud1D(icol,K).LE.2.5.AND.cldfra3d(i,k,j).gt.0. &
+     &                            .AND. (XLAND(I,J)-1.5).LT.0.) then      !--- Land
+                     recloud1D(icol,K) = 7.5
+                  endif
+               ENDDO
+      enddo
+   enddo 
+!$acc end kernels
+            ENDIF
+
+            IF ( has_reqi .ne. 0) THEN
+!$acc kernels
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+               DO K=kts,kte
+                  reice1D(icol,K) = MAX(10., re_ice(I,K,J)*1.E6)
+                  if (reice1D(icol,K).LE.10..AND.cldfra3d(i,k,j).gt.0.) then
+                     idx_rei = int(t3d(i,k,j)-179.)
+                     idx_rei = min(max(idx_rei,1),75)
+                     corr = t3d(i,k,j) - int(t3d(i,k,j))
+                     reice1D(icol,K) = retab(idx_rei)*(1.-corr) +      &
+     &                                 retab(idx_rei+1)*corr
+                     reice1D(icol,K) = MAX(reice1D(icol,K), 10.0)
+                  endif
+               ENDDO
+      enddo
+   enddo 
+!$acc end kernels
+            ENDIF
+
+            IF ( has_reqs .ne. 0) THEN
+!$acc kernels
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+               DO K=kts,kte
+                  resnow1D(icol,K) = MAX(10., re_snow(I,K,J)*1.E6)
+               ENDDO
+      enddo
+   enddo 
+!$acc end kernels
+            ENDIF
+         ENDIF
+
+! Layer indexing goes bottom to top here for all fields.
+! Water vapor and ozone are converted from mmr to vmr. 
+! Pressures are in units of mb here. 
+
+!$acc kernels
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+
+         plev(icol,1) = p8w(I,1,J)/100.
+         tlev(icol,1) = t8w(I,1,J)
+         tsfc(icol) = tsk(i,j)
+         do k = kts, kte
+            plev(icol,k+1) = p8w(I,K+1,J)/100.
+         enddo
+         do k = kts, kte
+            QV1D_K=QV3D(I,K,J)
+            QV1D_K=max(0.,QV1D_K)
+            QV1D_K=AMAX1(QV1D_K,1.E-12)
+            play(icol,k) = p3d(I,K,J)/100. !p1d(k)
+            pdel(icol,k) = plev(icol,k) - plev(icol,k+1)
+            tlay(icol,k) = t3d(I,K,J) ! t1d(k)
+            tlev(icol,k+1) = t8w(I,K+1,J)
+            h2ovmr(icol,k) = qv1d_k * amdw
+            co2vmr(icol,k) = co2
+            o2vmr(icol,k) = o2
+            ch4vmr(icol,k) = ch4
+            n2ovmr(icol,k) = n2o
+         enddo
+
+!  Define profile values for extra layer from model top to top of atmosphere. 
+!  The top layer temperature for all gridpoints is set to the top layer-1 
+!  temperature plus a constant (0 K) that represents an isothermal layer    
+!  above ptop.  Top layer interface temperatures are linearly interpolated 
+!  from the layer temperatures.  
+
+         play(icol,kte+1) = 0.5 * plev(icol,kte+1)
+         tlay(icol,kte+1) = tlev(icol,kte+1) + 0.0
+         plev(icol,kte+2) = 1.0e-5
+         tlev(icol,kte+2) = tlev(icol,kte+1) + 0.0
+         h2ovmr(icol,kte+1) = h2ovmr(icol,kte) 
+         co2vmr(icol,kte+1) = co2vmr(icol,kte) 
+         o2vmr(icol,kte+1) = o2vmr(icol,kte) 
+         ch4vmr(icol,kte+1) = ch4vmr(icol,kte) 
+         n2ovmr(icol,kte+1) = n2ovmr(icol,kte) 
+
+      enddo
+   enddo 
+!$acc end kernels
+
+! Get ozone profile including amount in extra layer above model top
+!         call inirad (o3mmr,plev,kts,kte)
+         call inirad_1 (o3mmr,plev,its,ite,kts,kte,jts,jte,0)
+
+!$acc kernels
+!$acc loop independent
+   do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+        if(present_o33d) then
+         do k = kts, kte+1
+            o3vmr(icol,k) = o3mmr(icol,k) * amdo
+!            IF ( PRESENT( O33D ) ) THEN
+            if(o3input .eq. 2)then
+               if(k.le.kte)then
+                 o3vmr(icol,k) = O33D(I,K,J) !o31d(k)
+               else
+! apply shifted climatology profile above model top
+                 o3vmr(icol,k) = O33D(I,KTE,J) - o3mmr(icol,kte)*amdo + o3mmr(icol,k)*amdo
+                 if(o3vmr(icol,k) .le. 0.)o3vmr(icol,k) = o3mmr(icol,k)*amdo
+               endif
+            endif
+!            ENDIF
+         enddo
+        else
+         do k = kts, kte+1
+            o3vmr(icol,k) = o3mmr(icol,k) * amdo
+         enddo
+        endif
+      enddo
+   enddo 
+!$acc end kernels
+
+! Set surface albedo for direct and diffuse radiation in UV/visible and
+! near-IR spectral regions
+! -------------- Zhenxin 2011-06-20 ----------- !
+
+! ------- 1.  Commented by Zhenxin 2011-06-20 for SSiB coupling modified ---- !
+!         asdir(icol) = albedo(i,j)
+!         asdif(icol) = albedo(i,j)
+!         aldir(icol) = albedo(i,j)
+!         aldif(icol) = albedo(i,j)
+! -------    End of Comments    ------ !
+
+! ------- 2. New Addition  ------ !
+    IF ( sf_surface_physics .eq. 8) THEN
+!$acc data copyin(ALSWVISDIR,ALSWVISDIF,ALSWNIRDIR,ALSWNIRDIF)    
+!$acc kernels
+!$acc loop independent
+      do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+        IF(XLAND(i,j) .LT. 1.5) THEN
+         asdir(icol) = ALSWVISDIR(I,J)
+         asdif(icol) = ALSWVISDIF(I,J)
+         aldir(icol) = ALSWNIRDIR(I,J)
+         aldif(icol) = ALSWNIRDIF(I,J)
+        ELSE
+         asdir(icol) = albedo(i,j)
+         asdif(icol) = albedo(i,j)
+         aldir(icol) = albedo(i,j)
+         aldif(icol) = albedo(i,j)
+        ENDIF
+      enddo
+      enddo 
+!$acc end kernels
+!$acc end data
+    ELSE
+!$acc kernels
+!$acc loop independent
+      do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+         asdir(icol) = albedo(i,j)
+         asdif(icol) = albedo(i,j)
+         aldir(icol) = albedo(i,j)
+         aldif(icol) = albedo(i,j)
+      enddo
+      enddo 
+!$acc end kernels
+    ENDIF
+
+
+! This logic is tortured because cannot test F_QI unless
+! it is present, and order of evaluation of expressions
+! is not specified in Fortran
+
+            IF ( PRESENT ( F_QI ) ) THEN
+              predicate = F_QI
+            ELSE
+              predicate = .FALSE.
+            ENDIF
+
+!$acc kernels
+! latitude loop
+!$acc loop independent
+   j_loop: do j = jts,jte
+
+! longitude loop
+!$acc loop independent private(QG1D,QC1D,QR1D,QI1D,QS1D,QNDROP1D)
+      i_loop: do i = its,ite
+!
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+
+! Do shortwave by default, deactivate below if sun below horizon
+!         dorrsw = .true.
+
+
+! Perform shortwave calculation if sun above horizon
+!         if (dorrsw) then
+
+         DO K=kts,kte
+!            QV1D(K)=0.
+            QC1D(K)=0.
+            QR1D(K)=0.
+            QI1D(K)=0.
+            QS1D(K)=0.
+!            CLDFRA1D(k)=0.
+            QNDROP1D(k)=0.
+         ENDDO
+
+! moist variables
+
+         IF (ICLOUD .ne. 0) THEN
+!            IF ( PRESENT( CLDFRA3D ) ) THEN
+!              DO K=kts,kte
+!                 CLDFRA1D(k)=CLDFRA3D(I,K,J)
+!              ENDDO
+!            ENDIF
+!
+            IF (PRESENT_F_QC .AND. PRESENT_QC3D) THEN
+              IF ( F_QC) THEN
+                 DO K=kts,kte
+                    QC1D(K)=QC3D(I,K,J)
+                    QC1D(K)=max(0.,QC1D(K))
+                 ENDDO
+              ENDIF
+            ENDIF
+
+            IF (PRESENT_F_QR .AND. PRESENT_QR3D) THEN
+              IF ( F_QR) THEN
+                 DO K=kts,kte
+                    QR1D(K)=QR3D(I,K,J)
+                    QR1D(K)=max(0.,QR1D(K))
+                 ENDDO
+              ENDIF
+            ENDIF
+
+            IF ( PRESENT(F_QNDROP).AND.PRESENT(QNDROP3D)) THEN
+             IF (F_QNDROP) THEN
+              DO K=kts,kte
+               qndrop1d(K)=qndrop3d(I,K,J)
+              ENDDO
+             ENDIF
+            ENDIF
+
+! For MP option 3
+            IF (.NOT. predicate .and. .not. warm_rain) THEN
+               DO K=kts,kte
+                  !IF (T1D(K) .lt. 273.15) THEN
+                  IF (t3d(I,K,J) .lt. 273.15) THEN
+                  QI1D(K)=QC1D(K)
+                  QS1D(K)=QR1D(K)
+                  QC1D(K)=0.
+                  QR1D(K)=0.
+                  ENDIF
+               ENDDO
+            ENDIF
+
+            IF (PRESENT_F_QI .AND. PRESENT_QI3D) THEN
+               IF (F_QI) THEN
+                  DO K=kts,kte
+                     QI1D(K)=QI3D(I,K,J)
+                     QI1D(K)=max(0.,QI1D(K))
+                  ENDDO
+               ENDIF
+            ENDIF
+
+            IF (PRESENT_F_QS .AND. PRESENT_QS3D) THEN
+               IF (F_QS) THEN
+                  DO K=kts,kte
+                     QS1D(K)=QS3D(I,K,J)
+                     QS1D(K)=max(0.,QS1D(K))
+                  ENDDO
+               ENDIF
+            ENDIF
+
+            IF (PRESENT_F_QG .AND. PRESENT_QG3D) THEN
+               IF (F_QG) THEN
+                  DO K=kts,kte
+                     QG1D(K)=QG3D(I,K,J)
+                     QG1D(K)=max(0.,QG1D(K))
+                  ENDDO
+               ENDIF
+            ENDIF
+
+! mji - For MP option 5
+            IF ( PRESENT_F_QI .and. PRESENT_F_QC .and. PRESENT_F_QS .and. PRESENT_F_ICE_PHY ) THEN
+               IF ( F_QC .and. .not. F_QI .and. F_QS ) THEN
+                  DO K=kts,kte
+                     qi1d(k) = 0.1*qs3d(i,k,j)
+                     qs1d(k) = 0.9*qs3d(i,k,j)
+                     qc1d(k) = qc3d(i,k,j)
+                     qi1d(k) = max(0.,qi1d(k))
+                     qc1d(k) = max(0.,qc1d(k))
+                  ENDDO
+               ENDIF
+            ENDIF
+
+         ENDIF
+
+
+! Set up input for shortwave
+!         ncol = 1
+
+! Select cloud liquid and ice optics parameterization options
+! For passing in cloud optical properties directly:
+!         icld = 2
+!         inflgsw = 0
+!         iceflgsw = 0
+!         liqflgsw = 0
+! For passing in cloud physical properties; cloud optics parameterized in RRTMG:
+         icld = 2
+         inflgsw = 2
+         iceflgsw = 3
+         liqflgsw = 1
+
+!Mukul change the flags here with reference to the new effective cloud/ice/snow radius
+         IF (ICLOUD .ne. 0) THEN
+            IF ( has_reqc .ne. 0) THEN
+               inflgsw = 3
+            ENDIF
+
+            IF ( has_reqi .ne. 0) THEN
+               inflgsw  = 4
+               iceflgsw = 4
+            ENDIF
+
+            IF ( has_reqs .ne. 0) THEN
+               inflgsw  = 5
+               iceflgsw = 5
+            ENDIF
+         ENDIF
+
+! Set solar constant
+         scon = solcon
+! For Earth/Sun distance adjustment in RRTMG
+!         dyofyr = julday
+!         adjes = 0.0 
+! For WRF, solar constant is already provided with eccentricity adjustment,
+! so do not do this in RRTMG
+         dyofyr = 0
+         adjes = 1.0 
+
+! ----------  End of fds_Zhenxin 2011-06-20   --------------!
+
+! Define cloud optical properties for radiation (inflgsw = 0)
+! This option is not currently active
+! Cloud and precipitation paths in g/m2 
+! qi=0 if no ice phase
+! qs=0 if no ice phase
+
+! ARom: inflgsw is greate than 0 by default
+#if 0
+         if (inflgsw .eq. 0) then
+
+! Set cloud fraction and cloud optical properties here; not yet active
+            do k = kts, kte
+!               cldfrac(icol,k) = cldfra1d(k)
+               do nb = 1, nbndsw
+                  taucld(icol,k,nb) = 0.0
+                  ssacld(icol,k,nb) = 1.0
+                  asmcld(icol,k,nb) = 0.0
+                  fsfcld(icol,k,nb) = 0.0
+               enddo
+            enddo
+
+! Zero out cloud physical property arrays; not used when passing optical properties
+! into radiation
+            do k = kts, kte
+               clwpth(icol,k) = 0.0
+               ciwpth(icol,k) = 0.0
+               rel(icol,k) = 10.0
+               rei(icol,k) = 10.
+            enddo
+         endif
+#endif
+
+! Define cloud physical properties for radiation (inflgsw = 1 or 2)
+! Cloud fraction
+! Set cloud arrays if passing cloud physical properties into radiation
+         if (inflgsw .gt. 0) then 
+!            do k = kts, kte
+!               cldfrac(icol,k) = cldfra1d(k)
+!            enddo
+
+! Compute cloud water/ice paths and particle sizes for input to radiation (CAM method)
+            pcols = ncol
+            pver = kte - kts + 1
+            gravmks = g
+            landfrac(icol) = 2.-XLAND(I,J)
+            landm(icol) = landfrac(icol)
+            snowh(icol) = 0.001*SNOW(I,J)
+            icefrac(icol) = XICE(I,J)
+
+! From module_ra_cam: Convert liquid and ice mixing ratios to water paths;
+! pdel is in mb here; convert back to Pa (*100.)
+! Water paths are in units of g/m2
+! snow added as ice cloud (JD 091022)
+            do k = kts, kte
+               gicewp = (qi1d(k)+qs1d(k)) * pdel(icol,k)*100.0 / gravmks * 1000.0     ! Grid box ice water path.
+               gliqwp = qc1d(k) * pdel(icol,k)*100.0 / gravmks * 1000.0     ! Grid box liquid water path.
+               cicewp(icol,k) = gicewp / max(0.01,cldfrac(icol,k))               ! In-cloud ice water path.
+               cliqwp(icol,k) = gliqwp / max(0.01,cldfrac(icol,k))               ! In-cloud liquid water path.
+            end do
+
+! Mukul
+!..The ice water path is already sum of cloud ice and snow, but when we have explicit
+!.. ice effective radius, overwrite the ice path with only the cloud ice variable,
+!.. leaving out the snow for its own effect.
+           if(iceflgsw.ge.4)then 
+              do k = kts, kte
+                     gicewp = qi1d(k) * pdel(icol,k)*100.0 / gravmks * 1000.0     ! Grid box ice water path.
+                     cicewp(icol,k) = gicewp / max(0.01,cldfrac(icol,k))               ! In-cloud ice water path.
+              end do
+           end if
+
+!..Here the snow path is adjusted if (radiation) effective radius of snow is
+!.. larger than what we currently have in the lookup tables.  Since mass goes
+!.. rather close to diameter squared, adjust the mixing ratio of snow used
+!.. to compute its water path in combination with the max diameter.  Not a
+!.. perfect fix, but certainly better than using all snow mass when diameter is
+!.. far larger than table currently contains and crystal sizes much larger than
+!.. about 140 microns have lesser impact than those much smaller sizes.
+
+           if(iceflgsw.eq.5)then
+              do k = kts, kte
+                 snow_mass_factor = 1.0                 
+                 if (resnow1d(icol,k) .gt. 130.)then 
+                     snow_mass_factor = (130.0/resnow1d(icol,k))*(130.0/resnow1d(icol,k))
+                     resnow1d(icol,k)   = 130.0
+                 endif
+                 gsnowp = qs1d(k) * snow_mass_factor * pdel(icol,k)*100.0 / gravmks * 1000.0     ! Grid box snow water path.
+                 csnowp(icol,k) = gsnowp / max(0.01,cldfrac(icol,k))
+              end do
+           end if
+
+
+#ifndef _OPENACC
+!link the aerosol feedback to cloud  -czhao
+  if( PRESENT( progn ) ) then
+    if (progn == 1) then
+!jdfcz     if(prescribe==0) then
+
+      pi = 4.*atan(1.0)
+      third=1./3.
+      rhoh2o=1.e3
+      relconst=3/(4.*pi*rhoh2o)
+!     minimun liquid water path to calculate rel
+!     corresponds to optical depth of 1.e-3 for radius 4 microns.
+      lwpmin=3.e-5
+      do k = kts, kte
+         reliq(icol,k) = 10.
+         if( PRESENT( F_QNDROP ) ) then
+            if( F_QNDROP ) then
+              if ( qc1d(k)*pdel(icol,k).gt.lwpmin.and. &
+                   qndrop1d(k).gt.1000. ) then
+               reliq(icol,k)=(relconst*qc1d(k)/qndrop1d(k))**third ! effective radius in m
+!           apply scaling from Martin et al., JAS 51, 1830.
+               reliq(icol,k)=1.1*reliq(icol,k)
+               reliq(icol,k)=reliq(icol,k)*1.e6 ! convert from m to microns
+               reliq(icol,k)=max(reliq(icol,k),4.)
+               reliq(icol,k)=min(reliq(icol,k),20.)
+              end if
+            end if
+         end if
+      end do
+!jdfcz     else ! prescribe 
+! following Kiehl
+!      call relcalc(icol, pcols, pver, tlay, landfrac, landm, icefrac, reliq, snowh)
+!      write(0,*) 'sw prescribe aerosol',maxval(qndrop3d)
+!jdfcz     endif
+    else  ! progn   (progn=1)
+      call relcalc(icol, pcols, pver, tlay, landfrac, landm, icefrac, reliq, snowh)
+    endif
+  else   !progn   (PRESENT)
+#endif
+      call relcalc(icol, pcols, pver, tlay, landfrac, landm, icefrac, reliq, snowh)
+#ifndef _OPENACC
+  endif
+#endif
+
+! following Kristjansson and Mitchell
+      call reicalc(icol, pcols, pver, tlay, reice)
+
+
+!..If we already have effective radius of cloud and ice, then just overwrite what
+!.. was computed in the relcalc and reicalc subroutines above.
+
+      if (inflgsw .ge. 3) then
+         do k = kts, kte
+            reliq(icol,k) = recloud1d(icol,k)
+         end do
+      endif
+      if (iceflgsw .ge. 4) then
+         do k = kts, kte
+            reice(icol,k) = reice1d(icol,k)
+         end do
+      endif
+
+
+! Limit upper bound of reice for Fu ice parameterization and convert
+! from effective radius to generalized effective size (*1.0315; Fu, 1996)
+            if (iceflgsw .eq. 3) then
+               do k = kts, kte
+                  reice(icol,k) = reice(icol,k) * 1.0315
+                  reice(icol,k) = min(140.0,reice(icol,k))
+               end do
+            endif
+
+!if CAMMGMP is used, use output from CAMMGMP            
+!PMA
+#ifndef _OPENACC
+            if(is_CAMMGMP_used) then
+               do k = kts, kte
+                  if ( qi1d(k) .gt. 1.e-20 .or. qs1d(k) .gt. 1.e-20) then
+                     reice(icol,k) = iradius(i,k,j)
+                  else
+                     reice(icol,k) = 25.
+                  end if
+                  reice(icol,k) = max(5., min(140.0,reice(icol,k)))
+                  if ( qc1d(k) .gt. 1.e-20) then
+                     reliq(icol,k) = lradius(i,k,j)
+                  else
+                     reliq(icol,k) = 10.
+                  end if
+                  reliq(icol,k) = max(2.5, min(60.0,reliq(icol,k)))
+               enddo
+            endif
+#endif
+! End of dorrsw check
+!      endif
+         endif ! if (inflgsw .gt. 0)
+
+      enddo i_loop
+   enddo j_loop                                           
+!$acc end kernels
+
+!$acc kernels
+!$acc loop independent
+      do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+      ! if (inflgsw .gt. 0)
+      icol = i-its+1 + (j-jts)*(ite-its+1)
+! if (inflgsw .gt. 0) 
+! ARom: it's always so
+! Set cloud physical property arrays
+            do k = kts, kte
+               clwpth(icol,k) = cliqwp(icol,k)
+               ciwpth(icol,k) = cicewp(icol,k)
+               rel(icol,k) = reliq(icol,k)
+               rei(icol,k) = reice(icol,k)
+            enddo
+
+!Mukul
+            IF (ICLOUD .ne. 0 .and.has_reqs .ne. 0) THEN
+!            if (inflgsw .eq. 5) then
+               do k = kts, kte
+                  cswpth(icol,k) = csnowp(icol,k)
+                  res(icol,k) = resnow1d(icol,k)
+               end do
+            else
+               do k = kts, kte
+                  cswpth(icol,k) = 0.0
+                  res(icol,k) = 10.0
+               end do
+            endif
+!         endif ! if (inflgsw .gt. 0)
+
+! No clouds are allowed in the extra layer from model top to TOA
+         clwpth(icol,kte+1) = 0.
+         ciwpth(icol,kte+1) = 0.
+         cswpth(icol,kte+1) = 0.
+         rel(icol,kte+1) = 10.
+         rei(icol,kte+1) = 10.
+         res(icol,kte+1) = 10.
+      enddo
+	  enddo
+!$acc end kernels
+
+!$acc kernels
+!$acc loop independent
+      do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+      ! if (inflgsw .gt. 0)
+      icol = i-its+1 + (j-jts)*(ite-its+1)
+! Zero out cloud optical properties here, calculated in radiation 
+            do k = kts, kte+1
+               do nb = 1, nbndsw
+                  taucld(icol,k,nb) = 0.0
+                  ssacld(icol,k,nb) = 1.0
+                  asmcld(icol,k,nb) = 0.0
+                  fsfcld(icol,k,nb) = 0.0
+               enddo
+            enddo
+      enddo
+      enddo
+!$acc end kernels	  
+
+! mji - mcica sub-column generator called inside rrtmg_sw for gpu
+!         iplon = 1
+!         irng = 0
+!         permuteseed = 1
+! Sub-column generator for McICA
+!         call mcica_subcol_sw(iplon, icol, nlay, icld, permuteseed, irng, play, &
+!                       cldfrac, ciwpth, clwpth, cswpth, rei, rel, res, taucld, ssacld, asmcld, fsfcld, &
+!                       cldfmcl, ciwpmcl, clwpmcl, cswpmcl, reicmcl, relqmcl, resnmcl, &
+!                       taucmcl, ssacmcl, asmcmcl, fsfcmcl)
+
+!--------------------------------------------------------------------------
+! Aerosol optical depth, single scattering albedo and asymmetry parameter -czhao 03/2010
+!--------------------------------------------------------------------------
+! by layer for each RRTMG shortwave band
+! No aerosols in top layer above model top (kte+1).
+!cz        do nb = 1, nbndsw
+!cz           do k = kts, kte+1
+!cz              tauaer(icol,k,nb) = 0.
+!cz              ssaaer(icol,k,nb) = 1.
+!cz              asmaer(icol,k,nb) = 0.
+!cz           enddo
+!cz        enddo
+
+! ... Aerosol effects. Added aerosol feedbacks from Chem , 03/2010 -czhao
+!
+!$acc kernels
+!$acc loop independent
+      do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+
+      icol = i-its+1 + (j-jts)*(ite-its+1)
+      do nb = 1, nbndsw
+      do k = kts,kte+1
+         tauaer(icol,k,nb) = 0.
+         ssaaer(icol,k,nb) = 1.
+         asmaer(icol,k,nb) = 0.
+      end do
+      end do
+      enddo
+      enddo
+!$acc end kernels
+
+      if ( present (tauaer3d_sw) ) then
+! ---- jararias 11/2012
+         if ( aer_opt .eq. 2) then
+!$acc data copyin(tauaer3d_sw,ssaaer3d_sw,asyaer3d_sw)
+!$acc kernels
+!$acc loop independent
+      do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+
+      icol = i-its+1 + (j-jts)*(ite-its+1)
+            do nb=1,nbndsw
+               do k=kts,kte
+                  tauaer(icol,k,nb)=tauaer3d_sw(i,k,j,nb)
+                  ssaaer(icol,k,nb)=ssaaer3d_sw(i,k,j,nb)
+                  asmaer(icol,k,nb)=asyaer3d_sw(i,k,j,nb)
+               end do
+            end do
+      enddo
+      enddo
+!$acc end kernels
+!$acc end data
+         end if
+      end if
+
+#if ( WRF_CHEM == 1 )
+#ifdef _OPENACC
+   call wrf_error_fatal('WRF_CHEM not tested for RRTMG_FAST (init part)')
+#endif
+      do j = jts,jte
+      do i = its,ite
+   IF ( AER_RA_FEEDBACK == 1) then
+      do nb = 1, nbndsw
+         wavemid(nb)=0.5*(wavemin(nb)+wavemax(nb))  ! um
+      do k = kts,kte      !wig
+
+! convert optical properties at 300,400,600, and 999 to conform to the band wavelengths
+! tauaer - use angstrom exponent
+        if(tauaer300(i,k,j).gt.thresh .and. tauaer999(i,k,j).gt.thresh) then
+           ang=alog(tauaer300(i,k,j)/tauaer999(i,k,j))/alog(999./300.)
+           tauaer(icol,k,nb)=tauaer400(i,k,j)*(0.4/wavemid(nb))**ang
+           !tauaer(icol,k,nb)=tauaer600(i,k,j)*(0.6/wavemid(nb))**ang 
+!jm TODO need to fix these so they are not writing to stderr, stdout 20141218
+           if (i==30.and.j==49.and.k==2.and.nb==12) then
+            write(0,*) 'TAU from 600 vs 400 in RRTMG',tauaer600(i,k,j),tauaer400(i,k,j)
+            print*, 'TAU from 600 vs 400 in RRTMG',tauaer600(i,k,j),tauaer400(i,k,j)
+            write(0,*) tauaer600(i,k,j)*(0.6/wavemid(nb))**ang,tauaer400(i,k,j)*(0.4/wavemid(nb))**ang
+            print*, tauaer600(i,k,j)*(0.6/wavemid(nb))**ang,tauaer400(i,k,j)*(0.4/wavemid(nb))**ang
+           endif
+! ssa - linear interpolation; extrapolation
+           slope=(waer600(i,k,j)-waer400(i,k,j))/.2
+           ssaaer(icol,k,nb) = slope*(wavemid(nb)-.6)+waer600(i,k,j)
+           if(ssaaer(icol,k,nb).lt.0.4) ssaaer(icol,k,nb)=0.4
+           if(ssaaer(icol,k,nb).ge.1.0) ssaaer(icol,k,nb)=1.0
+! g - linear interpolation;extrapolation
+           slope=(gaer600(i,k,j)-gaer400(i,k,j))/.2
+           asmaer(icol,k,nb) = slope*(wavemid(nb)-.6)+gaer600(i,k,j) ! notice reversed varaibles
+           if(asmaer(icol,k,nb).lt.0.5) asmaer(icol,k,nb)=0.5
+           if(asmaer(icol,k,nb).ge.1.0) asmaer(icol,k,nb)=1.0
+        endif
+      end do ! k
+      end do ! nb
+
+!wig beg
+      do nb = 1, nbndsw
+         slope = 0.  !use slope as a sum holder
+         do k = kts,kte
+            slope = slope + tauaer(icol,k,nb)
+         end do
+         if( slope < 0. ) then
+            write(msg,'("ERROR: Negative total optical depth of ",f8.2,&
+             " at point i,j,nb=",3i5)') slope,i,j,nb
+            call wrf_error_fatal(msg)
+         else if( slope > 6. ) then
+            call wrf_message("-------------------------")
+            write(msg,'("WARNING: Large total sw optical depth of ",f8.2,&
+             " at point i,j,nb=",3i5)') slope,i,j,nb
+            call wrf_message(msg)
+
+            call wrf_message("Diagnostics 1: k, tauaer300, tauaer400,&
+               tauaer600, tauaer999, tauaer")
+            do k=kts,kte
+               write(msg,'(i4,5f8.2)') k, tauaer300(i,k,j), tauaer400(i,k,j), &
+                    tauaer600(i,k,j), tauaer999(i,k,j),tauaer(icol,k,nb)
+               call wrf_message(msg)
+               !czhao set an up-limit here to avoid segmentation fault 
+               !from extreme AOD
+               tauaer(icol,k,nb)=tauaer(icol,k,nb)*6.0/slope 
+            end do
+
+            call wrf_message("Diagnostics 2: k, gaer300, gaer400, gaer600,&
+               gaer999")
+            do k=kts,kte
+               write(msg,'(i4,4f8.2)') k, gaer300(i,k,j), gaer400(i,k,j), &
+                    gaer600(i,k,j), gaer999(i,k,j)
+               call wrf_message(msg)
+            end do
+
+            call wrf_message("Diagnostics 3: k, waer300, waer400, waer600,&
+               waer999")
+            do k=kts,kte
+               write(msg,'(i4,4f8.2)') k, waer300(i,k,j), waer400(i,k,j), &
+                    waer600(i,k,j), waer999(i,k,j)
+               call wrf_message(msg)
+            end do
+
+            call wrf_message("Diagnostics 4: k, ssaal, asyal, taual")
+            do k=kts-1,kte
+               write(msg,'(i4,3f8.2)') k, ssaaer(i,k,nb), asmaer(i,k,nb), tauaer(i,k,nb)
+               call wrf_message(msg)
+            end do
+            call wrf_message("-------------------------")
+         endif
+      enddo  ! nb
+      endif  ! aer_ra_feedback
+
+      enddo
+      enddo
+#endif
+
+
+! Zero array for input of aerosol optical thickness for use with
+! ECMWF aerosol types (not used)
+      iaer = 0
+!$acc kernels
+!$acc loop independent
+      do j = jts,jte
+!$acc loop independent
+      do i = its,ite
+
+      icol = i-its+1 + (j-jts)*(ite-its+1)
+      do na = 1, naerec
+         do k = kts, kte+1
+            ecaer(icol,k,na) = 0.
+         enddo
+      enddo
+      enddo
+      enddo
+!$acc end kernels
+
+      IF ( PRESENT( aerod ) ) THEN
+      if ( aer_opt .eq. 0 .or. aer_opt .eq. 2 ) then
+         iaer = 10
+      else if ( aer_opt .eq. 1 ) then
+         iaer = 6
+!$acc data copyin(aerod)
+!$acc kernels
+!$acc loop independent
+         do j = jts,jte
+!$acc loop independent
+         do i = its,ite
+
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+         do na = 1, naerec
+            do k = kts, kte
+               ecaer(icol,k,na) = aerod(i,k,j,na)
+            enddo
+         enddo
+         enddo
+         enddo
+!$acc end kernels
+!$acc end data		 
+      endif
+      ENDIF
+
+! End of grid loops
+!$acc exit data delete(re_ice) if(has_reqi)
+!$acc exit data delete(re_cloud) if(has_reqc)
+!$acc exit data delete(re_snow) if(has_reqs)
+
+
+! Call RRTMG shortwave radiation model
+! Perform shortwave calculation if sun above horizon in any part of grid
+! Do not perform shortwave calculations if all of grid is in darkness
+	  dorrsw = .true.
+      if (icnt .eq. 0) dorrsw = .false.
+      if (dorrsw) then
+! Add extra layer from top of model to top of atmosphere
+         nlay = (kte - kts + 1) + 1
+
+         call rrtmg_sw &
+            (rpart   ,ncol    ,nlay    ,icld    ,iaer   , &
+             play    ,plev    ,tlay    ,tlev    ,tsfc   , &
+             h2ovmr  ,o3vmr   ,co2vmr  ,ch4vmr  ,n2ovmr ,o2vmr , &
+             asdir   ,asdif   ,aldir   ,aldif   , &
+             coszen  ,adjes   ,dyofyr  ,scon    , &
+             inflgsw ,iceflgsw,liqflgsw,cldfrac , &
+             taucld  ,ssacld  ,asmcld  ,fsfcld  , &
+             ciwpth  ,clwpth  ,cswpth  ,rei     ,rel     ,res, &
+             tauaer  ,ssaaer  ,asmaer  ,ecaer   , &
+             swuflx  ,swdflx  ,swhr    ,swuflxc ,swdflxc ,swhrc, &
+! -----      Zhenxin added for ssib coupiling 2011-06-20 --------!
+             sibvisdir, sibvisdif, sibnirdir, sibnirdif,         &
+! --------------------   End of addition by Zhenxin 2011-06-20 ------!
+             swdkdir, swdkdif                      &  ! jararias, 2012/08/10
+                                                  )
+
+      endif
+!$acc end data
+   100 continue
+!$acc exit data copyout(coszr) delete(coszen)
+
+! Output net absorbed shortwave surface flux and shortwave cloud forcing
+! at the top of atmosphere (W/m2)
+
+! latitude loop
+   j_loop2: do j = jts,jte
+! longitude loop
+      i_loop2: do i = its,ite
+      coszrs = 1.
+! Use calculated output only if in daylight, otherwise output is zero
+      dorrsw = .true.
+      if (coszr(i,j).le.0.0) dorrsw = .false.
+! Complete shortwave calculation if sun above horizon
+      if (dorrsw) then
+
+         if (present(xcoszen)) then
+            coszr(i,j)=xcoszen(i,j)
+            coszrs=xcoszen(i,j)
+         else
+            call wrf_error_fatal('xcoszen must be passed into RRTMG_SWRAD_FAST')
+         endif
+
+
+         icol = i-its+1 + (j-jts)*(ite-its+1)
+
+         gsw(i,j) = swdflx(icol,1) - swuflx(icol,1)
+         swcf(i,j) = (swdflx(icol,kte+2) - swuflx(icol,kte+2)) - (swdflxc(icol,kte+2) - swuflxc(icol,kte+2))
+
+! mji - write
+!         swut(i,j) = swuflx(icol,kte+2)
+!         swdb(i,j) = swdflx(icol,1)
+!
+         if (present(swupt)) then 
+! Output up and down toa fluxes for total and clear sky
+            swupt(i,j)     = swuflx(icol,kte+2)
+            swuptc(i,j)    = swuflxc(icol,kte+2)
+            swdnt(i,j)     = swdflx(icol,kte+2)
+            swdntc(i,j)    = swdflxc(icol,kte+2)
+! Output up and down surface fluxes for total and clear sky
+            swupb(i,j)     = swuflx(icol,1)
+            swupbc(i,j)    = swuflxc(icol,1)
+            swdnb(i,j)     = swdflx(icol,1)
+! Added by Zhenxin for 4 compenants of swdown radiation
+            swvisdir(i,j)  = sibvisdir(icol,1)
+            swvisdif(i,j)  = sibvisdif(icol,1)
+            swnirdir(i,j)  = sibnirdir(icol,1)
+            swnirdif(i,j)  = sibnirdif(icol,1)
+!  Ended, Zhenxin (2011/06/20)
+            swdnbc(i,j)    = swdflxc(icol,1)
+         endif
+            swddir(i,j)    = swdkdir(icol,1)       ! jararias 2013/08/10
+            swddni(i,j)    = swddir(i,j) / coszrs  ! jararias 2013/08/10
+            swddif(i,j)    = swdkdif(icol,1)          ! jararias 2013/08/10
+
+! Output up and down layer fluxes for total and clear sky.
+! Vertical ordering is from bottom to top in units of W m-2. 
+         if ( present (swupflx) ) then
+         do k=kts,kte+2
+            swupflx(i,k,j)  = swuflx(icol,k)
+            swupflxc(i,k,j) = swuflxc(icol,k)
+            swdnflx(i,k,j)  = swdflx(icol,k)
+            swdnflxc(i,k,j) = swdflxc(icol,k)
+         enddo
+         endif
+
+! Output heating rate tendency; convert heating rate from K/d to K/s
+! Heating rate arrays are ordered vertically from bottom to top here. 
+         do k=kts,kte 
+            tten1d(k) = swhr(icol,k)/86400.
+            rthratensw(i,k,j) = tten1d(k)/pi3d(i,k,j)
+         enddo
+
+      else
+         if (present(swupt)) then 
+! Output up and down toa fluxes for total and clear sky
+            swupt(i,j)     = 0.
+            swuptc(i,j)    = 0.
+            swdnt(i,j)     = 0.
+            swdntc(i,j)    = 0.
+! Output up and down surface fluxes for total and clear sky
+            swupb(i,j)     = 0.
+            swupbc(i,j)    = 0.
+            swdnb(i,j)     = 0.
+            swdnbc(i,j)    = 0.
+            swvisdir(i,j)  = 0.  ! Add by Zhenxin (2011/06/20)
+            swvisdif(i,j)  = 0.
+            swnirdir(i,j)  = 0.
+            swnirdif(i,j)  = 0.  ! Add by Zhenxin (2011/06/20)
+         endif
+            swddir(i,j)    = 0.  ! jararias 2013/08/10
+            swddni(i,j)    = 0.  ! jararias 2013/08/10
+            swddif(i,j)    = 0.  ! jararias 2013/08/10
+
+      endif
+
+      end do i_loop2
+   end do j_loop2                                           
+
+! mji - write
+!      do j=jts,jte
+!      write(62,995) (swut(i,j),i=its,ite)
+!      enddo
+!      do j=jts,jte
+!      write(62,995) (swdb(i,j),i=its,ite)
+!      enddo
+! 995  format(1p6e12.5)
+
+!-------------------------------------------------------------------
+
+   END SUBROUTINE RRTMG_SWRAD_FAST
+
+ 
+!====================================================================
+   SUBROUTINE rrtmg_swinit_fast(                                         &
+                       allowed_to_read ,                            &
+                       ids, ide, jds, jde, kds, kde,                &
+                       ims, ime, jms, jme, kms, kme,                &
+                       its, ite, jts, jte, kts, kte                 )
+!--------------------------------------------------------------------
+   IMPLICIT NONE
+!--------------------------------------------------------------------
+
+   LOGICAL , INTENT(IN)           :: allowed_to_read
+   INTEGER , INTENT(IN)           :: ids, ide, jds, jde, kds, kde,  &
+                                     ims, ime, jms, jme, kms, kme,  &
+                                     its, ite, jts, jte, kts, kte
+
+! Read in absorption coefficients and other data
+   IF ( allowed_to_read ) THEN
+     CALL rrtmg_swlookuptable
+   ENDIF
+
+! Perform g-point reduction and other initializations
+! Specific heat of dry air (cp) used in flux to heating rate conversion factor.
+   call rrtmg_sw_ini(cp)
+
+   END SUBROUTINE rrtmg_swinit_fast
+
+
+! **************************************************************************     
+      SUBROUTINE rrtmg_swlookuptable
+! **************************************************************************     
+
+      IMPLICIT NONE
+
+! Local                                    
+      INTEGER :: i
+      LOGICAL                 :: opened
+      LOGICAL , EXTERNAL      :: wrf_dm_on_monitor
+
+      CHARACTER*80 errmess
+      INTEGER rrtmg_unit
+
+      IF ( wrf_dm_on_monitor() ) THEN
+        DO i = 10,99
+          INQUIRE ( i , OPENED = opened )
+          IF ( .NOT. opened ) THEN
+            rrtmg_unit = i
+            GOTO 2010
+          ENDIF
+        ENDDO
+        rrtmg_unit = -1
+ 2010   CONTINUE
+      ENDIF
+      CALL wrf_dm_bcast_bytes ( rrtmg_unit , IWORDSIZE )
+      IF ( rrtmg_unit < 0 ) THEN
+        CALL wrf_error_fatal ( 'module_ra_rrtmg_swf: rrtm_swlookuptable: Can not '// &
+                               'find unused fortran unit to read in lookup table.' )
+      ENDIF
+
+      IF ( wrf_dm_on_monitor() ) THEN
+        OPEN(rrtmg_unit,FILE='RRTMG_SW_DATA',                  &
+             FORM='UNFORMATTED',STATUS='OLD',ERR=9009)
+      ENDIF
+
+      call sw_kgb16(rrtmg_unit)
+      call sw_kgb17(rrtmg_unit)
+      call sw_kgb18(rrtmg_unit)
+      call sw_kgb19(rrtmg_unit)
+      call sw_kgb20(rrtmg_unit)
+      call sw_kgb21(rrtmg_unit)
+      call sw_kgb22(rrtmg_unit)
+      call sw_kgb23(rrtmg_unit)
+      call sw_kgb24(rrtmg_unit)
+      call sw_kgb25(rrtmg_unit)
+      call sw_kgb26(rrtmg_unit)
+      call sw_kgb27(rrtmg_unit)
+      call sw_kgb28(rrtmg_unit)
+      call sw_kgb29(rrtmg_unit)
+
+      IF ( wrf_dm_on_monitor() ) CLOSE (rrtmg_unit)
+
+      RETURN
+9009  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error opening '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      END SUBROUTINE rrtmg_swlookuptable
+
+! **************************************************************************
+!  RRTMG Shortwave Radiative Transfer Model
+!  Atmospheric and Environmental Research, Inc., Cambridge, MA
+!
+!  Original by J.Delamere, Atmospheric & Environmental Research.
+!  Reformatted for F90: JJMorcrette, ECMWF
+!  Revision for GCMs:  Michael J. Iacono, AER, July 2002
+!  Further F90 reformatting:  Michael J. Iacono, AER, June 2006
+!
+!  This file contains 14 READ statements that include the 
+!  absorption coefficients and other data for each of the 14 shortwave
+!  spectral bands used in RRTMG_SW.  Here, the data are defined for 16
+!  g-points, or sub-intervals, per band.  These data are combined and
+!  weighted using a mapping procedure in module RRTMG_SW_INIT to reduce
+!  the total number of g-points from 224 to 112 for use in the GCM.
+! **************************************************************************
+
+! **************************************************************************
+      subroutine sw_kgb16(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg16_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            rayl, strrat1, layreffr
+!      use rrsw_kg16_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, rayl
+!      use rrtmg_sw_taumol, only : strrat1, layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array rayl contains the Rayleigh extinction coefficient at v = 2925 cm-1.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+!     The array FORREFO contains the coefficient of the water vapor
+!     foreign-continuum (including the energy term).  The first 
+!     index refers to reference temperature (296,260,224,260) and 
+!     pressure (970,475,219,3 mbar) levels.  The second index 
+!     runs over the g-channel (1 to 16).
+
+!     The array SELFREFO contains the coefficient of the water vapor
+!     self-continuum (including the energy term).  The first index
+!     refers to temperature in 7.2 degree increments.  For instance,
+!     JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+!     etc.  The second index runs over the g-channel (1 to 16).
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         rayl, strrat1, layreffr, kao, kbo, selfrefo, forrefo, sfluxrefo
+      DM_BCAST_REAL(rayl)
+      DM_BCAST_REAL(strrat1)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(selfrefo)
+      DM_BCAST_MACRO(forrefo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb16
+
+! **************************************************************************
+      subroutine sw_kgb17(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg17_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            rayl, strrat, layreffr
+!      use rrsw_kg17_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, rayl
+!      use rrtmg_sw_taumol, only : strrat, layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array rayl contains the Rayleigh extinction coefficient at v = 3625 cm-1.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+!     The array FORREFO contains the coefficient of the water vapor
+!     foreign-continuum (including the energy term).  The first 
+!     index refers to reference temperature (296,260,224,260) and 
+!     pressure (970,475,219,3 mbar) levels.  The second index 
+!     runs over the g-channel (1 to 16).
+
+!     The array SELFREFO contains the coefficient of the water vapor
+!     self-continuum (including the energy term).  The first index
+!     refers to temperature in 7.2 degree increments.  For instance,
+!     JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+!     etc.  The second index runs over the g-channel (1 to 16).
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         rayl, strrat, layreffr, kao, kbo, selfrefo, forrefo, sfluxrefo
+      DM_BCAST_REAL(rayl)
+      DM_BCAST_REAL(strrat)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(selfrefo)
+      DM_BCAST_MACRO(forrefo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb17
+
+! **************************************************************************
+      subroutine sw_kgb18(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg18_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            rayl, strrat, layreffr
+!      use rrsw_kg18_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, rayl
+!      use rrtmg_sw_taumol, only : strrat, layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array rayl contains the Rayleigh extinction coefficient at v = 4325 cm-1.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+!     The array FORREFO contains the coefficient of the water vapor
+!     foreign-continuum (including the energy term).  The first 
+!     index refers to reference temperature (296,260,224,260) and 
+!     pressure (970,475,219,3 mbar) levels.  The second index 
+!     runs over the g-channel (1 to 16).
+
+!     The array SELFREFO contains the coefficient of the water vapor
+!     self-continuum (including the energy term).  The first index
+!     refers to temperature in 7.2 degree increments.  For instance,
+!     JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+!     etc.  The second index runs over the g-channel (1 to 16).
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         rayl, strrat, layreffr, kao, kbo, selfrefo, forrefo, sfluxrefo
+      DM_BCAST_REAL(rayl)
+      DM_BCAST_REAL(strrat)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(selfrefo)
+      DM_BCAST_MACRO(forrefo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb18 
+
+! **************************************************************************
+      subroutine sw_kgb19(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg19_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            rayl, strrat, layreffr
+!      use rrsw_kg19_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, rayl
+!      use rrtmg_sw_taumol, only : strrat, layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array rayl contains the Rayleigh extinction coefficient at v = 4900 cm-1.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+!     The array FORREFO contains the coefficient of the water vapor
+!     foreign-continuum (including the energy term).  The first 
+!     index refers to reference temperature (296,260,224,260) and 
+!     pressure (970,475,219,3 mbar) levels.  The second index 
+!     runs over the g-channel (1 to 16).
+
+!     The array SELFREFO contains the coefficient of the water vapor
+!     self-continuum (including the energy term).  The first index
+!     refers to temperature in 7.2 degree increments.  For instance,
+!     JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+!     etc.  The second index runs over the g-channel (1 to 16).
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         rayl, strrat, layreffr, kao, kbo, selfrefo, forrefo, sfluxrefo
+      DM_BCAST_REAL(rayl)
+      DM_BCAST_REAL(strrat)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(selfrefo)
+      DM_BCAST_MACRO(forrefo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb19
+
+! **************************************************************************
+      subroutine sw_kgb20(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg20_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            absch4o, rayl, layreffr
+!      use rrsw_kg20_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+!                            absch4o, rayl
+!      use rrtmg_sw_taumol, only : layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array rayl contains the Rayleigh extinction coefficient at v = 5670 cm-1.
+
+!     Array absch4o contains the absorption coefficients for methane.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+!     The array FORREFO contains the coefficient of the water vapor
+!     foreign-continuum (including the energy term).  The first 
+!     index refers to reference temperature (296,260,224,260) and 
+!     pressure (970,475,219,3 mbar) levels.  The second index 
+!     runs over the g-channel (1 to 16).
+
+!     The array SELFREFO contains the coefficient of the water vapor
+!     self-continuum (including the energy term).  The first index
+!     refers to temperature in 7.2 degree increments.  For instance,
+!     JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+!     etc.  The second index runs over the g-channel (1 to 16).
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         rayl, layreffr, absch4o, kao, kbo, selfrefo, forrefo, sfluxrefo
+      DM_BCAST_REAL(rayl)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(absch4o)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(selfrefo)
+      DM_BCAST_MACRO(forrefo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb20
+
+! **************************************************************************
+      subroutine sw_kgb21(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg21_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            rayl, strrat, layreffr
+!      use rrsw_kg21_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, rayl
+!      use rrtmg_sw_taumol, only : strrat, layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array rayl contains the Rayleigh extinction coefficient at v = 6925 cm-1.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+!     The array FORREFO contains the coefficient of the water vapor
+!     foreign-continuum (including the energy term).  The first 
+!     index refers to reference temperature (296,260,224,260) and 
+!     pressure (970,475,219,3 mbar) levels.  The second index 
+!     runs over the g-channel (1 to 16).
+
+!     The array SELFREFO contains the coefficient of the water vapor
+!     self-continuum (including the energy term).  The first index
+!     refers to temperature in 7.2 degree increments.  For instance,
+!     JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+!     etc.  The second index runs over the g-channel (1 to 16).
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         rayl, strrat, layreffr, kao, kbo, selfrefo, forrefo, sfluxrefo
+      DM_BCAST_REAL(rayl)
+      DM_BCAST_REAL(strrat)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(selfrefo)
+      DM_BCAST_MACRO(forrefo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb21
+
+! **************************************************************************
+      subroutine sw_kgb22(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg22_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            rayl, strrat, layreffr
+!      use rrsw_kg22_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, rayl
+!      use rrtmg_sw_taumol, only : strrat, layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array rayl contains the Rayleigh extinction coefficient at v = 8000 cm-1.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+!     The array FORREFO contains the coefficient of the water vapor
+!     foreign-continuum (including the energy term).  The first 
+!     index refers to reference temperature (296,260,224,260) and 
+!     pressure (970,475,219,3 mbar) levels.  The second index 
+!     runs over the g-channel (1 to 16).
+
+!     The array SELFREFO contains the coefficient of the water vapor
+!     self-continuum (including the energy term).  The first index
+!     refers to temperature in 7.2 degree increments.  For instance,
+!     JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+!     etc.  The second index runs over the g-channel (1 to 16).
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         rayl, strrat, layreffr, kao, kbo, selfrefo, forrefo, sfluxrefo
+      DM_BCAST_REAL(rayl)
+      DM_BCAST_REAL(strrat)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(selfrefo)
+      DM_BCAST_MACRO(forrefo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb22
+
+! **************************************************************************
+      subroutine sw_kgb23(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg23_f, only : kao, selfrefo, forrefo, sfluxrefo, &
+                            raylo, givfac, layreffr
+!      use rrsw_kg23_f, only : kao, selfrefo, forrefo, sfluxrefo, raylo
+!      use rrtmg_sw_taumol, only : givfac, layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array raylo contains the Rayleigh extinction coefficient at all v for this band
+
+!     Array givfac is the average Giver et al. correction factor for this band. 
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array FORREFO contains the coefficient of the water vapor
+!     foreign-continuum (including the energy term).  The first 
+!     index refers to reference temperature (296,260,224,260) and 
+!     pressure (970,475,219,3 mbar) levels.  The second index 
+!     runs over the g-channel (1 to 16).
+
+!     The array SELFREFO contains the coefficient of the water vapor
+!     self-continuum (including the energy term).  The first index
+!     refers to temperature in 7.2 degree increments.  For instance,
+!     JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+!     etc.  The second index runs over the g-channel (1 to 16).
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         raylo, givfac, layreffr, kao, selfrefo, forrefo, sfluxrefo
+      DM_BCAST_MACRO(raylo)
+      DM_BCAST_REAL(givfac)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(selfrefo)
+      DM_BCAST_MACRO(forrefo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb23
+
+! **************************************************************************
+      subroutine sw_kgb24(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg24_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            raylao, raylbo, abso3ao, abso3bo, strrat, layreffr
+!      use rrsw_kg24_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+!                            raylao, raylbo, abso3ao, abso3bo
+!      use rrtmg_sw_taumol, only : strrat, layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Arrays raylao and raylbo contain the Rayleigh extinction coefficient at 
+!     all v for this band for the upper and lower atmosphere.
+
+!     Arrays abso3ao and abso3bo contain the ozone absorption coefficient at 
+!     all v for this band for the upper and lower atmosphere.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+!     The array FORREFO contains the coefficient of the water vapor
+!     foreign-continuum (including the energy term).  The first 
+!     index refers to reference temperature (296,260,224,260) and 
+!     pressure (970,475,219,3 mbar) levels.  The second index 
+!     runs over the g-channel (1 to 16).
+
+!     The array SELFREFO contains the coefficient of the water vapor
+!     self-continuum (including the energy term).  The first index
+!     refers to temperature in 7.2 degree increments.  For instance,
+!     JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+!     etc.  The second index runs over the g-channel (1 to 16).
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         raylao, raylbo, strrat, layreffr, abso3ao, abso3bo, kao, kbo, selfrefo, &
+         forrefo, sfluxrefo
+      DM_BCAST_MACRO(raylao)
+      DM_BCAST_MACRO(raylbo)
+      DM_BCAST_REAL(strrat)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(abso3ao)
+      DM_BCAST_MACRO(abso3bo)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(selfrefo)
+      DM_BCAST_MACRO(forrefo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb24
+
+! **************************************************************************
+      subroutine sw_kgb25(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg25_f, only : kao, sfluxrefo, &
+                            raylo, abso3ao, abso3bo, layreffr
+!      use rrsw_kg25_f, only : kao, sfluxrefo, raylo, abso3ao, abso3bo
+!      use rrtmg_sw_taumol, only : layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array raylo contains the Rayleigh extinction coefficient at all v = 2925 cm-1.
+
+!     Arrays abso3ao and abso3bo contain the ozone absorption coefficient at 
+!     all v for this band for the upper and lower atmosphere.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         raylo, layreffr, abso3ao, abso3bo, kao, sfluxrefo
+      DM_BCAST_MACRO(raylo)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(abso3ao)
+      DM_BCAST_MACRO(abso3bo)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb25
+
+! **************************************************************************
+      subroutine sw_kgb26(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg26_f, only : sfluxrefo, raylo
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array raylo contains the Rayleigh extinction coefficient at all v for this band.
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         raylo, sfluxrefo
+      DM_BCAST_MACRO(raylo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb26
+
+! **************************************************************************
+      subroutine sw_kgb27(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg27_f, only : kao, kbo, sfluxrefo, raylo, &
+                            scalekur, layreffr
+!      use rrsw_kg27_f, only : kao, kbo, sfluxrefo, raylo
+!      use rrtmg_sw_taumol, only : scalekur, layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+!     The values in array sfluxrefo were obtained using the "low resolution"
+!     version of the Kurucz solar source function.  For unknown reasons,
+!     the total irradiance in this band differs from the corresponding
+!     total in the "high-resolution" version of the Kurucz function.
+!     Therefore, these values are scaled by the factor SCALEKUR.
+
+!     Array raylo contains the Rayleigh extinction coefficient at all v = 2925 cm-1.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         raylo, scalekur, layreffr, kao, kbo, sfluxrefo
+      DM_BCAST_MACRO(raylo)
+      DM_BCAST_REAL(scalekur)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb27
+
+! **************************************************************************
+      subroutine sw_kgb28(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg28_f, only : kao, kbo, sfluxrefo, &
+                            rayl, strrat, layreffr
+!      use rrsw_kg28_f, only : kao, kbo, sfluxrefo, rayl
+!      use rrtmg_sw_taumol, only : strrat, layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array raylo contains the Rayleigh extinction coefficient at all v = ???? cm-1.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         rayl, strrat, layreffr, kao, kbo, sfluxrefo
+      DM_BCAST_REAL(rayl)
+      DM_BCAST_REAL(strrat)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb28
+
+! **************************************************************************
+      subroutine sw_kgb29(rrtmg_unit)
+! **************************************************************************
+
+      use rrsw_kg29_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+                            absh2oo, absco2o, rayl, layreffr
+!      use rrsw_kg29_f, only : kao, kbo, selfrefo, forrefo, sfluxrefo, &
+!                            absh2oo, absco2o, rayl
+!      use rrtmg_sw_taumol, only : layreffr
+
+      implicit none
+      save
+
+! Input
+      integer, intent(in) :: rrtmg_unit
+
+! Local                                    
+      character*80 errmess
+      logical, external  :: wrf_dm_on_monitor
+
+!     Array sfluxrefo contains the Kurucz solar source function for this band. 
+
+!     Array rayl contains the Rayleigh extinction coefficient at all v = 2200 cm-1.
+
+!     Array absh2oo contains the water vapor absorption coefficient for this band.
+
+!     Array absco2o contains the carbon dioxide absorption coefficient for this band.
+
+!     The array KAO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels> ~100mb, temperatures, and binary
+!     species parameters (see taumol.f for definition).  The first 
+!     index in the array, JS, runs from 1 to 9, and corresponds to 
+!     different values of the binary species parameter.  For instance, 
+!     JS=1 refers to dry air, JS = 2 corresponds to the paramter value 1/8, 
+!     JS = 3 corresponds to the parameter value 2/8, etc.  The second index
+!     in the array, JT, which runs from 1 to 5, corresponds to different
+!     temperatures.  More specifically, JT = 3 means that the data are for
+!     the reference temperature TREF for this  pressure level, JT = 2 refers
+!     to TREF-15, JT = 1 is for TREF-30, JT = 4 is for TREF+15, and JT = 5
+!     is for TREF+30.  The third index, JP, runs from 1 to 13 and refers
+!     to the JPth reference pressure level (see taumol.f for these levels
+!     in mb).  The fourth index, IG, goes from 1 to 16, and indicates
+!     which g-interval the absorption coefficients are for.
+
+!     The array KBO contains absorption coefs at the 16 chosen g-values 
+!     for a range of pressure levels < ~100mb and temperatures. The first 
+!     index in the array, JT, which runs from 1 to 5, corresponds to 
+!     different temperatures.  More specifically, JT = 3 means that the 
+!     data are for the reference temperature TREF for this pressure 
+!     level, JT = 2 refers to the temperature TREF-15, JT = 1 is for
+!     TREF-30, JT = 4 is for TREF+15, and JT = 5 is for TREF+30.  
+!     The second index, JP, runs from 13 to 59 and refers to the JPth
+!     reference pressure level (see taumol.f for the value of these
+!     pressure levels in mb).  The third index, IG, goes from 1 to 16,
+!     and tells us which g-interval the absorption coefficients are for.
+
+!     The array FORREFO contains the coefficient of the water vapor
+!     foreign-continuum (including the energy term).  The first 
+!     index refers to reference temperature (296,260,224,260) and 
+!     pressure (970,475,219,3 mbar) levels.  The second index 
+!     runs over the g-channel (1 to 16).
+
+!     The array SELFREFO contains the coefficient of the water vapor
+!     self-continuum (including the energy term).  The first index
+!     refers to temperature in 7.2 degree increments.  For instance,
+!     JT = 1 refers to a temperature of 245.6, JT = 2 refers to 252.8,
+!     etc.  The second index runs over the g-channel (1 to 16).
+
+#define DM_BCAST_MACRO(A) CALL wrf_dm_bcast_bytes ( A , size ( A ) * RWORDSIZE )
+#define DM_BCAST_REAL(A) CALL wrf_dm_bcast_real ( A , 1 )
+#define DM_BCAST_INTEGER(A) CALL wrf_dm_bcast_integer ( A , 1 )
+
+      IF ( wrf_dm_on_monitor() ) READ (rrtmg_unit,ERR=9010) &
+         rayl, layreffr, absh2oo, absco2o, kao, kbo, selfrefo, forrefo, sfluxrefo
+      DM_BCAST_REAL(rayl)
+      DM_BCAST_INTEGER(layreffr)
+      DM_BCAST_MACRO(absh2oo)
+      DM_BCAST_MACRO(absco2o)
+      DM_BCAST_MACRO(kao)
+      DM_BCAST_MACRO(kbo)
+      DM_BCAST_MACRO(selfrefo)
+      DM_BCAST_MACRO(forrefo)
+      DM_BCAST_MACRO(sfluxrefo)
+
+      RETURN
+9010  CONTINUE
+      WRITE( errmess , '(A,I4)' ) 'module_ra_rrtmg_swf: error reading '// &
+                                  'RRTMG_SW_DATA on unit ',rrtmg_unit
+      CALL wrf_error_fatal(errmess)
+
+      end subroutine sw_kgb29
+
+!------------------------------------------------------------------
+
+      END MODULE module_ra_rrtmg_swf

--- a/src/fromNVIDIA/module_sf_noahdrv.F
+++ b/src/fromNVIDIA/module_sf_noahdrv.F
@@ -1,0 +1,4994 @@
+MODULE module_sf_noahdrv
+
+!-------------------------------
+  USE module_sf_noahlsm,  only: SFLX, XLF, XLV, CP, R_D, RHOWATER, NATURAL, SHDTBL, LUTYPE, SLTYPE, STBOLT, &
+      &                         KARMAN, LUCATS, NROTBL, RSTBL, RGLTBL, HSTBL, SNUPTBL, MAXALB, LAIMINTBL,   &
+      &                         LAIMAXTBL, Z0MINTBL, Z0MAXTBL, ALBEDOMINTBL, ALBEDOMAXTBL, EMISSMINTBL,     &
+      &                         EMISSMAXTBL, TOPT_DATA, CMCMAX_DATA, CFACTR_DATA, RSMAX_DATA, BARE, NLUS,   &
+      &                         SLCATS, BB, DRYSMC, F11, MAXSMC, REFSMC, SATPSI, SATDK, SATDW, WLTSMC, QTZ, &
+      &                         NSLTYPE, SLPCATS, SLOPE_DATA, SBETA_DATA, FXEXP_DATA, CSOIL_DATA,           &
+      &                         SALP_DATA, REFDK_DATA, REFKDT_DATA, FRZK_DATA, ZBOT_DATA, CZIL_DATA,        &
+      &                         SMLOW_DATA, SMHIGH_DATA, LVCOEF_DATA, NSLOPE, &
+      &                         FRH2O,ZTOPVTBL,ZBOTVTBL
+
+  USE module_sf_urban,    only: urban, oasis, IRI_SCHEME
+  USE module_sf_noahlsm_glacial_only, only: sflx_glacial
+  USE module_sf_bep,      only: bep
+  USE module_sf_bep_bem,  only: bep_bem
+  USE module_ra_gfdleta,  only: cal_mon_day
+#if ( WRF_CHEM == 1 )
+  USE module_data_gocart_dust
+#endif
+!-------------------------------
+
+!
+CONTAINS
+!
+!----------------------------------------------------------------
+! Urban related variable are added to arguments - urban
+!----------------------------------------------------------------
+   SUBROUTINE lsm(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
+                  HFX,QFX,LH,GRDFLX, QGH,GSW,SWDOWN,GLW,SMSTAV,SMSTOT, &
+                  SFCRUNOFF, UDRUNOFF,IVGTYP,ISLTYP,ISURBAN,ISICE,VEGFRA,    &
+                  ALBEDO,ALBBCK,ZNT,Z0,TMN,XLAND,XICE,EMISS,EMBCK,   &
+                  SNOWC,QSFC,RAINBL,MMINLU,                     &
+                  num_soil_layers,DT,DZS,ITIMESTEP,             &
+                  SMOIS,TSLB,SNOW,CANWAT,                       &
+                  CHS,CHS2,CQS2,CPM,ROVCP,SR,chklowq,lai,qz0,   & !H
+                  myj,frpcpn,                                   &
+                  SH2O,SNOWH,                                   & !H
+                  U_PHY,V_PHY,                                  & !I
+                  SNOALB,SHDMIN,SHDMAX,                         & !I
+                  SNOTIME,                                      & !?
+                  ACSNOM,ACSNOW,                                & !O
+                  SNOPCX,                                       & !O
+                  POTEVP,                                       & !O
+                  SMCREL,                                       & !O
+                  XICE_THRESHOLD,                               &
+                  RDLAI2D,USEMONALB,                            &
+                  RIB,                                          & !?
+                  NOAHRES,                                      &
+! Noah UA changes
+                  ua_phys,flx4_2d,fvb_2d,fbur_2d,fgsn_2d,       &
+                  ids,ide, jds,jde, kds,kde,                    &
+                  ims,ime, jms,jme, kms,kme,                    &
+                  its,ite, jts,jte, kts,kte,                    &
+                  sf_urban_physics,                             &
+                  CMR_SFCDIF,CHR_SFCDIF,CMC_SFCDIF,CHC_SFCDIF,  &
+                  CMGR_SFCDIF,CHGR_SFCDIF,                      &
+!Optional Urban
+                  TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D, & !H urban
+                  UC_URB2D,                                     & !H urban
+                  XXXR_URB2D,XXXB_URB2D,XXXG_URB2D,XXXC_URB2D,  & !H urban
+                  TRL_URB3D,TBL_URB3D,TGL_URB3D,                & !H urban
+                  SH_URB2D,LH_URB2D,G_URB2D,RN_URB2D,TS_URB2D,  & !H urban
+                  PSIM_URB2D,PSIH_URB2D,U10_URB2D,V10_URB2D,    & !O urban
+                  GZ1OZ0_URB2D,  AKMS_URB2D,                    & !O urban
+                  TH2_URB2D,Q2_URB2D, UST_URB2D,                & !O urban
+                  DECLIN_URB,COSZ_URB2D,OMG_URB2D,              & !I urban
+                  XLAT_URB2D,                                   & !I urban
+                  num_roof_layers, num_wall_layers,             & !I urban
+                  num_road_layers, DZR, DZB, DZG,               & !I urban
+                  CMCR_URB2D,TGR_URB2D,TGRL_URB3D,SMR_URB3D,    & !H urban
+                  DRELR_URB2D,DRELB_URB2D,DRELG_URB2D,          & !H urban
+                  FLXHUMR_URB2D,FLXHUMB_URB2D,FLXHUMG_URB2D,    & !H urban
+                  julian, julyr,                                & !H urban
+                  FRC_URB2D,UTYPE_URB2D,                        & !O
+                  num_urban_layers,                             & !I multi-layer urban
+                  num_urban_hi,                                 & !I multi-layer urban
+                  trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,      & !H multi-layer urban
+                  tlev_urb3d,qlev_urb3d,                        & !H multi-layer urban
+                  tw1lev_urb3d,tw2lev_urb3d,                    & !H multi-layer urban
+                  tglev_urb3d,tflev_urb3d,                      & !H multi-layer urban
+                  sf_ac_urb3d,lf_ac_urb3d,cm_ac_urb3d,          & !H multi-layer urban
+                  sfvent_urb3d,lfvent_urb3d,                    & !H multi-layer urban
+                  sfwin1_urb3d,sfwin2_urb3d,                    & !H multi-layer urban
+                  sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,    & !H multi-layer urban
+                  lp_urb2d,hi_urb2d,lb_urb2d,hgt_urb2d,         & !H multi-layer urban
+                  mh_urb2d,stdh_urb2d,lf_urb2d,                 & !SLUCM
+                  th_phy,rho,p_phy,ust,                         & !I multi-layer urban
+                  gmt,julday,xlong,xlat,                        & !I multi-layer urban
+                  a_u_bep,a_v_bep,a_t_bep,a_q_bep,              & !O multi-layer urban
+                  a_e_bep,b_u_bep,b_v_bep,                      & !O multi-layer urban
+                  b_t_bep,b_q_bep,b_e_bep,dlg_bep,              & !O multi-layer urban
+                  dl_u_bep,sf_bep,vl_bep,sfcheadrt,INFXSRT, soldrain      )   !O multi-layer urban         
+
+!----------------------------------------------------------------
+    IMPLICIT NONE
+!----------------------------------------------------------------
+!----------------------------------------------------------------
+! --- atmospheric (WRF generic) variables
+!-- DT          time step (seconds)
+!-- DZ8W        thickness of layers (m)
+!-- T3D         temperature (K)
+!-- QV3D        3D water vapor mixing ratio (Kg/Kg)
+!-- P3D         3D pressure (Pa)
+!-- FLHC        exchange coefficient for heat (m/s)
+!-- FLQC        exchange coefficient for moisture (m/s)
+!-- PSFC        surface pressure (Pa)
+!-- XLAND       land mask (1 for land, 2 for water)
+!-- QGH         saturated mixing ratio at 2 meter
+!-- GSW         downward short wave flux at ground surface (W/m^2)
+!-- GLW         downward long wave flux at ground surface (W/m^2)
+!-- History variables
+!-- CANWAT      canopy moisture content (mm)
+!-- TSK         surface temperature (K)
+!-- TSLB        soil temp (k)
+!-- SMOIS       total soil moisture content (volumetric fraction)
+!-- SH2O        unfrozen soil moisture content (volumetric fraction)
+!                note: frozen soil moisture (i.e., soil ice) = SMOIS - SH2O
+!-- SNOWH       actual snow depth (m)
+!-- SNOW        liquid water-equivalent snow depth (m)
+!-- ALBEDO      time-varying surface albedo including snow effect (unitless fraction)
+!-- ALBBCK      background surface albedo (unitless fraction)
+!-- CHS          surface exchange coefficient for heat and moisture (m s-1);
+!-- CHS2        2m surface exchange coefficient for heat  (m s-1);
+!-- CQS2        2m surface exchange coefficient for moisture (m s-1);
+! --- soil variables
+!-- num_soil_layers   the number of soil layers
+!-- ZS          depths of centers of soil layers   (m)
+!-- DZS         thicknesses of soil layers (m)
+!-- SLDPTH      thickness of each soil layer (m, same as DZS)
+!-- TMN         soil temperature at lower boundary (K)
+!-- SMCWLT      wilting point (volumetric)
+!-- SMCDRY      dry soil moisture threshold where direct evap from
+!               top soil layer ends (volumetric)
+!-- SMCREF      soil moisture threshold below which transpiration begins to
+!                   stress (volumetric)
+!-- SMCMAX      porosity, i.e. saturated value of soil moisture (volumetric)
+!-- NROOT       number of root layers, a function of veg type, determined
+!               in subroutine redprm.
+!-- SMSTAV      Soil moisture availability for evapotranspiration (
+!                   fraction between SMCWLT and SMCMXA)
+!-- SMSTOT      Total soil moisture content frozen+unfrozen) in the soil column (mm)
+! --- snow variables
+!-- SNOWC       fraction snow coverage (0-1.0)
+! --- vegetation variables
+!-- SNOALB      upper bound on maximum albedo over deep snow
+!-- SHDMIN      minimum areal fractional coverage of annual green vegetation
+!-- SHDMAX      maximum areal fractional coverage of annual green vegetation
+!-- XLAI        leaf area index (dimensionless)
+!-- Z0BRD       Background fixed roughness length (M)
+!-- Z0          Background vroughness length (M) as function
+!-- ZNT         Time varying roughness length (M) as function
+!-- ALBD(IVGTPK,ISN) background albedo reading from a table
+! --- LSM output
+!-- HFX         upward heat flux at the surface (W/m^2)
+!-- QFX         upward moisture flux at the surface (kg/m^2/s)
+!-- LH          upward moisture flux at the surface (W m-2)
+!-- GRDFLX(I,J) ground heat flux (W m-2)
+!-- FDOWN       radiation forcing at the surface (W m-2) = SOLDN*(1-alb)+LWDN
+!----------------------------------------------------------------------------
+!-- EC          canopy water evaporation ((W m-2)
+!-- EDIR        direct soil evaporation (W m-2)
+!-- ET          plant transpiration from a particular root layer (W m-2)
+!-- ETT         total plant transpiration (W m-2)
+!-- ESNOW       sublimation from (or deposition to if <0) snowpack (W m-2)
+!-- DRIP        through-fall of precip and/or dew in excess of canopy
+!                 water-holding capacity (m)
+!-- DEW         dewfall (or frostfall for t<273.15) (M)
+!-- SMAV        Soil Moisture Availability for each layer, as a fraction
+!                 between SMCWLT and SMCMAX (dimensionless fraction)
+! ----------------------------------------------------------------------
+!-- BETA        ratio of actual/potential evap (dimensionless)
+!-- ETP         potential evaporation (W m-2)
+! ----------------------------------------------------------------------
+!-- FLX1        precip-snow sfc (W m-2)
+!-- FLX2        freezing rain latent heat flux (W m-2)
+!-- FLX3        phase-change heat flux from snowmelt (W m-2)
+! ----------------------------------------------------------------------
+!-- ACSNOM      snow melt (mm) (water equivalent)
+!-- ACSNOW      accumulated snow fall (mm) (water equivalent)
+!-- SNOPCX      snow phase change heat flux (W/m^2)
+!-- POTEVP      accumulated potential evaporation (m)
+!-- RIB         Documentation needed!!!
+! ----------------------------------------------------------------------
+!-- RUNOFF1     surface runoff (m s-1), not infiltrating the surface
+!-- RUNOFF2     subsurface runoff (m s-1), drainage out bottom of last
+!                  soil layer (baseflow)
+!  important note: here RUNOFF2 is actually the sum of RUNOFF2 and RUNOFF3
+!-- RUNOFF3     numerical trunctation in excess of porosity (smcmax)
+!                  for a given soil layer at the end of a time step (m s-1).
+!SFCRUNOFF     Surface Runoff (mm)
+!UDRUNOFF      Total Underground Runoff (mm), which is the sum of RUNOFF2 and RUNOFF3
+! ----------------------------------------------------------------------
+!-- RC          canopy resistance (s m-1)
+!-- PC          plant coefficient (unitless fraction, 0-1) where PC*ETP = actual transp
+!-- RSMIN       minimum canopy resistance (s m-1)
+!-- RCS         incoming solar rc factor (dimensionless)
+!-- RCT         air temperature rc factor (dimensionless)
+!-- RCQ         atmos vapor pressure deficit rc factor (dimensionless)
+!-- RCSOIL      soil moisture rc factor (dimensionless)
+
+!-- EMISS       surface emissivity (between 0 and 1)
+!-- EMBCK       Background surface emissivity (between 0 and 1)
+
+!-- ROVCP       R/CP
+!               (R_d/R_v) (dimensionless)
+!-- ids         start index for i in domain
+!-- ide         end index for i in domain
+!-- jds         start index for j in domain
+!-- jde         end index for j in domain
+!-- kds         start index for k in domain
+!-- kde         end index for k in domain
+!-- ims         start index for i in memory
+!-- ime         end index for i in memory
+!-- jms         start index for j in memory
+!-- jme         end index for j in memory
+!-- kms         start index for k in memory
+!-- kme         end index for k in memory
+!-- its         start index for i in tile
+!-- ite         end index for i in tile
+!-- jts         start index for j in tile
+!-- jte         end index for j in tile
+!-- kts         start index for k in tile
+!-- kte         end index for k in tile
+!
+!-- SR          fraction of frozen precip (0.0 to 1.0)
+!----------------------------------------------------------------
+
+! IN only
+
+   INTEGER,  INTENT(IN   )   ::     ids,ide, jds,jde, kds,kde,  &
+                                    ims,ime, jms,jme, kms,kme,  &
+                                    its,ite, jts,jte, kts,kte
+
+   INTEGER,  INTENT(IN   )   ::  sf_urban_physics               !urban
+   INTEGER,  INTENT(IN   )   ::  isurban
+   INTEGER,  INTENT(IN   )   ::  isice
+   INTEGER,  INTENT(IN   )   ::  julian, julyr                  !urban
+
+!added by Wei Yu  for routing
+    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+             INTENT(INOUT)  :: sfcheadrt,INFXSRT,soldrain 
+    real :: etpnd1
+!end added
+
+
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN   )    ::                            TMN, &
+                                                         XLAND, &
+                                                          XICE, &
+                                                        VEGFRA, &
+                                                        SHDMIN, &
+                                                        SHDMAX, &
+                                                        SNOALB, &
+                                                           GSW, &
+                                                        SWDOWN, & !added 10 jan 2007
+                                                           GLW, &
+                                                        RAINBL, &
+                                                        EMBCK,  &
+                                                        SR
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)    ::                         ALBBCK, &
+                                                            Z0
+   CHARACTER(LEN=*), INTENT(IN   )    ::                 MMINLU
+
+   REAL,    DIMENSION( ims:ime, kms:kme, jms:jme )            , &
+            INTENT(IN   )    ::                           QV3D, &
+                                                         p8w3D, &
+                                                          DZ8W, &
+                                                          T3D
+   REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+             INTENT(IN   )               ::               QGH,  &
+                                                          CPM
+
+   INTEGER, DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN   )    ::                         IVGTYP, &
+                                                        ISLTYP
+
+   INTEGER, INTENT(IN)       ::     num_soil_layers,ITIMESTEP
+
+   REAL,     INTENT(IN   )   ::     DT,ROVCP
+
+   REAL,     DIMENSION(1:num_soil_layers), INTENT(IN)::DZS
+
+! IN and OUT
+
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ), &
+             INTENT(INOUT)   ::                          SMOIS, & ! total soil moisture
+                                                         SH2O,  & ! new soil liquid
+                                                         TSLB     ! TSLB     STEMP
+
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ), &
+             INTENT(OUT)     ::                         SMCREL
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)    ::                            TSK, & !was TGB (temperature)
+                                                           HFX, &
+                                                           QFX, &
+                                                            LH, &
+                                                        GRDFLX, &
+                                                          QSFC,&
+                                                          CQS2,&
+                                                          CHS,   &
+                                                          CHS2,&
+                                                          SNOW, &
+                                                         SNOWC, &
+                                                         SNOWH, & !new
+                                                        CANWAT, &
+                                                        SMSTAV, &
+                                                        SMSTOT, &
+                                                     SFCRUNOFF, &
+                                                      UDRUNOFF, &
+                                                        ACSNOM, &
+                                                        ACSNOW, &
+                                                       SNOTIME, &
+                                                        SNOPCX, &
+                                                        EMISS,  &
+                                                          RIB,  &
+                                                        POTEVP, &
+                                                        ALBEDO, &
+                                                           ZNT
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(OUT)      ::                         NOAHRES
+
+! Noah UA changes
+   LOGICAL,                                INTENT(IN)  :: UA_PHYS
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: FLX4_2D,FVB_2D,FBUR_2D,FGSN_2D
+   REAL                                                :: FLX4,FVB,FBUR,FGSN
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+               INTENT(OUT)    ::                        CHKLOWQ
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LAI
+   REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(IN) ::        QZ0
+
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMGR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHGR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMC_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHC_SFCDIF
+! Local variables (moved here from driver to make routine thread safe, 20031007 jm)
+
+      REAL, DIMENSION(1:num_soil_layers) ::  ET
+
+      REAL, DIMENSION(1:num_soil_layers) ::  SMAV
+
+      REAL  ::  BETA, ETP, SSOIL,EC, EDIR, ESNOW, ETT,        &
+                FLX1,FLX2,FLX3, DRIP,DEW,FDOWN,RC,PC,RSMIN,XLAI,  &
+!                RCS,RCT,RCQ,RCSOIL
+                RCS,RCT,RCQ,RCSOIL,FFROZP
+
+    LOGICAL,    INTENT(IN   )    ::     myj,frpcpn
+
+! DECLARATIONS - LOGICAL
+! ----------------------------------------------------------------------
+      LOGICAL, PARAMETER :: LOCAL=.false.
+      LOGICAL :: FRZGRA, SNOWNG
+
+      LOGICAL :: IPRINT
+
+! ----------------------------------------------------------------------
+! DECLARATIONS - INTEGER
+! ----------------------------------------------------------------------
+      INTEGER :: I,J, ICE,NSOIL,SLOPETYP,SOILTYP,VEGTYP
+      INTEGER :: NROOT
+      INTEGER :: KZ ,K
+      INTEGER :: NS
+! ----------------------------------------------------------------------
+! DECLARATIONS - REAL
+! ----------------------------------------------------------------------
+
+      REAL  :: SHMIN,SHMAX,DQSDT2,LWDN,PRCP,PRCPRAIN,                    &
+               Q2SAT,Q2SATI,SFCPRS,SFCSPD,SFCTMP,SHDFAC,SNOALB1,         &
+               SOLDN,TBOT,ZLVL, Q2K,ALBBRD, ALBEDOK, ETA, ETA_KINEMATIC, &
+               EMBRD,                                                    &
+               Z0K,RUNOFF1,RUNOFF2,RUNOFF3,SHEAT,SOLNET,E2SAT,SFCTSNO,   &
+! mek, WRF testing, expanded diagnostics
+               SOLUP,LWUP,RNET,RES,Q1SFC,TAIRV !,SATFLG
+! MEK MAY 2007
+      REAL ::  FDTLIW
+! MEK JUL2007 for pot. evap.
+      REAL :: RIBB
+      REAL ::  FDTW
+
+      REAL  :: EMISSI
+
+      REAL  :: SNCOVR,SNEQV,SNOWHK,CMC, CHK,TH2
+
+      REAL  :: SMCDRY,SMCMAX,SMCREF,SMCWLT,SNOMLT,SOILM,SOILW,Q1,T1
+      REAL  :: SNOTIME1    ! LSTSNW1 INITIAL NUMBER OF TIMESTEPS SINCE LAST SNOWFALL
+
+      REAL  :: DUMMY,Z0BRD
+!
+      REAL  :: COSZ, SOLARDIRECT
+!
+      REAL, DIMENSION(1:num_soil_layers)::  SLDPTH, STC,SMC,SWC
+!
+      REAL, DIMENSION(1:num_soil_layers) ::     ZSOIL, RTDIS
+      REAL, PARAMETER  :: TRESH=.95E0, A2=17.67,A3=273.15,A4=29.65,   &
+                          T0=273.16E0, ELWV=2.50E6,  A23M4=A2*(A3-A4)
+! MEK MAY 2007
+      REAL, PARAMETER  :: ROW=1.E3,ELIW=XLF,ROWLIW=ROW*ELIW
+
+! ----------------------------------------------------------------------
+! DECLARATIONS START - urban
+! ----------------------------------------------------------------------
+
+! input variables surface_driver --> lsm
+     INTEGER, INTENT(IN) :: num_roof_layers
+     INTEGER, INTENT(IN) :: num_wall_layers
+     INTEGER, INTENT(IN) :: num_road_layers
+     REAL, OPTIONAL, DIMENSION(1:num_roof_layers), INTENT(IN) :: DZR
+     REAL, OPTIONAL, DIMENSION(1:num_wall_layers), INTENT(IN) :: DZB
+     REAL, OPTIONAL, DIMENSION(1:num_road_layers), INTENT(IN) :: DZG
+     REAL, OPTIONAL, INTENT(IN) :: DECLIN_URB
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: COSZ_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: OMG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: XLAT_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: U_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: V_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: TH_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: P_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: RHO
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: UST
+
+     LOGICAL, intent(in) :: rdlai2d
+     LOGICAL, intent(in) :: USEMONALB
+
+! input variables lsm --> urban
+     INTEGER :: UTYPE_URB ! urban type [urban=1, suburban=2, rural=3]
+     REAL :: TA_URB       ! potential temp at 1st atmospheric level [K]
+     REAL :: QA_URB       ! mixing ratio at 1st atmospheric level  [kg/kg]
+     REAL :: UA_URB       ! wind speed at 1st atmospheric level    [m/s]
+     REAL :: U1_URB       ! u at 1st atmospheric level             [m/s]
+     REAL :: V1_URB       ! v at 1st atmospheric level             [m/s]
+     REAL :: SSG_URB      ! downward total short wave radiation    [W/m/m]
+     REAL :: LLG_URB      ! downward long wave radiation           [W/m/m]
+     REAL :: RAIN_URB     ! precipitation                          [mm/h]
+     REAL :: RHOO_URB     ! air density                            [kg/m^3]
+     REAL :: ZA_URB       ! first atmospheric level                [m]
+     REAL :: DELT_URB     ! time step                              [s]
+     REAL :: SSGD_URB     ! downward direct short wave radiation   [W/m/m]
+     REAL :: SSGQ_URB     ! downward diffuse short wave radiation  [W/m/m]
+     REAL :: XLAT_URB     ! latitude                               [deg]
+     REAL :: COSZ_URB     ! cosz
+     REAL :: OMG_URB      ! hour angle
+     REAL :: ZNT_URB      ! roughness length                       [m]
+     REAL :: TR_URB
+     REAL :: TB_URB
+     REAL :: TG_URB
+     REAL :: TC_URB
+     REAL :: QC_URB
+     REAL :: UC_URB
+     REAL :: XXXR_URB
+     REAL :: XXXB_URB
+     REAL :: XXXG_URB
+     REAL :: XXXC_URB
+     REAL, DIMENSION(1:num_roof_layers) :: TRL_URB  ! roof layer temp [K]
+     REAL, DIMENSION(1:num_wall_layers) :: TBL_URB  ! wall layer temp [K]
+     REAL, DIMENSION(1:num_road_layers) :: TGL_URB  ! road layer temp [K]
+     LOGICAL  :: LSOLAR_URB
+
+!===Yang,2014/10/08,hydrological variable for single layer UCM===
+     INTEGER :: jmonth, jday, tloc
+     INTEGER :: IRIOPTION, USOIL, DSOIL
+     REAL :: AOASIS, OMG
+     REAL :: DRELR_URB
+     REAL :: DRELB_URB
+     REAL :: DRELG_URB
+     REAL :: FLXHUMR_URB
+     REAL :: FLXHUMB_URB
+     REAL :: FLXHUMG_URB
+     REAL :: CMCR_URB
+     REAL :: TGR_URB
+     REAL, DIMENSION(1:num_roof_layers) :: SMR_URB  ! green roof layer moisture
+     REAL, DIMENSION(1:num_roof_layers) :: TGRL_URB ! green roof layer temp [K]
+
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FLXHUMR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FLXHUMB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FLXHUMG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMCR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TGR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_roof_layers, jms:jme ), INTENT(INOUT) :: TGRL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_roof_layers, jms:jme ), INTENT(INOUT) :: SMR_URB3D
+
+
+! state variable surface_driver <--> lsm <--> urban
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: QC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: UC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: SH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: G_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: RN_URB2D
+!
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TS_URB2D
+
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_roof_layers, jms:jme ), INTENT(INOUT) :: TRL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_wall_layers, jms:jme ), INTENT(INOUT) :: TBL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_road_layers, jms:jme ), INTENT(INOUT) :: TGL_URB3D
+
+! output variable lsm --> surface_driver
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: PSIM_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: PSIH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: GZ1OZ0_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: U10_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: V10_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: TH2_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: Q2_URB2D
+!
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: AKMS_URB2D
+!
+     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: UST_URB2D
+     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: FRC_URB2D
+     INTEGER, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: UTYPE_URB2D
+
+
+! output variables urban --> lsm
+     REAL :: TS_URB     ! surface radiative temperature    [K]
+     REAL :: QS_URB     ! surface humidity                 [-]
+     REAL :: SH_URB     ! sensible heat flux               [W/m/m]
+     REAL :: LH_URB     ! latent heat flux                 [W/m/m]
+     REAL :: LH_KINEMATIC_URB ! latent heat flux, kinetic  [kg/m/m/s]
+     REAL :: SW_URB     ! upward short wave radiation flux [W/m/m]
+     REAL :: ALB_URB    ! time-varying albedo            [fraction]
+     REAL :: LW_URB     ! upward long wave radiation flux  [W/m/m]
+     REAL :: G_URB      ! heat flux into the ground        [W/m/m]
+     REAL :: RN_URB     ! net radiation                    [W/m/m]
+     REAL :: PSIM_URB   ! shear f for momentum             [-]
+     REAL :: PSIH_URB   ! shear f for heat                 [-]
+     REAL :: GZ1OZ0_URB   ! shear f for heat                 [-]
+     REAL :: U10_URB    ! wind u component at 10 m         [m/s]
+     REAL :: V10_URB    ! wind v component at 10 m         [m/s]
+     REAL :: TH2_URB    ! potential temperature at 2 m     [K]
+     REAL :: Q2_URB     ! humidity at 2 m                  [-]
+     REAL :: CHS_URB
+     REAL :: CHS2_URB
+     REAL :: UST_URB
+! NUDAPT Parameters urban --> lam
+     REAL :: mh_urb
+     REAL :: stdh_urb
+     REAL :: lp_urb
+     REAL :: hgt_urb
+     REAL, DIMENSION(4) :: lf_urb
+! Variables for multi-layer UCM (Martilli et al. 2002)
+   REAL, OPTIONAL, INTENT(IN  )   ::                                   GMT 
+   INTEGER, OPTIONAL, INTENT(IN  ) ::                               JULDAY
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   )        ::XLAT, XLONG
+   INTEGER, INTENT(IN  ) ::                               NUM_URBAN_LAYERS
+   INTEGER, INTENT(IN  ) ::                               NUM_URBAN_HI
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: trb_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tgb_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tlev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: qlev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1lev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2lev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tglev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tflev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lf_ac_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sf_ac_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: cm_ac_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sfvent_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lfvent_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin1_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin2_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw1_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw2_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfr_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfg_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_hi, jms:jme ), INTENT(IN) :: hi_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: lp_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: lb_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: hgt_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: mh_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: stdh_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 4, jms:jme ), INTENT(IN) :: lf_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_u_bep   !Implicit momemtum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_v_bep   !Implicit momemtum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_t_bep   !Implicit component pot. temperature
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_q_bep   !Implicit momemtum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_e_bep   !Implicit component TKE
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_u_bep   !Explicit momentum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_v_bep   !Explicit momentum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_t_bep   !Explicit component pot. temperature
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_q_bep   !Implicit momemtum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_e_bep   !Explicit component TKE
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::vl_bep    !Fraction air volume in grid cell
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::dlg_bep   !Height above ground
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::sf_bep  !Fraction air at the face of grid cell
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::dl_u_bep  !Length scale
+
+! Local variables for multi-layer UCM (Martilli et al. 2002)
+   REAL,    DIMENSION( its:ite, jts:jte ) :: HFX_RURAL,LH_RURAL,GRDFLX_RURAL ! ,RN_RURAL
+   REAL,    DIMENSION( its:ite, jts:jte ) :: QFX_RURAL ! ,QSFC_RURAL,UMOM_RURAL,VMOM_RURAL
+   REAL,    DIMENSION( its:ite, jts:jte ) :: ALB_RURAL,EMISS_RURAL,TSK_RURAL ! ,UST_RURAL
+!   REAL,    DIMENSION( ims:ime, jms:jme ) :: QSFC_URB
+   REAL,    DIMENSION( its:ite, jts:jte ) :: HFX_URB,UMOM_URB,VMOM_URB
+   REAL,    DIMENSION( its:ite, jts:jte ) :: QFX_URB
+!   REAL,    DIMENSION( ims:ime, jms:jme ) :: ALBEDO_URB,EMISS_URB,UMOM,VMOM,UST
+   REAL, DIMENSION(its:ite,jts:jte) ::EMISS_URB
+   REAL, DIMENSION(its:ite,jts:jte) :: RL_UP_URB
+   REAL, DIMENSION(its:ite,jts:jte) ::RS_ABS_URB
+   REAL, DIMENSION(its:ite,jts:jte) ::GRDFLX_URB
+   REAL :: SIGMA_SB,RL_UP_RURAL,RL_UP_TOT,RS_ABS_TOT,UMOM,VMOM
+   REAL :: r1,r2,r3
+   REAL :: CMR_URB, CHR_URB, CMC_URB, CHC_URB, CMGR_URB, CHGR_URB
+   REAL :: frc_urb,lb_urb
+   REAL :: check 
+! ----------------------------------------------------------------------
+! DECLARATIONS END - urban
+! ----------------------------------------------------------------------
+
+  REAL, PARAMETER  :: CAPA=R_D/CP
+  REAL :: APELM,APES,SFCTH2,PSFC
+  real, intent(in) :: xice_threshold
+  character(len=80) :: message_text
+  character(len=1024):: msg
+
+  FLX4  = 0.0 !BSINGH - Initialized to 0.0
+  FVB   = 0.0 !BSINGH - Initialized to 0.0
+  FBUR  = 0.0 !BSINGH - Initialized to 0.0
+  FGSN  = 0.0 !BSINGH - Initialized to 0.0
+  SOILW = 0.0 !BSINGH - Initialized to 0.0
+
+! MEK MAY 2007
+      FDTLIW=DT/ROWLIW
+! MEK JUL2007
+      FDTW=DT/(XLV*RHOWATER)
+! debug printout
+         IPRINT=.false.
+
+!      SLOPETYP=2
+      SLOPETYP=1
+!      SHDMIN=0.00
+
+
+      NSOIL=num_soil_layers
+
+     DO NS=1,NSOIL
+     SLDPTH(NS)=DZS(NS)
+     ENDDO
+
+
+      IF(ITIMESTEP.EQ.1)THEN
+        DO J=jts,jte
+        DO 50 I=its,ite
+!*** initialize soil conditions for IHOP 31 May case
+!         IF((XLAND(I,J)-1.5) < 0.)THEN
+!            if (I==108.and.j==85) then
+!                  DO NS=1,NSOIL
+!                      SMOIS(I,NS,J)=0.10
+!                      SH2O(I,NS,J)=0.10
+!                  enddo
+!             endif
+!         ENDIF
+
+!*** SET ZERO-VALUE FOR SOME OUTPUT DIAGNOSTIC ARRAYS
+          IF((XLAND(I,J)-1.5).GE.0.)THEN
+! check sea-ice point
+#if 0
+            IF( XICE(I,J).GE. XICE_THRESHOLD .and. IPRINT ) PRINT*, ' sea-ice at water point, I=',I,'J=',J
+#endif
+!***   Open Water Case
+            SMSTAV(I,J)=1.0
+            SMSTOT(I,J)=1.0
+            DO NS=1,NSOIL
+              SMOIS(I,NS,J)=1.0
+              TSLB(I,NS,J)=273.16                                          !STEMP
+              SMCREL(I,NS,J)=1.0
+            ENDDO
+          ELSE
+            IF ( XICE(I,J) .GE. XICE_THRESHOLD ) THEN
+!***        SEA-ICE CASE
+              SMSTAV(I,J)=1.0
+              SMSTOT(I,J)=1.0
+              DO NS=1,NSOIL
+                SMOIS(I,NS,J)=1.0
+                SMCREL(I,NS,J)=1.0
+              ENDDO
+            ENDIF
+          ENDIF
+!
+   50   CONTINUE
+        ENDDO
+      ENDIF                                                               ! end of initialization over ocean
+
+#ifdef _OPENACC  
+      IF(SF_URBAN_PHYSICS.gt.0) THEN
+	     call wrf_error_fatal('SF_URBAN_PHYSICS.gt.0 was not implemented with OpenACC')
+	  ENDIF
+#else
+#define URBAN_ACC
+#endif
+     DO J=jts,jte
+     DO I=its,ite
+        IF((XLAND(I,J)-1.5).GE.0.)THEN
+! Open water points 
+          TSK_RURAL(I,J)=TSK(I,J)
+          HFX_RURAL(I,J)=HFX(I,J)
+          QFX_RURAL(I,J)=QFX(I,J)
+          LH_RURAL(I,J)=LH(I,J)
+          EMISS_RURAL(I,J)=EMISS(I,J)
+          GRDFLX_RURAL(I,J)=GRDFLX(I,J)
+	ENDIF
+     ENDDO
+     ENDDO
+
+     DO J=jts,jte
+     DO I=its,ite
+        IF((XLAND(I,J)-1.5).LT.0. .and. XICE(I,J) >= XICE_THRESHOLD) THEN
+        ! Sea-ice case
+
+        DO NS = 1, NSOIL
+          SH2O(I,NS,J) = 1.0
+        ENDDO
+        LAI(I,J) = 0.01
+        ENDIF
+     ENDDO
+     ENDDO
+
+     DO J=jts,jte
+     DO I=its,ite
+! convert from mixing ratio to specific humidity
+         Q2K=QV3D(i,1,j)/(1.0+QV3D(i,1,j))
+!
+!         Q2SAT=QGH(I,j)
+         Q2SAT=QGH(I,J)/(1.0+QGH(I,J))        ! Q2SAT is sp humidity
+! add check on myj=.true.
+!        IF((Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+        IF((myj).AND.(Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+          CHKLOWQ(I,J)=0.
+        ELSE
+          CHKLOWQ(I,J)=1.
+        ENDIF
+
+     ENDDO
+     ENDDO
+!-----------------------------------------------------------------------
+     JLOOP : DO J=jts,jte
+      ILOOP : DO I=its,ite
+        IF((XLAND(I,J)-1.5).GE.0.) cycle        ! begining of land/sea if block
+		IF(XICE(I,J) >= XICE_THRESHOLD) cycle   ! Sea-ice case
+! surface pressure
+        PSFC=P8w3D(i,1,j)
+! pressure in middle of lowest layer
+        SFCPRS=(P8W3D(I,KTS+1,j)+P8W3D(i,KTS,j))*0.5
+! convert from mixing ratio to specific humidity
+         Q2K=QV3D(i,1,j)/(1.0+QV3D(i,1,j))
+!
+!         Q2SAT=QGH(I,j)
+         Q2SAT=QGH(I,J)/(1.0+QGH(I,J))        ! Q2SAT is sp humidity
+#if 0
+! add check on myj=.true.
+!        IF((Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+        IF((myj).AND.(Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+          SATFLG=0.
+          CHKLOWQ(I,J)=0.
+        ELSE
+          SATFLG=1.0
+          CHKLOWQ(I,J)=1.
+        ENDIF
+#endif
+        SFCTMP=T3D(i,1,j)
+        ZLVL=0.5*DZ8W(i,1,j)
+
+!        TH2=SFCTMP+(0.0097545*ZLVL)
+! calculate SFCTH2 via Exner function vs lapse-rate (above)
+         APES=(1.E5/PSFC)**CAPA
+         APELM=(1.E5/SFCPRS)**CAPA
+         SFCTH2=SFCTMP*APELM
+         TH2=SFCTH2/APES
+!
+         EMISSI = EMISS(I,J)
+         LWDN=GLW(I,J)*EMISSI
+! SOLDN is total incoming solar
+        SOLDN=SWDOWN(I,J)
+! GSW is net downward solar
+!        SOLNET=GSW(I,J)
+! use mid-day albedo to determine net downward solar (no solar zenith angle correction)
+        SOLNET=SOLDN*(1.-ALBEDO(I,J))
+        PRCP=RAINBL(i,j)/DT
+        VEGTYP=IVGTYP(I,J)
+        SOILTYP=ISLTYP(I,J)
+        SHDFAC=VEGFRA(I,J)/100.
+        T1=TSK(I,J)
+        CHK=CHS(I,J)
+        SHMIN=SHDMIN(I,J)/100. !NEW
+        SHMAX=SHDMAX(I,J)/100. !NEW
+! convert snow water equivalent from mm to meter
+        SNEQV=SNOW(I,J)*0.001
+! snow depth in meters
+        SNOWHK=SNOWH(I,J)
+        SNCOVR=SNOWC(I,J)
+
+! if "SR" present, set frac of frozen precip ("FFROZP") = snow-ratio ("SR", range:0-1)
+! SR from e.g. Ferrier microphysics
+! otherwise define from 1st atmos level temperature
+       IF(FRPCPN) THEN
+          FFROZP=SR(I,J)
+        ELSE
+          IF (SFCTMP <=  273.15) THEN
+            FFROZP = 1.0
+	  ELSE
+	    FFROZP = 0.0
+	  ENDIF
+        ENDIF
+!***
+#if 0
+        IF((XLAND(I,J)-1.5).GE.0.)THEN                                  ! begining of land/sea if block
+! Open water points
+          TSK_RURAL(I,J)=TSK(I,J)
+          HFX_RURAL(I,J)=HFX(I,J)
+          QFX_RURAL(I,J)=QFX(I,J)
+          LH_RURAL(I,J)=LH(I,J)
+          EMISS_RURAL(I,J)=EMISS(I,J)
+          GRDFLX_RURAL(I,J)=GRDFLX(I,J)
+        ELSE
+#endif		
+! Land or sea-ice case
+
+#if 0
+          IF (XICE(I,J) >= XICE_THRESHOLD) THEN
+             ! Sea-ice point
+             ICE = 1
+          ELSE 
+#endif
+	  IF ( VEGTYP == ISICE ) THEN
+             ! Land-ice point
+             ICE = -1
+          ELSE
+             ! Neither sea ice or land ice.
+             ICE=0
+          ENDIF
+          DQSDT2=Q2SAT*A23M4/(SFCTMP-A4)**2
+
+          IF(SNOW(I,J).GT.0.0)THEN
+! snow on surface (use ice saturation properties)
+            SFCTSNO=SFCTMP
+            E2SAT=611.2*EXP(6174.*(1./273.15 - 1./SFCTSNO))
+            Q2SATI=0.622*E2SAT/(SFCPRS-E2SAT)
+            Q2SATI=Q2SATI/(1.0+Q2SATI)    ! spec. hum.
+            IF (T1 .GT. 273.14) THEN
+! warm ground temps, weight the saturation between ice and water according to SNOWC
+              Q2SAT=Q2SAT*(1.-SNOWC(I,J)) + Q2SATI*SNOWC(I,J)
+              DQSDT2=DQSDT2*(1.-SNOWC(I,J)) + Q2SATI*6174./(SFCTSNO**2)*SNOWC(I,J)
+            ELSE
+! cold ground temps, use ice saturation only
+              Q2SAT=Q2SATI
+              DQSDT2=Q2SATI*6174./(SFCTSNO**2)
+            ENDIF
+! for snow cover fraction at 0 C, ground temp will not change, so DQSDT2 effectively zero
+            IF(T1 .GT. 273. .AND. SNOWC(I,J) .GT. 0.)DQSDT2=DQSDT2*(1.-SNOWC(I,J))
+          ENDIF
+
+          ! Land-ice or land points use the usual deep-soil temperature.
+          TBOT=TMN(I,J)
+
+          IF(VEGTYP.EQ.25) SHDFAC=0.0000
+          IF(VEGTYP.EQ.26) SHDFAC=0.0000
+          IF(VEGTYP.EQ.27) SHDFAC=0.0000
+          IF(SOILTYP.EQ.14.AND.XICE(I,J).EQ.0.)THEN
+#if 0
+         IF(IPRINT)PRINT*,' SOIL TYPE FOUND TO BE WATER AT A LAND-POINT'
+         IF(IPRINT)PRINT*,i,j,'RESET SOIL in surfce.F'
+#endif
+            SOILTYP=7
+          ENDIF
+          SNOALB1 = SNOALB(I,J)
+          CMC=CANWAT(I,J)
+
+!-------------------------------------------
+!*** convert snow depth from mm to meter
+!
+!          IF(RDMAXALB) THEN
+!           SNOALB=ALBMAX(I,J)*0.01
+!         ELSE
+!           SNOALB=MAXALB(IVGTPK)*0.01
+!         ENDIF
+
+!        SNOALB1=0.80
+!        SHMIN=0.00
+        ALBBRD=ALBBCK(I,J)
+        Z0BRD=Z0(I,J)
+        EMBRD=EMBCK(I,J)
+        SNOTIME1 = SNOTIME(I,J)
+        RIBB=RIB(I,J)
+!FEI: temporaray arrays above need to be changed later by using SI
+
+          DO NS=1,NSOIL
+            SMC(NS)=SMOIS(I,NS,J)
+            STC(NS)=TSLB(I,NS,J)                                          !STEMP
+            SWC(NS)=SH2O(I,NS,J)
+          ENDDO
+!
+          if ( (SNEQV.ne.0..AND.SNOWHK.eq.0.).or.(SNOWHK.le.SNEQV) )THEN
+            SNOWHK= 5.*SNEQV
+          endif
+!
+
+!Fei: urban. for urban surface, if calling UCM, redefine the natural surface in cities as
+! the "NATURAL" category in the VEGPARM.TBL
+#ifdef URBAN_ACC	
+	   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+                IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                  IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+		 VEGTYP = NATURAL
+                 SHDFAC = SHDTBL(NATURAL)
+                 ALBEDOK =0.2         !  0.2
+                 ALBBRD  =0.2         !0.2
+                 EMISSI = 0.98                                 !for VEGTYP=5
+		 IF ( FRC_URB2D(I,J) < 0.99 ) THEN
+                   if(sf_urban_physics.eq.1)then
+           T1= ( TSK(I,J) -FRC_URB2D(I,J) * TS_URB2D (I,J) )/ (1-FRC_URB2D(I,J))
+                   elseif((sf_urban_physics.eq.2).OR.(sf_urban_physics.eq.3))then
+                r1= (tsk(i,j)**4.)
+                r2= frc_urb2d(i,j)*(ts_urb2d(i,j)**4.)
+                r3= (1.-frc_urb2d(i,j))
+                t1= ((r1-r2)/r3)**.25
+                   endif
+	         ELSE
+		 T1 = TSK(I,J)
+                 ENDIF
+                ENDIF
+           ELSE
+#endif   
+                 IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                  IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+                  VEGTYP = ISURBAN
+           	 ENDIF
+#ifdef URBAN_ACC
+           ENDIF
+#endif   
+
+!===Yang, 2014/10/08, hydrological processes for urban vegetation in single layer UCM===
+           AOASIS = 1.0
+           USOIL = 1
+           DSOIL = 2
+           IRIOPTION=IRI_SCHEME
+#ifdef URBAN_ACC
+	  IF(SF_URBAN_PHYSICS == 1) THEN
+           OMG= OMG_URB2D(I,J)   
+           tloc=mod(int(OMG/3.14159*180./15.+12.+0.5 ),24)
+           if (tloc.lt.0) tloc=tloc+24
+           if (tloc==0) tloc=24
+           CALL cal_mon_day(julian,julyr,jmonth,jday) 
+           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+            AOASIS = oasis  ! urban oasis effect
+                   IF (IRIOPTION ==1) THEN
+                   IF (tloc==21 .or. tloc==22) THEN  !irrigation on vegetaion in urban area, MAY-SEP, 9-10pm
+                   IF (jmonth==5 .or. jmonth==6 .or. jmonth==7 .or. jmonth==8 .or. jmonth==9) THEN
+!                      IF (SMC(USOIL) .LT. SMCREF) SMC(USOIL)= SMCREF
+!                      IF (SMC(DSOIL) .LT. SMCREF) SMC(DSOIL)= SMCREF
+                      IF (SMC(USOIL) .LT. SMCREF) SMC(USOIL)= REFSMC(ISLTYP(I,J))                      
+                      IF (SMC(DSOIL) .LT. SMCREF) SMC(DSOIL)= REFSMC(ISLTYP(I,J))                    
+                   ENDIF
+                   ENDIF
+                   ENDIF
+                ENDIF
+           ENDIF
+
+	  IF(SF_URBAN_PHYSICS == 2 .or. SF_URBAN_PHYSICS == 3) THEN
+          IF(AOASIS > 1.0) THEN
+          CALL wrf_error_fatal('Urban oasis option is for SF_URBAN_PHYSICS == 1 only')
+          ENDIF
+          IF(IRIOPTION == 1) THEN
+          CALL wrf_error_fatal('Urban irrigation option is for SF_URBAN_PHYSICS == 1 only')
+          ENDIF
+          ENDIF
+#endif
+#if 0
+          IF(IPRINT) THEN
+!
+       print*, 'BEFORE SFLX, in Noahlsm_driver'
+       print*, 'ICE', ICE, 'DT',DT, 'ZLVL',ZLVL, 'NSOIL', NSOIL,   &
+       'SLDPTH', SLDPTH, 'LOCAL',LOCAL, 'LUTYPE',&
+        LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN, 'SOLDN',SOLDN,      &
+        'SFCPRS',SFCPRS, 'PRCP',PRCP,'SFCTMP',SFCTMP,'Q2K',Q2K,   &
+         'TH2',TH2,'Q2SAT',Q2SAT,'DQSDT2',DQSDT2,'VEGTYP', VEGTYP,&
+         'SOILTYP',SOILTYP, 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC,&
+         'SHMIN',SHMIN, 'ALBBRD',ALBBRD,'SNOALB1',SNOALB1,'TBOT',&
+          TBOT, 'Z0BRD',Z0BRD, 'Z0K',Z0K, 'CMC',CMC, 'T1',T1,'STC',&
+          STC, 'SMC',SMC, 'SWC',SWC,'SNOWHK',SNOWHK,'SNEQV',SNEQV,&
+          'ALBEDOK',ALBEDOK,'CHK',CHK,'ETA',ETA,'SHEAT',SHEAT,      &
+          'ETA_KINEMATIC',ETA_KINEMATIC, 'FDOWN',FDOWN,'EC',EC,   &
+          'EDIR',EDIR,'ET',ET,'ETT',ETT,'ESNOW',ESNOW,'DRIP',DRIP,&
+          'DEW',DEW,'BETA',BETA,'ETP',ETP,'SSOIL',SSOIL,'FLX1',FLX1,&
+          'FLX2',FLX2,'FLX3',FLX3,'SNOMLT',SNOMLT,'SNCOVR',SNCOVR,&
+          'RUNOFF1',RUNOFF1,'RUNOFF2',RUNOFF2,'RUNOFF3',RUNOFF3, &
+          'RC',RC, 'PC',PC,'RSMIN',RSMIN,'XLAI',XLAI,'RCS',RCS,  &
+          'RCT',RCT,'RCQ',RCQ,'RCSOIL',RCSOIL,'SOILW',SOILW,     &
+          'SOILM',SOILM,'Q1',Q1,'SMCWLT',SMCWLT,'SMCDRY',SMCDRY,&
+          'SMCREF',SMCREF,'SMCMAX',SMCMAX,'NROOT',NROOT
+           endif
+#endif
+
+          IF (rdlai2d) THEN
+             xlai = lai(i,j)
+          endif
+#if 0
+    IF ( ICE == 1 ) THEN
+
+       ! Sea-ice case
+
+       DO NS = 1, NSOIL
+          SH2O(I,NS,J) = 1.0
+       ENDDO
+       LAI(I,J) = 0.01
+
+       CYCLE ILOOP
+
+    ELSE
+#endif   
+    IF (ICE == 0) THEN
+
+       ! Non-glacial land
+       
+       CALL SFLX (I,J,FFROZP, ISURBAN, DT,ZLVL,NSOIL,SLDPTH,       &    !C
+                 LOCAL,                                            &    !L
+                 LUTYPE, SLTYPE,                                   &    !CL
+                 LWDN,SOLDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,DUMMY,   &    !F
+                 DUMMY,DUMMY, DUMMY,                               &    !F PRCPRAIN not used
+                 TH2,Q2SAT,DQSDT2,                                 &    !I
+                 VEGTYP,SOILTYP,SLOPETYP,SHDFAC,SHMIN,SHMAX,       &    !I
+                 ALBBRD, SNOALB1,TBOT, Z0BRD, Z0K, EMISSI, EMBRD,  &    !S
+                 CMC,T1,STC,SMC,SWC,SNOWHK,SNEQV,ALBEDOK,CHK,dummy,&    !H
+                 ETA,SHEAT, ETA_KINEMATIC,FDOWN,                   &    !O
+                 EC,EDIR,ET,ETT,ESNOW,DRIP,DEW,                    &    !O
+                 BETA,ETP,SSOIL,                                   &    !O
+                 FLX1,FLX2,FLX3,                                   &    !O
+		 FLX4,FVB,FBUR,FGSN,UA_PHYS,                       &    !UA 
+                 SNOMLT,SNCOVR,                                    &    !O
+                 RUNOFF1,RUNOFF2,RUNOFF3,                          &    !O
+                 RC,PC,RSMIN,XLAI,RCS,RCT,RCQ,RCSOIL,              &    !O
+                 SOILW,SOILM,Q1,SMAV,                              &    !D
+                 RDLAI2D,USEMONALB,                                &
+                 SNOTIME1,                                         &
+                 RIBB,                                             &
+                 SMCWLT,SMCDRY,SMCREF,SMCMAX,NROOT,                &
+                 sfcheadrt(i,j),                                   &    !I
+                 INFXSRT(i,j),ETPND1,AOASIS                        &    !O
+                 )
+
+#ifdef WRF_HYDRO
+                 soldrain(i,j) = RUNOFF2*DT*1000.0
+#endif
+    ELSEIF (ICE == -1) THEN
+
+       !
+       ! Set values that the LSM is expected to update,
+       ! but don't get updated for glacial points.
+       !
+       SOILM = 0.0 !BSINGH(PNNL)- SOILM is undefined for this case, it is used for diagnostics so setting it to zero
+       XLAI = 0.01 ! KWM Should this be Zero over land ice?  Does this value matter?
+       RUNOFF2 = 0.0
+       RUNOFF3 = 0.0
+       DO NS = 1, NSOIL
+          SWC(NS) = 1.0
+          SMC(NS) = 1.0
+          SMAV(NS) = 1.0
+       ENDDO
+       CALL SFLX_GLACIAL(I,J,ISICE,FFROZP,DT,ZLVL,NSOIL,SLDPTH,   &    !C
+            &    LWDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,              &    !F
+            &    TH2,Q2SAT,DQSDT2,                                &    !I
+            &    ALBBRD, SNOALB1,TBOT, Z0BRD, Z0K, EMISSI, EMBRD, &    !S
+            &    T1,STC(1:NSOIL),SNOWHK,SNEQV,ALBEDOK,CHK,        &    !H
+            &    ETA,SHEAT,ETA_KINEMATIC,FDOWN,                   &    !O
+            &    ESNOW,DEW,                                       &    !O
+            &    ETP,SSOIL,                                       &    !O
+            &    FLX1,FLX2,FLX3,                                  &    !O
+            &    SNOMLT,SNCOVR,                                   &    !O
+            &    RUNOFF1,                                         &    !O
+            &    Q1,                                              &    !D
+            &    SNOTIME1,                                        &
+            &    RIBB)
+
+    ENDIF
+
+       lai(i,j) = xlai
+
+#if 0
+          IF(IPRINT) THEN
+
+       print*, 'AFTER SFLX, in Noahlsm_driver'
+       print*, 'ICE', ICE, 'DT',DT, 'ZLVL',ZLVL, 'NSOIL', NSOIL,   &
+       'SLDPTH', SLDPTH, 'LOCAL',LOCAL, 'LUTYPE',&
+        LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN, 'SOLDN',SOLDN,      &
+        'SFCPRS',SFCPRS, 'PRCP',PRCP,'SFCTMP',SFCTMP,'Q2K',Q2K,   &
+         'TH2',TH2,'Q2SAT',Q2SAT,'DQSDT2',DQSDT2,'VEGTYP', VEGTYP,&
+          'SOILTYP',SOILTYP, 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC,&
+         'SHDMIN',SHMIN, 'ALBBRD',ALBBRD,'SNOALB',SNOALB1,'TBOT',&
+          TBOT, 'Z0BRD',Z0BRD, 'Z0K',Z0K, 'CMC',CMC, 'T1',T1,'STC',&
+          STC, 'SMC',SMC, 'SWc',SWC,'SNOWHK',SNOWHK,'SNEQV',SNEQV,&
+          'ALBEDOK',ALBEDOK,'CHK',CHK,'ETA',ETA,'SHEAT',SHEAT,      &
+          'ETA_KINEMATIC',ETA_KINEMATIC, 'FDOWN',FDOWN,'EC',EC,   &
+          'EDIR',EDIR,'ET',ET,'ETT',ETT,'ESNOW',ESNOW,'DRIP',DRIP,&
+          'DEW',DEW,'BETA',BETA,'ETP',ETP,'SSOIL',SSOIL,'FLX1',FLX1,&
+          'FLX2',FLX2,'FLX3',FLX3,'SNOMLT',SNOMLT,'SNCOVR',SNCOVR,&
+          'RUNOFF1',RUNOFF1,'RUNOFF2',RUNOFF2,'RUNOFF3',RUNOFF3, &
+          'RC',RC, 'PC',PC,'RSMIN',RSMIN,'XLAI',XLAI,'RCS',RCS,  &
+          'RCT',RCT,'RCQ',RCQ,'RCSOIL',RCSOIL,'SOILW',SOILW,     &
+          'SOILM',SOILM,'Q1',Q1,'SMCWLT',SMCWLT,'SMCDRY',SMCDRY,&
+          'SMCREF',SMCREF,'SMCMAX',SMCMAX,'NROOT',NROOT
+           endif
+#endif
+!***  UPDATE STATE VARIABLES
+          CANWAT(I,J)=CMC
+          SNOW(I,J)=SNEQV*1000.
+!          SNOWH(I,J)=SNOWHK*1000.
+          SNOWH(I,J)=SNOWHK                   ! SNOWHK in meters
+          ALBEDO(I,J)=ALBEDOK
+          ALB_RURAL(I,J)=ALBEDOK
+          ALBBCK(I,J)=ALBBRD
+          Z0(I,J)=Z0BRD
+          EMISS(I,J) = EMISSI
+          EMISS_RURAL(I,J) = EMISSI
+! Noah: activate time-varying roughness length (V3.3 Feb 2011)
+          ZNT(I,J)=Z0K
+          TSK(I,J)=T1
+          TSK_RURAL(I,J)=T1
+          HFX(I,J)=SHEAT
+          HFX_RURAL(I,J)=SHEAT
+! MEk Jul07 add potential evap accum
+        POTEVP(I,J)=POTEVP(I,J)+ETP*FDTW
+          QFX(I,J)=ETA_KINEMATIC
+          QFX_RURAL(I,J)=ETA_KINEMATIC
+
+#ifdef WRF_HYDRO
+!added by Wei Yu
+!         QFX(I,J) = QFX(I,J) + ETPND1
+!         ETA = ETA + ETPND1/2.501E6*dt
+!end added by Wei Yu
+#endif
+
+
+          LH(I,J)=ETA
+          LH_RURAL(I,J)=ETA
+          GRDFLX(I,J)=SSOIL
+          GRDFLX_RURAL(I,J)=SSOIL
+          SNOWC(I,J)=SNCOVR
+          CHS2(I,J)=CQS2(I,J)
+          SNOTIME(I,J) = SNOTIME1
+!      prevent diagnostic ground q (q1) from being greater than qsat(tsk)
+!      as happens over snow cover where the cqs2 value also becomes irrelevant
+!      by setting cqs2=chs in this situation the 2m q should become just qv(k=1)
+! ww: comment out this change to avoid Q2 drop due to change of radiative flux
+!         IF (Q1 .GT. QSFC(I,J)) THEN
+!           CQS2(I,J) = CHS(I,J)
+!         ENDIF
+!          QSFC(I,J)=Q1
+! Convert QSFC back to mixing ratio
+           QSFC(I,J)= Q1/(1.0-Q1)
+!
+           ! QSFC_RURAL(I,J)= Q1/(1.0-Q1)
+! Calculate momentum flux from rural surface for use with multi-layer UCM (Martilli et al. 2002)
+
+          DO 80 NS=1,NSOIL
+           SMOIS(I,NS,J)=SMC(NS)
+           TSLB(I,NS,J)=STC(NS)                                        !  STEMP
+           SH2O(I,NS,J)=SWC(NS)
+   80     CONTINUE
+!       ENDIF
+
+        FLX4_2D(I,J)  = FLX4
+	FVB_2D(I,J)   = FVB
+	FBUR_2D(I,J)  = FBUR
+	FGSN_2D(I,J)  = FGSN
+
+     !
+     ! Residual of surface energy balance equation terms
+     !
+
+     IF ( UA_PHYS ) THEN
+         noahres(i,j) = ( solnet + lwdn ) - sheat + ssoil - eta &
+              - ( emissi * STBOLT * (t1**4) ) - flx1 - flx2 - flx3 - flx4
+
+     ELSE
+         noahres(i,j) = ( solnet + lwdn ) - sheat + ssoil - eta &
+              - ( emissi * STBOLT * (t1**4) ) - flx1 - flx2 - flx3
+     ENDIF
+
+#ifdef URBAN_ACC
+        IF (SF_URBAN_PHYSICS == 1 ) THEN                                              ! Beginning of UCM CALL if block
+!--------------------------------------
+! URBAN CANOPY MODEL START - urban
+!--------------------------------------
+! Input variables lsm --> urban
+
+
+          IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+              IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33 ) THEN
+
+! Call urban
+
+!
+            UTYPE_URB = UTYPE_URB2D(I,J) !urban type (low, high or industrial)
+
+            TA_URB    = SFCTMP           ! [K]
+            QA_URB    = Q2K              ! [kg/kg]
+            UA_URB    = SQRT(U_PHY(I,1,J)**2.+V_PHY(I,1,J)**2.)
+            U1_URB    = U_PHY(I,1,J)
+            V1_URB    = V_PHY(I,1,J)
+            IF(UA_URB < 1.) UA_URB=1.    ! [m/s]
+            SSG_URB   = SOLDN            ! [W/m/m]
+            SSGD_URB  = 0.8*SOLDN        ! [W/m/m]
+            SSGQ_URB  = SSG_URB-SSGD_URB ! [W/m/m]
+            LLG_URB   = GLW(I,J)         ! [W/m/m]
+            RAIN_URB  = RAINBL(I,J)      ! [mm]
+            RHOO_URB  = SFCPRS / (287.04 * SFCTMP * (1.0+ 0.61 * Q2K)) ![kg/m/m/m]
+            ZA_URB    = ZLVL             ! [m]
+            DELT_URB  = DT               ! [sec]
+            XLAT_URB  = XLAT_URB2D(I,J)  ! [deg]
+            COSZ_URB  = COSZ_URB2D(I,J)  !
+            OMG_URB   = OMG_URB2D(I,J)   !
+            ZNT_URB   = ZNT(I,J)
+
+            LSOLAR_URB = .FALSE.
+
+            TR_URB = TR_URB2D(I,J)
+            TB_URB = TB_URB2D(I,J)
+            TG_URB = TG_URB2D(I,J)
+            TC_URB = TC_URB2D(I,J)
+            QC_URB = QC_URB2D(I,J)
+            UC_URB = UC_URB2D(I,J)
+
+            TGR_URB   = TGR_URB2D(I,J)
+            CMCR_URB  = CMCR_URB2D(I,J)
+            FLXHUMR_URB = FLXHUMR_URB2D(I,J)
+            FLXHUMB_URB = FLXHUMB_URB2D(I,J)
+            FLXHUMG_URB = FLXHUMG_URB2D(I,J)
+            DRELR_URB = DRELR_URB2D(I,J)
+            DRELB_URB = DRELB_URB2D(I,J)
+            DRELG_URB = DRELG_URB2D(I,J)
+
+            DO K = 1,num_roof_layers
+              TRL_URB(K) = TRL_URB3D(I,K,J)
+              SMR_URB(K) = SMR_URB3D(I,K,J)
+              TGRL_URB(K)= TGRL_URB3D(I,K,J)
+            END DO
+            DO K = 1,num_wall_layers
+              TBL_URB(K) = TBL_URB3D(I,K,J)
+            END DO
+            DO K = 1,num_road_layers
+              TGL_URB(K) = TGL_URB3D(I,K,J)
+            END DO
+
+            XXXR_URB = XXXR_URB2D(I,J)
+            XXXB_URB = XXXB_URB2D(I,J)
+            XXXG_URB = XXXG_URB2D(I,J)
+            XXXC_URB = XXXC_URB2D(I,J)
+!
+!
+!      Limits to avoid dividing by small number
+            if (CHS(I,J) < 1.0E-04) then
+               CHS(I,J)  = 1.0E-04
+            endif
+            if (CHS2(I,J) < 1.0E-04) then
+               CHS2(I,J)  = 1.0E-04
+            endif
+            if (CQS2(I,J) < 1.0E-04) then
+               CQS2(I,J)  = 1.0E-04
+            endif
+!
+            CHS_URB  = CHS(I,J)
+            CHS2_URB = CHS2(I,J)
+            IF (PRESENT(CMR_SFCDIF)) THEN
+               CMR_URB = CMR_SFCDIF(I,J)
+               CHR_URB = CHR_SFCDIF(I,J)
+               CMGR_URB = CMGR_SFCDIF(I,J)
+               CHGR_URB = CHGR_SFCDIF(I,J)
+               CMC_URB = CMC_SFCDIF(I,J)
+               CHC_URB = CHC_SFCDIF(I,J)
+            ENDIF
+
+! NUDAPT for SLUCM
+            mh_urb = mh_urb2d(I,J)
+            stdh_urb = stdh_urb2d(I,J)
+            lp_urb = lp_urb2d(I,J)
+            hgt_urb = hgt_urb2d(I,J)
+            lf_urb = 0.0
+            DO K = 1,4
+              lf_urb(K)=lf_urb2d(I,K,J)
+            ENDDO
+            frc_urb = frc_urb2d(I,J)
+            lb_urb = lb_urb2d(I,J)
+            check = 0
+            if (I.eq.73.and.J.eq.125)THEN
+               check = 1
+            end if
+!
+! Call urban
+            CALL cal_mon_day(julian,julyr,jmonth,jday)
+            CALL urban(LSOLAR_URB,                                      & ! I
+                       num_roof_layers,num_wall_layers,num_road_layers, & ! C
+                       DZR,DZB,DZG,                                     & ! C
+                       UTYPE_URB,TA_URB,QA_URB,UA_URB,U1_URB,V1_URB,SSG_URB, & ! I
+                       SSGD_URB,SSGQ_URB,LLG_URB,RAIN_URB,RHOO_URB,     & ! I
+                       ZA_URB,DECLIN_URB,COSZ_URB,OMG_URB,              & ! I
+                       XLAT_URB,DELT_URB,ZNT_URB,                       & ! I
+                       CHS_URB, CHS2_URB,                               & ! I
+                       TR_URB, TB_URB, TG_URB, TC_URB, QC_URB,UC_URB,   & ! H
+                       TRL_URB,TBL_URB,TGL_URB,                         & ! H
+                       XXXR_URB, XXXB_URB, XXXG_URB, XXXC_URB,          & ! H
+                       TS_URB,QS_URB,SH_URB,LH_URB,LH_KINEMATIC_URB,    & ! O
+                       SW_URB,ALB_URB,LW_URB,G_URB,RN_URB,PSIM_URB,PSIH_URB, & ! O
+                       GZ1OZ0_URB,                                      & !O
+                       CMR_URB, CHR_URB, CMC_URB, CHC_URB,              &
+                       U10_URB, V10_URB, TH2_URB, Q2_URB,               & ! O
+                       UST_URB,mh_urb, stdh_urb, lf_urb, lp_urb,        & ! 0
+                       hgt_urb,frc_urb,lb_urb, check,CMCR_URB,TGR_URB,  & ! H
+                       TGRL_URB,SMR_URB,CMGR_URB,CHGR_URB,jmonth,       & ! H
+                       DRELR_URB,DRELB_URB,                             & ! H
+                       DRELG_URB,FLXHUMR_URB,FLXHUMB_URB,FLXHUMG_URB)                            
+
+#if 0
+          IF(IPRINT) THEN
+
+       print*, 'AFTER CALL URBAN'
+       print*,'num_roof_layers',num_roof_layers, 'num_wall_layers',  &
+        num_wall_layers,                                             &
+       'DZR',DZR,'DZB',DZB,'DZG',DZG,'UTYPE_URB',UTYPE_URB,'TA_URB', &
+        TA_URB,                                                      &
+        'QA_URB',QA_URB,'UA_URB',UA_URB,'U1_URB',U1_URB,'V1_URB',    &
+         V1_URB,                                                     &
+         'SSG_URB',SSG_URB,'SSGD_URB',SSGD_URB,'SSGQ_URB',SSGQ_URB,  &
+        'LLG_URB',LLG_URB,'RAIN_URB',RAIN_URB,'RHOO_URB',RHOO_URB,   &
+        'ZA_URB',ZA_URB, 'DECLIN_URB',DECLIN_URB,'COSZ_URB',COSZ_URB,&
+        'OMG_URB',OMG_URB,'XLAT_URB',XLAT_URB,'DELT_URB',DELT_URB,   &
+         'ZNT_URB',ZNT_URB,'TR_URB',TR_URB, 'TB_URB',TB_URB,'TG_URB',&
+         TG_URB,'TC_URB',TC_URB,'QC_URB',QC_URB,'TRL_URB',TRL_URB,   &
+          'TBL_URB',TBL_URB,'TGL_URB',TGL_URB,'XXXR_URB',XXXR_URB,   &
+         'XXXB_URB',XXXB_URB,'XXXG_URB',XXXG_URB,'XXXC_URB',XXXC_URB,&
+         'TS_URB',TS_URB,'QS_URB',QS_URB,'SH_URB',SH_URB,'LH_URB',   &
+         LH_URB, 'LH_KINEMATIC_URB',LH_KINEMATIC_URB,'SW_URB',SW_URB,&
+         'ALB_URB',ALB_URB,'LW_URB',LW_URB,'G_URB',G_URB,'RN_URB',   &
+          RN_URB, 'PSIM_URB',PSIM_URB,'PSIH_URB',PSIH_URB,          &
+         'U10_URB',U10_URB,'V10_URB',V10_URB,'TH2_URB',TH2_URB,      &
+          'Q2_URB',Q2_URB,'CHS_URB',CHS_URB,'CHS2_URB',CHS2_URB
+           endif
+#endif
+
+            TS_URB2D(I,J) = TS_URB
+
+            ALBEDO(I,J) = FRC_URB2D(I,J)*ALB_URB+(1-FRC_URB2D(I,J))*ALBEDOK   ![-]
+            HFX(I,J) = FRC_URB2D(I,J)*SH_URB+(1-FRC_URB2D(I,J))*SHEAT         ![W/m/m]
+            QFX(I,J) = FRC_URB2D(I,J)*LH_KINEMATIC_URB &
+                     + (1-FRC_URB2D(I,J))*ETA_KINEMATIC                ![kg/m/m/s]
+            LH(I,J) = FRC_URB2D(I,J)*LH_URB+(1-FRC_URB2D(I,J))*ETA            ![W/m/m]
+            GRDFLX(I,J) = FRC_URB2D(I,J)*G_URB+(1-FRC_URB2D(I,J))*SSOIL       ![W/m/m]
+            TSK(I,J) = FRC_URB2D(I,J)*TS_URB+(1-FRC_URB2D(I,J))*T1            ![K]
+            Q1 = FRC_URB2D(I,J)*QS_URB+(1-FRC_URB2D(I,J))*Q1            ![-]
+! Convert QSFC back to mixing ratio
+            QSFC(I,J)= Q1/(1.0-Q1)
+            UST(I,J)= FRC_URB2D(I,J)*UST_URB+(1-FRC_URB2D(I,J))*UST(I,J)      ![m/s]
+
+#if 0
+    IF(IPRINT)THEN
+
+    print*, ' FRC_URB2D', FRC_URB2D,                        &
+    'ALB_URB',ALB_URB, 'ALBEDOK',ALBEDOK, &
+    'ALBEDO(I,J)',  ALBEDO(I,J),                  &
+    'SH_URB',SH_URB,'SHEAT',SHEAT, 'HFX(I,J)',HFX(I,J),  &
+    'LH_KINEMATIC_URB',LH_KINEMATIC_URB,'ETA_KINEMATIC',  &
+     ETA_KINEMATIC, 'QFX(I,J)',QFX(I,J),                  &
+    'LH_URB',LH_URB, 'ETA',ETA, 'LH(I,J)',LH(I,J),        &
+    'G_URB',G_URB,'SSOIL',SSOIL,'GRDFLX(I,J)', GRDFLX(I,J),&
+    'TS_URB',TS_URB,'T1',T1,'TSK(I,J)',TSK(I,J),          &
+    'QS_URB',QS_URB,'Q1',Q1,'QSFC(I,J)',QSFC(I,J)
+     endif
+#endif
+
+
+
+! Renew Urban State Varialbes
+
+            TR_URB2D(I,J) = TR_URB
+            TB_URB2D(I,J) = TB_URB
+            TG_URB2D(I,J) = TG_URB
+            TC_URB2D(I,J) = TC_URB
+            QC_URB2D(I,J) = QC_URB
+            UC_URB2D(I,J) = UC_URB
+
+            TGR_URB2D(I,J) =TGR_URB 
+            CMCR_URB2D(I,J)=CMCR_URB
+            FLXHUMR_URB2D(I,J)=FLXHUMR_URB 
+            FLXHUMB_URB2D(I,J)=FLXHUMB_URB
+            FLXHUMG_URB2D(I,J)=FLXHUMG_URB
+            DRELR_URB2D(I,J) = DRELR_URB 
+            DRELB_URB2D(I,J) = DRELB_URB 
+            DRELG_URB2D(I,J) = DRELG_URB
+
+            DO K = 1,num_roof_layers
+              TRL_URB3D(I,K,J) = TRL_URB(K)
+              SMR_URB3D(I,K,J) = SMR_URB(K)
+              TGRL_URB3D(I,K,J)= TGRL_URB(K)
+            END DO
+            DO K = 1,num_wall_layers
+              TBL_URB3D(I,K,J) = TBL_URB(K)
+            END DO
+            DO K = 1,num_road_layers
+              TGL_URB3D(I,K,J) = TGL_URB(K)
+            END DO
+            XXXR_URB2D(I,J) = XXXR_URB
+            XXXB_URB2D(I,J) = XXXB_URB
+            XXXG_URB2D(I,J) = XXXG_URB
+            XXXC_URB2D(I,J) = XXXC_URB
+
+            SH_URB2D(I,J)    = SH_URB
+            LH_URB2D(I,J)    = LH_URB
+            G_URB2D(I,J)     = G_URB
+            RN_URB2D(I,J)    = RN_URB
+            PSIM_URB2D(I,J)  = PSIM_URB
+            PSIH_URB2D(I,J)  = PSIH_URB
+            GZ1OZ0_URB2D(I,J)= GZ1OZ0_URB
+            U10_URB2D(I,J)   = U10_URB
+            V10_URB2D(I,J)   = V10_URB
+            TH2_URB2D(I,J)   = TH2_URB
+            Q2_URB2D(I,J)    = Q2_URB
+            UST_URB2D(I,J)   = UST_URB
+            AKMS_URB2D(I,J)  = KARMAN * UST_URB2D(I,J)/(GZ1OZ0_URB2D(I,J)-PSIM_URB2D(I,J))
+            IF (PRESENT(CMR_SFCDIF)) THEN
+               CMR_SFCDIF(I,J) = CMR_URB
+               CHR_SFCDIF(I,J) = CHR_URB
+               CMGR_SFCDIF(I,J) = CMGR_URB
+               CHGR_SFCDIF(I,J) = CHGR_URB
+               CMC_SFCDIF(I,J) = CMC_URB
+               CHC_SFCDIF(I,J) = CHC_URB
+            ENDIF
+          END IF
+
+         ENDIF                                   ! end of UCM CALL if block
+#endif
+!--------------------------------------
+! Urban Part End - urban
+!--------------------------------------
+
+!***  DIAGNOSTICS
+          SMSTAV(I,J)=SOILW
+          SMSTOT(I,J)=SOILM*1000.
+          DO NS=1,NSOIL
+          SMCREL(I,NS,J)=SMAV(NS)
+          ENDDO
+
+
+!         Convert the water unit into mm
+          SFCRUNOFF(I,J)=SFCRUNOFF(I,J)+RUNOFF1*DT*1000.0
+          UDRUNOFF(I,J)=UDRUNOFF(I,J)+RUNOFF2*DT*1000.0
+! snow defined when fraction of frozen precip (FFROZP) > 0.5,
+          IF(FFROZP.GT.0.5)THEN
+            ACSNOW(I,J)=ACSNOW(I,J)+PRCP*DT
+          ENDIF
+          IF(SNOW(I,J).GT.0.)THEN
+            ACSNOM(I,J)=ACSNOM(I,J)+SNOMLT*1000.
+! accumulated snow-melt energy
+            SNOPCX(I,J)=SNOPCX(I,J)-SNOMLT/FDTLIW
+          ENDIF
+#if 0
+        ENDIF                                                           ! endif of land-sea test
+#endif
+      ENDDO ILOOP                                                       ! of I loop
+   ENDDO JLOOP                                                          ! of J loop
+
+#if 0   
+   write(msg,*) 'll:', sum(noahres(its:ite,jts:jte)),sum(FLX4_2D(its:ite,jts:jte)), &
+                       sum(FVB_2D(its:ite,jts:jte)),sum(FBUR_2D(its:ite,jts:jte)),sum(FGSN_2D(its:ite,jts:jte)), &
+					   sum(lai(its:ite,jts:jte)),sum(CANWAT(its:ite,jts:jte)),sum(SNOW(its:ite,jts:jte)),        &
+					   sum(SNOWH(its:ite,jts:jte)),sum(ALBEDO(its:ite,jts:jte)),sum(ALBBCK(its:ite,jts:jte)),    &
+					   sum(Z0(its:ite,jts:jte)),sum(EMISS(its:ite,jts:jte)),sum(ZNT(its:ite,jts:jte)),           &
+					   sum(TSK(its:ite,jts:jte)),sum(HFX(its:ite,jts:jte)),sum(POTEVP(its:ite,jts:jte))       
+   call wrf_debug(0,msg)
+   write(msg,*) 'll:', sum(QFX(its:ite,jts:jte)),sum(LH(its:ite,jts:jte)),sum(GRDFLX(its:ite,jts:jte)),sum(SNOWC(its:ite,jts:jte)),     &
+                       sum(CHS2(its:ite,jts:jte)),sum(SNOTIME(its:ite,jts:jte)),sum(QSFC(its:ite,jts:jte)),      &
+					   sum(SNOPCX(its:ite,jts:jte)),sum(ACSNOM(its:ite,jts:jte)),sum(UDRUNOFF(its:ite,jts:jte)), &
+					   sum(SFCRUNOFF(its:ite,jts:jte)),sum(SMSTAV(its:ite,jts:jte))
+   call wrf_debug(0,msg)
+   write(msg,*) 'll:',sum(SMOIS(its:ite,1:NSOIL,jts:jte)),sum(TSLB(its:ite,1:NSOIL,jts:jte)),sum(SH2O(its:ite,1:NSOIL,jts:jte)),sum(SMCREL(its:ite,1:NSOIL,jts:jte))
+   call wrf_debug(0,msg)
+#endif   
+
+#ifdef URBAN_ACC
+      IF (SF_URBAN_PHYSICS == 2) THEN
+
+
+         do j=jts,jte
+         do i=its,ite
+            EMISS_URB(i,j)=0.
+            RL_UP_URB(i,j)=0.
+            RS_ABS_URB(i,j)=0.
+            GRDFLX_URB(i,j)=0.
+            b_q_bep(i,kts:kte,j)=0.
+         end do
+         end do
+       CALL BEP(frc_urb2d,utype_urb2d,itimestep,dz8w,dt,u_phy,v_phy,   &
+                th_phy,rho,p_phy,swdown,glw,                           &
+                gmt,julday,xlong,xlat,declin_urb,cosz_urb2d,omg_urb2d, &
+                num_urban_layers,num_urban_hi,                         &
+                trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,               &
+                sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,             &
+                lp_urb2d,hi_urb2d,lb_urb2d,hgt_urb2d,                  &
+                a_u_bep,a_v_bep,a_t_bep,                               &
+                a_e_bep,b_u_bep,b_v_bep,                               &
+                b_t_bep,b_e_bep,b_q_bep,dlg_bep,                       &
+                dl_u_bep,sf_bep,vl_bep,                                &
+                rl_up_urb,rs_abs_urb,emiss_urb,grdflx_urb,             &
+                ids,ide, jds,jde, kds,kde,                             &
+                ims,ime, jms,jme, kms,kme,                             &
+                its,ite, jts,jte, kts,kte )
+
+       ENDIF
+
+       
+       IF (SF_URBAN_PHYSICS == 3) THEN
+
+
+         do j=jts,jte
+         do i=its,ite
+            EMISS_URB(i,j)=0.
+            RL_UP_URB(i,j)=0.
+            RS_ABS_URB(i,j)=0.
+            GRDFLX_URB(i,j)=0.
+            b_q_bep(i,kts:kte,j)=0.
+         end do
+         end do
+        
+
+       CALL BEP_BEM(frc_urb2d,utype_urb2d,itimestep,dz8w,dt,u_phy,v_phy, &
+                th_phy,rho,p_phy,swdown,glw,                           &
+                gmt,julday,xlong,xlat,declin_urb,cosz_urb2d,omg_urb2d, &
+                num_urban_layers,num_urban_hi,                         &
+                trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,               &
+                tlev_urb3d,qlev_urb3d,tw1lev_urb3d,tw2lev_urb3d,       &
+                tglev_urb3d,tflev_urb3d,sf_ac_urb3d,lf_ac_urb3d,       &
+                cm_ac_urb3d,sfvent_urb3d,lfvent_urb3d,                 &
+                sfwin1_urb3d,sfwin2_urb3d,                             &
+                sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,             &
+                lp_urb2d,hi_urb2d,lb_urb2d,hgt_urb2d,                  &
+                a_u_bep,a_v_bep,a_t_bep,                               &
+                a_e_bep,b_u_bep,b_v_bep,                               &
+                b_t_bep,b_e_bep,b_q_bep,dlg_bep,                       &
+                dl_u_bep,sf_bep,vl_bep,                                &
+                rl_up_urb,rs_abs_urb,emiss_urb,grdflx_urb,qv3d,        &
+                ids,ide, jds,jde, kds,kde,                             &
+                ims,ime, jms,jme, kms,kme,                             &
+                its,ite, jts,jte, kts,kte )
+
+       ENDIF
+
+    if((sf_urban_physics.eq.2).OR.(sf_urban_physics.eq.3))then         !Bep begin
+! fix the value of the Stefan-Boltzmann constant
+         sigma_sb=5.67e-08
+         do j=jts,jte
+         do i=its,ite
+            UMOM_URB(I,J)=0.
+            VMOM_URB(I,J)=0.
+            HFX_URB(I,J)=0.
+            QFX_URB(I,J)=0.
+         do k=kts,kte
+            a_u_bep(i,k,j)=a_u_bep(i,k,j)*frc_urb2d(i,j)
+            a_v_bep(i,k,j)=a_v_bep(i,k,j)*frc_urb2d(i,j)
+            a_t_bep(i,k,j)=a_t_bep(i,k,j)*frc_urb2d(i,j)
+            a_q_bep(i,k,j)=0.        
+            a_e_bep(i,k,j)=0.
+            b_u_bep(i,k,j)=b_u_bep(i,k,j)*frc_urb2d(i,j)
+            b_v_bep(i,k,j)=b_v_bep(i,k,j)*frc_urb2d(i,j)
+            b_t_bep(i,k,j)=b_t_bep(i,k,j)*frc_urb2d(i,j)
+            b_q_bep(i,k,j)=b_q_bep(i,k,j)*frc_urb2d(i,j)
+            b_e_bep(i,k,j)=b_e_bep(i,k,j)*frc_urb2d(i,j)
+            HFX_URB(I,J)=HFX_URB(I,J)+B_T_BEP(I,K,J)*RHO(I,K,J)*CP*                &
+                          DZ8W(I,K,J)*VL_BEP(I,K,J)
+            QFX_URB(I,J)=QFX_URB(I,J)+B_Q_BEP(I,K,J)*               &
+                          DZ8W(I,K,J)*VL_BEP(I,K,J)
+            UMOM_URB(I,J)=UMOM_URB(I,J)+ (A_U_BEP(I,K,J)*U_PHY(I,K,J)+             &
+                          B_U_BEP(I,K,J))*DZ8W(I,K,J)*VL_BEP(I,K,J)
+            VMOM_URB(I,J)=VMOM_URB(I,J)+ (A_V_BEP(I,K,J)*V_PHY(I,K,J)+             &
+                          B_V_BEP(I,K,J))*DZ8W(I,K,J)*VL_BEP(I,K,J)
+            vl_bep(i,k,j)=(1.-frc_urb2d(i,j))+vl_bep(i,k,j)*frc_urb2d(i,j)
+            sf_bep(i,k,j)=(1.-frc_urb2d(i,j))+sf_bep(i,k,j)*frc_urb2d(i,j)
+         end do
+            a_u_bep(i,1,j)=(1.-frc_urb2d(i,j))*(-ust(I,J)*ust(I,J))/dz8w(i,1,j)/   &
+                           ((u_phy(i,1,j)**2+v_phy(i,1,j)**2.)**.5)+a_u_bep(i,1,j)
+            a_v_bep(i,1,j)=(1.-frc_urb2d(i,j))*(-ust(I,J)*ust(I,J))/dz8w(i,1,j)/   &
+                           ((u_phy(i,1,j)**2+v_phy(i,1,j)**2.)**.5)+a_v_bep(i,1,j)
+            b_t_bep(i,1,j)=(1.-frc_urb2d(i,j))*hfx_rural(i,j)/dz8w(i,1,j)/rho(i,1,j)/CP+ &
+                            b_t_bep(i,1,j)
+            b_q_bep(i,1,j)=(1.-frc_urb2d(i,j))*qfx_rural(i,j)/dz8w(i,1,j)/rho(i,1,j)+b_q_bep(i,1,j)
+            umom=(1.-frc_urb2d(i,j))*ust(i,j)*ust(i,j)*u_phy(i,1,j)/               &
+                         ((u_phy(i,1,j)**2+v_phy(i,1,j)**2.)**.5)+umom_urb(i,j)
+            vmom=(1.-frc_urb2d(i,j))*ust(i,j)*ust(i,j)*v_phy(i,1,j)/               &
+                         ((u_phy(i,1,j)**2+v_phy(i,1,j)**2.)**.5)+vmom_urb(i,j)
+            sf_bep(i,1,j)=1.
+           
+! compute upward longwave radiation from the rural part and total
+!           rl_up_rural=-emiss_rural(i,j)*sigma_sb*(tsk_rural(i,j)**4.)-(1.-emiss_rural(i,j))*glw(i,j)
+!           rl_up_tot=(1.-frc_urb2d(i,j))*rl_up_rural+frc_urb2d(i,j)*rl_up_urb(i,j)   
+!           emiss(i,j)=(1.-frc_urb2d(i,j))*emiss_rural(i,j)+frc_urb2d(i,j)*emiss_urb(i,j)
+! using the emissivity and the total longwave upward radiation estimate the averaged skin temperature
+           IF (FRC_URB2D(I,J).GT.0.) THEN
+              rl_up_rural=-emiss_rural(i,j)*sigma_sb*(tsk_rural(i,j)**4.)-(1.-emiss_rural(i,j))*glw(i,j)
+              rl_up_tot=(1.-frc_urb2d(i,j))*rl_up_rural+frc_urb2d(i,j)*rl_up_urb(i,j)   
+              emiss(i,j)=(1.-frc_urb2d(i,j))*emiss_rural(i,j)+frc_urb2d(i,j)*emiss_urb(i,j)
+              ts_urb2d(i,j)=(max(0.,(-rl_up_urb(i,j)-(1.-emiss_urb(i,j))*glw(i,j))/emiss_urb(i,j)/sigma_sb))**0.25
+              tsk(i,j)=(max(0., (-1.*rl_up_tot-(1.-emiss(i,j))*glw(i,j) )/emiss(i,j)/sigma_sb))**.25
+           rs_abs_tot=(1.-frc_urb2d(i,j))*swdown(i,j)*(1.-albedo(i,j))+frc_urb2d(i,j)*rs_abs_urb(i,j)  
+          if(swdown(i,j).gt.0.)then
+           albedo(i,j)=1.-rs_abs_tot/swdown(i,j)
+          else
+           albedo(i,j)=alb_rural(i,j)
+          endif
+! rename *_urb to sh_urb2d,lh_urb2d,g_urb2d,rn_urb2d
+         grdflx(i,j)= (1.-frc_urb2d(i,j))*grdflx_rural(i,j)+frc_urb2d(i,j)*grdflx_urb(i,j) 
+         qfx(i,j)=(1.-frc_urb2d(i,j))*qfx_rural(i,j)+qfx_urb(i,j)
+!        lh(i,j)=(1.-frc_urb2d(i,j))*qfx_rural(i,j)*xlv
+         lh(i,j)=qfx(i,j)*xlv
+         HFX(I,J) = HFX_URB(I,J)+(1-FRC_URB2D(I,J))*HFX_RURAL(I,J)         ![W/m/m]
+            SH_URB2D(I,J)    = HFX_URB(I,J)/FRC_URB2D(I,J)
+            LH_URB2D(I,J)    = qfx_urb(i,j)*xlv
+            G_URB2D(I,J)     = grdflx_urb(i,j)
+            RN_URB2D(I,J)    = rs_abs_urb(i,j)+emiss_urb(i,j)*glw(i,j)-rl_up_urb(i,j)
+            ust(i,j)=(umom**2.+vmom**2.)**.25
+!          if(tsk(i,j).gt.350)write(*,*)'tsk too big!',i,j,tsk(i,j)
+!          if(tsk(i,j).lt.260)write(*,*)'tsk too small!',i,j,tsk(i,j),rl_up_tot,rl_up_urb(i,j),rl_up_rural
+!                    print*,'ivgtyp,i,j,sigma_sb',ivgtyp(i,j),i,j,sigma_sb
+!                    print*,'hfx,lh,qfx,grdflx,ts_urb2d',hfx(i,j),lh(i,j),qfx(i,j),grdflx(i,j),ts_urb2d(i,j)
+!                    print*,'tsk,albedo,emiss',tsk(i,j),albedo(i,j),emiss(i,j)
+!                if(i.eq.56.and.j.eq.29)then
+!                    print*,'ivgtyp, qfx, hfx',ivgtyp(i,j),hfx_rural(i,j),qfx_rural(i,j)
+!                    print*,'emiss_rural,emiss_urb',emiss_rural(i,j),emiss_urb(i,j)
+!                    print*,'rl_up_rural,rl_up_urb(i,j)',rl_up_rural,rl_up_urb(i,j)
+!                    print*,'tsk_rural,ts_urb2d(i,j),tsk',tsk_rural(i,j),ts_urb2d(i,j),tsk(i,j)
+!                    print*,'reconstruction fei',((emiss(i,j)*tsk(i,j)**4.-frc_urb2d(i,j)*emiss_urb(i,j)*ts_urb2d(i,j)**4.)/(emiss_rural(i,j)*(1.-frc_urb2d(i,j))))**.25
+!                    print*,'ivgtyp,hfx,hfx_urb,hfx_rural',hfx(i,j),hfx_urb(i,j),hfx_rural(i,j)
+!                    print*,'lh,lh_rural',lh(i,j),lh_rural(i,j)
+!                    print*,'qfx',qfx(i,j)
+!                    print*,'ts_urb2d',ts_urb2d(i,j)
+!                    print*,'ust',ust(i,j)
+!                    print*,'swdown,glw',swdown(i,j),glw(i,j)
+!                endif
+            else
+              SH_URB2D(I,J)    = 0.
+              LH_URB2D(I,J)    = 0.
+              G_URB2D(I,J)     = 0.
+              RN_URB2D(I,J)    = 0.
+            endif
+!          IF( IVGTYP(I,J) == 1 .or. IVGTYP(I,J) == 31 .or. &
+!                  IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+!                    print*,'ivgtyp, qfx, hfx',ivgtyp(i,j),hfx_rural(i,j),qfx_rural(i,j)
+!                    print*,'ivgtyp,hfx,hfx_urb,hfx_rural',hfx(i,j),hfx_urb(i,j),hfx_rural(i,j)
+!                    print*,'lh,lh_rural',lh(i,j),lh_rural(i,j)
+!                    print*,'qfx',qfx(i,j)
+!                    print*,'ts_urb2d',ts_urb2d(i,j)
+!                    print*,'ust',ust(i,j)
+!          endif
+        enddo
+        enddo
+
+
+       endif                                                           !Bep end
+#endif
+!------------------------------------------------------
+   END SUBROUTINE lsm
+!------------------------------------------------------
+
+  SUBROUTINE LSMINIT(VEGFRA,SNOW,SNOWC,SNOWH,CANWAT,SMSTAV,    &
+                     SMSTOT, SFCRUNOFF,UDRUNOFF,ACSNOW,        &
+                     ACSNOM,IVGTYP,ISLTYP,TSLB,SMOIS,SH2O,ZS,DZS, &
+                     MMINLU,                                   &
+                     SNOALB, FNDSOILW, FNDSNOWH, RDMAXALB,     &
+                     num_soil_layers, restart,                 &
+                     allowed_to_read ,                         &
+                     ids,ide, jds,jde, kds,kde,                &
+                     ims,ime, jms,jme, kms,kme,                &
+                     its,ite, jts,jte, kts,kte                 )
+
+   INTEGER,  INTENT(IN   )   ::     ids,ide, jds,jde, kds,kde,  &
+                                    ims,ime, jms,jme, kms,kme,  &
+                                    its,ite, jts,jte, kts,kte
+
+   INTEGER, INTENT(IN)       ::     num_soil_layers
+
+   LOGICAL , INTENT(IN) :: restart , allowed_to_read
+
+   REAL,    DIMENSION( num_soil_layers), INTENT(INOUT) :: ZS, DZS
+
+   REAL,    DIMENSION( ims:ime, num_soil_layers, jms:jme )    , &
+            INTENT(INOUT)    ::                          SMOIS, &  !Total soil moisture
+                                                         SH2O,  &  !liquid soil moisture
+                                                         TSLB      !STEMP
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)    ::                           SNOW, &
+                                                         SNOWH, &
+                                                         SNOWC, &
+                                                        SNOALB, &
+                                                        CANWAT, &
+                                                        SMSTAV, &
+                                                        SMSTOT, &
+                                                     SFCRUNOFF, &
+                                                      UDRUNOFF, &
+                                                        ACSNOW, &
+                                                        VEGFRA, &
+                                                        ACSNOM
+
+   INTEGER, DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN)       ::                         IVGTYP, &
+                                                        ISLTYP
+   CHARACTER(LEN=*),  INTENT(IN)      ::                MMINLU
+
+   LOGICAL, INTENT(IN)       ::                      FNDSOILW , &
+                                                     FNDSNOWH
+   LOGICAL, INTENT(IN)       ::                      RDMAXALB
+
+
+   INTEGER                   :: L
+   REAL                      :: BX, SMCMAX, PSISAT, FREE
+   REAL, PARAMETER           :: BLIM = 5.5, HLICE = 3.335E5,    &
+                                GRAV = 9.81, T0 = 273.15
+   INTEGER                   :: errflag
+   CHARACTER(LEN=80)         :: err_message
+
+   character*256 :: MMINSL
+        MMINSL='STAS'
+!
+
+! initialize three Noah LSM related tables
+   IF ( allowed_to_read ) THEN
+     CALL wrf_message( 'INITIALIZE THREE Noah LSM RELATED TABLES' )
+     CALL  SOIL_VEG_GEN_PARM( MMINLU, MMINSL )
+   ENDIF
+
+! GAC-->
+! 20130219 - No longer need these - see module_data_gocart_dust
+!#if ( WRF_CHEM == 1 )
+!!
+!! need this parameter for dust parameterization in wrf/chem
+!!
+!   do I=1,NSLTYPE
+!      porosity(i)=maxsmc(i)
+!      drypoint(i)=drysmc(i)
+!   enddo
+!#endif
+! <--GAC
+
+   IF(.not.restart)THEN
+
+   itf=min0(ite,ide-1)
+   jtf=min0(jte,jde-1)
+
+   errflag = 0
+   DO j = jts,jtf
+     DO i = its,itf
+       IF ( ISLTYP( i,j ) .LT. 1 ) THEN
+         errflag = 1
+         WRITE(err_message,*)"module_sf_noahlsm.F: lsminit: out of range ISLTYP ",i,j,ISLTYP( i,j )
+         CALL wrf_message(err_message)
+       ENDIF
+       IF(.not.RDMAXALB) THEN
+          SNOALB(i,j)=MAXALB(IVGTYP(i,j))*0.01
+       ENDIF
+     ENDDO
+   ENDDO
+   IF ( errflag .EQ. 1 ) THEN
+      CALL wrf_error_fatal( "module_sf_noahlsm.F: lsminit: out of range value "// &
+                            "of ISLTYP. Is this field in the input?" )
+   ENDIF
+
+! initialize soil liquid water content SH2O
+
+!  IF(.NOT.FNDSOILW) THEN
+
+! If no SWC, do the following
+!         PRINT *,'SOIL WATER NOT FOUND - VALUE SET IN LSMINIT'
+        DO J = jts,jtf
+        DO I = its,itf
+          BX = BB(ISLTYP(I,J))
+          SMCMAX = MAXSMC(ISLTYP(I,J))
+          PSISAT = SATPSI(ISLTYP(I,J))
+         if ((bx > 0.0).and.(smcmax > 0.0).and.(psisat > 0.0)) then
+          DO NS=1, num_soil_layers
+! ----------------------------------------------------------------------
+!SH2O  <= SMOIS for T < 273.149K (-0.001C)
+             IF (TSLB(I,NS,J) < 273.149) THEN
+! ----------------------------------------------------------------------
+! first guess following explicit solution for Flerchinger Eqn from Koren
+! et al, JGR, 1999, Eqn 17 (KCOUNT=0 in FUNCTION FRH2O).
+! ISLTPK is soil type
+              BX = BB(ISLTYP(I,J))
+              SMCMAX = MAXSMC(ISLTYP(I,J))
+              PSISAT = SATPSI(ISLTYP(I,J))
+              IF ( BX >  BLIM ) BX = BLIM
+              FK=(( (HLICE/(GRAV*(-PSISAT))) *                              &
+                 ((TSLB(I,NS,J)-T0)/TSLB(I,NS,J)) )**(-1/BX) )*SMCMAX
+              IF (FK < 0.02) FK = 0.02
+              SH2O(I,NS,J) = MIN( FK, SMOIS(I,NS,J) )
+! ----------------------------------------------------------------------
+! now use iterative solution for liquid soil water content using
+! FUNCTION FRH2O with the initial guess for SH2O from above explicit
+! first guess.
+              CALL FRH2O (FREE,TSLB(I,NS,J),SMOIS(I,NS,J),SH2O(I,NS,J),    &
+                 SMCMAX,BX,PSISAT)
+              SH2O(I,NS,J) = FREE
+             ELSE             ! of IF (TSLB(I,NS,J)
+! ----------------------------------------------------------------------
+! SH2O = SMOIS ( for T => 273.149K (-0.001C)
+              SH2O(I,NS,J)=SMOIS(I,NS,J)
+! ----------------------------------------------------------------------
+             ENDIF            ! of IF (TSLB(I,NS,J)
+          END DO              ! of DO NS=1, num_soil_layers
+         else                 ! of if ((bx > 0.0)
+          DO NS=1, num_soil_layers
+           SH2O(I,NS,J)=SMOIS(I,NS,J)
+          END DO
+         endif                ! of if ((bx > 0.0)
+        ENDDO                 ! DO I = its,itf
+        ENDDO                 ! DO J = jts,jtf
+!  ENDIF                       ! of IF(.NOT.FNDSOILW)THEN
+
+! initialize physical snow height SNOWH
+
+        IF(.NOT.FNDSNOWH)THEN
+! If no SNOWH do the following
+          CALL wrf_message( 'SNOW HEIGHT NOT FOUND - VALUE DEFINED IN LSMINIT' )
+          DO J = jts,jtf
+          DO I = its,itf
+            SNOWH(I,J)=SNOW(I,J)*0.005               ! SNOW in mm and SNOWH in m
+          ENDDO
+          ENDDO
+        ENDIF
+
+! initialize canopy water to ZERO
+
+!          GO TO 110
+!         print*,'Note that canopy water content (CANWAT) is set to ZERO in LSMINIT'
+          DO J = jts,jtf
+          DO I = its,itf
+            CANWAT(I,J)=0.0
+          ENDDO
+          ENDDO
+ 110      CONTINUE
+
+   ENDIF
+!------------------------------------------------------------------------------
+  END SUBROUTINE lsminit
+!------------------------------------------------------------------------------
+
+
+
+!-----------------------------------------------------------------
+        SUBROUTINE SOIL_VEG_GEN_PARM( MMINLU, MMINSL)
+!-----------------------------------------------------------------
+
+        USE module_wrf_error
+        IMPLICIT NONE
+
+        CHARACTER(LEN=*), INTENT(IN) :: MMINLU, MMINSL
+        integer :: LUMATCH, IINDEX, LC, NUM_SLOPE
+        integer :: ierr
+        INTEGER , PARAMETER :: OPEN_OK = 0
+
+        character*128 :: mess , message
+        logical, external :: wrf_dm_on_monitor
+
+
+!-----SPECIFY VEGETATION RELATED CHARACTERISTICS :
+!             ALBBCK: SFC albedo (in percentage)
+!                 Z0: Roughness length (m)
+!             SHDFAC: Green vegetation fraction (in percentage)
+!  Note: The ALBEDO, Z0, and SHDFAC values read from the following table
+!          ALBEDO, amd Z0 are specified in LAND-USE TABLE; and SHDFAC is
+!          the monthly green vegetation data
+!             CMXTBL: MAX CNPY Capacity (m)
+!             NROTBL: Rooting depth (layer)
+!              RSMIN: Mimimum stomatal resistance (s m-1)
+!              RSMAX: Max. stomatal resistance (s m-1)
+!                RGL: Parameters used in radiation stress function
+!                 HS: Parameter used in vapor pressure deficit functio
+!               TOPT: Optimum transpiration air temperature. (K)
+!             CMCMAX: Maximum canopy water capacity
+!             CFACTR: Parameter used in the canopy inteception calculati
+!               SNUP: Threshold snow depth (in water equivalent m) that
+!                     implies 100% snow cover
+!                LAI: Leaf area index (dimensionless)
+!             MAXALB: Upper bound on maximum albedo over deep snow
+!
+!-----READ IN VEGETAION PROPERTIES FROM VEGPARM.TBL
+!
+
+       IF ( wrf_dm_on_monitor() ) THEN
+
+        OPEN(19, FILE='VEGPARM.TBL',FORM='FORMATTED',STATUS='OLD',IOSTAT=ierr)
+        IF(ierr .NE. OPEN_OK ) THEN
+          WRITE(message,FMT='(A)') &
+          'module_sf_noahlsm.F: soil_veg_gen_parm: failure opening VEGPARM.TBL'
+          CALL wrf_error_fatal ( message )
+        END IF
+
+
+        LUMATCH=0
+
+        FIND_LUTYPE : DO WHILE (LUMATCH == 0)
+           READ (19,*,END=2002)
+           READ (19,*,END=2002)LUTYPE
+           READ (19,*)LUCATS,IINDEX
+
+           IF(LUTYPE.EQ.MMINLU)THEN
+              WRITE( mess , * ) 'LANDUSE TYPE = ' // TRIM ( LUTYPE ) // ' FOUND', LUCATS,' CATEGORIES'
+              CALL wrf_message( mess )
+              LUMATCH=1
+           ELSE
+              call wrf_message ( "Skipping over LUTYPE = " // TRIM ( LUTYPE ) )
+              DO LC = 1, LUCATS+14
+                 read(19,*)
+              ENDDO
+           ENDIF
+        ENDDO FIND_LUTYPE
+! prevent possible array overwrite, Bill Bovermann, IBM, May 6, 2008
+        IF ( SIZE(SHDTBL)       < LUCATS .OR. &
+             SIZE(NROTBL)       < LUCATS .OR. &
+             SIZE(RSTBL)        < LUCATS .OR. &
+             SIZE(RGLTBL)       < LUCATS .OR. &
+             SIZE(HSTBL)        < LUCATS .OR. &
+             SIZE(SNUPTBL)      < LUCATS .OR. &
+             SIZE(MAXALB)       < LUCATS .OR. &
+             SIZE(LAIMINTBL)    < LUCATS .OR. &
+             SIZE(LAIMAXTBL)    < LUCATS .OR. &
+             SIZE(Z0MINTBL)     < LUCATS .OR. &
+             SIZE(Z0MAXTBL)     < LUCATS .OR. &
+             SIZE(ALBEDOMINTBL) < LUCATS .OR. &
+             SIZE(ALBEDOMAXTBL) < LUCATS .OR. &
+             SIZE(ZTOPVTBL) < LUCATS .OR. &
+             SIZE(ZBOTVTBL) < LUCATS .OR. &
+             SIZE(EMISSMINTBL ) < LUCATS .OR. &
+             SIZE(EMISSMAXTBL ) < LUCATS ) THEN
+           CALL wrf_error_fatal('Table sizes too small for value of LUCATS in module_sf_noahdrv.F')
+        ENDIF
+
+        IF(LUTYPE.EQ.MMINLU)THEN
+          DO LC=1,LUCATS
+              READ (19,*)IINDEX,SHDTBL(LC),                        &
+                        NROTBL(LC),RSTBL(LC),RGLTBL(LC),HSTBL(LC), &
+                        SNUPTBL(LC),MAXALB(LC), LAIMINTBL(LC),     &
+                        LAIMAXTBL(LC),EMISSMINTBL(LC),             &
+                        EMISSMAXTBL(LC), ALBEDOMINTBL(LC),         &
+                        ALBEDOMAXTBL(LC), Z0MINTBL(LC), Z0MAXTBL(LC),&
+			ZTOPVTBL(LC), ZBOTVTBL(LC)
+          ENDDO
+!
+          READ (19,*)
+          READ (19,*)TOPT_DATA
+          READ (19,*)
+          READ (19,*)CMCMAX_DATA
+          READ (19,*)
+          READ (19,*)CFACTR_DATA
+          READ (19,*)
+          READ (19,*)RSMAX_DATA
+          READ (19,*)
+          READ (19,*)BARE
+          READ (19,*)
+          READ (19,*)NATURAL
+        ENDIF
+!
+ 2002   CONTINUE
+
+        CLOSE (19)
+        IF (LUMATCH == 0) then
+           CALL wrf_error_fatal ("Land Use Dataset '"//MMINLU//"' not found in VEGPARM.TBL.")
+        ENDIF
+      ENDIF
+
+      CALL wrf_dm_bcast_string  ( LUTYPE  , 4 )
+      CALL wrf_dm_bcast_integer ( LUCATS  , 1 )
+      CALL wrf_dm_bcast_integer ( IINDEX  , 1 )
+      CALL wrf_dm_bcast_integer ( LUMATCH , 1 )
+      CALL wrf_dm_bcast_real    ( SHDTBL  , NLUS )
+      CALL wrf_dm_bcast_real    ( NROTBL  , NLUS )
+      CALL wrf_dm_bcast_real    ( RSTBL   , NLUS )
+      CALL wrf_dm_bcast_real    ( RGLTBL  , NLUS )
+      CALL wrf_dm_bcast_real    ( HSTBL   , NLUS )
+      CALL wrf_dm_bcast_real    ( SNUPTBL , NLUS )
+      CALL wrf_dm_bcast_real    ( LAIMINTBL    , NLUS )
+      CALL wrf_dm_bcast_real    ( LAIMAXTBL    , NLUS )
+      CALL wrf_dm_bcast_real    ( Z0MINTBL     , NLUS )
+      CALL wrf_dm_bcast_real    ( Z0MAXTBL     , NLUS )
+      CALL wrf_dm_bcast_real    ( EMISSMINTBL  , NLUS )
+      CALL wrf_dm_bcast_real    ( EMISSMAXTBL  , NLUS )
+      CALL wrf_dm_bcast_real    ( ALBEDOMINTBL , NLUS )
+      CALL wrf_dm_bcast_real    ( ALBEDOMAXTBL , NLUS )
+      CALL wrf_dm_bcast_real    ( ZTOPVTBL , NLUS )
+      CALL wrf_dm_bcast_real    ( ZBOTVTBL , NLUS )
+      CALL wrf_dm_bcast_real    ( MAXALB  , NLUS )
+      CALL wrf_dm_bcast_real    ( TOPT_DATA    , 1 )
+      CALL wrf_dm_bcast_real    ( CMCMAX_DATA  , 1 )
+      CALL wrf_dm_bcast_real    ( CFACTR_DATA  , 1 )
+      CALL wrf_dm_bcast_real    ( RSMAX_DATA  , 1 )
+      CALL wrf_dm_bcast_integer ( BARE    , 1 )
+      CALL wrf_dm_bcast_integer ( NATURAL , 1 )
+
+!
+!-----READ IN SOIL PROPERTIES FROM SOILPARM.TBL
+!
+      IF ( wrf_dm_on_monitor() ) THEN
+        OPEN(19, FILE='SOILPARM.TBL',FORM='FORMATTED',STATUS='OLD',IOSTAT=ierr)
+        IF(ierr .NE. OPEN_OK ) THEN
+          WRITE(message,FMT='(A)') &
+          'module_sf_noahlsm.F: soil_veg_gen_parm: failure opening SOILPARM.TBL'
+          CALL wrf_error_fatal ( message )
+        END IF
+
+        WRITE(mess,*) 'INPUT SOIL TEXTURE CLASSIFICATION = ', TRIM ( MMINSL )
+        CALL wrf_message( mess )
+
+        LUMATCH=0
+
+        READ (19,*)
+        READ (19,2000,END=2003)SLTYPE
+ 2000   FORMAT (A4)
+        READ (19,*)SLCATS,IINDEX
+        IF(SLTYPE.EQ.MMINSL)THEN
+            WRITE( mess , * ) 'SOIL TEXTURE CLASSIFICATION = ', TRIM ( SLTYPE ) , ' FOUND', &
+                  SLCATS,' CATEGORIES'
+            CALL wrf_message ( mess )
+          LUMATCH=1
+        ENDIF
+! prevent possible array overwrite, Bill Bovermann, IBM, May 6, 2008
+        IF ( SIZE(BB    ) < SLCATS .OR. &
+             SIZE(DRYSMC) < SLCATS .OR. &
+             SIZE(F11   ) < SLCATS .OR. &
+             SIZE(MAXSMC) < SLCATS .OR. &
+             SIZE(REFSMC) < SLCATS .OR. &
+             SIZE(SATPSI) < SLCATS .OR. &
+             SIZE(SATDK ) < SLCATS .OR. &
+             SIZE(SATDW ) < SLCATS .OR. &
+             SIZE(WLTSMC) < SLCATS .OR. &
+             SIZE(QTZ   ) < SLCATS  ) THEN
+           CALL wrf_error_fatal('Table sizes too small for value of SLCATS in module_sf_noahdrv.F')
+        ENDIF
+        IF(SLTYPE.EQ.MMINSL)THEN
+          DO LC=1,SLCATS
+              READ (19,*) IINDEX,BB(LC),DRYSMC(LC),F11(LC),MAXSMC(LC),&
+                        REFSMC(LC),SATPSI(LC),SATDK(LC), SATDW(LC),   &
+                        WLTSMC(LC), QTZ(LC)
+          ENDDO
+        ENDIF
+
+ 2003   CONTINUE
+
+        CLOSE (19)
+      ENDIF
+
+      CALL wrf_dm_bcast_integer ( LUMATCH , 1 )
+      CALL wrf_dm_bcast_string  ( SLTYPE  , 4 )
+      CALL wrf_dm_bcast_string  ( MMINSL  , 4 )  ! since this is reset above, see oct2 ^
+      CALL wrf_dm_bcast_integer ( SLCATS  , 1 )
+      CALL wrf_dm_bcast_integer ( IINDEX  , 1 )
+      CALL wrf_dm_bcast_real    ( BB      , NSLTYPE )
+      CALL wrf_dm_bcast_real    ( DRYSMC  , NSLTYPE )
+      CALL wrf_dm_bcast_real    ( F11     , NSLTYPE )
+      CALL wrf_dm_bcast_real    ( MAXSMC  , NSLTYPE )
+      CALL wrf_dm_bcast_real    ( REFSMC  , NSLTYPE )
+      CALL wrf_dm_bcast_real    ( SATPSI  , NSLTYPE )
+      CALL wrf_dm_bcast_real    ( SATDK   , NSLTYPE )
+      CALL wrf_dm_bcast_real    ( SATDW   , NSLTYPE )
+      CALL wrf_dm_bcast_real    ( WLTSMC  , NSLTYPE )
+      CALL wrf_dm_bcast_real    ( QTZ     , NSLTYPE )
+
+      IF(LUMATCH.EQ.0)THEN
+          CALL wrf_message( 'SOIl TEXTURE IN INPUT FILE DOES NOT ' )
+          CALL wrf_message( 'MATCH SOILPARM TABLE'                 )
+          CALL wrf_error_fatal ( 'INCONSISTENT OR MISSING SOILPARM FILE' )
+      ENDIF
+
+!
+!-----READ IN GENERAL PARAMETERS FROM GENPARM.TBL
+!
+      IF ( wrf_dm_on_monitor() ) THEN
+        OPEN(19, FILE='GENPARM.TBL',FORM='FORMATTED',STATUS='OLD',IOSTAT=ierr)
+        IF(ierr .NE. OPEN_OK ) THEN
+          WRITE(message,FMT='(A)') &
+          'module_sf_noahlsm.F: soil_veg_gen_parm: failure opening GENPARM.TBL'
+          CALL wrf_error_fatal ( message )
+        END IF
+
+        READ (19,*)
+        READ (19,*)
+        READ (19,*) NUM_SLOPE
+
+          SLPCATS=NUM_SLOPE
+! prevent possible array overwrite, Bill Bovermann, IBM, May 6, 2008
+          IF ( SIZE(slope_data) < NUM_SLOPE ) THEN
+            CALL wrf_error_fatal('NUM_SLOPE too large for slope_data array in module_sf_noahdrv')
+          ENDIF
+
+          DO LC=1,SLPCATS
+              READ (19,*)SLOPE_DATA(LC)
+          ENDDO
+
+          READ (19,*)
+          READ (19,*)SBETA_DATA
+          READ (19,*)
+          READ (19,*)FXEXP_DATA
+          READ (19,*)
+          READ (19,*)CSOIL_DATA
+          READ (19,*)
+          READ (19,*)SALP_DATA
+          READ (19,*)
+          READ (19,*)REFDK_DATA
+          READ (19,*)
+          READ (19,*)REFKDT_DATA
+          READ (19,*)
+          READ (19,*)FRZK_DATA
+          READ (19,*)
+          READ (19,*)ZBOT_DATA
+          READ (19,*)
+          READ (19,*)CZIL_DATA
+          READ (19,*)
+          READ (19,*)SMLOW_DATA
+          READ (19,*)
+          READ (19,*)SMHIGH_DATA
+          READ (19,*)
+          READ (19,*)LVCOEF_DATA
+        CLOSE (19)
+      ENDIF
+
+      CALL wrf_dm_bcast_integer ( NUM_SLOPE    ,  1 )
+      CALL wrf_dm_bcast_integer ( SLPCATS      ,  1 )
+      CALL wrf_dm_bcast_real    ( SLOPE_DATA   ,  NSLOPE )
+      CALL wrf_dm_bcast_real    ( SBETA_DATA   ,  1 )
+      CALL wrf_dm_bcast_real    ( FXEXP_DATA   ,  1 )
+      CALL wrf_dm_bcast_real    ( CSOIL_DATA   ,  1 )
+      CALL wrf_dm_bcast_real    ( SALP_DATA    ,  1 )
+      CALL wrf_dm_bcast_real    ( REFDK_DATA   ,  1 )
+      CALL wrf_dm_bcast_real    ( REFKDT_DATA  ,  1 )
+      CALL wrf_dm_bcast_real    ( FRZK_DATA    ,  1 )
+      CALL wrf_dm_bcast_real    ( ZBOT_DATA    ,  1 )
+      CALL wrf_dm_bcast_real    ( CZIL_DATA    ,  1 )
+      CALL wrf_dm_bcast_real    ( SMLOW_DATA   ,  1 )
+      CALL wrf_dm_bcast_real    ( SMHIGH_DATA  ,  1 )
+      CALL wrf_dm_bcast_real    ( LVCOEF_DATA  ,  1 )
+
+
+!-----------------------------------------------------------------
+      END SUBROUTINE SOIL_VEG_GEN_PARM
+!-----------------------------------------------------------------
+
+!===========================================================================
+!
+! subroutine lsm_mosaic: a tiling approach for Noah LSM
+!
+!=========================================================================== 
+
+SUBROUTINE lsm_mosaic(DZ8W,QV3D,P8W3D,T3D,TSK,                      &
+                  HFX,QFX,LH,GRDFLX, QGH,GSW,SWDOWN,GLW,SMSTAV,SMSTOT, &
+                  SFCRUNOFF, UDRUNOFF,IVGTYP,ISLTYP,ISURBAN,ISICE,VEGFRA,    &
+                  ALBEDO,ALBBCK,ZNT,Z0,TMN,XLAND,XICE,EMISS,EMBCK,   &
+                  SNOWC,QSFC,RAINBL,MMINLU,                     &
+                  num_soil_layers,DT,DZS,ITIMESTEP,             &
+                  SMOIS,TSLB,SNOW,CANWAT,                       &
+                  CHS,CHS2,CQS2,CPM,ROVCP,SR,chklowq,lai,qz0,   & !H
+                  myj,frpcpn,                                   &
+                  SH2O,SNOWH,                                   & !H
+                  U_PHY,V_PHY,                                  & !I
+                  SNOALB,SHDMIN,SHDMAX,                         & !I
+                  SNOTIME,                                      & !?
+                  ACSNOM,ACSNOW,                                & !O
+                  SNOPCX,                                       & !O
+                  POTEVP,                                       & !O
+                  SMCREL,                                       & !O
+                  XICE_THRESHOLD,                               &
+                  RDLAI2D,USEMONALB,                            &
+                  RIB,                                          & !?
+                  NOAHRES,                                      &
+                 NLCAT,landusef,landusef2,                       & ! danli mosaic
+                 sf_surface_mosaic,mosaic_cat,mosaic_cat_index,  & ! danli mosaic 
+                 TSK_mosaic,QSFC_mosaic,                         & ! danli mosaic 
+                 TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic,           & ! danli mosaic 
+                 CANWAT_mosaic,SNOW_mosaic,                      & ! danli mosaic
+                 SNOWH_mosaic,SNOWC_mosaic,                      & ! danli mosaic 
+                 ALBEDO_mosaic,ALBBCK_mosaic,                    & ! danli mosaic
+                 EMISS_mosaic, EMBCK_mosaic,                     & ! danli mosaic
+                 ZNT_mosaic, Z0_mosaic,                          & ! danli mosaic 
+                 HFX_mosaic,QFX_mosaic,                          & ! danli mosaic
+                 LH_mosaic, GRDFLX_mosaic, SNOTIME_mosaic,       & ! danli mosaic                   
+! Noah UA changes
+                  ua_phys,flx4_2d,fvb_2d,fbur_2d,fgsn_2d,       &
+                  ids,ide, jds,jde, kds,kde,                    &
+                  ims,ime, jms,jme, kms,kme,                    &
+                  its,ite, jts,jte, kts,kte,                    &
+                  sf_urban_physics,                             &
+                  CMR_SFCDIF,CHR_SFCDIF,CMC_SFCDIF,CHC_SFCDIF,  &
+                  CMGR_SFCDIF,CHGR_SFCDIF,                      &
+!Optional Urban
+                  TR_URB2D,TB_URB2D,TG_URB2D,TC_URB2D,QC_URB2D, & !H urban
+                  UC_URB2D,                                     & !H urban
+                  XXXR_URB2D,XXXB_URB2D,XXXG_URB2D,XXXC_URB2D,  & !H urban
+                  TRL_URB3D,TBL_URB3D,TGL_URB3D,                & !H urban
+                  SH_URB2D,LH_URB2D,G_URB2D,RN_URB2D,TS_URB2D,  & !H urban
+                  TR_URB2D_mosaic,TB_URB2D_mosaic,              & !H urban  danli mosaic
+                  TG_URB2D_mosaic,TC_URB2D_mosaic,              & !H urban  danli mosaic
+                  QC_URB2D_mosaic,UC_URB2D_mosaic,              & !H urban  danli mosaic                  
+                  TRL_URB3D_mosaic,TBL_URB3D_mosaic,            & !H urban  danli mosaic
+                  TGL_URB3D_mosaic,                             & !H urban  danli mosaic
+                  SH_URB2D_mosaic,LH_URB2D_mosaic,              & !H urban  danli mosaic
+                  G_URB2D_mosaic,RN_URB2D_mosaic,               & !H urban  danli mosaic
+                  TS_URB2D_mosaic,                              & !H urban  danli mosaic
+                  TS_RUL2D_mosaic,                              & !H urban  danli mosaic                  
+                  PSIM_URB2D,PSIH_URB2D,U10_URB2D,V10_URB2D,    & !O urban
+                  GZ1OZ0_URB2D,  AKMS_URB2D,                    & !O urban
+                  TH2_URB2D,Q2_URB2D, UST_URB2D,                & !O urban
+                  DECLIN_URB,COSZ_URB2D,OMG_URB2D,              & !I urban
+                  XLAT_URB2D,                                   & !I urban
+                  num_roof_layers, num_wall_layers,             & !I urban
+                  num_road_layers, DZR, DZB, DZG,               & !I urban
+                  CMCR_URB2D,TGR_URB2D,TGRL_URB3D,SMR_URB3D,    & !H urban
+                  julian,julyr,                                 & !H urban
+                  DRELR_URB2D,DRELB_URB2D,DRELG_URB2D,          & !H urban
+                  FLXHUMR_URB2D,FLXHUMB_URB2D,FLXHUMG_URB2D,    & !H urban
+                  FRC_URB2D,UTYPE_URB2D,                        & !O
+                  num_urban_layers,                             & !I multi-layer urban
+                  num_urban_hi,                                 & !I multi-layer urban
+                  trb_urb4d,tw1_urb4d,tw2_urb4d,tgb_urb4d,      & !H multi-layer urban
+                  tlev_urb3d,qlev_urb3d,                        & !H multi-layer urban
+                  tw1lev_urb3d,tw2lev_urb3d,                    & !H multi-layer urban
+                  tglev_urb3d,tflev_urb3d,                      & !H multi-layer urban
+                  sf_ac_urb3d,lf_ac_urb3d,cm_ac_urb3d,          & !H multi-layer urban
+                  sfvent_urb3d,lfvent_urb3d,                    & !H multi-layer urban
+                  sfwin1_urb3d,sfwin2_urb3d,                    & !H multi-layer urban
+                  sfw1_urb3d,sfw2_urb3d,sfr_urb3d,sfg_urb3d,    & !H multi-layer urban
+                  lp_urb2d,hi_urb2d,lb_urb2d,hgt_urb2d,         & !H multi-layer urban
+                  mh_urb2d,stdh_urb2d,lf_urb2d,                 & !SLUCM
+                  th_phy,rho,p_phy,ust,                         & !I multi-layer urban
+                  gmt,julday,xlong,xlat,                        & !I multi-layer urban
+                  a_u_bep,a_v_bep,a_t_bep,a_q_bep,              & !O multi-layer urban
+                  a_e_bep,b_u_bep,b_v_bep,                      & !O multi-layer urban
+                  b_t_bep,b_q_bep,b_e_bep,dlg_bep,              & !O multi-layer urban
+                  dl_u_bep,sf_bep,vl_bep,sfcheadrt,INFXSRT, soldrain      )   !O multi-layer urban         
+
+!----------------------------------------------------------------
+    IMPLICIT NONE
+!----------------------------------------------------------------
+!----------------------------------------------------------------
+! --- atmospheric (WRF generic) variables
+!-- DT          time step (seconds)
+!-- DZ8W        thickness of layers (m)
+!-- T3D         temperature (K)
+!-- QV3D        3D water vapor mixing ratio (Kg/Kg)
+!-- P3D         3D pressure (Pa)
+!-- FLHC        exchange coefficient for heat (m/s)
+!-- FLQC        exchange coefficient for moisture (m/s)
+!-- PSFC        surface pressure (Pa)
+!-- XLAND       land mask (1 for land, 2 for water)
+!-- QGH         saturated mixing ratio at 2 meter
+!-- GSW         downward short wave flux at ground surface (W/m^2)
+!-- GLW         downward long wave flux at ground surface (W/m^2)
+!-- History variables
+!-- CANWAT      canopy moisture content (mm)
+!-- TSK         surface temperature (K)
+!-- TSLB        soil temp (k)
+!-- SMOIS       total soil moisture content (volumetric fraction)
+!-- SH2O        unfrozen soil moisture content (volumetric fraction)
+!                note: frozen soil moisture (i.e., soil ice) = SMOIS - SH2O
+!-- SNOWH       actual snow depth (m)
+!-- SNOW        liquid water-equivalent snow depth (m)
+!-- ALBEDO      time-varying surface albedo including snow effect (unitless fraction)
+!-- ALBBCK      background surface albedo (unitless fraction)
+!-- CHS          surface exchange coefficient for heat and moisture (m s-1);
+!-- CHS2        2m surface exchange coefficient for heat  (m s-1);
+!-- CQS2        2m surface exchange coefficient for moisture (m s-1);
+! --- soil variables
+!-- num_soil_layers   the number of soil layers
+!-- ZS          depths of centers of soil layers   (m)
+!-- DZS         thicknesses of soil layers (m)
+!-- SLDPTH      thickness of each soil layer (m, same as DZS)
+!-- TMN         soil temperature at lower boundary (K)
+!-- SMCWLT      wilting point (volumetric)
+!-- SMCDRY      dry soil moisture threshold where direct evap from
+!               top soil layer ends (volumetric)
+!-- SMCREF      soil moisture threshold below which transpiration begins to
+!                   stress (volumetric)
+!-- SMCMAX      porosity, i.e. saturated value of soil moisture (volumetric)
+!-- NROOT       number of root layers, a function of veg type, determined
+!               in subroutine redprm.
+!-- SMSTAV      Soil moisture availability for evapotranspiration (
+!                   fraction between SMCWLT and SMCMXA)
+!-- SMSTOT      Total soil moisture content frozen+unfrozen) in the soil column (mm)
+! --- snow variables
+!-- SNOWC       fraction snow coverage (0-1.0)
+! --- vegetation variables
+!-- SNOALB      upper bound on maximum albedo over deep snow
+!-- SHDMIN      minimum areal fractional coverage of annual green vegetation
+!-- SHDMAX      maximum areal fractional coverage of annual green vegetation
+!-- XLAI        leaf area index (dimensionless)
+!-- Z0BRD       Background fixed roughness length (M)
+!-- Z0          Background vroughness length (M) as function
+!-- ZNT         Time varying roughness length (M) as function
+!-- ALBD(IVGTPK,ISN) background albedo reading from a table
+! --- LSM output
+!-- HFX         upward heat flux at the surface (W/m^2)
+!-- QFX         upward moisture flux at the surface (kg/m^2/s)
+!-- LH          upward moisture flux at the surface (W m-2)
+!-- GRDFLX(I,J) ground heat flux (W m-2)
+!-- FDOWN       radiation forcing at the surface (W m-2) = SOLDN*(1-alb)+LWDN
+!----------------------------------------------------------------------------
+!-- EC          canopy water evaporation ((W m-2)
+!-- EDIR        direct soil evaporation (W m-2)
+!-- ET          plant transpiration from a particular root layer (W m-2)
+!-- ETT         total plant transpiration (W m-2)
+!-- ESNOW       sublimation from (or deposition to if <0) snowpack (W m-2)
+!-- DRIP        through-fall of precip and/or dew in excess of canopy
+!                 water-holding capacity (m)
+!-- DEW         dewfall (or frostfall for t<273.15) (M)
+!-- SMAV        Soil Moisture Availability for each layer, as a fraction
+!                 between SMCWLT and SMCMAX (dimensionless fraction)
+! ----------------------------------------------------------------------
+!-- BETA        ratio of actual/potential evap (dimensionless)
+!-- ETP         potential evaporation (W m-2)
+! ----------------------------------------------------------------------
+!-- FLX1        precip-snow sfc (W m-2)
+!-- FLX2        freezing rain latent heat flux (W m-2)
+!-- FLX3        phase-change heat flux from snowmelt (W m-2)
+! ----------------------------------------------------------------------
+!-- ACSNOM      snow melt (mm) (water equivalent)
+!-- ACSNOW      accumulated snow fall (mm) (water equivalent)
+!-- SNOPCX      snow phase change heat flux (W/m^2)
+!-- POTEVP      accumulated potential evaporation (m)
+!-- RIB         Documentation needed!!!
+! ----------------------------------------------------------------------
+!-- RUNOFF1     surface runoff (m s-1), not infiltrating the surface
+!-- RUNOFF2     subsurface runoff (m s-1), drainage out bottom of last
+!                  soil layer (baseflow)
+!  important note: here RUNOFF2 is actually the sum of RUNOFF2 and RUNOFF3
+!-- RUNOFF3     numerical trunctation in excess of porosity (smcmax)
+!                  for a given soil layer at the end of a time step (m s-1).
+!SFCRUNOFF     Surface Runoff (mm)
+!UDRUNOFF      Total Underground Runoff (mm), which is the sum of RUNOFF2 and RUNOFF3
+! ----------------------------------------------------------------------
+!-- RC          canopy resistance (s m-1)
+!-- PC          plant coefficient (unitless fraction, 0-1) where PC*ETP = actual transp
+!-- RSMIN       minimum canopy resistance (s m-1)
+!-- RCS         incoming solar rc factor (dimensionless)
+!-- RCT         air temperature rc factor (dimensionless)
+!-- RCQ         atmos vapor pressure deficit rc factor (dimensionless)
+!-- RCSOIL      soil moisture rc factor (dimensionless)
+
+!-- EMISS       surface emissivity (between 0 and 1)
+!-- EMBCK       Background surface emissivity (between 0 and 1)
+
+!-- ROVCP       R/CP
+!               (R_d/R_v) (dimensionless)
+!-- ids         start index for i in domain
+!-- ide         end index for i in domain
+!-- jds         start index for j in domain
+!-- jde         end index for j in domain
+!-- kds         start index for k in domain
+!-- kde         end index for k in domain
+!-- ims         start index for i in memory
+!-- ime         end index for i in memory
+!-- jms         start index for j in memory
+!-- jme         end index for j in memory
+!-- kms         start index for k in memory
+!-- kme         end index for k in memory
+!-- its         start index for i in tile
+!-- ite         end index for i in tile
+!-- jts         start index for j in tile
+!-- jte         end index for j in tile
+!-- kts         start index for k in tile
+!-- kte         end index for k in tile
+!
+!-- SR          fraction of frozen precip (0.0 to 1.0)
+!----------------------------------------------------------------
+
+! IN only
+
+   INTEGER,  INTENT(IN   )   ::     ids,ide, jds,jde, kds,kde,  &
+                                    ims,ime, jms,jme, kms,kme,  &
+                                    its,ite, jts,jte, kts,kte
+
+   INTEGER,  INTENT(IN   )   ::  sf_urban_physics               !urban
+   INTEGER,  INTENT(IN   )   ::  isurban
+   INTEGER,  INTENT(IN   )   ::  isice
+   INTEGER,  INTENT(IN   )   ::  julian,julyr
+
+!added by Wei Yu  for routing
+    REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+             INTENT(INOUT)  :: sfcheadrt,INFXSRT,soldrain 
+    real :: etpnd1
+!end added
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN   )    ::                            TMN, &
+                                                         XLAND, &
+                                                          XICE, &
+                                                        VEGFRA, &
+                                                        SHDMIN, &
+                                                        SHDMAX, &
+                                                        SNOALB, &
+                                                           GSW, &
+                                                        SWDOWN, & !added 10 jan 2007
+                                                           GLW, &
+                                                        RAINBL, &
+                                                        SR
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)    ::                         ALBBCK, &
+                                                            Z0, &
+                                                         EMBCK                  ! danli mosaic
+                                                         
+   CHARACTER(LEN=*), INTENT(IN   )    ::                 MMINLU
+
+   REAL,    DIMENSION( ims:ime, kms:kme, jms:jme )            , &
+            INTENT(IN   )    ::                           QV3D, &
+                                                         p8w3D, &
+                                                          DZ8W, &
+                                                          T3D
+   REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+             INTENT(IN   )               ::               QGH,  &
+                                                          CPM
+
+   INTEGER, DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN   )    ::                          ISLTYP
+                                                        
+   INTEGER, DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT   )    ::                         IVGTYP                   ! for mosaic danli
+
+   INTEGER, INTENT(IN)       ::     num_soil_layers,ITIMESTEP
+
+   REAL,     INTENT(IN   )   ::     DT,ROVCP
+
+   REAL,     DIMENSION(1:num_soil_layers), INTENT(IN)::DZS
+
+! IN and OUT
+
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ), &
+             INTENT(INOUT)   ::                          SMOIS, & ! total soil moisture
+                                                         SH2O,  & ! new soil liquid
+                                                         TSLB     ! TSLB     STEMP
+
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ), &
+             INTENT(OUT)     ::                         SMCREL
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)    ::                            TSK, & !was TGB (temperature)
+                                                           HFX, &
+                                                           QFX, &
+                                                            LH, &
+                                                        GRDFLX, &
+                                                          QSFC,&
+                                                          CQS2,&
+                                                          CHS,   &
+                                                          CHS2,&
+                                                          SNOW, &
+                                                         SNOWC, &
+                                                         SNOWH, & !new
+                                                        CANWAT, &
+                                                        SMSTAV, &
+                                                        SMSTOT, &
+                                                     SFCRUNOFF, &
+                                                      UDRUNOFF, &
+                                                        ACSNOM, &
+                                                        ACSNOW, &
+                                                       SNOTIME, &
+                                                        SNOPCX, &
+                                                        EMISS,  &
+                                                          RIB,  &
+                                                        POTEVP, &
+                                                        ALBEDO, &
+                                                           ZNT
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(OUT)      ::                         NOAHRES
+
+! Noah UA changes
+   LOGICAL,                                INTENT(IN)  :: UA_PHYS
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: FLX4_2D,FVB_2D,FBUR_2D,FGSN_2D
+   REAL                                                :: FLX4,FVB,FBUR,FGSN
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+               INTENT(OUT)    ::                        CHKLOWQ
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LAI
+   REAL,DIMENSION(IMS:IME,JMS:JME),INTENT(IN) ::        QZ0
+
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMGR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHGR_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMC_SFCDIF
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CHC_SFCDIF
+! Local variables (moved here from driver to make routine thread safe, 20031007 jm)
+
+      REAL, DIMENSION(1:num_soil_layers) ::  ET
+
+      REAL, DIMENSION(1:num_soil_layers) ::  SMAV
+
+      REAL  ::  BETA, ETP, SSOIL,EC, EDIR, ESNOW, ETT,        &
+                FLX1,FLX2,FLX3, DRIP,DEW,FDOWN,RC,PC,RSMIN,XLAI,  &
+!                RCS,RCT,RCQ,RCSOIL
+                RCS,RCT,RCQ,RCSOIL,FFROZP
+
+    LOGICAL,    INTENT(IN   )    ::     myj,frpcpn
+
+! DECLARATIONS - LOGICAL
+! ----------------------------------------------------------------------
+      LOGICAL, PARAMETER :: LOCAL=.false.
+      LOGICAL :: FRZGRA, SNOWNG
+
+      LOGICAL :: IPRINT
+
+! ----------------------------------------------------------------------
+! DECLARATIONS - INTEGER
+! ----------------------------------------------------------------------
+      INTEGER :: I,J, ICE,NSOIL,SLOPETYP,SOILTYP,VEGTYP
+      INTEGER :: NROOT
+      INTEGER :: KZ ,K
+      INTEGER :: NS
+! ----------------------------------------------------------------------
+! DECLARATIONS - REAL
+! ----------------------------------------------------------------------
+
+      REAL  :: SHMIN,SHMAX,DQSDT2,LWDN,PRCP,PRCPRAIN,                    &
+               Q2SAT,Q2SATI,SFCPRS,SFCSPD,SFCTMP,SHDFAC,SNOALB1,         &
+               SOLDN,TBOT,ZLVL, Q2K,ALBBRD, ALBEDOK, ETA, ETA_KINEMATIC, &
+               EMBRD,                                                    &
+               Z0K,RUNOFF1,RUNOFF2,RUNOFF3,SHEAT,SOLNET,E2SAT,SFCTSNO,   &
+! mek, WRF testing, expanded diagnostics
+               SOLUP,LWUP,RNET,RES,Q1SFC,TAIRV,SATFLG
+! MEK MAY 2007
+      REAL ::  FDTLIW
+! MEK JUL2007 for pot. evap.
+      REAL :: RIBB
+      REAL ::  FDTW
+
+      REAL  :: EMISSI
+
+      REAL  :: SNCOVR,SNEQV,SNOWHK,CMC, CHK,TH2
+
+      REAL  :: SMCDRY,SMCMAX,SMCREF,SMCWLT,SNOMLT,SOILM,SOILW,Q1,T1
+      REAL  :: SNOTIME1    ! LSTSNW1 INITIAL NUMBER OF TIMESTEPS SINCE LAST SNOWFALL
+
+      REAL  :: DUMMY,Z0BRD
+!
+      REAL  :: COSZ, SOLARDIRECT
+!
+      REAL, DIMENSION(1:num_soil_layers)::  SLDPTH, STC,SMC,SWC
+!
+      REAL, DIMENSION(1:num_soil_layers) ::     ZSOIL, RTDIS
+      REAL, PARAMETER  :: TRESH=.95E0, A2=17.67,A3=273.15,A4=29.65,   &
+                          T0=273.16E0, ELWV=2.50E6,  A23M4=A2*(A3-A4)
+! MEK MAY 2007
+      REAL, PARAMETER  :: ROW=1.E3,ELIW=XLF,ROWLIW=ROW*ELIW
+
+! ----------------------------------------------------------------------
+! DECLARATIONS START - urban
+! ----------------------------------------------------------------------
+
+! input variables surface_driver --> lsm
+     INTEGER, INTENT(IN) :: num_roof_layers
+     INTEGER, INTENT(IN) :: num_wall_layers
+     INTEGER, INTENT(IN) :: num_road_layers
+     REAL, OPTIONAL, DIMENSION(1:num_roof_layers), INTENT(IN) :: DZR
+     REAL, OPTIONAL, DIMENSION(1:num_wall_layers), INTENT(IN) :: DZB
+     REAL, OPTIONAL, DIMENSION(1:num_road_layers), INTENT(IN) :: DZG
+     REAL, OPTIONAL, INTENT(IN) :: DECLIN_URB
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: COSZ_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: OMG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: XLAT_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: U_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: V_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: TH_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: P_PHY
+     REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(IN) :: RHO
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: UST
+
+     LOGICAL, intent(in) :: rdlai2d
+     LOGICAL, intent(in) :: USEMONALB
+
+! input variables lsm --> urban
+     INTEGER :: UTYPE_URB ! urban type [urban=1, suburban=2, rural=3]
+     REAL :: TA_URB       ! potential temp at 1st atmospheric level [K]
+     REAL :: QA_URB       ! mixing ratio at 1st atmospheric level  [kg/kg]
+     REAL :: UA_URB       ! wind speed at 1st atmospheric level    [m/s]
+     REAL :: U1_URB       ! u at 1st atmospheric level             [m/s]
+     REAL :: V1_URB       ! v at 1st atmospheric level             [m/s]
+     REAL :: SSG_URB      ! downward total short wave radiation    [W/m/m]
+     REAL :: LLG_URB      ! downward long wave radiation           [W/m/m]
+     REAL :: RAIN_URB     ! precipitation                          [mm/h]
+     REAL :: RHOO_URB     ! air density                            [kg/m^3]
+     REAL :: ZA_URB       ! first atmospheric level                [m]
+     REAL :: DELT_URB     ! time step                              [s]
+     REAL :: SSGD_URB     ! downward direct short wave radiation   [W/m/m]
+     REAL :: SSGQ_URB     ! downward diffuse short wave radiation  [W/m/m]
+     REAL :: XLAT_URB     ! latitude                               [deg]
+     REAL :: COSZ_URB     ! cosz
+     REAL :: OMG_URB      ! hour angle
+     REAL :: ZNT_URB      ! roughness length                       [m]
+     REAL :: TR_URB
+     REAL :: TB_URB
+     REAL :: TG_URB
+     REAL :: TC_URB
+     REAL :: QC_URB
+     REAL :: UC_URB
+     REAL :: XXXR_URB
+     REAL :: XXXB_URB
+     REAL :: XXXG_URB
+     REAL :: XXXC_URB
+     REAL, DIMENSION(1:num_roof_layers) :: TRL_URB  ! roof layer temp [K]
+     REAL, DIMENSION(1:num_wall_layers) :: TBL_URB  ! wall layer temp [K]
+     REAL, DIMENSION(1:num_road_layers) :: TGL_URB  ! road layer temp [K]
+     LOGICAL  :: LSOLAR_URB
+
+!===Yang,2014/10/08,hydrological variable for single layer UCM===
+     INTEGER :: jmonth, jday, tloc
+     INTEGER :: IRIOPTION, USOIL, DSOIL
+     REAL :: AOASIS, OMG
+     REAL :: DRELR_URB
+     REAL :: DRELB_URB
+     REAL :: DRELG_URB
+     REAL :: FLXHUMR_URB
+     REAL :: FLXHUMB_URB
+     REAL :: FLXHUMG_URB
+     REAL :: CMCR_URB
+     REAL :: TGR_URB
+     REAL, DIMENSION(1:num_roof_layers) :: SMR_URB  ! green roof layer moisture
+     REAL, DIMENSION(1:num_roof_layers) :: TGRL_URB ! green roof layer temp [K]
+
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: DRELG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FLXHUMR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FLXHUMB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FLXHUMG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: CMCR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TGR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_roof_layers, jms:jme ), INTENT(INOUT) :: TGRL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_roof_layers, jms:jme ), INTENT(INOUT) :: SMR_URB3D
+
+! state variable surface_driver <--> lsm <--> urban
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: QC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: UC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXR_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXB_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXG_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: XXXC_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: SH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: LH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: G_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: RN_URB2D
+!
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: TS_URB2D
+
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_roof_layers, jms:jme ), INTENT(INOUT) :: TRL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_wall_layers, jms:jme ), INTENT(INOUT) :: TBL_URB3D
+     REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_road_layers, jms:jme ), INTENT(INOUT) :: TGL_URB3D
+
+! output variable lsm --> surface_driver
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: PSIM_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: PSIH_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: GZ1OZ0_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: U10_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: V10_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: TH2_URB2D
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: Q2_URB2D
+!
+     REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: AKMS_URB2D
+!
+     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(OUT) :: UST_URB2D
+     REAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: FRC_URB2D                ! change this to inout, danli mosaic
+     INTEGER, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: UTYPE_URB2D
+
+! output variables urban --> lsm
+     REAL :: TS_URB     ! surface radiative temperature    [K]
+     REAL :: QS_URB     ! surface humidity                 [-]
+     REAL :: SH_URB     ! sensible heat flux               [W/m/m]
+     REAL :: LH_URB     ! latent heat flux                 [W/m/m]
+     REAL :: LH_KINEMATIC_URB ! latent heat flux, kinetic  [kg/m/m/s]
+     REAL :: SW_URB     ! upward short wave radiation flux [W/m/m]
+     REAL :: ALB_URB    ! time-varying albedo            [fraction]
+     REAL :: LW_URB     ! upward long wave radiation flux  [W/m/m]
+     REAL :: G_URB      ! heat flux into the ground        [W/m/m]
+     REAL :: RN_URB     ! net radiation                    [W/m/m]
+     REAL :: PSIM_URB   ! shear f for momentum             [-]
+     REAL :: PSIH_URB   ! shear f for heat                 [-]
+     REAL :: GZ1OZ0_URB   ! shear f for heat                 [-]
+     REAL :: U10_URB    ! wind u component at 10 m         [m/s]
+     REAL :: V10_URB    ! wind v component at 10 m         [m/s]
+     REAL :: TH2_URB    ! potential temperature at 2 m     [K]
+     REAL :: Q2_URB     ! humidity at 2 m                  [-]
+     REAL :: CHS_URB
+     REAL :: CHS2_URB
+     REAL :: UST_URB
+! NUDAPT Parameters urban --> lam
+     REAL :: mh_urb
+     REAL :: stdh_urb
+     REAL :: lp_urb
+     REAL :: hgt_urb
+     REAL, DIMENSION(4) :: lf_urb
+! Variables for multi-layer UCM (Martilli et al. 2002)
+   REAL, OPTIONAL, INTENT(IN  )   ::                                   GMT 
+   INTEGER, OPTIONAL, INTENT(IN  ) ::                               JULDAY
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN   )        ::XLAT, XLONG
+   INTEGER, INTENT(IN  ) ::                               NUM_URBAN_LAYERS
+   INTEGER, INTENT(IN  ) ::                               NUM_URBAN_HI
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: trb_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tgb_urb4d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tlev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: qlev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw1lev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tw2lev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tglev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: tflev_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lf_ac_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sf_ac_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: cm_ac_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: sfvent_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) :: lfvent_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin1_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfwin2_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw1_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfw2_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfr_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_layers, jms:jme ), INTENT(INOUT) :: sfg_urb3d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_urban_hi, jms:jme ), INTENT(IN) :: hi_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: lp_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: lb_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: hgt_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: mh_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme ), INTENT(IN) :: stdh_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, 4, jms:jme ), INTENT(IN) :: lf_urb2d
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_u_bep   !Implicit momemtum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_v_bep   !Implicit momemtum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_t_bep   !Implicit component pot. temperature
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_q_bep   !Implicit momemtum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::a_e_bep   !Implicit component TKE
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_u_bep   !Explicit momentum component X-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_v_bep   !Explicit momentum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_t_bep   !Explicit component pot. temperature
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_q_bep   !Implicit momemtum component Y-direction
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::b_e_bep   !Explicit component TKE
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::vl_bep    !Fraction air volume in grid cell
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::dlg_bep   !Height above ground
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::sf_bep  !Fraction air at the face of grid cell
+   REAL, OPTIONAL, DIMENSION( ims:ime, kms:kme, jms:jme ), INTENT(INOUT) ::dl_u_bep  !Length scale
+
+! Local variables for multi-layer UCM (Martilli et al. 2002)
+   REAL,    DIMENSION( its:ite, jts:jte ) :: HFX_RURAL,LH_RURAL,GRDFLX_RURAL ! ,RN_RURAL
+   REAL,    DIMENSION( its:ite, jts:jte ) :: QFX_RURAL ! ,QSFC_RURAL,UMOM_RURAL,VMOM_RURAL
+   REAL,    DIMENSION( its:ite, jts:jte ) :: ALB_RURAL,EMISS_RURAL,TSK_RURAL ! ,UST_RURAL
+!   REAL,    DIMENSION( ims:ime, jms:jme ) :: QSFC_URB
+   REAL,    DIMENSION( its:ite, jts:jte ) :: HFX_URB,UMOM_URB,VMOM_URB
+   REAL,    DIMENSION( its:ite, jts:jte ) :: QFX_URB
+!   REAL,    DIMENSION( ims:ime, jms:jme ) :: ALBEDO_URB,EMISS_URB,UMOM,VMOM,UST
+   REAL, DIMENSION(its:ite,jts:jte) ::EMISS_URB
+   REAL, DIMENSION(its:ite,jts:jte) :: RL_UP_URB
+   REAL, DIMENSION(its:ite,jts:jte) ::RS_ABS_URB
+   REAL, DIMENSION(its:ite,jts:jte) ::GRDFLX_URB
+   REAL :: SIGMA_SB,RL_UP_RURAL,RL_UP_TOT,RS_ABS_TOT,UMOM,VMOM
+   REAL :: r1,r2,r3
+   REAL :: CMR_URB, CHR_URB, CMC_URB, CHC_URB, CMGR_URB, CHGR_URB
+   REAL :: frc_urb,lb_urb
+   REAL :: check 
+! ----------------------------------------------------------------------
+! DECLARATIONS END - urban
+! ----------------------------------------------------------------------
+!-------------------------------------------------
+! Noah-mosaic related variables are added to declaration  (danli)
+!-------------------------------------------------
+  
+  INTEGER, INTENT(IN) :: sf_surface_mosaic    
+  INTEGER, INTENT(IN) :: mosaic_cat, NLCAT
+  REAL, DIMENSION( ims:ime, NLCAT, jms:jme ), INTENT(IN) :: landusef 
+  REAL, DIMENSION( ims:ime, NLCAT, jms:jme ), INTENT(INOUT) ::landusef2 
+  INTEGER, DIMENSION( ims:ime, NLCAT, jms:jme ), INTENT(INOUT) :: mosaic_cat_index 
+
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        TSK_mosaic, QSFC_mosaic, CANWAT_mosaic, SNOW_mosaic,SNOWH_mosaic, SNOWC_mosaic 
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        ALBEDO_mosaic,ALBBCK_mosaic, EMISS_mosaic, EMBCK_mosaic, ZNT_mosaic, Z0_mosaic,   &
+        HFX_mosaic,QFX_mosaic, LH_mosaic, GRDFLX_mosaic,SNOTIME_mosaic    
+  REAL, DIMENSION( ims:ime, 1:num_soil_layers*mosaic_cat, jms:jme ), OPTIONAL, INTENT(INOUT)::   &
+        TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic
+  REAL, DIMENSION( ims:ime, jms:jme ) :: TSK_mosaic_avg, QSFC_mosaic_avg, CANWAT_mosaic_avg,SNOW_mosaic_avg,SNOWH_mosaic_avg, &
+                                         SNOWC_mosaic_avg, HFX_mosaic_avg, QFX_mosaic_avg, LH_mosaic_avg, GRDFLX_mosaic_avg,  &
+                                         ALBEDO_mosaic_avg, ALBBCK_mosaic_avg, EMISS_mosaic_avg, EMBCK_mosaic_avg,            &
+                                         ZNT_mosaic_avg, Z0_mosaic_avg, SNOTIME_mosaic_avg, FAREA_mosaic_avg  
+  REAL, DIMENSION( ims:ime, 1:num_soil_layers, jms:jme )                     ::   &
+        TSLB_mosaic_avg,SMOIS_mosaic_avg,SH2O_mosaic_avg
+  
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        TR_URB2D_mosaic, TB_URB2D_mosaic, TG_URB2D_mosaic, TC_URB2D_mosaic,QC_URB2D_mosaic, UC_URB2D_mosaic, &
+        SH_URB2D_mosaic,LH_URB2D_mosaic,G_URB2D_mosaic,RN_URB2D_mosaic,TS_URB2D_mosaic, TS_RUL2D_mosaic  
+                  
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_roof_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TRL_URB3D_mosaic
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_wall_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TBL_URB3D_mosaic
+   REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_road_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TGL_URB3D_mosaic
+
+  INTEGER, DIMENSION( ims:ime, jms:jme ) ::    IVGTYP_dominant
+  INTEGER ::  mosaic_i, URBAN_METHOD, zo_avg_option
+  REAL :: FAREA
+  LOGICAL :: IPRINT_mosaic, Noah_call
+!-------------------------------------------------
+! Noah-mosaic related variables declaration end (danli)
+!-------------------------------------------------
+
+  REAL, PARAMETER  :: CAPA=R_D/CP
+  REAL :: APELM,APES,SFCTH2,PSFC
+  real, intent(in) :: xice_threshold
+  character(len=80) :: message_text
+
+! MEK MAY 2007
+      FDTLIW=DT/ROWLIW
+! MEK JUL2007
+      FDTW=DT/(XLV*RHOWATER)
+! debug printout
+      IPRINT=.false.
+      IPRINT_mosaic=.false.
+
+!      SLOPETYP=2
+      SLOPETYP=1
+!      SHDMIN=0.00
+
+      NSOIL=num_soil_layers
+
+     DO NS=1,NSOIL
+     SLDPTH(NS)=DZS(NS)
+     ENDDO
+
+     JLOOP : DO J=jts,jte
+
+      IF(ITIMESTEP.EQ.1)THEN
+        DO 50 I=its,ite
+!*** initialize soil conditions for IHOP 31 May case
+!         IF((XLAND(I,J)-1.5) < 0.)THEN
+!            if (I==108.and.j==85) then
+!                  DO NS=1,NSOIL
+!                      SMOIS(I,NS,J)=0.10
+!                      SH2O(I,NS,J)=0.10
+!                  enddo
+!             endif
+!         ENDIF
+
+!*** SET ZERO-VALUE FOR SOME OUTPUT DIAGNOSTIC ARRAYS
+          IF((XLAND(I,J)-1.5).GE.0.)THEN
+! check sea-ice point
+#if 0
+            IF( XICE(I,J).GE. XICE_THRESHOLD .and. IPRINT ) PRINT*, ' sea-ice at water point, I=',I,'J=',J
+#endif
+!***   Open Water Case
+            SMSTAV(I,J)=1.0
+            SMSTOT(I,J)=1.0
+            DO NS=1,NSOIL
+              SMOIS(I,NS,J)=1.0
+              TSLB(I,NS,J)=273.16                                          !STEMP
+              SMCREL(I,NS,J)=1.0
+            ENDDO
+          ELSE
+            IF ( XICE(I,J) .GE. XICE_THRESHOLD ) THEN
+!***        SEA-ICE CASE
+              SMSTAV(I,J)=1.0
+              SMSTOT(I,J)=1.0
+              DO NS=1,NSOIL
+                SMOIS(I,NS,J)=1.0
+                SMCREL(I,NS,J)=1.0
+              ENDDO
+            ENDIF
+          ENDIF
+!
+   50   CONTINUE
+      ENDIF                                                               ! end of initialization over ocean
+
+!-----------------------------------------------------------------------
+      ILOOP : DO I=its,ite
+      
+         IF (((XLAND(I,J)-1.5).LT.0.) .AND. (XICE(I,J) < XICE_THRESHOLD) ) THEN
+               
+               IVGTYP_dominant(I,J)=IVGTYP(I,J)                                   ! save this
+      
+            ! INITIALIZE THE AREA-AVERAGED FLUXES 
+               
+                 TSK_mosaic_avg(i,j)= 0                              ! from 3D to 2D
+                 QSFC_mosaic_avg(i,j)= 0
+                 CANWAT_mosaic_avg(i,j)= 0
+                 SNOW_mosaic_avg(i,j)= 0
+                 SNOWH_mosaic_avg(i,j)= 0
+                 SNOWC_mosaic_avg(i,j)= 0
+            
+                          DO NS=1,NSOIL
+            
+                     TSLB_mosaic_avg(i,NS,j)=0
+                     SMOIS_mosaic_avg(i,NS,j)=0
+                     SH2O_mosaic_avg(i,NS,j)=0
+            
+                         ENDDO
+            
+                 HFX_mosaic_avg(i,j)= 0
+                 QFX_mosaic_avg(i,j)= 0  
+                 LH_mosaic_avg(i,j)=  0 
+                 GRDFLX_mosaic_avg(i,j)= 0
+                 ALBEDO_mosaic_avg(i,j)=0
+                 ALBBCK_mosaic_avg(i,j)=0
+                 EMISS_mosaic_avg(i,j)=0
+                 EMBCK_mosaic_avg(i,j)=0
+                 ZNT_mosaic_avg(i,j)=0
+                 Z0_mosaic_avg(i,j)=0  
+                 FAREA_mosaic_avg(i,j)=0  
+            
+            ! add a new loop for the mosaic_cat
+            
+               DO mosaic_i = mosaic_cat, 1, -1
+               
+            !   if (mosaic_cat_index(I,mosaic_i,J) .EQ. 16 ) then
+            !   PRINT*, 'you still have water tiles at','i=',i,'j=',j, 'mosaic_i',mosaic_i
+            !   PRINT*, 'xland',xland(i,j),'xice',xice(i,j)
+            !   endif
+               
+               IVGTYP(I,J)=mosaic_cat_index(I,mosaic_i,J)                         ! replace it with the mosaic one          
+               TSK(I,J)=TSK_mosaic(I,mosaic_i,J)                                  ! from 3D to 2D
+               QSFC(i,j)=QSFC_mosaic(I,mosaic_i,J)
+               CANWAT(i,j)=CANWAT_mosaic(i,mosaic_i,j) 
+               SNOW(i,j)=SNOW_mosaic(i,mosaic_i,j) 
+               SNOWH(i,j)=SNOWH_mosaic(i,mosaic_i,j)  
+               SNOWC(i,j)=SNOWC_mosaic(i,mosaic_i,j)
+            
+                ALBEDO(i,j) = ALBEDO_mosaic(i,mosaic_i,j)
+                ALBBCK(i,j)= ALBBCK_mosaic(i,mosaic_i,j) 
+                EMISS(i,j)= EMISS_mosaic(i,mosaic_i,j) 
+                EMBCK(i,j)= EMBCK_mosaic(i,mosaic_i,j) 
+                ZNT(i,j)= ZNT_mosaic(i,mosaic_i,j) 
+                Z0(i,j)= Z0_mosaic(i,mosaic_i,j)    
+            
+                 SNOTIME(i,j)= SNOTIME_mosaic(i,mosaic_i,j)          
+              
+                          DO NS=1,NSOIL
+            
+                     TSLB(i,NS,j)=TSLB_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)
+                     SMOIS(i,NS,j)=SMOIS_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)
+                     SH2O(i,NS,j)=SH2O_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)
+            
+                          ENDDO
+            
+                       IF(IPRINT_mosaic) THEN
+            
+                   print*, 'BEFORE SFLX, in Noahdrv.F'
+                   print*, 'mosaic_cat', mosaic_cat, 'IVGTYP',IVGTYP(i,j), 'TSK',TSK(i,j),'HFX',HFX(i,j), 'QSFC', QSFC(i,j),   &
+                   'CANWAT', CANWAT(i,j), 'SNOW',SNOW(i,j), 'ALBEDO',ALBEDO(i,j), 'TSLB',TSLB(i,1,j),'CHS',CHS(i,j),'ZNT',ZNT(i,j)
+            
+                       ENDIF
+            
+            !-----------------------------------------------------------------------
+            ! insert the NOAH model here for the non-urban one and the urban one  DANLI
+            !-----------------------------------------------------------------------
+            
+      ! surface pressure
+              PSFC=P8w3D(i,1,j)
+      ! pressure in middle of lowest layer
+              SFCPRS=(P8W3D(I,KTS+1,j)+P8W3D(i,KTS,j))*0.5
+      ! convert from mixing ratio to specific humidity
+               Q2K=QV3D(i,1,j)/(1.0+QV3D(i,1,j))
+      !
+      !         Q2SAT=QGH(I,j)
+               Q2SAT=QGH(I,J)/(1.0+QGH(I,J))        ! Q2SAT is sp humidity
+      ! add check on myj=.true.
+      !        IF((Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+              IF((myj).AND.(Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+                SATFLG=0.
+                CHKLOWQ(I,J)=0.
+              ELSE
+                SATFLG=1.0
+                CHKLOWQ(I,J)=1.
+              ENDIF
+      
+              SFCTMP=T3D(i,1,j)
+              ZLVL=0.5*DZ8W(i,1,j)
+      
+      !        TH2=SFCTMP+(0.0097545*ZLVL)
+      ! calculate SFCTH2 via Exner function vs lapse-rate (above)
+               APES=(1.E5/PSFC)**CAPA
+               APELM=(1.E5/SFCPRS)**CAPA
+               SFCTH2=SFCTMP*APELM
+               TH2=SFCTH2/APES
+      !
+               EMISSI = EMISS(I,J)
+               LWDN=GLW(I,J)*EMISSI
+      ! SOLDN is total incoming solar
+              SOLDN=SWDOWN(I,J)
+      ! GSW is net downward solar
+      !        SOLNET=GSW(I,J)
+      ! use mid-day albedo to determine net downward solar (no solar zenith angle correction)
+              SOLNET=SOLDN*(1.-ALBEDO(I,J))
+              PRCP=RAINBL(i,j)/DT
+              VEGTYP=IVGTYP(I,J)
+              SOILTYP=ISLTYP(I,J)
+              SHDFAC=VEGFRA(I,J)/100.
+              T1=TSK(I,J)
+              CHK=CHS(I,J)
+              SHMIN=SHDMIN(I,J)/100. !NEW
+              SHMAX=SHDMAX(I,J)/100. !NEW
+      ! convert snow water equivalent from mm to meter
+              SNEQV=SNOW(I,J)*0.001
+      ! snow depth in meters
+              SNOWHK=SNOWH(I,J)
+              SNCOVR=SNOWC(I,J)
+      
+      ! if "SR" present, set frac of frozen precip ("FFROZP") = snow-ratio ("SR", range:0-1)
+      ! SR from e.g. Ferrier microphysics
+      ! otherwise define from 1st atmos level temperature
+             IF(FRPCPN) THEN
+                FFROZP=SR(I,J)
+              ELSE
+                IF (SFCTMP <=  273.15) THEN
+                  FFROZP = 1.0
+      	  ELSE
+      	    FFROZP = 0.0
+      	  ENDIF
+              ENDIF
+      !***
+              IF((XLAND(I,J)-1.5).GE.0.)THEN                                  ! begining of land/sea if block
+      ! Open water points
+                TSK_RURAL(I,J)=TSK(I,J)
+                HFX_RURAL(I,J)=HFX(I,J)
+                QFX_RURAL(I,J)=QFX(I,J)
+                LH_RURAL(I,J)=LH(I,J)
+                EMISS_RURAL(I,J)=EMISS(I,J)
+                GRDFLX_RURAL(I,J)=GRDFLX(I,J)
+              ELSE
+      ! Land or sea-ice case
+      
+                IF (XICE(I,J) >= XICE_THRESHOLD) THEN
+                   ! Sea-ice point
+                   ICE = 1
+                ELSE IF ( VEGTYP == ISICE ) THEN
+                   ! Land-ice point
+                   ICE = -1
+                ELSE
+                   ! Neither sea ice or land ice.
+                   ICE=0
+                ENDIF
+                DQSDT2=Q2SAT*A23M4/(SFCTMP-A4)**2
+      
+                IF(SNOW(I,J).GT.0.0)THEN
+      ! snow on surface (use ice saturation properties)
+                  SFCTSNO=SFCTMP
+                  E2SAT=611.2*EXP(6174.*(1./273.15 - 1./SFCTSNO))
+                  Q2SATI=0.622*E2SAT/(SFCPRS-E2SAT)
+                  Q2SATI=Q2SATI/(1.0+Q2SATI)    ! spec. hum.
+                  IF (T1 .GT. 273.14) THEN
+      ! warm ground temps, weight the saturation between ice and water according to SNOWC
+                    Q2SAT=Q2SAT*(1.-SNOWC(I,J)) + Q2SATI*SNOWC(I,J)
+                    DQSDT2=DQSDT2*(1.-SNOWC(I,J)) + Q2SATI*6174./(SFCTSNO**2)*SNOWC(I,J)
+                  ELSE
+      ! cold ground temps, use ice saturation only
+                    Q2SAT=Q2SATI
+                    DQSDT2=Q2SATI*6174./(SFCTSNO**2)
+                  ENDIF
+      ! for snow cover fraction at 0 C, ground temp will not change, so DQSDT2 effectively zero
+                  IF(T1 .GT. 273. .AND. SNOWC(I,J) .GT. 0.)DQSDT2=DQSDT2*(1.-SNOWC(I,J))
+                ENDIF
+      
+                ! Land-ice or land points use the usual deep-soil temperature.
+                TBOT=TMN(I,J)
+      
+                IF(VEGTYP.EQ.25) SHDFAC=0.0000
+                IF(VEGTYP.EQ.26) SHDFAC=0.0000
+                IF(VEGTYP.EQ.27) SHDFAC=0.0000
+                IF(SOILTYP.EQ.14.AND.XICE(I,J).EQ.0.)THEN
+#if 0
+               IF(IPRINT)PRINT*,' SOIL TYPE FOUND TO BE WATER AT A LAND-POINT'
+               IF(IPRINT)PRINT*,i,j,'RESET SOIL in surfce.F'
+#endif
+                  SOILTYP=7
+                ENDIF
+                SNOALB1 = SNOALB(I,J)
+                CMC=CANWAT(I,J)
+      
+      !-------------------------------------------
+      !*** convert snow depth from mm to meter
+      !
+      !          IF(RDMAXALB) THEN
+      !           SNOALB=ALBMAX(I,J)*0.01
+      !         ELSE
+      !           SNOALB=MAXALB(IVGTPK)*0.01
+      !         ENDIF
+      
+      !        SNOALB1=0.80
+      !        SHMIN=0.00
+              ALBBRD=ALBBCK(I,J)
+              Z0BRD=Z0(I,J)
+              EMBRD=EMBCK(I,J)
+              SNOTIME1 = SNOTIME(I,J)
+              RIBB=RIB(I,J)
+      !FEI: temporaray arrays above need to be changed later by using SI
+      
+                DO NS=1,NSOIL
+                  SMC(NS)=SMOIS(I,NS,J)
+                  STC(NS)=TSLB(I,NS,J)                                          !STEMP
+                  SWC(NS)=SH2O(I,NS,J)
+                ENDDO
+      !
+                if ( (SNEQV.ne.0..AND.SNOWHK.eq.0.).or.(SNOWHK.le.SNEQV) )THEN
+                  SNOWHK= 5.*SNEQV
+                endif
+      !
+      
+      !Fei: urban. for urban surface, if calling UCM, redefine the natural surface in cities as
+      ! the "NATURAL" category in the VEGPARM.TBL
+      	
+      	!   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+                       
+      
+           !           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+           !            IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+           !	 VEGTYP = NATURAL
+           !            SHDFAC = SHDTBL(NATURAL)
+           !            ALBEDOK =0.2         !  0.2
+           !            ALBBRD  =0.2         !0.2
+           !            EMISSI = 0.98                                 !for VEGTYP=5
+           !	 IF ( FRC_URB2D(I,J) < 0.99 ) THEN
+          !               if(sf_urban_physics.eq.1)then
+          !       T1= ( TSK(I,J) -FRC_URB2D(I,J) * TS_URB2D (I,J) )/ (1-FRC_URB2D(I,J))
+          !               elseif((sf_urban_physics.eq.2).OR.(sf_urban_physics.eq.3))then
+          !            r1= (tsk(i,j)**4.)
+          !            r2= frc_urb2d(i,j)*(ts_urb2d(i,j)**4.)
+          !            r3= (1.-frc_urb2d(i,j))
+         !             t1= ((r1-r2)/r3)**.25
+         !                endif
+         !	         ELSE
+         !		 T1 = TSK(I,J)
+         !              ENDIF
+         !             ENDIF
+          !       ELSE
+           !            IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+          !              IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+           !             VEGTYP = ISURBAN
+           !      	 ENDIF
+           !      ENDIF
+      
+            Noah_call=.TRUE.
+      
+            If ( SF_URBAN_PHYSICS == 0 ) THEN   ! ONLY NOAH
+      
+                 IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                       IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+                       Noah_call = .TRUE.                 
+                       VEGTYP = ISURBAN
+                 ENDIF
+      
+            ENDIF
+            
+            IF(SF_URBAN_PHYSICS == 1) THEN
+      
+                 IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                       IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN   
+              	
+                       Noah_call = .TRUE.                       
+              	       VEGTYP = NATURAL                                              
+                       SHDFAC = SHDTBL(NATURAL)
+                       ALBEDOK =0.2         !  0.2
+                       ALBBRD  =0.2         !  0.2
+                       EMISSI = 0.98        !  for VEGTYP=5       
+                       
+      		      T1= TS_RUL2D_mosaic(I,mosaic_i,J)
+                       
+                 ENDIF
+      
+            ENDIF
+
+!===Yang, 2014/10/08, hydrological processes for urban vegetation in single layer UCM===
+           AOASIS = 1.0
+           USOIL = 1
+           DSOIL = 2
+           IRIOPTION=IRI_SCHEME
+           OMG= OMG_URB2D(I,J)   
+           tloc=mod(int(OMG/3.14159*180./15.+12.+0.5 ),24)
+           if (tloc.lt.0) tloc=tloc+24
+           if (tloc==0) tloc=24
+           CALL cal_mon_day(julian,julyr,jmonth,jday) 
+	  IF(SF_URBAN_PHYSICS == 1) THEN
+           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+            AOASIS = oasis  ! urban oasis effect
+                   IF (IRIOPTION ==1) THEN
+                   IF (tloc==21 .or. tloc==22) THEN  !irrigation on vegetaion in urban area, MAY-SEP, 9-10pm
+                   IF (jmonth==5 .or. jmonth==6 .or. jmonth==7 .or. jmonth==8 .or. jmonth==9) THEN
+                      IF (SMC(USOIL) .LT. SMCREF) SMC(USOIL)= REFSMC(ISLTYP(I,J))
+                      IF (SMC(DSOIL) .LT. SMCREF) SMC(DSOIL)= REFSMC(ISLTYP(I,J))
+                   ENDIF
+                   ENDIF
+                   ENDIF
+                ENDIF
+           ENDIF
+
+	  IF(SF_URBAN_PHYSICS == 2 .or. SF_URBAN_PHYSICS == 3) THEN
+          IF(AOASIS > 1.0) THEN
+          CALL wrf_error_fatal('Urban oasis option is for SF_URBAN_PHYSICS == 1 only')
+          ENDIF
+          IF(IRIOPTION == 1) THEN
+          CALL wrf_error_fatal('Urban irrigation option is for SF_URBAN_PHYSICS == 1 only')
+          ENDIF
+          ENDIF
+            
+            IF( SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+!             print*, 'MOSAIC is not designed to work with SF_URBAN_PHYSICS=2 or SF_URBAN_PHYSICS=3'
+            ENDIF
+      
+         IF (Noah_call) THEN
+#if 0
+                IF(IPRINT) THEN
+      !
+             print*, 'BEFORE SFLX, in Noahlsm_driver'
+             print*, 'ICE', ICE, 'DT',DT, 'ZLVL',ZLVL, 'NSOIL', NSOIL,   &
+             'SLDPTH', SLDPTH, 'LOCAL',LOCAL, 'LUTYPE',&
+              LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN, 'SOLDN',SOLDN,      &
+              'SFCPRS',SFCPRS, 'PRCP',PRCP,'SFCTMP',SFCTMP,'Q2K',Q2K,   &
+               'TH2',TH2,'Q2SAT',Q2SAT,'DQSDT2',DQSDT2,'VEGTYP', VEGTYP,&
+               'SOILTYP',SOILTYP, 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC,&
+               'SHMIN',SHMIN, 'ALBBRD',ALBBRD,'SNOALB1',SNOALB1,'TBOT',&
+                TBOT, 'Z0BRD',Z0BRD, 'Z0K',Z0K, 'CMC',CMC, 'T1',T1,'STC',&
+                STC, 'SMC',SMC, 'SWC',SWC,'SNOWHK',SNOWHK,'SNEQV',SNEQV,&
+                'ALBEDOK',ALBEDOK,'CHK',CHK,'ETA',ETA,'SHEAT',SHEAT,      &
+                'ETA_KINEMATIC',ETA_KINEMATIC, 'FDOWN',FDOWN,'EC',EC,   &
+                'EDIR',EDIR,'ET',ET,'ETT',ETT,'ESNOW',ESNOW,'DRIP',DRIP,&
+                'DEW',DEW,'BETA',BETA,'ETP',ETP,'SSOIL',SSOIL,'FLX1',FLX1,&
+                'FLX2',FLX2,'FLX3',FLX3,'SNOMLT',SNOMLT,'SNCOVR',SNCOVR,&
+                'RUNOFF1',RUNOFF1,'RUNOFF2',RUNOFF2,'RUNOFF3',RUNOFF3, &
+                'RC',RC, 'PC',PC,'RSMIN',RSMIN,'XLAI',XLAI,'RCS',RCS,  &
+                'RCT',RCT,'RCQ',RCQ,'RCSOIL',RCSOIL,'SOILW',SOILW,     &
+                'SOILM',SOILM,'Q1',Q1,'SMCWLT',SMCWLT,'SMCDRY',SMCDRY,&
+                'SMCREF',SMCREF,'SMCMAX',SMCMAX,'NROOT',NROOT
+                 endif
+#endif
+      
+                IF (rdlai2d) THEN
+                   xlai = lai(i,j)
+                endif
+      
+          IF ( ICE == 1 ) THEN
+      
+             ! Sea-ice case
+      
+             DO NS = 1, NSOIL
+                SH2O(I,NS,J) = 1.0
+             ENDDO
+             LAI(I,J) = 0.01
+      
+             CYCLE ILOOP
+      
+          ELSEIF (ICE == 0) THEN
+      
+             ! Non-glacial land
+      
+             CALL SFLX (I,J,FFROZP, ISURBAN, DT,ZLVL,NSOIL,SLDPTH,       &    !C
+                       LOCAL,                                            &    !L
+                       LUTYPE, SLTYPE,                                   &    !CL
+                       LWDN,SOLDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,DUMMY,   &    !F
+                       DUMMY,DUMMY, DUMMY,                               &    !F PRCPRAIN not used
+                       TH2,Q2SAT,DQSDT2,                                 &    !I
+                       VEGTYP,SOILTYP,SLOPETYP,SHDFAC,SHMIN,SHMAX,       &    !I
+                       ALBBRD, SNOALB1,TBOT, Z0BRD, Z0K, EMISSI, EMBRD,  &    !S
+                       CMC,T1,STC,SMC,SWC,SNOWHK,SNEQV,ALBEDOK,CHK,dummy,&    !H
+                       ETA,SHEAT, ETA_KINEMATIC,FDOWN,                   &    !O
+                       EC,EDIR,ET,ETT,ESNOW,DRIP,DEW,                    &    !O
+                       BETA,ETP,SSOIL,                                   &    !O
+                       FLX1,FLX2,FLX3,                                   &    !O
+      		 FLX4,FVB,FBUR,FGSN,UA_PHYS,                             &    !UA 
+                       SNOMLT,SNCOVR,                                    &    !O
+                       RUNOFF1,RUNOFF2,RUNOFF3,                          &    !O
+                       RC,PC,RSMIN,XLAI,RCS,RCT,RCQ,RCSOIL,              &    !O
+                       SOILW,SOILM,Q1,SMAV,                              &    !D
+                       RDLAI2D,USEMONALB,                                &
+                       SNOTIME1,                                         &
+                       RIBB,                                             &
+                       SMCWLT,SMCDRY,SMCREF,SMCMAX,NROOT,                &
+                       sfcheadrt(i,j),                                   &    !I
+                       INFXSRT(i,j),ETPND1,AOASIS                        &    !O
+                       )
+      
+#ifdef WRF_HYDRO
+                       soldrain(i,j) = RUNOFF2*DT*1000.0
+#endif
+          ELSEIF (ICE == -1) THEN
+      
+             !
+             ! Set values that the LSM is expected to update,
+             ! but don't get updated for glacial points.
+             !
+             SOILM = 0.0 !BSINGH(PNNL)- SOILM is undefined for this case, it is used for diagnostics so setting it to zero
+             XLAI = 0.01 ! KWM Should this be Zero over land ice?  Does this value matter?
+             RUNOFF2 = 0.0
+             RUNOFF3 = 0.0
+             DO NS = 1, NSOIL
+                SWC(NS) = 1.0
+                SMC(NS) = 1.0
+                SMAV(NS) = 1.0
+             ENDDO
+             CALL SFLX_GLACIAL(I,J,ISICE,FFROZP,DT,ZLVL,NSOIL,SLDPTH,   &    !C
+                  &    LWDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,              &    !F
+                  &    TH2,Q2SAT,DQSDT2,                                &    !I
+                  &    ALBBRD, SNOALB1,TBOT, Z0BRD, Z0K, EMISSI, EMBRD, &    !S
+                  &    T1,STC(1:NSOIL),SNOWHK,SNEQV,ALBEDOK,CHK,        &    !H
+                  &    ETA,SHEAT,ETA_KINEMATIC,FDOWN,                   &    !O
+                  &    ESNOW,DEW,                                       &    !O
+                  &    ETP,SSOIL,                                       &    !O
+                  &    FLX1,FLX2,FLX3,                                  &    !O
+                  &    SNOMLT,SNCOVR,                                   &    !O
+                  &    RUNOFF1,                                         &    !O
+                  &    Q1,                                              &    !D
+                  &    SNOTIME1,                                        &
+                  &    RIBB)
+      
+          ENDIF
+      
+             lai(i,j) = xlai
+      
+#if 0
+                IF(IPRINT) THEN
+      
+             print*, 'AFTER SFLX, in Noahlsm_driver'
+             print*, 'ICE', ICE, 'DT',DT, 'ZLVL',ZLVL, 'NSOIL', NSOIL,   &
+             'SLDPTH', SLDPTH, 'LOCAL',LOCAL, 'LUTYPE',&
+              LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN, 'SOLDN',SOLDN,      &
+              'SFCPRS',SFCPRS, 'PRCP',PRCP,'SFCTMP',SFCTMP,'Q2K',Q2K,   &
+               'TH2',TH2,'Q2SAT',Q2SAT,'DQSDT2',DQSDT2,'VEGTYP', VEGTYP,&
+                'SOILTYP',SOILTYP, 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC,&
+               'SHDMIN',SHMIN, 'ALBBRD',ALBBRD,'SNOALB',SNOALB1,'TBOT',&
+                TBOT, 'Z0BRD',Z0BRD, 'Z0K',Z0K, 'CMC',CMC, 'T1',T1,'STC',&
+                STC, 'SMC',SMC, 'SWc',SWC,'SNOWHK',SNOWHK,'SNEQV',SNEQV,&
+                'ALBEDOK',ALBEDOK,'CHK',CHK,'ETA',ETA,'SHEAT',SHEAT,      &
+                'ETA_KINEMATIC',ETA_KINEMATIC, 'FDOWN',FDOWN,'EC',EC,   &
+                'EDIR',EDIR,'ET',ET,'ETT',ETT,'ESNOW',ESNOW,'DRIP',DRIP,&
+                'DEW',DEW,'BETA',BETA,'ETP',ETP,'SSOIL',SSOIL,'FLX1',FLX1,&
+                'FLX2',FLX2,'FLX3',FLX3,'SNOMLT',SNOMLT,'SNCOVR',SNCOVR,&
+                'RUNOFF1',RUNOFF1,'RUNOFF2',RUNOFF2,'RUNOFF3',RUNOFF3, &
+                'RC',RC, 'PC',PC,'RSMIN',RSMIN,'XLAI',XLAI,'RCS',RCS,  &
+                'RCT',RCT,'RCQ',RCQ,'RCSOIL',RCSOIL,'SOILW',SOILW,     &
+                'SOILM',SOILM,'Q1',Q1,'SMCWLT',SMCWLT,'SMCDRY',SMCDRY,&
+                'SMCREF',SMCREF,'SMCMAX',SMCMAX,'NROOT',NROOT
+                 endif
+#endif
+      
+      !***  UPDATE STATE VARIABLES
+                CANWAT(I,J)=CMC
+                SNOW(I,J)=SNEQV*1000.
+      !          SNOWH(I,J)=SNOWHK*1000.
+                SNOWH(I,J)=SNOWHK                   ! SNOWHK in meters
+                ALBEDO(I,J)=ALBEDOK
+                ALB_RURAL(I,J)=ALBEDOK
+                ALBBCK(I,J)=ALBBRD
+                Z0(I,J)=Z0BRD
+                EMISS(I,J) = EMISSI
+                EMISS_RURAL(I,J) = EMISSI
+      ! Noah: activate time-varying roughness length (V3.3 Feb 2011)
+                ZNT(I,J)=Z0K
+                TSK(I,J)=T1
+                TSK_RURAL(I,J)=T1
+                HFX(I,J)=SHEAT
+                HFX_RURAL(I,J)=SHEAT
+      ! MEk Jul07 add potential evap accum
+              POTEVP(I,J)=POTEVP(I,J)+ETP*FDTW
+                QFX(I,J)=ETA_KINEMATIC
+                QFX_RURAL(I,J)=ETA_KINEMATIC
+      
+#ifdef WRF_HYDRO
+      !added by Wei Yu
+      !         QFX(I,J) = QFX(I,J) + ETPND1
+      !         ETA = ETA + ETPND1/2.501E6*dt
+      !end added by Wei Yu
+#endif
+      
+                LH(I,J)=ETA
+                LH_RURAL(I,J)=ETA
+                GRDFLX(I,J)=SSOIL
+                GRDFLX_RURAL(I,J)=SSOIL
+                SNOWC(I,J)=SNCOVR
+                CHS2(I,J)=CQS2(I,J)
+                SNOTIME(I,J) = SNOTIME1
+      !      prevent diagnostic ground q (q1) from being greater than qsat(tsk)
+      !      as happens over snow cover where the cqs2 value also becomes irrelevant
+      !      by setting cqs2=chs in this situation the 2m q should become just qv(k=1)
+                IF (Q1 .GT. QSFC(I,J)) THEN
+                  CQS2(I,J) = CHS(I,J)
+                ENDIF
+      !          QSFC(I,J)=Q1
+      ! Convert QSFC back to mixing ratio
+                 QSFC(I,J)= Q1/(1.0-Q1)
+      !
+                 ! QSFC_RURAL(I,J)= Q1/(1.0-Q1)
+      ! Calculate momentum flux from rural surface for use with multi-layer UCM (Martilli et al. 2002)
+      
+                DO 81 NS=1,NSOIL
+                 SMOIS(I,NS,J)=SMC(NS)
+                 TSLB(I,NS,J)=STC(NS)                                        !  STEMP
+                 SH2O(I,NS,J)=SWC(NS)
+         81     CONTINUE
+      !       ENDIF
+      
+              FLX4_2D(I,J)  = FLX4
+      	FVB_2D(I,J)   = FVB
+      	FBUR_2D(I,J)  = FBUR
+      	FGSN_2D(I,J)  = FGSN
+      
+           !
+           ! Residual of surface energy balance equation terms
+           !
+      
+           IF ( UA_PHYS ) THEN
+               noahres(i,j) = ( solnet + lwdn ) - sheat + ssoil - eta &
+                    - ( emissi * STBOLT * (t1**4) ) - flx1 - flx2 - flx3 - flx4
+      
+           ELSE
+               noahres(i,j) = ( solnet + lwdn ) - sheat + ssoil - eta &
+                    - ( emissi * STBOLT * (t1**4) ) - flx1 - flx2 - flx3
+           ENDIF
+      
+               ENDIF   !ENDIF FOR Noah_call
+               
+              IF (SF_URBAN_PHYSICS == 1 ) THEN                                              ! Beginning of UCM CALL if block
+      !--------------------------------------
+      ! URBAN CANOPY MODEL START - urban
+      !--------------------------------------
+      ! Input variables lsm --> urban
+      
+                IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                    IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33 ) THEN            
+      
+                !  UTYPE_URB = UTYPE_URB2D(I,J) !urban type (low, high or industrial)
+                !  this need to be changed in the mosaic danli
+      
+                IF(IVGTYP(I,J)==ISURBAN) UTYPE_URB=2
+                IF(IVGTYP(I,J)==31) UTYPE_URB=3
+                IF(IVGTYP(I,J)==32) UTYPE_URB=2
+                IF(IVGTYP(I,J)==33) UTYPE_URB=1
+                        
+                IF(UTYPE_URB==3) FRC_URB2D(I,J)=0.5
+                IF(UTYPE_URB==2) FRC_URB2D(I,J)=0.9
+                IF(UTYPE_URB==1) FRC_URB2D(I,J)=0.95
+      
+                  TA_URB    = SFCTMP           ! [K]
+                  QA_URB    = Q2K              ! [kg/kg]
+                  UA_URB    = SQRT(U_PHY(I,1,J)**2.+V_PHY(I,1,J)**2.)
+                  U1_URB    = U_PHY(I,1,J)
+                  V1_URB    = V_PHY(I,1,J)
+                  IF(UA_URB < 1.) UA_URB=1.    ! [m/s]
+                  SSG_URB   = SOLDN            ! [W/m/m]
+                  SSGD_URB  = 0.8*SOLDN        ! [W/m/m]
+                  SSGQ_URB  = SSG_URB-SSGD_URB ! [W/m/m]
+                  LLG_URB   = GLW(I,J)         ! [W/m/m]
+                  RAIN_URB  = RAINBL(I,J)      ! [mm]
+                  RHOO_URB  = SFCPRS / (287.04 * SFCTMP * (1.0+ 0.61 * Q2K)) ![kg/m/m/m]
+                  ZA_URB    = ZLVL             ! [m]
+                  DELT_URB  = DT               ! [sec]
+                  XLAT_URB  = XLAT_URB2D(I,J)  ! [deg]
+                  COSZ_URB  = COSZ_URB2D(I,J)  !
+                  OMG_URB   = OMG_URB2D(I,J)   !
+                  ZNT_URB   = ZNT(I,J)
+      
+                  LSOLAR_URB = .FALSE.
+                  
+      ! mosaic 3D to 2D
+      
+         TR_URB2D(I,J)=TR_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         TB_URB2D(I,J)=TB_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         TG_URB2D(I,J)=TG_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         TC_URB2D(I,J)=TC_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         QC_URB2D(I,J)=QC_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         UC_URB2D(I,J)=UC_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+         TS_URB2D(I,J)=TS_URB2D_mosaic(I,mosaic_i,J)                         ! replace it with the mosaic one          
+      
+                  DO K = 1,num_roof_layers
+                    TRL_URB3D(I,K,J) = TRL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)
+                  END DO
+                  DO K = 1,num_wall_layers
+                    TBL_URB3D(I,K,J) = TBL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)
+                  END DO
+                  DO K = 1,num_road_layers
+                    TGL_URB3D(I,K,J) = TGL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)
+                  END DO
+      
+      ! mosaic 2D to 1D            
+      
+                  TR_URB = TR_URB2D(I,J)
+                  TB_URB = TB_URB2D(I,J)
+                  TG_URB = TG_URB2D(I,J)
+                  TC_URB = TC_URB2D(I,J)
+                  QC_URB = QC_URB2D(I,J)
+                  UC_URB = UC_URB2D(I,J)
+      
+                  DO K = 1,num_roof_layers
+                    TRL_URB(K) = TRL_URB3D(I,K,J)
+                    SMR_URB(K) = SMR_URB3D(I,K,J)
+                    TGRL_URB(K)= TGRL_URB3D(I,K,J)
+                  END DO
+                  DO K = 1,num_wall_layers
+                    TBL_URB(K) = TBL_URB3D(I,K,J)
+                  END DO
+                  DO K = 1,num_road_layers
+                    TGL_URB(K) = TGL_URB3D(I,K,J)
+                  END DO
+                  
+                  TGR_URB   = TGR_URB2D(I,J)
+                  CMCR_URB  = CMCR_URB2D(I,J)
+                  FLXHUMR_URB = FLXHUMR_URB2D(I,J)
+                  FLXHUMB_URB = FLXHUMB_URB2D(I,J)
+                  FLXHUMG_URB = FLXHUMG_URB2D(I,J)
+                  DRELR_URB = DRELR_URB2D(I,J)
+                  DRELB_URB = DRELB_URB2D(I,J)
+                  DRELG_URB = DRELG_URB2D(I,J)
+      
+                  XXXR_URB = XXXR_URB2D(I,J)
+                  XXXB_URB = XXXB_URB2D(I,J)
+                  XXXG_URB = XXXG_URB2D(I,J)
+                  XXXC_URB = XXXC_URB2D(I,J)
+      !
+      !      Limits to avoid dividing by small number
+                  if (CHS(I,J) < 1.0E-02) then
+                     CHS(I,J)  = 1.0E-02
+                  endif
+                  if (CHS2(I,J) < 1.0E-02) then
+                     CHS2(I,J)  = 1.0E-02
+                  endif
+                  if (CQS2(I,J) < 1.0E-02) then
+                     CQS2(I,J)  = 1.0E-02
+                  endif
+      !
+                  CHS_URB  = CHS(I,J)
+                  CHS2_URB = CHS2(I,J)
+                  IF (PRESENT(CMR_SFCDIF)) THEN
+                     CMR_URB = CMR_SFCDIF(I,J)
+                     CHR_URB = CHR_SFCDIF(I,J)
+                     CMGR_URB = CMGR_SFCDIF(I,J)
+                     CHGR_URB = CHGR_SFCDIF(I,J)
+                     CMC_URB = CMC_SFCDIF(I,J)
+                     CHC_URB = CHC_SFCDIF(I,J)
+                  ENDIF
+      
+      ! NUDAPT for SLUCM
+                  mh_urb = mh_urb2d(I,J)
+                  stdh_urb = stdh_urb2d(I,J)
+                  lp_urb = lp_urb2d(I,J)
+                  hgt_urb = hgt_urb2d(I,J)
+                  lf_urb = 0.0
+                  DO K = 1,4
+                    lf_urb(K)=lf_urb2d(I,K,J)
+                  ENDDO
+                  frc_urb = frc_urb2d(I,J)
+                  lb_urb = lb_urb2d(I,J)
+                  check = 0
+                  if (I.eq.73.and.J.eq.125)THEN
+                     check = 1
+                  end if
+      !
+      ! Call urban
+                  CALL cal_mon_day(julian,julyr,jmonth,jday)      
+                  CALL urban(LSOLAR_URB,                                      & ! I
+                             num_roof_layers,num_wall_layers,num_road_layers, & ! C
+                             DZR,DZB,DZG,                                     & ! C
+                             UTYPE_URB,TA_URB,QA_URB,UA_URB,U1_URB,V1_URB,SSG_URB, & ! I
+                             SSGD_URB,SSGQ_URB,LLG_URB,RAIN_URB,RHOO_URB,     & ! I
+                             ZA_URB,DECLIN_URB,COSZ_URB,OMG_URB,              & ! I
+                             XLAT_URB,DELT_URB,ZNT_URB,                       & ! I
+                             CHS_URB, CHS2_URB,                               & ! I
+                             TR_URB, TB_URB, TG_URB, TC_URB, QC_URB,UC_URB,   & ! H
+                             TRL_URB,TBL_URB,TGL_URB,                         & ! H
+                             XXXR_URB, XXXB_URB, XXXG_URB, XXXC_URB,          & ! H
+                             TS_URB,QS_URB,SH_URB,LH_URB,LH_KINEMATIC_URB,    & ! O
+                             SW_URB,ALB_URB,LW_URB,G_URB,RN_URB,PSIM_URB,PSIH_URB, & ! O
+                             GZ1OZ0_URB,                                      & !O
+                             CMR_URB, CHR_URB, CMC_URB, CHC_URB,              &
+                             U10_URB, V10_URB, TH2_URB, Q2_URB,               & ! O
+                             UST_URB,mh_urb, stdh_urb, lf_urb, lp_urb,        & ! 0
+                             hgt_urb,frc_urb,lb_urb, check,CMCR_URB,TGR_URB,  & ! H
+                             TGRL_URB,SMR_URB,CMGR_URB,CHGR_URB,jmonth,       & ! H
+                             DRELR_URB,DRELB_URB,                             & ! H
+                             DRELG_URB,FLXHUMR_URB,FLXHUMB_URB,FLXHUMG_URB)     
+      
+#if 0
+                IF(IPRINT) THEN
+      
+             print*, 'AFTER CALL URBAN'
+             print*,'num_roof_layers',num_roof_layers, 'num_wall_layers',  &
+              num_wall_layers,                                             &
+             'DZR',DZR,'DZB',DZB,'DZG',DZG,'UTYPE_URB',UTYPE_URB,'TA_URB', &
+              TA_URB,                                                      &
+              'QA_URB',QA_URB,'UA_URB',UA_URB,'U1_URB',U1_URB,'V1_URB',    &
+               V1_URB,                                                     &
+               'SSG_URB',SSG_URB,'SSGD_URB',SSGD_URB,'SSGQ_URB',SSGQ_URB,  &
+              'LLG_URB',LLG_URB,'RAIN_URB',RAIN_URB,'RHOO_URB',RHOO_URB,   &
+              'ZA_URB',ZA_URB, 'DECLIN_URB',DECLIN_URB,'COSZ_URB',COSZ_URB,&
+              'OMG_URB',OMG_URB,'XLAT_URB',XLAT_URB,'DELT_URB',DELT_URB,   &
+               'ZNT_URB',ZNT_URB,'TR_URB',TR_URB, 'TB_URB',TB_URB,'TG_URB',&
+               TG_URB,'TC_URB',TC_URB,'QC_URB',QC_URB,'TRL_URB',TRL_URB,   &
+                'TBL_URB',TBL_URB,'TGL_URB',TGL_URB,'XXXR_URB',XXXR_URB,   &
+               'XXXB_URB',XXXB_URB,'XXXG_URB',XXXG_URB,'XXXC_URB',XXXC_URB,&
+               'TS_URB',TS_URB,'QS_URB',QS_URB,'SH_URB',SH_URB,'LH_URB',   &
+               LH_URB, 'LH_KINEMATIC_URB',LH_KINEMATIC_URB,'SW_URB',SW_URB,&
+               'ALB_URB',ALB_URB,'LW_URB',LW_URB,'G_URB',G_URB,'RN_URB',   &
+                RN_URB, 'PSIM_URB',PSIM_URB,'PSIH_URB',PSIH_URB,          &
+               'U10_URB',U10_URB,'V10_URB',V10_URB,'TH2_URB',TH2_URB,      &
+                'Q2_URB',Q2_URB,'CHS_URB',CHS_URB,'CHS2_URB',CHS2_URB
+                 endif
+#endif
+      
+                  TS_URB2D(I,J) = TS_URB
+      
+                  ALBEDO(I,J) = FRC_URB2D(I,J)*ALB_URB+(1-FRC_URB2D(I,J))*ALBEDOK   ![-]
+                  HFX(I,J) = FRC_URB2D(I,J)*SH_URB+(1-FRC_URB2D(I,J))*SHEAT         ![W/m/m]
+                  QFX(I,J) = FRC_URB2D(I,J)*LH_KINEMATIC_URB &
+                           + (1-FRC_URB2D(I,J))*ETA_KINEMATIC                ![kg/m/m/s]
+                  LH(I,J) = FRC_URB2D(I,J)*LH_URB+(1-FRC_URB2D(I,J))*ETA            ![W/m/m]
+                  GRDFLX(I,J) = FRC_URB2D(I,J)*G_URB+(1-FRC_URB2D(I,J))*SSOIL       ![W/m/m]
+                  TSK(I,J) = FRC_URB2D(I,J)*TS_URB+(1-FRC_URB2D(I,J))*T1            ![K]
+                  Q1 = FRC_URB2D(I,J)*QS_URB+(1-FRC_URB2D(I,J))*Q1            ![-]
+      ! Convert QSFC back to mixing ratio
+                  QSFC(I,J)= Q1/(1.0-Q1)
+                  UST(I,J)= FRC_URB2D(I,J)*UST_URB+(1-FRC_URB2D(I,J))*UST(I,J)      ![m/s]
+                  ZNT(I,J)= EXP(FRC_URB2D(I,J)*ALOG(ZNT_URB)+(1-FRC_URB2D(I,J))* ALOG(ZNT(I,J)))   ! ADD BY DAN
+
+#if 0
+          IF(IPRINT)THEN
+      
+          print*, ' FRC_URB2D', FRC_URB2D,                        &
+          'ALB_URB',ALB_URB, 'ALBEDOK',ALBEDOK, &
+          'ALBEDO(I,J)',  ALBEDO(I,J),                  &
+          'SH_URB',SH_URB,'SHEAT',SHEAT, 'HFX(I,J)',HFX(I,J),  &
+          'LH_KINEMATIC_URB',LH_KINEMATIC_URB,'ETA_KINEMATIC',  &
+           ETA_KINEMATIC, 'QFX(I,J)',QFX(I,J),                  &
+          'LH_URB',LH_URB, 'ETA',ETA, 'LH(I,J)',LH(I,J),        &
+          'G_URB',G_URB,'SSOIL',SSOIL,'GRDFLX(I,J)', GRDFLX(I,J),&
+          'TS_URB',TS_URB,'T1',T1,'TSK(I,J)',TSK(I,J),          &
+          'QS_URB',QS_URB,'Q1',Q1,'QSFC(I,J)',QSFC(I,J)
+           endif
+#endif
+      
+      ! Renew Urban State Varialbes
+      
+                  TR_URB2D(I,J) = TR_URB
+                  TB_URB2D(I,J) = TB_URB
+                  TG_URB2D(I,J) = TG_URB
+                  TC_URB2D(I,J) = TC_URB
+                  QC_URB2D(I,J) = QC_URB
+                  UC_URB2D(I,J) = UC_URB
+      
+                  DO K = 1,num_roof_layers
+                    TRL_URB3D(I,K,J) = TRL_URB(K)
+                    SMR_URB3D(I,K,J) = SMR_URB(K)
+                    TGRL_URB3D(I,K,J)= TGRL_URB(K)
+                  END DO
+                  DO K = 1,num_wall_layers
+                    TBL_URB3D(I,K,J) = TBL_URB(K)
+                  END DO
+                  DO K = 1,num_road_layers
+                    TGL_URB3D(I,K,J) = TGL_URB(K)
+                  END DO
+
+                  TGR_URB2D(I,J) =TGR_URB 
+                  CMCR_URB2D(I,J)=CMCR_URB
+            	    FLXHUMR_URB2D(I,J)=FLXHUMR_URB 
+                  FLXHUMB_URB2D(I,J)=FLXHUMB_URB
+                  FLXHUMG_URB2D(I,J)=FLXHUMG_URB
+                  DRELR_URB2D(I,J) = DRELR_URB 
+                  DRELB_URB2D(I,J) = DRELB_URB 
+                  DRELG_URB2D(I,J) = DRELG_URB
+           
+                  XXXR_URB2D(I,J) = XXXR_URB
+                  XXXB_URB2D(I,J) = XXXB_URB
+                  XXXG_URB2D(I,J) = XXXG_URB
+                  XXXC_URB2D(I,J) = XXXC_URB
+      
+                  SH_URB2D(I,J)    = SH_URB
+                  LH_URB2D(I,J)    = LH_URB
+                  G_URB2D(I,J)     = G_URB
+                  RN_URB2D(I,J)    = RN_URB
+                  PSIM_URB2D(I,J)  = PSIM_URB
+                  PSIH_URB2D(I,J)  = PSIH_URB
+                  GZ1OZ0_URB2D(I,J)= GZ1OZ0_URB
+                  U10_URB2D(I,J)   = U10_URB
+                  V10_URB2D(I,J)   = V10_URB
+                  TH2_URB2D(I,J)   = TH2_URB
+                  Q2_URB2D(I,J)    = Q2_URB
+                  UST_URB2D(I,J)   = UST_URB
+                  AKMS_URB2D(I,J)  = KARMAN * UST_URB2D(I,J)/(GZ1OZ0_URB2D(I,J)-PSIM_URB2D(I,J))
+                  IF (PRESENT(CMR_SFCDIF)) THEN
+                     CMR_SFCDIF(I,J) = CMR_URB
+                     CHR_SFCDIF(I,J) = CHR_URB
+                     CMGR_SFCDIF(I,J) = CMGR_URB
+                     CHGR_SFCDIF(I,J) = CHGR_URB
+                     CMC_SFCDIF(I,J) = CMC_URB
+                     CHC_SFCDIF(I,J) = CHC_URB
+                  ENDIF
+                  
+                     ! 2D to 3D  mosaic danli
+      	    	              
+      	    	                       TR_URB2D_mosaic(I,mosaic_i,J)=TR_URB2D(I,J)                               
+      	    	    	               TB_URB2D_mosaic(I,mosaic_i,J)=TB_URB2D(I,J)                                   
+      	    	    	               TG_URB2D_mosaic(I,mosaic_i,J)=TG_URB2D(I,J)                                   
+      	    	    	               TC_URB2D_mosaic(I,mosaic_i,J)=TC_URB2D(I,J)                                  
+      	    	    	               QC_URB2D_mosaic(I,mosaic_i,J)=QC_URB2D(I,J)                                   
+      	    	    	               UC_URB2D_mosaic(I,mosaic_i,J)=UC_URB2D(I,J)                                   
+      	    	    	               TS_URB2D_mosaic(I,mosaic_i,J)=TS_URB2D(I,J)                                   
+      	    	    	               TS_RUL2D_mosaic(I,mosaic_i,J)=T1                                
+      	    	    	  	  
+      	    	    	  	              DO K = 1,num_roof_layers
+      	    	    	  	                TRL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)=TRL_URB3D(I,K,J) 
+      	    	    	  	              END DO
+      	    	    	  	              DO K = 1,num_wall_layers
+      	    	    	  	                TBL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)=TBL_URB3D(I,K,J) 
+      	    	    	  	              END DO
+      	    	    	  	              DO K = 1,num_road_layers
+      	    	    	  	                TGL_URB3D_mosaic(I,K+(mosaic_i-1)*num_roof_layers,J)=TGL_URB3D(I,K,J) 
+      	    	    	                        END DO
+      	    	    	            
+      	    	    	              SH_URB2D_mosaic(I,mosaic_i,J) = SH_URB2D(I,J)
+      	    	    	  	      LH_URB2D_mosaic(I,mosaic_i,J) = LH_URB2D(I,J)
+      	    	    	              G_URB2D_mosaic(I,mosaic_i,J)  = G_URB2D(I,J)
+                                    RN_URB2D_mosaic(I,mosaic_i,J) = RN_URB2D(I,J)
+                                    
+                END IF
+      
+               ENDIF                                   ! end of UCM CALL if block
+      !--------------------------------------
+      ! Urban Part End - urban
+      !--------------------------------------
+      
+      !***  DIAGNOSTICS
+                SMSTAV(I,J)=SOILW
+                SMSTOT(I,J)=SOILM*1000.
+                DO NS=1,NSOIL
+                SMCREL(I,NS,J)=SMAV(NS)
+                ENDDO
+      
+      !         Convert the water unit into mm
+                SFCRUNOFF(I,J)=SFCRUNOFF(I,J)+RUNOFF1*DT*1000.0
+                UDRUNOFF(I,J)=UDRUNOFF(I,J)+RUNOFF2*DT*1000.0
+      ! snow defined when fraction of frozen precip (FFROZP) > 0.5,
+                IF(FFROZP.GT.0.5)THEN
+                  ACSNOW(I,J)=ACSNOW(I,J)+PRCP*DT
+                ENDIF
+                IF(SNOW(I,J).GT.0.)THEN
+                  ACSNOM(I,J)=ACSNOM(I,J)+SNOMLT*1000.
+      ! accumulated snow-melt energy
+                  SNOPCX(I,J)=SNOPCX(I,J)-SNOMLT/FDTLIW
+                ENDIF
+      
+              ENDIF                                                           ! endif of land-sea test
+      
+      !-----------------------------------------------------------------------
+      ! Done with the Noah-UCM MOSAIC  DANLI
+      !-----------------------------------------------------------------------
+      
+                  TSK_mosaic(i,mosaic_i,j)=TSK(i,j)                           ! from 2D to 3D
+                  QSFC_mosaic(i,mosaic_i,j)=QSFC(i,j)
+                  CANWAT_mosaic(i,mosaic_i,j)=CANWAT(i,j) 
+                  SNOW_mosaic(i,mosaic_i,j)=SNOW(i,j) 
+                  SNOWH_mosaic(i,mosaic_i,j)=SNOWH(i,j)  
+                  SNOWC_mosaic(i,mosaic_i,j)=SNOWC(i,j) 
+      
+                  ALBEDO_mosaic(i,mosaic_i,j)=ALBEDO(i,j) 
+                  ALBBCK_mosaic(i,mosaic_i,j)=ALBBCK(i,j)  
+                  EMISS_mosaic(i,mosaic_i,j)=EMISS(i,j) 
+                  EMBCK_mosaic(i,mosaic_i,j)=EMBCK(i,j)  
+                  ZNT_mosaic(i,mosaic_i,j)=ZNT(i,j)  
+                  Z0_mosaic(i,mosaic_i,j)=Z0(i,j)    
+                                                                                       
+                  HFX_mosaic(i,mosaic_i,j)=HFX(i,j) 
+                  QFX_mosaic(i,mosaic_i,j)=QFX(i,j)  
+                  LH_mosaic(i,mosaic_i,j)=LH(i,j)  
+                  GRDFLX_mosaic(i,mosaic_i,j)=GRDFLX(i,j) 
+                  SNOTIME_mosaic(i,mosaic_i,j)=SNOTIME(i,j) 
+       
+                  DO NS=1,NSOIL
+        
+                  TSLB_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)=TSLB(i,NS,j)
+                  SMOIS_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)=SMOIS(i,NS,j)
+                  SH2O_mosaic(i,NSOIL*(mosaic_i-1)+NS,j)=SH2O(i,NS,j)  
+      
+                  ENDDO
+                  
+#if 0
+            IF(TSK_mosaic(i,mosaic_i,j) > 350 .OR. TSK_mosaic(i,mosaic_i,j) < 250 .OR. abs(HFX_mosaic(i,mosaic_i,j)) > 700 ) THEN
+                  print*, 'I', I, 'J', J, 'MOSAIC_I', MOSAIC_I
+                  print*, 'mosaic_cat_index',mosaic_cat_index(I,mosaic_i,J), 'landusef2',landusef2(i,mosaic_i,j)
+                  print*, 'TSK_mosaic', TSK_mosaic(i,mosaic_i,j), 'HFX_mosaic', HFX_mosaic(i,mosaic_i,j), &
+                          'LH_mosaic',LH_mosaic(i,mosaic_i,j),'GRDFLX_mosaic',GRDFLX_mosaic(i,mosaic_i,j)
+                  print*, 'ZNT_mosaic', ZNT_mosaic(i, mosaic_i,j), 'Z0_mosaic', Z0_mosaic(i,mosaic_i,j) 
+                  print*, 'FRC_URB2D',FRC_URB2D(I,J)
+                  print*, 'TS_URB',TS_URB2D(I,J),'T1',T1
+                  print*, 'SH_URB2D',SH_URB2D(I,J),'SHEAT',SHEAT
+                  print*, 'LH_URB',LH_URB2D(I,J),'ETA',ETA
+                  print*, 'TS_RUL2D',TS_RUL2D_mosaic(I,mosaic_i,J)
+                  
+            ENDIF
+#endif
+                  
+      !-----------------------------------------------------------------------
+      ! Now let's do the grid-averaging
+      !-----------------------------------------------------------------------
+      
+                  FAREA  = landusef2(i,mosaic_i,j)
+      
+                  TSK_mosaic_avg(i,j) = TSK_mosaic_avg(i,j) + (EMISS_mosaic(i,mosaic_i,j)*TSK_mosaic(i,mosaic_i,j)**4)*FAREA    ! conserve the longwave radiation
+                  
+                  QSFC_mosaic_avg(i,j) = QSFC_mosaic_avg(i,j) + QSFC_mosaic(i,mosaic_i,j)*FAREA
+                  CANWAT_mosaic_avg(i,j) = CANWAT_mosaic_avg(i,j) + CANWAT_mosaic(i,mosaic_i,j)*FAREA
+                  SNOW_mosaic_avg(i,j) = SNOW_mosaic_avg(i,j) + SNOW_mosaic(i,mosaic_i,j)*FAREA
+                  SNOWH_mosaic_avg(i,j) = SNOWH_mosaic_avg(i,j) + SNOWH_mosaic(i,mosaic_i,j)*FAREA
+                  SNOWC_mosaic_avg(i,j) = SNOWC_mosaic_avg(i,j) + SNOWC_mosaic(i,mosaic_i,j)*FAREA
+      
+                   DO NS=1,NSOIL
+      
+                 TSLB_mosaic_avg(i,NS,j)=TSLB_mosaic_avg(i,NS,j) + TSLB_mosaic(i,NS*mosaic_i,j)*FAREA
+                 SMOIS_mosaic_avg(i,NS,j)=SMOIS_mosaic_avg(i,NS,j) + SMOIS_mosaic(i,NS*mosaic_i,j)*FAREA
+                 SH2O_mosaic_avg(i,NS,j)=SH2O_mosaic_avg(i,NS,j) + SH2O_mosaic(i,NS*mosaic_i,j)*FAREA
+      
+                   ENDDO
+      
+                  FAREA_mosaic_avg(i,j)=FAREA_mosaic_avg(i,j)+FAREA
+                  HFX_mosaic_avg(i,j) = HFX_mosaic_avg(i,j) + HFX_mosaic(i,mosaic_i,j)*FAREA
+                  QFX_mosaic_avg(i,j) = QFX_mosaic_avg(i,j) + QFX_mosaic(i,mosaic_i,j)*FAREA
+                  LH_mosaic_avg(i,j) = LH_mosaic_avg(i,j) + LH_mosaic(i,mosaic_i,j)*FAREA
+                  GRDFLX_mosaic_avg(i,j)=GRDFLX_mosaic_avg(i,j)+GRDFLX_mosaic(i,mosaic_i,j)*FAREA
+                  
+                  ALBEDO_mosaic_avg(i,j)=ALBEDO_mosaic_avg(i,j)+ALBEDO_mosaic(i,mosaic_i,j)*FAREA
+                  ALBBCK_mosaic_avg(i,j)=ALBBCK_mosaic_avg(i,j)+ALBBCK_mosaic(i,mosaic_i,j)*FAREA
+                  EMISS_mosaic_avg(i,j)=EMISS_mosaic_avg(i,j)+EMISS_mosaic(i,mosaic_i,j)*FAREA
+                  EMBCK_mosaic_avg(i,j)=EMBCK_mosaic_avg(i,j)+EMBCK_mosaic(i,mosaic_i,j)*FAREA
+                  ZNT_mosaic_avg(i,j)=ZNT_mosaic_avg(i,j)+ALOG(ZNT_mosaic(i,mosaic_i,j))*FAREA
+                  Z0_mosaic_avg(i,j)=Z0_mosaic_avg(i,j)+ALOG(Z0_mosaic(i,mosaic_i,j))*FAREA
+       
+         ENDDO                     ! ENDDO FOR mosaic_i = 1, mosaic_cat
+      
+      !-----------------------------------------------------------------------
+      ! Now let's send the 3D values to the 2D variables that might be needed in other routines
+      !-----------------------------------------------------------------------
+      
+          IVGTYP(I,J)=IVGTYP_dominant(I,J)                                 ! the dominant vege category 
+          ALBEDO(i,j)=ALBEDO_mosaic_avg(i,j)
+          ALBBCK(i,j)=ALBBCK_mosaic_avg(i,j) 
+          EMISS(i,j)= EMISS_mosaic_avg(i,j) 
+          EMBCK(i,j)= EMBCK_mosaic_avg(i,j)  
+          ZNT(i,j)= EXP(ZNT_mosaic_avg(i,j)/FAREA_mosaic_avg(i,j))
+          Z0(i,j)= EXP(Z0_mosaic_avg(i,j)/FAREA_mosaic_avg(i,j))
+                                                                                       
+          TSK(i,j)=(TSK_mosaic_avg(I,J)/EMISS_mosaic_avg(I,J))**(0.25)                                  ! from 3D to 2D
+          QSFC(i,j)=QSFC_mosaic_avg(I,J)
+          CANWAT(i,j) = CANWAT_mosaic_avg(i,j)
+          SNOW(i,j) = SNOW_mosaic_avg(i,j)
+          SNOWH(i,j) = SNOWH_mosaic_avg(i,j)  
+          SNOWC(i,j) = SNOWC_mosaic_avg(i,j)    
+          
+          HFX(i,j) = HFX_mosaic_avg(i,j) 
+          QFX(i,j) = QFX_mosaic_avg(i,j) 
+          LH(i,j) = LH_mosaic_avg(i,j) 
+          GRDFLX(i,j)=GRDFLX_mosaic_avg(i,j)
+        
+                    DO NS=1,NSOIL
+      
+               TSLB(i,NS,j)=TSLB_mosaic_avg(i,NS,j)
+               SMOIS(i,NS,j)=SMOIS_mosaic_avg(i,NS,j)
+               SH2O(i,NS,j)=SH2O_mosaic_avg(i,NS,j)
+      
+                    ENDDO
+      
+      ELSE    ! This corresponds to IF ((sf_surface_mosaic == 1) .AND. ((XLAND(I,J)-1.5).LT.0.) .AND. (XICE(I,J) < XICE_THRESHOLD) ) THEN
+      
+      ! surface pressure
+              PSFC=P8w3D(i,1,j)
+      ! pressure in middle of lowest layer
+              SFCPRS=(P8W3D(I,KTS+1,j)+P8W3D(i,KTS,j))*0.5
+      ! convert from mixing ratio to specific humidity
+               Q2K=QV3D(i,1,j)/(1.0+QV3D(i,1,j))
+      !
+      !         Q2SAT=QGH(I,j)
+               Q2SAT=QGH(I,J)/(1.0+QGH(I,J))        ! Q2SAT is sp humidity
+      ! add check on myj=.true.
+      !        IF((Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+              IF((myj).AND.(Q2K.GE.Q2SAT*TRESH).AND.Q2K.LT.QZ0(I,J))THEN
+                SATFLG=0.
+                CHKLOWQ(I,J)=0.
+              ELSE
+                SATFLG=1.0
+                CHKLOWQ(I,J)=1.
+              ENDIF
+      
+              SFCTMP=T3D(i,1,j)
+              ZLVL=0.5*DZ8W(i,1,j)
+      
+      !        TH2=SFCTMP+(0.0097545*ZLVL)
+      ! calculate SFCTH2 via Exner function vs lapse-rate (above)
+               APES=(1.E5/PSFC)**CAPA
+               APELM=(1.E5/SFCPRS)**CAPA
+               SFCTH2=SFCTMP*APELM
+               TH2=SFCTH2/APES
+      !
+               EMISSI = EMISS(I,J)
+               LWDN=GLW(I,J)*EMISSI
+      ! SOLDN is total incoming solar
+              SOLDN=SWDOWN(I,J)
+      ! GSW is net downward solar
+      !        SOLNET=GSW(I,J)
+      ! use mid-day albedo to determine net downward solar (no solar zenith angle correction)
+              SOLNET=SOLDN*(1.-ALBEDO(I,J))
+              PRCP=RAINBL(i,j)/DT
+              VEGTYP=IVGTYP(I,J)
+              SOILTYP=ISLTYP(I,J)
+              SHDFAC=VEGFRA(I,J)/100.
+              T1=TSK(I,J)
+              CHK=CHS(I,J)
+              SHMIN=SHDMIN(I,J)/100. !NEW
+              SHMAX=SHDMAX(I,J)/100. !NEW
+      ! convert snow water equivalent from mm to meter
+              SNEQV=SNOW(I,J)*0.001
+      ! snow depth in meters
+              SNOWHK=SNOWH(I,J)
+              SNCOVR=SNOWC(I,J)
+      
+      ! if "SR" present, set frac of frozen precip ("FFROZP") = snow-ratio ("SR", range:0-1)
+      ! SR from e.g. Ferrier microphysics
+      ! otherwise define from 1st atmos level temperature
+             IF(FRPCPN) THEN
+                FFROZP=SR(I,J)
+              ELSE
+                IF (SFCTMP <=  273.15) THEN
+                  FFROZP = 1.0
+      	  ELSE
+      	    FFROZP = 0.0
+      	  ENDIF
+              ENDIF
+      !***
+              IF((XLAND(I,J)-1.5).GE.0.)THEN                                  ! begining of land/sea if block
+      ! Open water points
+                TSK_RURAL(I,J)=TSK(I,J)
+                HFX_RURAL(I,J)=HFX(I,J)
+                QFX_RURAL(I,J)=QFX(I,J)
+                LH_RURAL(I,J)=LH(I,J)
+                EMISS_RURAL(I,J)=EMISS(I,J)
+                GRDFLX_RURAL(I,J)=GRDFLX(I,J)
+              ELSE
+      ! Land or sea-ice case
+      
+                IF (XICE(I,J) >= XICE_THRESHOLD) THEN
+                   ! Sea-ice point
+                   ICE = 1
+                ELSE IF ( VEGTYP == ISICE ) THEN
+                   ! Land-ice point
+                   ICE = -1
+                ELSE
+                   ! Neither sea ice or land ice.
+                   ICE=0
+                ENDIF
+                DQSDT2=Q2SAT*A23M4/(SFCTMP-A4)**2
+      
+                IF(SNOW(I,J).GT.0.0)THEN
+      ! snow on surface (use ice saturation properties)
+                  SFCTSNO=SFCTMP
+                  E2SAT=611.2*EXP(6174.*(1./273.15 - 1./SFCTSNO))
+                  Q2SATI=0.622*E2SAT/(SFCPRS-E2SAT)
+                  Q2SATI=Q2SATI/(1.0+Q2SATI)    ! spec. hum.
+                  IF (T1 .GT. 273.14) THEN
+      ! warm ground temps, weight the saturation between ice and water according to SNOWC
+                    Q2SAT=Q2SAT*(1.-SNOWC(I,J)) + Q2SATI*SNOWC(I,J)
+                    DQSDT2=DQSDT2*(1.-SNOWC(I,J)) + Q2SATI*6174./(SFCTSNO**2)*SNOWC(I,J)
+                  ELSE
+      ! cold ground temps, use ice saturation only
+                    Q2SAT=Q2SATI
+                    DQSDT2=Q2SATI*6174./(SFCTSNO**2)
+                  ENDIF
+      ! for snow cover fraction at 0 C, ground temp will not change, so DQSDT2 effectively zero
+                  IF(T1 .GT. 273. .AND. SNOWC(I,J) .GT. 0.)DQSDT2=DQSDT2*(1.-SNOWC(I,J))
+                ENDIF
+      
+                ! Land-ice or land points use the usual deep-soil temperature.
+                TBOT=TMN(I,J)
+      
+                IF(VEGTYP.EQ.25) SHDFAC=0.0000
+                IF(VEGTYP.EQ.26) SHDFAC=0.0000
+                IF(VEGTYP.EQ.27) SHDFAC=0.0000
+                IF(SOILTYP.EQ.14.AND.XICE(I,J).EQ.0.)THEN
+#if 0
+               IF(IPRINT)PRINT*,' SOIL TYPE FOUND TO BE WATER AT A LAND-POINT'
+               IF(IPRINT)PRINT*,i,j,'RESET SOIL in surfce.F'
+#endif
+                  SOILTYP=7
+                ENDIF
+                SNOALB1 = SNOALB(I,J)
+                CMC=CANWAT(I,J)
+      
+      !-------------------------------------------
+      !*** convert snow depth from mm to meter
+      !
+      !          IF(RDMAXALB) THEN
+      !           SNOALB=ALBMAX(I,J)*0.01
+      !         ELSE
+      !           SNOALB=MAXALB(IVGTPK)*0.01
+      !         ENDIF
+      
+      !        SNOALB1=0.80
+      !        SHMIN=0.00
+              ALBBRD=ALBBCK(I,J)
+              Z0BRD=Z0(I,J)
+              EMBRD=EMBCK(I,J)
+              SNOTIME1 = SNOTIME(I,J)
+              RIBB=RIB(I,J)
+      !FEI: temporaray arrays above need to be changed later by using SI
+      
+                DO NS=1,NSOIL
+                  SMC(NS)=SMOIS(I,NS,J)
+                  STC(NS)=TSLB(I,NS,J)                                          !STEMP
+                  SWC(NS)=SH2O(I,NS,J)
+                ENDDO
+      !
+                if ( (SNEQV.ne.0..AND.SNOWHK.eq.0.).or.(SNOWHK.le.SNEQV) )THEN
+                  SNOWHK= 5.*SNEQV
+                endif
+      !
+      
+      !Fei: urban. for urban surface, if calling UCM, redefine the natural surface in cities as
+      ! the "NATURAL" category in the VEGPARM.TBL
+      	
+      	   IF(SF_URBAN_PHYSICS == 1.OR. SF_URBAN_PHYSICS==2.OR.SF_URBAN_PHYSICS==3 ) THEN
+                      IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                        IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+      		 VEGTYP = NATURAL
+                       SHDFAC = SHDTBL(NATURAL)
+                       ALBEDOK =0.2         !  0.2
+                       ALBBRD  =0.2         !0.2
+                       EMISSI = 0.98                                 !for VEGTYP=5
+      		 IF ( FRC_URB2D(I,J) < 0.99 ) THEN
+                         if(sf_urban_physics.eq.1)then
+                 T1= ( TSK(I,J) -FRC_URB2D(I,J) * TS_URB2D (I,J) )/ (1-FRC_URB2D(I,J))
+                         elseif((sf_urban_physics.eq.2).OR.(sf_urban_physics.eq.3))then
+                      r1= (tsk(i,j)**4.)
+                      r2= frc_urb2d(i,j)*(ts_urb2d(i,j)**4.)
+                      r3= (1.-frc_urb2d(i,j))
+                      t1= ((r1-r2)/r3)**.25
+                         endif
+      	         ELSE
+      		 T1 = TSK(I,J)
+                       ENDIF
+                      ENDIF
+                 ELSE
+                       IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                        IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+                        VEGTYP = ISURBAN
+                 	 ENDIF
+                 ENDIF
+
+
+!===Yang, 2014/10/08, hydrological processes for urban vegetation in single layer UCM===
+           AOASIS = 1.0
+           USOIL = 1
+           DSOIL = 2
+           IRIOPTION=IRI_SCHEME
+           OMG= OMG_URB2D(I,J)   
+           tloc=mod(int(OMG/3.14159*180./15.+12.+0.5 ),24)
+           if (tloc.lt.0) tloc=tloc+24
+           if (tloc==0) tloc=24
+           CALL cal_mon_day(julian,julyr,jmonth,jday) 
+	  IF(SF_URBAN_PHYSICS == 1) THEN
+           IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33) THEN
+            AOASIS = oasis  ! urban oasis effect
+                   IF (IRIOPTION ==1) THEN
+                   IF (tloc==21 .or. tloc==22) THEN  !irrigation on vegetaion in urban area, MAY-SEP, 9-10pm
+                   IF (jmonth==5 .or. jmonth==6 .or. jmonth==7 .or. jmonth==8 .or. jmonth==9) THEN
+                      IF (SMC(USOIL) .LT. SMCREF) SMC(USOIL)= REFSMC(ISLTYP(I,J))
+                      IF (SMC(DSOIL) .LT. SMCREF) SMC(DSOIL)= REFSMC(ISLTYP(I,J))
+                   ENDIF
+                   ENDIF
+                   ENDIF
+                ENDIF
+           ENDIF
+
+	  IF(SF_URBAN_PHYSICS == 2 .or. SF_URBAN_PHYSICS == 3) THEN
+          IF(AOASIS > 1.0) THEN
+          CALL wrf_error_fatal('Urban oasis option is for SF_URBAN_PHYSICS == 1 only')
+          ENDIF
+          IF(IRIOPTION == 1) THEN
+          CALL wrf_error_fatal('Urban irrigation option is for SF_URBAN_PHYSICS == 1 only')
+          ENDIF
+          ENDIF
+
+#if 0
+                IF(IPRINT) THEN
+      !
+             print*, 'BEFORE SFLX, in Noahlsm_driver'
+             print*, 'ICE', ICE, 'DT',DT, 'ZLVL',ZLVL, 'NSOIL', NSOIL,   &
+             'SLDPTH', SLDPTH, 'LOCAL',LOCAL, 'LUTYPE',&
+              LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN, 'SOLDN',SOLDN,      &
+              'SFCPRS',SFCPRS, 'PRCP',PRCP,'SFCTMP',SFCTMP,'Q2K',Q2K,   &
+               'TH2',TH2,'Q2SAT',Q2SAT,'DQSDT2',DQSDT2,'VEGTYP', VEGTYP,&
+               'SOILTYP',SOILTYP, 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC,&
+               'SHMIN',SHMIN, 'ALBBRD',ALBBRD,'SNOALB1',SNOALB1,'TBOT',&
+                TBOT, 'Z0BRD',Z0BRD, 'Z0K',Z0K, 'CMC',CMC, 'T1',T1,'STC',&
+                STC, 'SMC',SMC, 'SWC',SWC,'SNOWHK',SNOWHK,'SNEQV',SNEQV,&
+                'ALBEDOK',ALBEDOK,'CHK',CHK,'ETA',ETA,'SHEAT',SHEAT,      &
+                'ETA_KINEMATIC',ETA_KINEMATIC, 'FDOWN',FDOWN,'EC',EC,   &
+                'EDIR',EDIR,'ET',ET,'ETT',ETT,'ESNOW',ESNOW,'DRIP',DRIP,&
+                'DEW',DEW,'BETA',BETA,'ETP',ETP,'SSOIL',SSOIL,'FLX1',FLX1,&
+                'FLX2',FLX2,'FLX3',FLX3,'SNOMLT',SNOMLT,'SNCOVR',SNCOVR,&
+                'RUNOFF1',RUNOFF1,'RUNOFF2',RUNOFF2,'RUNOFF3',RUNOFF3, &
+                'RC',RC, 'PC',PC,'RSMIN',RSMIN,'XLAI',XLAI,'RCS',RCS,  &
+                'RCT',RCT,'RCQ',RCQ,'RCSOIL',RCSOIL,'SOILW',SOILW,     &
+                'SOILM',SOILM,'Q1',Q1,'SMCWLT',SMCWLT,'SMCDRY',SMCDRY,&
+                'SMCREF',SMCREF,'SMCMAX',SMCMAX,'NROOT',NROOT
+                 endif
+#endif
+      
+                IF (rdlai2d) THEN
+                   xlai = lai(i,j)
+                endif
+      
+          IF ( ICE == 1 ) THEN
+      
+             ! Sea-ice case
+      
+             DO NS = 1, NSOIL
+                SH2O(I,NS,J) = 1.0
+             ENDDO
+             LAI(I,J) = 0.01
+      
+             CYCLE ILOOP
+      
+          ELSEIF (ICE == 0) THEN
+      
+             ! Non-glacial land
+      
+             CALL SFLX (I,J,FFROZP, ISURBAN, DT,ZLVL,NSOIL,SLDPTH,       &    !C
+                       LOCAL,                                            &    !L
+                       LUTYPE, SLTYPE,                                   &    !CL
+                       LWDN,SOLDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,DUMMY,   &    !F
+                       DUMMY,DUMMY, DUMMY,                               &    !F PRCPRAIN not used
+                       TH2,Q2SAT,DQSDT2,                                 &    !I
+                       VEGTYP,SOILTYP,SLOPETYP,SHDFAC,SHMIN,SHMAX,       &    !I
+                       ALBBRD, SNOALB1,TBOT, Z0BRD, Z0K, EMISSI, EMBRD,  &    !S
+                       CMC,T1,STC,SMC,SWC,SNOWHK,SNEQV,ALBEDOK,CHK,dummy,&    !H
+                       ETA,SHEAT, ETA_KINEMATIC,FDOWN,                   &    !O
+                       EC,EDIR,ET,ETT,ESNOW,DRIP,DEW,                    &    !O
+                       BETA,ETP,SSOIL,                                   &    !O
+                       FLX1,FLX2,FLX3,                                   &    !O
+      		 FLX4,FVB,FBUR,FGSN,UA_PHYS,                             &    !UA 
+                       SNOMLT,SNCOVR,                                    &    !O
+                       RUNOFF1,RUNOFF2,RUNOFF3,                          &    !O
+                       RC,PC,RSMIN,XLAI,RCS,RCT,RCQ,RCSOIL,              &    !O
+                       SOILW,SOILM,Q1,SMAV,                              &    !D
+                       RDLAI2D,USEMONALB,                                &
+                       SNOTIME1,                                         &
+                       RIBB,                                             &
+                       SMCWLT,SMCDRY,SMCREF,SMCMAX,NROOT,                &
+                       sfcheadrt(i,j),                                   &    !I
+                       INFXSRT(i,j),ETPND1,AOASIS                        &    !O
+                       )
+      
+#ifdef WRF_HYDRO
+                       soldrain(i,j) = RUNOFF2*DT*1000.0
+#endif
+          ELSEIF (ICE == -1) THEN
+      
+             !
+             ! Set values that the LSM is expected to update,
+             ! but don't get updated for glacial points.
+             !
+             SOILM = 0.0 !BSINGH(PNNL)- SOILM is undefined for this case, it is used for diagnostics so setting it to zero
+             XLAI = 0.01 ! KWM Should this be Zero over land ice?  Does this value matter?
+             RUNOFF2 = 0.0
+             RUNOFF3 = 0.0
+             DO NS = 1, NSOIL
+                SWC(NS) = 1.0
+                SMC(NS) = 1.0
+                SMAV(NS) = 1.0
+             ENDDO
+             CALL SFLX_GLACIAL(I,J,ISICE,FFROZP,DT,ZLVL,NSOIL,SLDPTH,   &    !C
+                  &    LWDN,SOLNET,SFCPRS,PRCP,SFCTMP,Q2K,              &    !F
+                  &    TH2,Q2SAT,DQSDT2,                                &    !I
+                  &    ALBBRD, SNOALB1,TBOT, Z0BRD, Z0K, EMISSI, EMBRD, &    !S
+                  &    T1,STC(1:NSOIL),SNOWHK,SNEQV,ALBEDOK,CHK,        &    !H
+                  &    ETA,SHEAT,ETA_KINEMATIC,FDOWN,                   &    !O
+                  &    ESNOW,DEW,                                       &    !O
+                  &    ETP,SSOIL,                                       &    !O
+                  &    FLX1,FLX2,FLX3,                                  &    !O
+                  &    SNOMLT,SNCOVR,                                   &    !O
+                  &    RUNOFF1,                                         &    !O
+                  &    Q1,                                              &    !D
+                  &    SNOTIME1,                                        &
+                  &    RIBB)
+      
+          ENDIF
+      
+             lai(i,j) = xlai
+      
+#if 0
+                IF(IPRINT) THEN
+      
+             print*, 'AFTER SFLX, in Noahlsm_driver'
+             print*, 'ICE', ICE, 'DT',DT, 'ZLVL',ZLVL, 'NSOIL', NSOIL,   &
+             'SLDPTH', SLDPTH, 'LOCAL',LOCAL, 'LUTYPE',&
+              LUTYPE, 'SLTYPE',SLTYPE, 'LWDN',LWDN, 'SOLDN',SOLDN,      &
+              'SFCPRS',SFCPRS, 'PRCP',PRCP,'SFCTMP',SFCTMP,'Q2K',Q2K,   &
+               'TH2',TH2,'Q2SAT',Q2SAT,'DQSDT2',DQSDT2,'VEGTYP', VEGTYP,&
+                'SOILTYP',SOILTYP, 'SLOPETYP',SLOPETYP, 'SHDFAC',SHDFAC,&
+               'SHDMIN',SHMIN, 'ALBBRD',ALBBRD,'SNOALB',SNOALB1,'TBOT',&
+                TBOT, 'Z0BRD',Z0BRD, 'Z0K',Z0K, 'CMC',CMC, 'T1',T1,'STC',&
+                STC, 'SMC',SMC, 'SWc',SWC,'SNOWHK',SNOWHK,'SNEQV',SNEQV,&
+                'ALBEDOK',ALBEDOK,'CHK',CHK,'ETA',ETA,'SHEAT',SHEAT,      &
+                'ETA_KINEMATIC',ETA_KINEMATIC, 'FDOWN',FDOWN,'EC',EC,   &
+                'EDIR',EDIR,'ET',ET,'ETT',ETT,'ESNOW',ESNOW,'DRIP',DRIP,&
+                'DEW',DEW,'BETA',BETA,'ETP',ETP,'SSOIL',SSOIL,'FLX1',FLX1,&
+                'FLX2',FLX2,'FLX3',FLX3,'SNOMLT',SNOMLT,'SNCOVR',SNCOVR,&
+                'RUNOFF1',RUNOFF1,'RUNOFF2',RUNOFF2,'RUNOFF3',RUNOFF3, &
+                'RC',RC, 'PC',PC,'RSMIN',RSMIN,'XLAI',XLAI,'RCS',RCS,  &
+                'RCT',RCT,'RCQ',RCQ,'RCSOIL',RCSOIL,'SOILW',SOILW,     &
+                'SOILM',SOILM,'Q1',Q1,'SMCWLT',SMCWLT,'SMCDRY',SMCDRY,&
+                'SMCREF',SMCREF,'SMCMAX',SMCMAX,'NROOT',NROOT
+                 endif
+#endif
+      
+      !***  UPDATE STATE VARIABLES
+                CANWAT(I,J)=CMC
+                SNOW(I,J)=SNEQV*1000.
+      !          SNOWH(I,J)=SNOWHK*1000.
+                SNOWH(I,J)=SNOWHK                   ! SNOWHK in meters
+                ALBEDO(I,J)=ALBEDOK
+                ALB_RURAL(I,J)=ALBEDOK
+                ALBBCK(I,J)=ALBBRD
+                Z0(I,J)=Z0BRD
+                EMISS(I,J) = EMISSI
+                EMISS_RURAL(I,J) = EMISSI
+      ! Noah: activate time-varying roughness length (V3.3 Feb 2011)
+                ZNT(I,J)=Z0K
+                TSK(I,J)=T1
+                TSK_RURAL(I,J)=T1
+                HFX(I,J)=SHEAT
+                HFX_RURAL(I,J)=SHEAT
+      ! MEk Jul07 add potential evap accum
+              POTEVP(I,J)=POTEVP(I,J)+ETP*FDTW
+                QFX(I,J)=ETA_KINEMATIC
+                QFX_RURAL(I,J)=ETA_KINEMATIC
+      
+#ifdef WRF_HYDRO
+      !added by Wei Yu
+      !         QFX(I,J) = QFX(I,J) + ETPND1
+      !         ETA = ETA + ETPND1/2.501E6*dt
+      !end added by Wei Yu
+#endif
+      
+                LH(I,J)=ETA
+                LH_RURAL(I,J)=ETA
+                GRDFLX(I,J)=SSOIL
+                GRDFLX_RURAL(I,J)=SSOIL
+                SNOWC(I,J)=SNCOVR
+                CHS2(I,J)=CQS2(I,J)
+                SNOTIME(I,J) = SNOTIME1
+      !      prevent diagnostic ground q (q1) from being greater than qsat(tsk)
+      !      as happens over snow cover where the cqs2 value also becomes irrelevant
+      !      by setting cqs2=chs in this situation the 2m q should become just qv(k=1)
+                IF (Q1 .GT. QSFC(I,J)) THEN
+                  CQS2(I,J) = CHS(I,J)
+                ENDIF
+      !          QSFC(I,J)=Q1
+      ! Convert QSFC back to mixing ratio
+                 QSFC(I,J)= Q1/(1.0-Q1)
+      !
+                 ! QSFC_RURAL(I,J)= Q1/(1.0-Q1)
+      ! Calculate momentum flux from rural surface for use with multi-layer UCM (Martilli et al. 2002)
+      
+                DO 80 NS=1,NSOIL
+                 SMOIS(I,NS,J)=SMC(NS)
+                 TSLB(I,NS,J)=STC(NS)                                        !  STEMP
+                 SH2O(I,NS,J)=SWC(NS)
+         80     CONTINUE
+      !       ENDIF
+      
+              FLX4_2D(I,J)  = FLX4
+      	FVB_2D(I,J)   = FVB
+      	FBUR_2D(I,J)  = FBUR
+      	FGSN_2D(I,J)  = FGSN
+           !
+           ! Residual of surface energy balance equation terms
+           !
+      
+           IF ( UA_PHYS ) THEN
+               noahres(i,j) = ( solnet + lwdn ) - sheat + ssoil - eta &
+                    - ( emissi * STBOLT * (t1**4) ) - flx1 - flx2 - flx3 - flx4
+      
+           ELSE
+               noahres(i,j) = ( solnet + lwdn ) - sheat + ssoil - eta &
+                    - ( emissi * STBOLT * (t1**4) ) - flx1 - flx2 - flx3
+           ENDIF
+      
+              IF (SF_URBAN_PHYSICS == 1 ) THEN                                              ! Beginning of UCM CALL if block
+      !--------------------------------------
+      ! URBAN CANOPY MODEL START - urban
+      !--------------------------------------
+      ! Input variables lsm --> urban
+      
+                IF( IVGTYP(I,J) == ISURBAN .or. IVGTYP(I,J) == 31 .or. &
+                    IVGTYP(I,J) == 32 .or. IVGTYP(I,J) == 33 ) THEN
+      
+      ! Call urban
+      !
+                  UTYPE_URB = UTYPE_URB2D(I,J) !urban type (low, high or industrial)
+      
+                  TA_URB    = SFCTMP           ! [K]
+                  QA_URB    = Q2K              ! [kg/kg]
+                  UA_URB    = SQRT(U_PHY(I,1,J)**2.+V_PHY(I,1,J)**2.)
+                  U1_URB    = U_PHY(I,1,J)
+                  V1_URB    = V_PHY(I,1,J)
+                  IF(UA_URB < 1.) UA_URB=1.    ! [m/s]
+                  SSG_URB   = SOLDN            ! [W/m/m]
+                  SSGD_URB  = 0.8*SOLDN        ! [W/m/m]
+                  SSGQ_URB  = SSG_URB-SSGD_URB ! [W/m/m]
+                  LLG_URB   = GLW(I,J)         ! [W/m/m]
+                  RAIN_URB  = RAINBL(I,J)      ! [mm]
+                  RHOO_URB  = SFCPRS / (287.04 * SFCTMP * (1.0+ 0.61 * Q2K)) ![kg/m/m/m]
+                  ZA_URB    = ZLVL             ! [m]
+                  DELT_URB  = DT               ! [sec]
+                  XLAT_URB  = XLAT_URB2D(I,J)  ! [deg]
+                  COSZ_URB  = COSZ_URB2D(I,J)  !
+                  OMG_URB   = OMG_URB2D(I,J)   !
+                  ZNT_URB   = ZNT(I,J)
+      
+                  LSOLAR_URB = .FALSE.
+      
+                  TR_URB = TR_URB2D(I,J)
+                  TB_URB = TB_URB2D(I,J)
+                  TG_URB = TG_URB2D(I,J)
+                  TC_URB = TC_URB2D(I,J)
+                  QC_URB = QC_URB2D(I,J)
+                  UC_URB = UC_URB2D(I,J)
+      
+                  DO K = 1,num_roof_layers
+                    TRL_URB(K) = TRL_URB3D(I,K,J)
+                    SMR_URB(K) = SMR_URB3D(I,K,J)
+             	      TGRL_URB(K)= TGRL_URB3D(I,K,J)
+                  END DO
+                  DO K = 1,num_wall_layers
+                    TBL_URB(K) = TBL_URB3D(I,K,J)
+                  END DO
+                  DO K = 1,num_road_layers
+                    TGL_URB(K) = TGL_URB3D(I,K,J)
+                  END DO
+
+                  TGR_URB   = TGR_URB2D(I,J)
+                  CMCR_URB  = CMCR_URB2D(I,J)
+                  FLXHUMR_URB = FLXHUMR_URB2D(I,J)
+                  FLXHUMB_URB = FLXHUMB_URB2D(I,J)
+                  FLXHUMG_URB = FLXHUMG_URB2D(I,J)
+                  DRELR_URB = DRELR_URB2D(I,J)
+                  DRELB_URB = DRELB_URB2D(I,J)
+                  DRELG_URB = DRELG_URB2D(I,J)
+      
+                  XXXR_URB = XXXR_URB2D(I,J)
+                  XXXB_URB = XXXB_URB2D(I,J)
+                  XXXG_URB = XXXG_URB2D(I,J)
+                  XXXC_URB = XXXC_URB2D(I,J)
+      !
+      !      Limits to avoid dividing by small number
+                  if (CHS(I,J) < 1.0E-02) then
+                     CHS(I,J)  = 1.0E-02
+                  endif
+                  if (CHS2(I,J) < 1.0E-02) then
+                     CHS2(I,J)  = 1.0E-02
+                  endif
+                  if (CQS2(I,J) < 1.0E-02) then
+                     CQS2(I,J)  = 1.0E-02
+                  endif
+      !
+                  CHS_URB  = CHS(I,J)
+                  CHS2_URB = CHS2(I,J)
+                  IF (PRESENT(CMR_SFCDIF)) THEN
+                     CMR_URB = CMR_SFCDIF(I,J)
+                     CHR_URB = CHR_SFCDIF(I,J)
+                     CMGR_URB = CMGR_SFCDIF(I,J)
+                     CHGR_URB = CHGR_SFCDIF(I,J)
+                     CMC_URB = CMC_SFCDIF(I,J)
+                     CHC_URB = CHC_SFCDIF(I,J)
+                  ENDIF
+      
+      ! NUDAPT for SLUCM
+                  mh_urb = mh_urb2d(I,J)
+                  stdh_urb = stdh_urb2d(I,J)
+                  lp_urb = lp_urb2d(I,J)
+                  hgt_urb = hgt_urb2d(I,J)
+                  lf_urb = 0.0
+                  DO K = 1,4
+                    lf_urb(K)=lf_urb2d(I,K,J)
+                  ENDDO
+                  frc_urb = frc_urb2d(I,J)
+                  lb_urb = lb_urb2d(I,J)
+                  check = 0
+                  if (I.eq.73.and.J.eq.125)THEN
+                     check = 1
+                  end if
+      !
+      ! Call urban
+                  CALL cal_mon_day(julian,julyr,jmonth,jday)        
+                  CALL urban(LSOLAR_URB,                                      & ! I
+                             num_roof_layers,num_wall_layers,num_road_layers, & ! C
+                             DZR,DZB,DZG,                                     & ! C
+                             UTYPE_URB,TA_URB,QA_URB,UA_URB,U1_URB,V1_URB,SSG_URB, & ! I
+                             SSGD_URB,SSGQ_URB,LLG_URB,RAIN_URB,RHOO_URB,     & ! I
+                             ZA_URB,DECLIN_URB,COSZ_URB,OMG_URB,              & ! I
+                             XLAT_URB,DELT_URB,ZNT_URB,                       & ! I
+                             CHS_URB, CHS2_URB,                               & ! I
+                             TR_URB, TB_URB, TG_URB, TC_URB, QC_URB,UC_URB,   & ! H
+                             TRL_URB,TBL_URB,TGL_URB,                         & ! H
+                             XXXR_URB, XXXB_URB, XXXG_URB, XXXC_URB,          & ! H
+                             TS_URB,QS_URB,SH_URB,LH_URB,LH_KINEMATIC_URB,    & ! O
+                             SW_URB,ALB_URB,LW_URB,G_URB,RN_URB,PSIM_URB,PSIH_URB, & ! O
+                             GZ1OZ0_URB,                                      & !O
+                             CMR_URB, CHR_URB, CMC_URB, CHC_URB,              &
+                             U10_URB, V10_URB, TH2_URB, Q2_URB,               & ! O
+                             UST_URB,mh_urb, stdh_urb, lf_urb, lp_urb,        & ! 0
+                             hgt_urb,frc_urb,lb_urb, check,CMCR_URB,TGR_URB,  & ! H
+                             TGRL_URB,SMR_URB,CMGR_URB,CHGR_URB,jmonth,       & ! H
+                             DRELR_URB,DRELB_URB,                             & ! H
+                             DRELG_URB,FLXHUMR_URB,FLXHUMB_URB,FLXHUMG_URB)  
+      
+#if 0
+                IF(IPRINT) THEN
+      
+             print*, 'AFTER CALL URBAN'
+             print*,'num_roof_layers',num_roof_layers, 'num_wall_layers',  &
+              num_wall_layers,                                             &
+             'DZR',DZR,'DZB',DZB,'DZG',DZG,'UTYPE_URB',UTYPE_URB,'TA_URB', &
+              TA_URB,                                                      &
+              'QA_URB',QA_URB,'UA_URB',UA_URB,'U1_URB',U1_URB,'V1_URB',    &
+               V1_URB,                                                     &
+               'SSG_URB',SSG_URB,'SSGD_URB',SSGD_URB,'SSGQ_URB',SSGQ_URB,  &
+              'LLG_URB',LLG_URB,'RAIN_URB',RAIN_URB,'RHOO_URB',RHOO_URB,   &
+              'ZA_URB',ZA_URB, 'DECLIN_URB',DECLIN_URB,'COSZ_URB',COSZ_URB,&
+              'OMG_URB',OMG_URB,'XLAT_URB',XLAT_URB,'DELT_URB',DELT_URB,   &
+               'ZNT_URB',ZNT_URB,'TR_URB',TR_URB, 'TB_URB',TB_URB,'TG_URB',&
+               TG_URB,'TC_URB',TC_URB,'QC_URB',QC_URB,'TRL_URB',TRL_URB,   &
+                'TBL_URB',TBL_URB,'TGL_URB',TGL_URB,'XXXR_URB',XXXR_URB,   &
+               'XXXB_URB',XXXB_URB,'XXXG_URB',XXXG_URB,'XXXC_URB',XXXC_URB,&
+               'TS_URB',TS_URB,'QS_URB',QS_URB,'SH_URB',SH_URB,'LH_URB',   &
+               LH_URB, 'LH_KINEMATIC_URB',LH_KINEMATIC_URB,'SW_URB',SW_URB,&
+               'ALB_URB',ALB_URB,'LW_URB',LW_URB,'G_URB',G_URB,'RN_URB',   &
+                RN_URB, 'PSIM_URB',PSIM_URB,'PSIH_URB',PSIH_URB,          &
+               'U10_URB',U10_URB,'V10_URB',V10_URB,'TH2_URB',TH2_URB,      &
+                'Q2_URB',Q2_URB,'CHS_URB',CHS_URB,'CHS2_URB',CHS2_URB
+                 endif
+#endif
+      
+                  TS_URB2D(I,J) = TS_URB
+      
+                  ALBEDO(I,J) = FRC_URB2D(I,J)*ALB_URB+(1-FRC_URB2D(I,J))*ALBEDOK   ![-]
+                  HFX(I,J) = FRC_URB2D(I,J)*SH_URB+(1-FRC_URB2D(I,J))*SHEAT         ![W/m/m]
+                  QFX(I,J) = FRC_URB2D(I,J)*LH_KINEMATIC_URB &
+                           + (1-FRC_URB2D(I,J))*ETA_KINEMATIC                ![kg/m/m/s]
+                  LH(I,J) = FRC_URB2D(I,J)*LH_URB+(1-FRC_URB2D(I,J))*ETA            ![W/m/m]
+                  GRDFLX(I,J) = FRC_URB2D(I,J)*G_URB+(1-FRC_URB2D(I,J))*SSOIL       ![W/m/m]
+                  TSK(I,J) = FRC_URB2D(I,J)*TS_URB+(1-FRC_URB2D(I,J))*T1            ![K]
+                  Q1 = FRC_URB2D(I,J)*QS_URB+(1-FRC_URB2D(I,J))*Q1            ![-]
+      ! Convert QSFC back to mixing ratio
+                  QSFC(I,J)= Q1/(1.0-Q1)
+                  UST(I,J)= FRC_URB2D(I,J)*UST_URB+(1-FRC_URB2D(I,J))*UST(I,J)      ![m/s]
+      
+#if 0
+          IF(IPRINT)THEN
+      
+          print*, ' FRC_URB2D', FRC_URB2D,                        &
+          'ALB_URB',ALB_URB, 'ALBEDOK',ALBEDOK, &
+          'ALBEDO(I,J)',  ALBEDO(I,J),                  &
+          'SH_URB',SH_URB,'SHEAT',SHEAT, 'HFX(I,J)',HFX(I,J),  &
+          'LH_KINEMATIC_URB',LH_KINEMATIC_URB,'ETA_KINEMATIC',  &
+           ETA_KINEMATIC, 'QFX(I,J)',QFX(I,J),                  &
+          'LH_URB',LH_URB, 'ETA',ETA, 'LH(I,J)',LH(I,J),        &
+          'G_URB',G_URB,'SSOIL',SSOIL,'GRDFLX(I,J)', GRDFLX(I,J),&
+          'TS_URB',TS_URB,'T1',T1,'TSK(I,J)',TSK(I,J),          &
+          'QS_URB',QS_URB,'Q1',Q1,'QSFC(I,J)',QSFC(I,J)
+           endif
+#endif
+      
+      ! Renew Urban State Varialbes
+      
+                  TR_URB2D(I,J) = TR_URB
+                  TB_URB2D(I,J) = TB_URB
+                  TG_URB2D(I,J) = TG_URB
+                  TC_URB2D(I,J) = TC_URB
+                  QC_URB2D(I,J) = QC_URB
+                  UC_URB2D(I,J) = UC_URB
+      
+                  DO K = 1,num_roof_layers
+                    TRL_URB3D(I,K,J) = TRL_URB(K)
+                    SMR_URB3D(I,K,J) = SMR_URB(K)
+                    TGRL_URB3D(I,K,J)= TGRL_URB(K)
+                  END DO
+                  DO K = 1,num_wall_layers
+                    TBL_URB3D(I,K,J) = TBL_URB(K)
+                  END DO
+                  DO K = 1,num_road_layers
+                    TGL_URB3D(I,K,J) = TGL_URB(K)
+                  END DO
+                 
+                  TGR_URB2D(I,J) =TGR_URB 
+                  CMCR_URB2D(I,J)=CMCR_URB
+                  FLXHUMR_URB2D(I,J)=FLXHUMR_URB 
+                  FLXHUMB_URB2D(I,J)=FLXHUMB_URB
+                  FLXHUMG_URB2D(I,J)=FLXHUMG_URB
+                  DRELR_URB2D(I,J) = DRELR_URB 
+                  DRELB_URB2D(I,J) = DRELB_URB 
+                  DRELG_URB2D(I,J) = DRELG_URB
+
+                  XXXR_URB2D(I,J) = XXXR_URB
+                  XXXB_URB2D(I,J) = XXXB_URB
+                  XXXG_URB2D(I,J) = XXXG_URB
+                  XXXC_URB2D(I,J) = XXXC_URB
+      
+                  SH_URB2D(I,J)    = SH_URB
+                  LH_URB2D(I,J)    = LH_URB
+                  G_URB2D(I,J)     = G_URB
+                  RN_URB2D(I,J)    = RN_URB
+                  PSIM_URB2D(I,J)  = PSIM_URB
+                  PSIH_URB2D(I,J)  = PSIH_URB
+                  GZ1OZ0_URB2D(I,J)= GZ1OZ0_URB
+                  U10_URB2D(I,J)   = U10_URB
+                  V10_URB2D(I,J)   = V10_URB
+                  TH2_URB2D(I,J)   = TH2_URB
+                  Q2_URB2D(I,J)    = Q2_URB
+                  UST_URB2D(I,J)   = UST_URB
+                  AKMS_URB2D(I,J)  = KARMAN * UST_URB2D(I,J)/(GZ1OZ0_URB2D(I,J)-PSIM_URB2D(I,J))
+                  IF (PRESENT(CMR_SFCDIF)) THEN
+                     CMR_SFCDIF(I,J) = CMR_URB
+                     CHR_SFCDIF(I,J) = CHR_URB
+                     CMGR_SFCDIF(I,J) = CMGR_URB
+                     CHGR_SFCDIF(I,J) = CHGR_URB
+                     CMC_SFCDIF(I,J) = CMC_URB
+                     CHC_SFCDIF(I,J) = CHC_URB
+                  ENDIF
+                END IF
+      
+               ENDIF                                   ! end of UCM CALL if block
+      !--------------------------------------
+      ! Urban Part End - urban
+      !--------------------------------------
+      
+      !***  DIAGNOSTICS
+                SMSTAV(I,J)=SOILW
+                SMSTOT(I,J)=SOILM*1000.
+                DO NS=1,NSOIL
+                SMCREL(I,NS,J)=SMAV(NS)
+                ENDDO
+      
+      !         Convert the water unit into mm
+                SFCRUNOFF(I,J)=SFCRUNOFF(I,J)+RUNOFF1*DT*1000.0
+                UDRUNOFF(I,J)=UDRUNOFF(I,J)+RUNOFF2*DT*1000.0
+      ! snow defined when fraction of frozen precip (FFROZP) > 0.5,
+                IF(FFROZP.GT.0.5)THEN
+                  ACSNOW(I,J)=ACSNOW(I,J)+PRCP*DT
+                ENDIF
+                IF(SNOW(I,J).GT.0.)THEN
+                  ACSNOM(I,J)=ACSNOM(I,J)+SNOMLT*1000.
+      ! accumulated snow-melt energy
+                  SNOPCX(I,J)=SNOPCX(I,J)-SNOMLT/FDTLIW
+                ENDIF
+      
+              ENDIF                                                           ! endif of land-sea test
+
+      ENDIF                                           ! ENDIF FOR MOSAIC DANLI  ! This corresponds to IF ((sf_surface_mosaic == 1) .AND. ((XLAND(I,J)-1.5).LT.0.) .AND. (XICE(I,J) < XICE_THRESHOLD) ) THEN
+
+      ENDDO ILOOP                                                       ! of I loop
+   ENDDO JLOOP                                                          ! of J loop   
+       
+!------------------------------------------------------
+   END SUBROUTINE lsm_mosaic
+!------------------------------------------------------
+!===========================================================================
+!
+! subroutine lsm_mosaic_init: initialization of mosaic state variables
+!
+!===========================================================================   
+  
+   SUBROUTINE lsm_mosaic_init(IVGTYP,ISWATER,ISURBAN,ISICE, XLAND, XICE,fractional_seaice, &
+                  TSK,TSLB,SMOIS,SH2O,SNOW,SNOWC,SNOWH,CANWAT,    &
+                  ids,ide, jds,jde, kds,kde,                      &
+                  ims,ime, jms,jme, kms,kme,                      &
+                  its,ite, jts,jte, kts,kte, restart,             &
+                  landusef,landusef2,NLCAT,num_soil_layers        & 
+                  ,sf_surface_mosaic, mosaic_cat                  & 
+                  ,mosaic_cat_index                               &   
+                  ,TSK_mosaic,TSLB_mosaic                         &
+                  ,SMOIS_mosaic,SH2O_mosaic                       & 
+                  ,CANWAT_mosaic,SNOW_mosaic                      &
+                  ,SNOWH_mosaic,SNOWC_mosaic                      &
+                  ,ALBEDO,ALBBCK, EMISS, EMBCK,Z0                 &  !danli  
+                  ,ALBEDO_mosaic,ALBBCK_mosaic, EMISS_mosaic      &  !danli
+                  ,EMBCK_mosaic, ZNT_mosaic, Z0_mosaic            &  !danli
+                  ,TR_URB2D_mosaic,TB_URB2D_mosaic                &  !danli mosaic 
+                  ,TG_URB2D_mosaic,TC_URB2D_mosaic                &  !danli mosaic 
+                  ,QC_URB2D_mosaic                                &  !danli mosaic                  
+                  ,TRL_URB3D_mosaic,TBL_URB3D_mosaic              &  !danli mosaic 
+                  ,TGL_URB3D_mosaic                               &  !danli mosaic 
+                  ,SH_URB2D_mosaic,LH_URB2D_mosaic                &  !danli mosaic 
+                  ,G_URB2D_mosaic,RN_URB2D_mosaic                 &  !danli mosaic 
+                  ,TS_URB2D_mosaic                                &  !danli mosaic 
+                  ,TS_RUL2D_mosaic                                &  !danli mosaic                    
+                   ) 
+  
+    INTEGER,  INTENT(IN)   ::       ids,ide, jds,jde, kds,kde,  &
+                                    ims,ime, jms,jme, kms,kme,  &
+                                    its,ite, jts,jte, kts,kte 
+
+   INTEGER, INTENT(IN)       ::     NLCAT, num_soil_layers, ISWATER,ISURBAN, ISICE, fractional_seaice
+
+   LOGICAL , INTENT(IN) :: restart 
+
+!   REAL,    DIMENSION( num_soil_layers), INTENT(INOUT) :: ZS, DZS
+
+   REAL,    DIMENSION( ims:ime, num_soil_layers, jms:jme )    , &
+            INTENT(IN)    ::                             SMOIS, &  !Total soil moisture
+                                                         SH2O,  &  !liquid soil moisture       
+                                                         TSLB      !STEMP
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN)    ::                           SNOW, &
+                                                         SNOWH, &
+                                                         SNOWC, &
+                                                        CANWAT, &
+                                                        TSK, XICE, XLAND         
+  
+  INTEGER, INTENT(IN) :: sf_surface_mosaic  
+  INTEGER, INTENT(IN) :: mosaic_cat
+  INTEGER, DIMENSION( ims:ime, jms:jme ),INTENT(IN) :: IVGTYP
+  REAL, DIMENSION( ims:ime, NLCAT, jms:jme ) , INTENT(IN)::   LANDUSEF
+  REAL, DIMENSION( ims:ime, NLCAT, jms:jme ) , INTENT(INOUT)::   LANDUSEF2
+  
+  INTEGER, DIMENSION( ims:ime, NLCAT, jms:jme ), INTENT(INOUT) :: mosaic_cat_index 
+
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        TSK_mosaic, CANWAT_mosaic, SNOW_mosaic,SNOWH_mosaic, SNOWC_mosaic 
+  REAL, DIMENSION( ims:ime, 1:num_soil_layers*mosaic_cat, jms:jme ), OPTIONAL, INTENT(INOUT)::   &
+        TSLB_mosaic,SMOIS_mosaic,SH2O_mosaic
+  
+  REAL, DIMENSION( ims:ime, jms:jme ) , INTENT(IN)::   ALBEDO, ALBBCK, EMISS, EMBCK, Z0 
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        ALBEDO_mosaic,ALBBCK_mosaic, EMISS_mosaic, EMBCK_mosaic, ZNT_mosaic, Z0_mosaic
+
+  REAL, DIMENSION( ims:ime, 1:mosaic_cat, jms:jme ) , OPTIONAL, INTENT(INOUT)::   &
+        TR_URB2D_mosaic, TB_URB2D_mosaic, TG_URB2D_mosaic, TC_URB2D_mosaic,QC_URB2D_mosaic,  &
+        SH_URB2D_mosaic,LH_URB2D_mosaic,G_URB2D_mosaic,RN_URB2D_mosaic,TS_URB2D_mosaic, TS_RUL2D_mosaic  
+                    
+  REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_soil_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TRL_URB3D_mosaic
+  REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_soil_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TBL_URB3D_mosaic
+  REAL, OPTIONAL, DIMENSION( ims:ime, 1:num_soil_layers*mosaic_cat, jms:jme ), INTENT(INOUT) :: TGL_URB3D_mosaic    
+
+  INTEGER :: ij,i,j,mosaic_i,LastSwap,NumPairs,soil_k, Temp2,Temp5,Temp7, ICE,temp_index
+  REAL :: Temp, Temp3,Temp4,Temp6,xice_threshold
+  LOGICAL :: IPRINT
+  CHARACTER(len=256) :: message_text
+
+  IPRINT=.false.
+
+  if ( fractional_seaice == 0 ) then
+     xice_threshold = 0.5
+  else if ( fractional_seaice == 1 ) then
+     xice_threshold = 0.02
+  endif
+
+    IF(.not.restart)THEN
+  !===========================================================================   
+  ! CHOOSE THE TILES
+  !===========================================================================  
+  
+  itf=min0(ite,ide-1)
+  jtf=min0(jte,jde-1)
+
+  ! simple test
+   
+  DO i = its,itf
+     DO j = jts,jtf 
+        IF ((xland(i,j).LT. 1.5 ) .AND. (IVGTYP(i,j) .EQ. ISWATER)) THEN
+           PRINT*, 'BEFORE MOSAIC_INIT'
+           CALL wrf_message("BEFORE MOSAIC_INIT")
+           WRITE(message_text,fmt='(a,2I6,2F8.2,2I6)') 'I,J,xland,xice,mosaic_cat_index,ivgtyp = ', &
+                 I,J,xland(i,j),xice(i,j),mosaic_cat_index(I,1,J),IVGTYP(i,j)
+           CALL wrf_message(message_text)
+        ENDIF
+     ENDDO
+  ENDDO
+
+     DO i = its,itf
+        DO j = jts,jtf
+           DO mosaic_i=1,NLCAT
+              LANDUSEF2(i,mosaic_i,j)=LANDUSEF(i,mosaic_i,j)
+              mosaic_cat_index(i,mosaic_i,j)=mosaic_i
+           ENDDO
+        ENDDO
+     ENDDO
+
+     DO i = its,itf
+        DO j = jts,jtf
+          
+          NumPairs=NLCAT-1
+          
+          DO 
+               IF (NumPairs == 0) EXIT
+                   LastSwap = 1
+          DO  mosaic_i=1, NumPairs
+            IF(LANDUSEF2(i,mosaic_i, j) < LANDUSEF2(i,mosaic_i+1, j)  ) THEN
+               Temp = LANDUSEF2(i,mosaic_i, j)
+               LANDUSEF2(i,mosaic_i, j)=LANDUSEF2(i,mosaic_i+1, j)
+               LANDUSEF2(i,mosaic_i+1, j)=Temp            
+               LastSwap = mosaic_i 
+            
+               Temp2 =  mosaic_cat_index(i,mosaic_i,j)
+               mosaic_cat_index(i,mosaic_i,j)=mosaic_cat_index(i,mosaic_i+1,j)
+               mosaic_cat_index(i,mosaic_i+1,j)=Temp2
+            ENDIF
+          ENDDO
+               NumPairs = LastSwap - 1
+          ENDDO
+          
+        ENDDO
+      ENDDO
+
+  !===========================================================================   
+  ! For non-seaice grids, eliminate the seaice-tiles
+  !=========================================================================== 
+
+     DO i = its,itf
+        DO j = jts,jtf
+        
+         IF   (XLAND(I,J).LT.1.5)  THEN
+
+             ICE = 0
+                 IF( XICE(I,J).GE. XICE_THRESHOLD ) THEN
+                   WRITE (message_text,fmt='(a,2I5)') 'sea-ice at point, I and J = ', i,j
+                   CALL wrf_message(message_text)
+                 ICE = 1
+                 ENDIF   
+           
+          IF (ICE == 1)   Then         ! sea-ice case , eliminate sea-ice if they are not the dominant ones
+
+          IF (IVGTYP(i,j) == isice)  THEN    ! if this grid cell is dominanted by ice, then do nothing
+
+          ELSE
+
+                DO mosaic_i=2,mosaic_cat
+                   IF (mosaic_cat_index(i,mosaic_i,j) == isice ) THEN
+                       Temp4=LANDUSEF2(i,mosaic_i,j)
+                       Temp5=mosaic_cat_index(i,mosaic_i,j)
+
+                       LANDUSEF2(i,mosaic_i:NLCAT-1,j)=LANDUSEF2(i,mosaic_i+1:NLCAT,j)                       
+                       mosaic_cat_index(i,mosaic_i:NLCAT-1,j)=mosaic_cat_index(i,mosaic_i+1:NLCAT,j)
+
+                       LANDUSEF2(i,NLCAT,j)=Temp4
+                       mosaic_cat_index(i,NLCAT,j)=Temp5
+                   ENDIF 
+                 ENDDO
+
+          ENDIF   ! for (IVGTYP(i,j) == isice )
+          
+          ELSEIF (ICE ==0)  THEN
+          
+          IF ((mosaic_cat_index(I,1,J) .EQ. ISWATER)) THEN    
+          
+          ! xland < 1.5 but the dominant land use category based on our calculation is water
+	             
+           IF (IVGTYP(i,j) .EQ. ISWATER) THEN  
+           
+           ! xland < 1.5 but the dominant land use category based on the geogrid calculation is water, this must be wrong
+           
+              CALL wrf_message("IN MOSAIC_INIT")
+              WRITE(message_text,fmt='(a,3I6,2F8.2)') 'I,J,IVGTYP,XLAND,XICE = ',I,J,IVGTYP(I,J),xland(i,j),xice(i,j) 
+              CALL wrf_message(message_text)
+              CALL wrf_message("xland < 1.5 but the dominant land use category based on our calculation is water."//&
+                   "In addition, the dominant land use category based on the geogrid calculation is water, this must be wrong")
+           
+           ENDIF  ! for (IVGTYP(i,j) .EQ. ISWATER)
+           
+           IF (IVGTYP(i,j) .NE. ISWATER) THEN 
+           
+           ! xland < 1.5,   the dominant land use category based on our calculation is water, but based on the geogrid calculation is not water, which might be due to the inconsistence between land use data and land-sea mask
+           
+	       Temp4=LANDUSEF2(i,1,j)
+	       Temp5=mosaic_cat_index(i,1,j)
+	  
+	       LANDUSEF2(i,1:NLCAT-1,j)=LANDUSEF2(i,2:NLCAT,j)                       
+	       mosaic_cat_index(i,1:NLCAT-1,j)=mosaic_cat_index(i,2:NLCAT,j)
+	  
+	       LANDUSEF2(i,NLCAT,j)=Temp4
+	       mosaic_cat_index(i,NLCAT,j)=Temp5
+	             
+              CALL wrf_message("IN MOSAIC_INIT")
+              WRITE(message_text,fmt='(a,3I6,2F8.2)') 'I,J,IVGTYP,XLAND,XICE = ',I,J,IVGTYP(I,J),xland(i,j),xice(i,j) 
+              CALL wrf_message(message_text)
+              CALL wrf_message("xland < 1.5 but the dominant land use category based on our calculation is water."//&
+                   "this is fine as long as we change our calculation so that the dominant land use category is"//&
+                   "stwiched back to not water.")
+              WRITE(message_text,fmt='(a,2I6)') 'land use category has been switched, before and after values are ', &
+                   temp5,mosaic_cat_index(i,1,j)
+              CALL wrf_message(message_text)
+              WRITE(message_text,fmt='(a,2I6)') 'new dominant and second dominant cat are ', mosaic_cat_index(i,1,j),mosaic_cat_index(i,2,j)
+              CALL wrf_message(message_text)
+	             
+           ENDIF  ! for (IVGTYP(i,j) .NE. ISWATER)
+          
+           ELSE    !  for (mosaic_cat_index(I,1,J) .EQ. ISWATER)
+           
+                     DO mosaic_i=2,mosaic_cat
+	                IF (mosaic_cat_index(i,mosaic_i,j) == iswater ) THEN
+	                   Temp4=LANDUSEF2(i,mosaic_i,j)
+	                   Temp5=mosaic_cat_index(i,mosaic_i,j)
+	   
+	                   LANDUSEF2(i,mosaic_i:NLCAT-1,j)=LANDUSEF2(i,mosaic_i+1:NLCAT,j)                       
+	                   mosaic_cat_index(i,mosaic_i:NLCAT-1,j)=mosaic_cat_index(i,mosaic_i+1:NLCAT,j)
+	  
+	                   LANDUSEF2(i,NLCAT,j)=Temp4
+	                   mosaic_cat_index(i,NLCAT,j)=Temp5
+	                ENDIF 
+	              ENDDO
+             
+           ENDIF !  for (mosaic_cat_index(I,1,J) .EQ. ISWATER)
+             
+          ENDIF  !  for ICE == 1
+          
+      ELSE  ! FOR (XLAND(I,J).LT.1.5)
+      
+                 ICE = 0
+      
+                     IF( XICE(I,J).GE. XICE_THRESHOLD ) THEN
+                       WRITE (message_text,fmt='(a,2I6)') 'sea-ice at water point, I and J = ', i,j
+                       CALL wrf_message(message_text)
+                       ICE = 1
+                     ENDIF  
+      
+           IF ((mosaic_cat_index(I,1,J) .NE. ISWATER)) THEN    
+                
+                ! xland > 1.5 and the dominant land use category based on our calculation is not water
+      	             
+                 IF (IVGTYP(i,j) .NE. ISWATER) THEN  
+                 
+                 ! xland > 1.5 but the dominant land use category based on the geogrid calculation is not water, this must be wrong
+                 CALL wrf_message("IN MOSAIC_INIT")
+                 WRITE(message_text,fmt='(a,3I6,2F8.2)') 'I,J,IVGTYP,XLAND,XICE = ',I,J,IVGTYP(I,J),xland(i,j),xice(i,j)
+                 CALL wrf_message(message_text)
+                 CALL wrf_message("xland > 1.5 but the dominant land use category based on our calculation is not water."// &
+                      "in addition, the dominant land use category based on the geogrid calculation is not water,"//  &
+                      "this must be wrong.")
+                 ENDIF  ! for (IVGTYP(i,j) .NE. ISWATER)
+                 
+                 IF (IVGTYP(i,j) .EQ. ISWATER) THEN 
+                 
+                 ! xland > 1.5,   the dominant land use category based on our calculation is not water, but based on the geogrid calculation is water, which might be due to the inconsistence between land use data and land-sea mask
+
+                 CALL wrf_message("IN MOSAIC_INIT")
+                 WRITE(message_text,fmt='(a,3I6,2F8.2)') 'I,J,IVGTYP,XLAND,XICE = ',I,J,IVGTYP(I,J),xland(i,j),xice(i,j)
+                 CALL wrf_message(message_text)
+                 CALL wrf_message("xland > 1.5 but the dominant land use category based on our calculation is not water."// &
+                      "however, the dominant land use category based on the geogrid calculation is water")
+                 CALL wrf_message("This is fine. We do not need to do anyting because in the noaddrv, "//&
+                      "we use xland as a criterion for whether using"// &
+                      "mosaic or not when xland > 1.5, no mosaic will be used anyway")
+      	             
+                 ENDIF  ! for (IVGTYP(i,j) .NE. ISWATER)
+                
+           ENDIF !  for (mosaic_cat_index(I,1,J) .NE. ISWATER)
+      
+        ENDIF  ! FOR (XLAND(I,J).LT.1.5)
+
+          ENDDO
+      ENDDO
+      
+  !===========================================================================   
+  ! normalize
+  !=========================================================================== 
+
+     DO i = its,itf
+        DO j = jts,jtf
+
+          Temp6=0
+
+            DO mosaic_i=1,mosaic_cat
+               Temp6=Temp6+LANDUSEF2(i,mosaic_i,j)
+            ENDDO
+            
+            if (Temp6 .LT. 1e-5)  then
+            
+            Temp6 = 1e-5
+            WRITE (message_text,fmt='(a,e8.1)') 'the total land surface fraction is less than ', temp6
+            CALL wrf_message(message_text)
+            WRITE (message_text,fmt='(a,2I6,4F8.2)') 'some landusef values at i,j are ', &
+                 i,j,landusef2(i,1,j),landusef2(i,2,j),landusef2(i,3,j),landusef2(i,4,j)
+            CALL wrf_message(message_text)
+            WRITE (message_text,fmt='(a,2I6,3I6)') 'some mosaic cat values at i,j are ', &
+                 i,j,mosaic_cat_index(i,1,j),mosaic_cat_index(i,2,j),mosaic_cat_index(i,3,j) 
+            CALL wrf_message(message_text)
+            
+            endif
+
+            LANDUSEF2(i,1:mosaic_cat, j)=LANDUSEF2(i,1:mosaic_cat,j)*(1/Temp6)
+
+          ENDDO
+      ENDDO
+      
+  !===========================================================================   
+  ! initilize the variables
+  !===========================================================================   
+
+     DO i = its,itf
+        DO j = jts,jtf
+    
+             DO mosaic_i=1,mosaic_cat
+        
+            TSK_mosaic(i,mosaic_i,j)=TSK(i,j)          
+            CANWAT_mosaic(i,mosaic_i,j)=CANWAT(i,j) 
+            SNOW_mosaic(i,mosaic_i,j)=SNOW(i,j) 
+            SNOWH_mosaic(i,mosaic_i,j)=SNOWH(i,j)  
+            SNOWC_mosaic(i,mosaic_i,j)=SNOWC(i,j) 
+
+            ALBEDO_mosaic(i,mosaic_i,j)=ALBEDO(i,j)
+            ALBBCK_mosaic(i,mosaic_i,j)=ALBBCK(i,j)
+            EMISS_mosaic(i,mosaic_i,j)=EMISS(i,j) 
+            EMBCK_mosaic(i,mosaic_i,j)=EMBCK(i,j) 
+            ZNT_mosaic(i,mosaic_i,j)=Z0(i,j)
+            Z0_mosaic(i,mosaic_i,j)=Z0(i,j)              
+  
+              DO soil_k=1,num_soil_layers 
+  
+            TSLB_mosaic(i,num_soil_layers*(mosaic_i-1)+soil_k,j)=TSLB(i,soil_k,j)
+            SMOIS_mosaic(i,num_soil_layers*(mosaic_i-1)+soil_k,j)=SMOIS(i,soil_k,j)
+            SH2O_mosaic(i,num_soil_layers*(mosaic_i-1)+soil_k,j)=SH2O(i,soil_k,j)  
+          
+              ENDDO
+           
+           TR_URB2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           TB_URB2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           TG_URB2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           TC_URB2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           TS_URB2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           TS_RUL2D_mosaic(i,mosaic_i,j)=TSK(i,j)   
+           QC_URB2D_mosaic(i,mosaic_i,j)=0.01
+           SH_URB2D_mosaic(i,mosaic_i,j)=0
+           LH_URB2D_mosaic(i,mosaic_i,j)=0
+           G_URB2D_mosaic(i,mosaic_i,j)=0
+           RN_URB2D_mosaic(i,mosaic_i,j)=0
+          
+          TRL_URB3D_mosaic(I,4*(mosaic_i-1)+1,J)=TSLB(I,1,J)+0.
+          TRL_URB3D_mosaic(I,4*(mosaic_i-1)+2,J)=0.5*(TSLB(I,1,J)+TSLB(I,2,J))
+          TRL_URB3D_mosaic(I,4*(mosaic_i-1)+3,J)=TSLB(I,2,J)+0.
+          TRL_URB3D_mosaic(I,4*(mosaic_i-1)+4,J)=TSLB(I,2,J)+(TSLB(I,3,J)-TSLB(I,2,J))*0.29
+
+          TBL_URB3D_mosaic(I,4*(mosaic_i-1)+1,J)=TSLB(I,1,J)+0.
+          TBL_URB3D_mosaic(I,4*(mosaic_i-1)+2,J)=0.5*(TSLB(I,1,J)+TSLB(I,2,J))
+          TBL_URB3D_mosaic(I,4*(mosaic_i-1)+3,J)=TSLB(I,2,J)+0.
+          TBL_URB3D_mosaic(I,4*(mosaic_i-1)+4,J)=TSLB(I,2,J)+(TSLB(I,3,J)-TSLB(I,2,J))*0.29           
+                    
+          TGL_URB3D_mosaic(I,4*(mosaic_i-1)+1,J)=TSLB(I,1,J)
+          TGL_URB3D_mosaic(I,4*(mosaic_i-1)+2,J)=TSLB(I,2,J)
+          TGL_URB3D_mosaic(I,4*(mosaic_i-1)+3,J)=TSLB(I,3,J)
+          TGL_URB3D_mosaic(I,4*(mosaic_i-1)+4,J)=TSLB(I,4,J)
+           
+            ENDDO
+          ENDDO
+      ENDDO
+
+   ! simple test
+   
+       DO i = its,itf
+        DO j = jts,jtf 
+   
+           IF ((xland(i,j).LT. 1.5 ) .AND. (mosaic_cat_index(I,1,J) .EQ. ISWATER)) THEN
+             CALL wrf_message("After MOSAIC_INIT")
+             WRITE (message_text,fmt='(a,2I6,2F8.2,2I6)') 'weird xland,xice,mosaic_cat_index and ivgtyp at I,J = ', &
+                i,j,xland(i,j),xice(i,j),mosaic_cat_index(I,1,J),IVGTYP(i,j)
+             CALL wrf_message(message_text)
+           ENDIF
+           
+        ENDDO
+      ENDDO
+      
+ ENDIF      !  for not restart
+      
+!--------------------------------      
+  END SUBROUTINE lsm_mosaic_init  
+!--------------------------------  
+
+END MODULE module_sf_noahdrv

--- a/src/fromNVIDIA/module_sf_sfclayrev.F
+++ b/src/fromNVIDIA/module_sf_sfclayrev.F
@@ -1,0 +1,1457 @@
+!WRF:MODEL_LAYER:PHYSICS
+!
+MODULE module_sf_sfclayrev
+
+ REAL    , PARAMETER ::  VCONVC=1.
+ REAL    , PARAMETER ::  CZO=0.0185
+ REAL    , PARAMETER ::  OZO=1.59E-5
+
+ REAL,   DIMENSION(0:1000 ),SAVE :: psim_stab,psim_unstab,psih_stab,psih_unstab
+!$acc declare create(psim_stab,psim_unstab,psih_stab,psih_unstab) 
+
+CONTAINS
+
+!-------------------------------------------------------------------
+   SUBROUTINE SFCLAYREV(U3D,V3D,T3D,QV3D,P3D,dz8w,                    &
+                     CP,G,ROVCP,R,XLV,PSFC,CHS,CHS2,CQS2,CPM,      &
+                     ZNT,UST,PBLH,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH, &
+                     FM,FH,                                        &
+                     XLAND,HFX,QFX,LH,TSK,FLHC,FLQC,QGH,QSFC,RMOL, &
+                     U10,V10,TH2,T2,Q2,                            &
+                     GZ1OZ0,WSPD,BR,ISFFLX,DX,                     &
+                     SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
+                     KARMAN,EOMEG,STBOLT,                          &
+                     P1000mb,                                      &
+                     ids,ide, jds,jde, kds,kde,                    &
+                     ims,ime, jms,jme, kms,kme,                    &
+                     its,ite, jts,jte, kts,kte,                    &
+                     ustm,ck,cka,cd,cda,isftcflx,iz0tlnd,scm_force_flux           )
+!-------------------------------------------------------------------
+      IMPLICIT NONE
+!-------------------------------------------------------------------
+!   Changes in V3.7 over water surfaces:
+!          1. for ZNT/Cd, replacing constant OZO with 0.11*1.5E-5/UST(I)
+!             the COARE 3.5 (Edson et al. 2013) formulation is also available
+!          2. for VCONV, reducing magnitude by half
+!          3. for Ck, replacing Carlson-Boland with COARE 3
+!-------------------------------------------------------------------
+!-- U3D         3D u-velocity interpolated to theta points (m/s)
+!-- V3D         3D v-velocity interpolated to theta points (m/s)
+!-- T3D         temperature (K)
+!-- QV3D        3D water vapor mixing ratio (Kg/Kg)
+!-- P3D         3D pressure (Pa)
+!-- dz8w        dz between full levels (m)
+!-- CP          heat capacity at constant pressure for dry air (J/kg/K)
+!-- G           acceleration due to gravity (m/s^2)
+!-- ROVCP       R/CP
+!-- R           gas constant for dry air (J/kg/K)
+!-- XLV         latent heat of vaporization for water (J/kg)
+!-- PSFC        surface pressure (Pa)
+!-- ZNT         roughness length (m)
+!-- UST         u* in similarity theory (m/s)
+!-- USTM        u* in similarity theory (m/s) without vconv correction
+!               used to couple with TKE scheme
+!-- PBLH        PBL height from previous time (m)
+!-- MAVAIL      surface moisture availability (between 0 and 1)
+!-- ZOL         z/L height over Monin-Obukhov length
+!-- MOL         T* (similarity theory) (K)
+!-- REGIME      flag indicating PBL regime (stable, unstable, etc.)
+!-- PSIM        similarity stability function for momentum
+!-- PSIH        similarity stability function for heat
+!-- FM          integrated stability function for momentum
+!-- FH          integrated stability function for heat
+!-- XLAND       land mask (1 for land, 2 for water)
+!-- HFX         upward heat flux at the surface (W/m^2)
+!-- QFX         upward moisture flux at the surface (kg/m^2/s)
+!-- LH          net upward latent heat flux at surface (W/m^2)
+!-- TSK         surface temperature (K)
+!-- FLHC        exchange coefficient for heat (W/m^2/K)
+!-- FLQC        exchange coefficient for moisture (kg/m^2/s)
+!-- CHS         heat/moisture exchange coefficient for LSM (m/s)
+!-- QGH         lowest-level saturated mixing ratio
+!-- QSFC        ground saturated mixing ratio
+!-- U10         diagnostic 10m u wind
+!-- V10         diagnostic 10m v wind
+!-- TH2         diagnostic 2m theta (K)
+!-- T2          diagnostic 2m temperature (K)
+!-- Q2          diagnostic 2m mixing ratio (kg/kg)
+!-- GZ1OZ0      log(z/z0) where z0 is roughness length
+!-- WSPD        wind speed at lowest model level (m/s)
+!-- BR          bulk Richardson number in surface layer
+!-- ISFFLX      isfflx=1 for surface heat and moisture fluxes
+!-- DX          horizontal grid size (m)
+!-- SVP1        constant for saturation vapor pressure (kPa)
+!-- SVP2        constant for saturation vapor pressure (dimensionless)
+!-- SVP3        constant for saturation vapor pressure (K)
+!-- SVPT0       constant for saturation vapor pressure (K)
+!-- EP1         constant for virtual temperature (R_v/R_d - 1) (dimensionless)
+!-- EP2         constant for specific humidity calculation 
+!               (R_d/R_v) (dimensionless)
+!-- KARMAN      Von Karman constant
+!-- EOMEG       angular velocity of earth's rotation (rad/s)
+!-- STBOLT      Stefan-Boltzmann constant (W/m^2/K^4)
+!-- ck          enthalpy exchange coeff at 10 meters
+!-- cd          momentum exchange coeff at 10 meters
+!-- cka         enthalpy exchange coeff at the lowest model level
+!-- cda         momentum exchange coeff at the lowest model level
+!-- isftcflx    =0, (Charnock and Carlson-Boland); =1, AHW Ck, Cd, =2 Garratt
+!-- iz0tlnd     =0 Carlson-Boland, =1 Czil_new
+!-- ids         start index for i in domain
+!-- ide         end index for i in domain
+!-- jds         start index for j in domain
+!-- jde         end index for j in domain
+!-- kds         start index for k in domain
+!-- kde         end index for k in domain
+!-- ims         start index for i in memory
+!-- ime         end index for i in memory
+!-- jms         start index for j in memory
+!-- jme         end index for j in memory
+!-- kms         start index for k in memory
+!-- kme         end index for k in memory
+!-- its         start index for i in tile
+!-- ite         end index for i in tile
+!-- jts         start index for j in tile
+!-- jte         end index for j in tile
+!-- kts         start index for k in tile
+!-- kte         end index for k in tile
+!-------------------------------------------------------------------
+      INTEGER,  INTENT(IN )   ::        ids,ide, jds,jde, kds,kde, &
+                                        ims,ime, jms,jme, kms,kme, &
+                                        its,ite, jts,jte, kts,kte
+!                                                               
+      INTEGER,  INTENT(IN )   ::        ISFFLX
+      REAL,     INTENT(IN )   ::        SVP1,SVP2,SVP3,SVPT0
+      REAL,     INTENT(IN )   ::        EP1,EP2,KARMAN,EOMEG,STBOLT
+      REAL,     INTENT(IN )   ::        P1000mb
+!
+      REAL,     DIMENSION( ims:ime, kms:kme, jms:jme )           , &
+                INTENT(IN   )   ::                           dz8w
+                                        
+      REAL,     DIMENSION( ims:ime, kms:kme, jms:jme )           , &
+                INTENT(IN   )   ::                           QV3D, &
+                                                              P3D, &
+                                                              T3D
+
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(IN   )               ::             MAVAIL, &
+                                                             PBLH, &
+                                                            XLAND, &
+                                                              TSK
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(OUT  )               ::                U10, &
+                                                              V10, &
+                                                              TH2, &
+                                                               T2, &
+                                                               Q2, &
+                                                             QSFC
+
+!
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(INOUT)               ::             REGIME, &
+                                                              HFX, &
+                                                              QFX, &
+                                                               LH, &
+                                                          MOL,RMOL
+!m the following 5 are change to memory size
+!
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(INOUT)   ::                 GZ1OZ0,WSPD,BR, &
+                                                  PSIM,PSIH,FM,FH
+
+      REAL,     DIMENSION( ims:ime, kms:kme, jms:jme )           , &
+                INTENT(IN   )   ::                            U3D, &
+                                                              V3D
+                                        
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(IN   )               ::               PSFC
+
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(INOUT)   ::                            ZNT, &
+                                                              ZOL, &
+                                                              UST, &
+                                                              CPM, &
+                                                             CHS2, &
+                                                             CQS2, &
+                                                              CHS
+
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(INOUT)   ::                      FLHC,FLQC
+
+      REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+                INTENT(INOUT)   ::                                 &
+                                                              QGH
+                                    
+      REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
+ 
+      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme )              , &
+                INTENT(OUT)     ::                  ck,cka,cd,cda
+
+      REAL, OPTIONAL, DIMENSION( ims:ime, jms:jme )              , &
+                INTENT(INOUT)   ::                           USTM
+
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX, IZ0TLND
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
+! LOCAL VARS
+
+      REAL,     DIMENSION( its:ite ) ::                       U1D, &
+                                                              V1D, &
+                                                             QV1D, &
+                                                              P1D, &
+                                                              T1D
+
+      REAL,     DIMENSION( its:ite ) ::                    dz8w1d
+
+      INTEGER ::  I,J
+
+#ifndef _OPENACC
+      DO J=jts,jte
+        DO i=its,ite
+          dz8w1d(I) = dz8w(i,1,j)
+        ENDDO
+   
+        DO i=its,ite
+           U1D(i) =U3D(i,1,j)
+           V1D(i) =V3D(i,1,j)
+           QV1D(i)=QV3D(i,1,j)
+           P1D(i) =P3D(i,1,j)
+           T1D(i) =T3D(i,1,j)
+        ENDDO
+
+        !  Sending array starting locations of optional variables may cause
+        !  troubles, so we explicitly change the call.
+        CALL SFCLAYREV1D(J,U1D,V1D,T1D,QV1D,P1D,dz8w1d,               &
+                CP,G,ROVCP,R,XLV,PSFC(ims,j),CHS(ims,j),CHS2(ims,j),&
+                CQS2(ims,j),CPM(ims,j),PBLH(ims,j), RMOL(ims,j),   &
+                ZNT(ims,j),UST(ims,j),MAVAIL(ims,j),ZOL(ims,j),    &
+                MOL(ims,j),REGIME(ims,j),PSIM(ims,j),PSIH(ims,j),  &
+                FM(ims,j),FH(ims,j),                               &
+                XLAND(ims,j),HFX(ims,j),QFX(ims,j),TSK(ims,j),     &
+                U10(ims,j),V10(ims,j),TH2(ims,j),T2(ims,j),        &
+                Q2(ims,j),FLHC(ims,j),FLQC(ims,j),QGH(ims,j),      &
+                QSFC(ims,j),LH(ims,j),                             &
+                GZ1OZ0(ims,j),WSPD(ims,j),BR(ims,j),ISFFLX,DX,     &
+                SVP1,SVP2,SVP3,SVPT0,EP1,EP2,KARMAN,EOMEG,STBOLT,  &
+                P1000mb,                                           &
+                ids,ide, jds,jde, kds,kde,                         &
+                ims,ime, jms,jme, kms,kme,                         &
+                its,ite, jts,jte, kts,kte                          &
+#if ( EM_CORE == 1 )
+                ,isftcflx,iz0tlnd,scm_force_flux,                               &
+                USTM(ims,j),CK(ims,j),CKA(ims,j),                  &
+                CD(ims,j),CDA(ims,j)                               &
+#endif
+                                                                   )
+      ENDDO
+#else
+!$acc data pcreate( &
+!$acc      PSFC,CHS,CHS2,CQS2,CPM,RMOL,UST,MAVAIL,ZOL,    &
+!$acc      MOL,XLAND,TSK,CQS2,   &
+!$acc      TH2,T2,Q2,FLHC,FLQC,QGH,QSFC,LH)
+!$acc update device(RMOL,CQS2,MOL,QSFC)
+#if ( EM_CORE == 1 )
+!$acc data pcreate(USTM,CK,CKA,CD,CDA)
+#endif        
+        CALL SFCLAYREV1D(J,U3D,V3D,T3D,QV3D,P3D,dz8w,               &
+                CP,G,ROVCP,R,XLV,PSFC,CHS,CHS2,&
+                CQS2,CPM,PBLH, RMOL,   &
+                ZNT,UST,MAVAIL,ZOL,    &
+                MOL,REGIME,PSIM,PSIH,  &
+                FM,FH,                               &
+                XLAND,HFX,QFX,TSK,     &
+                U10,V10,TH2,T2,        &
+                Q2,FLHC,FLQC,QGH,      &
+                QSFC,LH,                             &
+                GZ1OZ0,WSPD,BR,ISFFLX,DX,     &
+                SVP1,SVP2,SVP3,SVPT0,EP1,EP2,KARMAN,EOMEG,STBOLT,  &
+                P1000mb,                                           &
+                ids,ide, jds,jde, kds,kde,                         &
+                ims,ime, jms,jme, kms,kme,                         &
+                its,ite, jts,jte, kts,kte                          &
+#if ( EM_CORE == 1 )
+                ,isftcflx,iz0tlnd,scm_force_flux,                               &
+                USTM,CK,CKA,                  &
+                CD,CDA                               &
+#endif
+                                                                   )
+#if ( EM_CORE == 1 )
+!$acc update host(CK,CKA,CD,CDA)
+!$acc end data
+#endif
+!$acc update host(  &
+!$acc      RMOL,ZOL,MOL,CQS2,   &
+!$acc      TH2,T2,Q2,QSFC,LH)
+!$acc end data
+#endif
+
+
+   END SUBROUTINE SFCLAYREV
+
+
+!-------------------------------------------------------------------
+   SUBROUTINE SFCLAYREV1D(JJ,UX,VX,T1D,QV1D,P1D,dz8w1d,                &
+                     CP,G,ROVCP,R,XLV,PSFCPA,CHS,CHS2,CQS2,CPM,PBLH,RMOL, &
+                     ZNT,UST,MAVAIL,ZOL,MOL,REGIME,PSIM,PSIH,FM,FH,&
+                     XLAND,HFX,QFX,TSK,                            &
+                     U10,V10,TH2,T2,Q2,FLHC,FLQC,QGH,              &
+                     QSFC,LH,GZ1OZ0,WSPD,BR,ISFFLX,DX,             &
+                     SVP1,SVP2,SVP3,SVPT0,EP1,EP2,                 &
+                     KARMAN,EOMEG,STBOLT,                          &
+                     P1000mb,                                      &
+                     ids,ide, jds,jde, kds,kde,                    &
+                     ims,ime, jms,jme, kms,kme,                    &
+                     its,ite, jts,jte, kts,kte,                    &
+                     isftcflx, iz0tlnd,scm_force_flux,                            &
+                     ustm,ck,cka,cd,cda                            )
+!-------------------------------------------------------------------
+      IMPLICIT NONE
+!-------------------------------------------------------------------
+      REAL,     PARAMETER     ::        XKA=2.4E-5
+      REAL,     PARAMETER     ::        PRT=1.
+
+      INTEGER,  INTENT(IN )   ::        ids,ide, jds,jde, kds,kde, &
+                                        ims,ime, jms,jme, kms,kme, &
+                                        its,ite, jts,jte, kts,kte, &
+                                        JJ
+!                                                               
+      INTEGER,  INTENT(IN )   ::        ISFFLX
+      REAL,     INTENT(IN )   ::        SVP1,SVP2,SVP3,SVPT0
+      REAL,     INTENT(IN )   ::        EP1,EP2,KARMAN,EOMEG,STBOLT
+      REAL,     INTENT(IN )   ::        P1000mb
+
+!
+#ifndef _OPENACC
+      REAL,     DIMENSION( ims:ime )                             , &
+#else
+      REAL,     DIMENSION( ims:ime,jms:jme )                     , &
+#endif
+                INTENT(IN   )               ::             MAVAIL, &
+                                                             PBLH, &
+                                                            XLAND, &
+                                                              TSK
+!
+#ifndef _OPENACC
+      REAL,     DIMENSION( ims:ime )                             , &
+#else
+      REAL,     DIMENSION( ims:ime,jms:jme )                     , &
+#endif
+                INTENT(IN   )               ::             PSFCPA
+
+#ifndef _OPENACC
+      REAL,     DIMENSION( ims:ime )                             , &
+#else
+      REAL,     DIMENSION( ims:ime,jms:jme )                     , &
+#endif
+                INTENT(INOUT)               ::             REGIME, &
+                                                              HFX, &
+                                                              QFX, &
+                                                         MOL,RMOL
+!m the following 5 are changed to memory size---
+!
+#ifndef _OPENACC
+      REAL,     DIMENSION( ims:ime )                             , &
+#else
+      REAL,     DIMENSION( ims:ime,jms:jme )                     , &
+#endif
+                INTENT(INOUT)   ::                 GZ1OZ0,WSPD,BR, &
+                                                  PSIM,PSIH,FM,FH
+
+#ifndef _OPENACC
+      REAL,     DIMENSION( ims:ime )                             , &
+#else
+      REAL,     DIMENSION( ims:ime,jms:jme )                     , &
+#endif
+                INTENT(INOUT)   ::                            ZNT, &
+                                                              ZOL, &
+                                                              UST, &
+                                                              CPM, &
+                                                             CHS2, &
+                                                             CQS2, &
+                                                              CHS
+
+#ifndef _OPENACC
+      REAL,     DIMENSION( ims:ime )                             , &
+#else
+      REAL,     DIMENSION( ims:ime,jms:jme )                     , &
+#endif
+                INTENT(INOUT)   ::                      FLHC,FLQC
+
+#ifndef _OPENACC
+      REAL,     DIMENSION( ims:ime )                             , &
+#else
+      REAL,     DIMENSION( ims:ime,jms:jme )                     , &
+#endif
+                INTENT(INOUT)   ::                                 &
+                                                              QGH
+
+#ifndef _OPENACC
+      REAL,     DIMENSION( ims:ime )                             , &
+#else
+      REAL,     DIMENSION( ims:ime,jms:jme )                     , &
+#endif
+                INTENT(OUT)     ::                        U10,V10, &
+                                                TH2,T2,Q2,QSFC,LH
+
+                                    
+      REAL,     INTENT(IN   )               ::   CP,G,ROVCP,R,XLV,DX
+
+! MODULE-LOCAL VARIABLES, DEFINED IN SUBROUTINE SFCLAY
+#ifndef _OPENACC
+      REAL,     DIMENSION( its:ite ),  INTENT(IN   )   ::  dz8w1d
+
+      REAL,     DIMENSION( its:ite ),  INTENT(IN   )   ::      UX, &
+                                                               VX, &
+                                                             QV1D, &
+                                                              P1D, &
+                                                              T1D
+#else
+      REAL,     DIMENSION( ims:ime,kms:kme,jms:jme )             , &
+                                       INTENT(IN   )   ::  dz8w1d
+      REAL,     DIMENSION( ims:ime,kms:kme,jms:jme )             , &
+                                       INTENT(IN   )   ::      UX, &
+                                                               VX, &
+                                                             QV1D, &
+                                                              P1D, &
+                                                              T1D
+
+#endif
+ 
+#ifndef _OPENACC 
+      REAL, OPTIONAL, DIMENSION( ims:ime )                       , &
+                INTENT(OUT)     ::                  ck,cka,cd,cda
+      REAL, OPTIONAL, DIMENSION( ims:ime )                       , &
+                INTENT(INOUT)   ::                           USTM
+#else
+      REAL, OPTIONAL, DIMENSION( ims:ime,jms:jme )               , &
+                INTENT(OUT)     ::                  ck,cka,cd,cda
+      REAL, OPTIONAL, DIMENSION( ims:ime,jms:jme )               , &
+                INTENT(INOUT)   ::                           USTM
+#endif
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     ISFTCFLX, IZ0TLND
+      INTEGER,  OPTIONAL,  INTENT(IN )   ::     SCM_FORCE_FLUX
+
+! LOCAL VARS
+
+#ifndef _OPENACC
+      REAL,     DIMENSION( its:ite )        ::                 ZA, &
+#else      
+      REAL,     DIMENSION( its:ite,jts:jte )::                 ZA, &
+#endif      
+                                                        THVX,ZQKL, &
+                                                           ZQKLP1, &
+                                                           THX,QX, &
+                                                            PSIH2, &
+                                                            PSIM2, &
+                                                           PSIH10, &
+                                                           PSIM10, &
+                                                           DENOMQ, &
+                                                          DENOMQ2, &
+                                                          DENOMT2, &
+                                                            WSPDI, &
+                                                           GZ2OZ0, &
+                                                           GZ10OZ0
+!
+#ifndef _OPENACC
+      REAL,     DIMENSION( its:ite )        ::                     &
+                                                      RHOX,GOVRTH, &
+                                                            TGDSA
+!
+      REAL,     DIMENSION( its:ite)         ::          SCR3,SCR4
+      REAL,     DIMENSION( its:ite )        ::         THGB, PSFC
+#else
+      REAL,     DIMENSION( its:ite,jts:jte )::                     &
+                                                      RHOX,GOVRTH, &
+                                                            TGDSA
+!
+      REAL,     DIMENSION( its:ite,jts:jte )::          SCR3,SCR4
+      REAL,     DIMENSION( its:ite,jts:jte )::         THGB, PSFC
+#endif
+!
+      INTEGER                               ::                 KL
+
+      INTEGER ::  N,I,J,K,KK,L,NZOL,NK,NZOL2,NZOL10
+
+      REAL    ::  PL,THCON,TVCON,E1
+      REAL    ::  ZL,TSKV,DTHVDZ,DTHVM,VCONV,RZOL,RZOL2,RZOL10,ZOL2,ZOL10
+      REAL    ::  DTG,PSIX,DTTHX,PSIX10,PSIT,PSIT2,PSIQ,PSIQ2,PSIQ10
+      REAL    ::  FLUXC,VSGD,Z0Q,VISC,RESTAR,CZIL,GZ0OZQ,GZ0OZT
+      REAL    ::  ZW, ZN1, ZN2
+!
+! .... paj ...
+!
+      REAL    :: zolzz,zol0
+!     REAL    :: zolri,zolri2
+!     REAL    :: psih_stable,psim_stable,psih_unstable,psim_unstable
+!     REAL    :: psih_stable_full,psim_stable_full,psih_unstable_full,psim_unstable_full
+      REAL    :: zl2,zl10,z0t
+#ifndef _OPENACC      
+      REAL,     DIMENSION( its:ite )        ::         pq,pq2,pq10
+#else
+      REAL,     DIMENSION( its:ite,jts:jte )::         pq,pq2,pq10
+#endif      
+      LOGICAL :: PRESENT_ISFTCFLX,PRESENT_CXX,PRESENT_IZ0TLND, &
+                 PRESENT_SCM_FORCE_FLUX, PRESENT_USTM
+      INTEGER ::     ISFTCFLX_, IZ0TLND_
+      INTEGER ::     SCM_FORCE_FLUX_
+!$acc routine(zolri) seq
+
+#ifdef _OPENACC
+#define U10(i) U10(i,j)
+#define V10(i) V10(i,j)
+#define TH2(i) TH2(i,j)
+#define T2(i) T2(i,j)
+#define Q2(i) Q2(i,j)
+#define QSFC(i) QSFC(i,j)
+#define LH(i) LH(i,j)
+#define FLHC(i) FLHC(i,j)
+#define FLQC(i) FLQC(i,j)
+#define QGH(i) QGH(i,j)
+#define ZNT(i) ZNT(i,j)
+#define ZOL(i) ZOL(i,j)
+#define UST(i) UST(i,j)
+#define CPM(i) CPM(i,j)
+#define CHS2(i) CHS2(i,j)
+#define CQS2(i) CQS2(i,j)
+#define CHS(i) CHS(i,j)
+#define MAVAIL(i) MAVAIL(i,j)
+#define PBLH(i) PBLH(i,j)
+#define XLAND(i) XLAND(i,j)
+#define TSK(i) TSK(i,j)
+#define REGIME(i) REGIME(i,j)
+#define HFX(i) HFX(i,j)
+#define QFX(i) QFX(i,j)
+#define MOL(i) MOL(i,j)
+#define RMOL(i) RMOL(i,j)
+#define GZ1OZ0(i) GZ1OZ0(i,j)
+#define WSPD(i) WSPD(i,j)
+#define BR(i) BR(i,j) 
+#define PSIM(i) PSIM(i,j)
+#define PSIH(i) PSIH(i,j)
+#define FM(i) FM(i,j)
+#define FH(i) FH(i,j)
+#define PSFCPA(i) PSFCPA(i,j)
+#define USTM(i) USTM(i,j)
+#define CK(i) CK(i,j)
+#define CKA(i) CKA(i,j)
+#define CD(i) CD(i,j)
+#define CDA(i) CDA(i,j)
+#define dz8w1d(i) dz8w1d(i,1,j)
+#define UX(i) UX(i,1,j)
+#define VX(i) VX(i,1,j)
+#define QV1D(i) QV1D(i,1,j)
+#define P1D(i) P1D(i,1,j)
+#define T1D(i) T1D(i,1,j)
+! local vars
+#define ZA(i) ZA(i,j)
+#define THVX(i) THVX(i,j)
+#define THX(i) THX(i,j)
+#define QX(i) QX(i,j)
+#define PSIH2(i) PSIH2(i,j)
+#define PSIM2(i) PSIM2(i,j)
+#define PSIH10(i) PSIH10(i,j)
+#define PSIM10(i) PSIM10(i,j)
+#define DENOMQ(i) DENOMQ(i,j)
+#define DENOMQ2(i) DENOMQ2(i,j)
+#define DENOMT2(i) DENOMT2(i,j)
+#define WSPDI(i) WSPDI(i,j)
+#define GZ2OZ0(i) GZ2OZ0(i,j)
+#define GZ10OZ0(i) GZ10OZ0(i,j)
+#define RHOX(i) RHOX(i,j)
+#define GOVRTH(i) GOVRTH(i,j)
+#define TGDSA(i) TGDSA(i,j)
+#define SCR3(i) SCR3(i,j)
+#define SCR4(i) SCR4(i,j)
+#define THGB(i) THGB(i,j)
+#define PSFC(i) PSFC(i,j)
+#define PQ(i) PQ(i,j)
+#define PQ2(i) PQ2(i,j)
+#define PQ10(i) PQ10(i,j)
+#endif
+
+!-------------------------------------------------------------------
+      KL=kte
+      PRESENT_ISFTCFLX = PRESENT(ISFTCFLX)
+      PRESENT_CXX = PRESENT(CK) .and. PRESENT(CD) .and. PRESENT(CKA) .and.  PRESENT(CDA)
+      PRESENT_IZ0TLND = PRESENT(IZ0TLND)
+      PRESENT_SCM_FORCE_FLUX = PRESENT(SCM_FORCE_FLUX)
+      PRESENT_USTM = PRESENT(USTM)
+      ISFTCFLX_ = 0
+      if(PRESENT_ISFTCFLX) ISFTCFLX_ = ISFTCFLX
+      IZ0TLND_ = 0
+      if(PRESENT_IZ0TLND) IZ0TLND_ = IZ0TLND
+      SCM_FORCE_FLUX_ = 0
+      if(PRESENT_SCM_FORCE_FLUX) SCM_FORCE_FLUX_ = SCM_FORCE_FLUX
+
+!$acc data create( ZA, THVX, THX, QX, PSIH2, PSIM2, &
+!$acc             PSIH10, PSIM10, DENOMQ, DENOMQ2, DENOMT2, WSPDI, &
+!$acc             GZ2OZ0, GZ10OZ0, RHOX, GOVRTH, TGDSA, SCR3, SCR4, &
+!$acc             THGB, PSFC, PQ, PQ2, PQ10) &
+!$acc     pcreate( U10, V10, TH2, T2, Q2, QSFC, LH, FLHC, FLQC, QGH, &
+!$acc             ZNT, ZOL, UST, CPM, CHS2, CQS2, CHS, MAVAIL, PBLH, &
+!$acc             XLAND, TSK, REGIME, HFX, QFX, MOL, RMOL, GZ1OZ0, &
+!$acc             WSPD, BR, PSIM, PSIH, FM, FH, PSFCPA, &
+#if ( EM_CORE == 1 )
+!$acc             USTM, CK, CKA, CD, CDA, &
+#endif
+!$acc             dz8w1d, UX, VX, QV1D, P1D, T1D )
+
+!$acc kernels
+#ifdef _OPENACC
+      DO J=jts,jte
+#endif      
+      DO i=its,ite
+! PSFC cb
+         PSFC(I)=PSFCPA(I)/1000.
+      ENDDO
+!                                                      
+!----CONVERT GROUND TEMPERATURE TO POTENTIAL TEMPERATURE:  
+!                                                            
+      DO 5 I=its,ite                                   
+        TGDSA(I)=TSK(I)                                    
+! PSFC cb
+!        THGB(I)=TSK(I)*(100./PSFC(I))**ROVCP                
+        THGB(I)=TSK(I)*(P1000mb/PSFCPA(I))**ROVCP   
+    5 CONTINUE                                               
+!                                                            
+!-----DECOUPLE FLUX-FORM VARIABLES TO GIVE U,V,T,THETA,THETA-VIR.,
+!     T-VIR., QV, AND QC AT CROSS POINTS AND AT KTAU-1.  
+!                                                                 
+!     *** NOTE ***                                           
+!         THE BOUNDARY WINDS MAY NOT BE ADEQUATELY AFFECTED BY FRICTION,         
+!         SO USE ONLY INTERIOR VALUES OF UX AND VX TO CALCULATE 
+!         TENDENCIES.                             
+!                                                           
+   10 CONTINUE                                                     
+
+!     DO 24 I=its,ite
+!        UX(I)=U1D(I)
+!        VX(I)=V1D(I)
+!  24 CONTINUE                                             
+                                                             
+   26 CONTINUE                                               
+                                                   
+!.....SCR3(I,K) STORE TEMPERATURE,                           
+!     SCR4(I,K) STORE VIRTUAL TEMPERATURE.                                       
+                                                                                 
+      DO 30 I=its,ite
+! PL cb
+         PL=P1D(I)/1000.
+         SCR3(I)=T1D(I)                                                   
+!         THCON=(100./PL)**ROVCP                                                 
+         THCON=(P1000mb*0.001/PL)**ROVCP
+         THX(I)=SCR3(I)*THCON                                               
+         SCR4(I)=SCR3(I)                                                    
+         THVX(I)=THX(I)                                                     
+         QX(I)=0.                                                             
+   30 CONTINUE                                                                 
+!                                                                                
+      DO I=its,ite
+         QGH(I)=0.                                                                
+         FLHC(I)=0.                                                               
+         FLQC(I)=0.                                                               
+         CPM(I)=CP                                                                
+      ENDDO
+!                                                                                
+!     IF(IDRY.EQ.1)GOTO 80                                                   
+      DO 50 I=its,ite
+         QX(I)=QV1D(I)                                                    
+         TVCON=(1.+EP1*QX(I))                                      
+         THVX(I)=THX(I)*TVCON                                               
+         SCR4(I)=SCR3(I)*TVCON                                              
+   50 CONTINUE                                                                 
+!                                                                                
+      DO 60 I=its,ite
+        E1=SVP1*EXP(SVP2*(TGDSA(I)-SVPT0)/(TGDSA(I)-SVP3))                       
+!  for land points QSFC can come from previous time step
+        if(XLAND(i) .gt.1.5.or. QSFC(I) .le.0.0) QSFC(I)=EP2*E1/(PSFC(I)-E1)                                                 
+! QGH CHANGED TO USE LOWEST-LEVEL AIR TEMP CONSISTENT WITH MYJSFC CHANGE
+! Q2SAT = QGH IN LSM
+        E1=SVP1*EXP(SVP2*(T1D(I)-SVPT0)/(T1D(I)-SVP3))                       
+        PL=P1D(I)/1000.
+        QGH(I)=EP2*E1/(PL-E1)                                                 
+        CPM(I)=CP*(1.+0.8*QX(I))                                   
+   60 CONTINUE                                                                   
+   80 CONTINUE
+                                                                                 
+!-----COMPUTE THE HEIGHT OF FULL- AND HALF-SIGMA LEVELS ABOVE GROUND             
+!     LEVEL, AND THE LAYER THICKNESSES.                                          
+                                                                                 
+#ifndef _OPENACC      
+      DO 90 I=its,ite
+        ZQKLP1(I)=0.
+        RHOX(I)=PSFC(I)*1000./(R*SCR4(I))                                       
+   90 CONTINUE                                                                   
+!                                                                                
+      DO 110 I=its,ite                                                   
+           ZQKL(I)=dz8w1d(I)+ZQKLP1(I)
+  110 CONTINUE                                                                 
+!                                                                                
+      DO 120 I=its,ite
+         ZA(I)=0.5*(ZQKL(I)+ZQKLP1(I))                                        
+  120 CONTINUE  
+#else
+     DO 90 I=its,ite
+       RHOX(I)=PSFC(I)*1000./(R*SCR4(I))
+       ZA(I)=0.5*dz8w1d(I)
+  90 CONTINUE
+#endif  
+!                                                                                
+      DO 160 I=its,ite
+        GOVRTH(I)=G/THX(I)                                                    
+  160 CONTINUE                                                                   
+                                                                                 
+!-----CALCULATE BULK RICHARDSON NO. OF SURFACE LAYER, ACCORDING TO               
+!     AKB(1976), EQ(12).                                                         
+                   
+      DO 260 I=its,ite
+        GZ1OZ0(I)=ALOG((ZA(I)+ZNT(I))/ZNT(I))   ! log((z+z0)/z0)                                     
+        GZ2OZ0(I)=ALOG((2.+ZNT(I))/ZNT(I))      ! log((2+z0)/z0)                           
+        GZ10OZ0(I)=ALOG((10.+ZNT(I))/ZNT(I))    ! log((10+z0)z0)                    
+! commented by ARom. ZL is not used in this loop
+!        IF((XLAND(I)-1.5).GE.0)THEN                                            
+!          ZL=ZNT(I)                                                            
+!        ELSE                                                                     
+!          ZL=0.01                                                                
+!        ENDIF                                                                    
+        WSPD(I)=SQRT(UX(I)*UX(I)+VX(I)*VX(I))                        
+
+        TSKV=THGB(I)*(1.+EP1*QSFC(I))                     
+        DTHVDZ=(THVX(I)-TSKV)                                                 
+!  Convective velocity scale Vc and subgrid-scale velocity Vsg
+!  following Beljaars (1994, QJRMS) and Mahrt and Sun (1995, MWR)
+!                                ... HONG Aug. 2001
+!
+!       VCONV = 0.25*sqrt(g/tskv*pblh(i)*dthvm)
+!      Use Beljaars over land, old MM5 (Wyngaard) formula over water
+        if (XLAND(i) .lt. 1.5) then
+        fluxc = max(HFX(i)/RHOX(i)/cp                    &
+              + ep1*tskv*QFX(i)/RHOX(i),0.)
+        VCONV = vconvc*(g/TGDSA(i)*PBLH(I)*fluxc)**.33
+        else
+        IF(-DTHVDZ.GE.0)THEN
+          DTHVM=-DTHVDZ
+        ELSE
+          DTHVM=0.
+        ENDIF
+!       VCONV = 2.*SQRT(DTHVM)
+! V3.7: reducing contribution in calm conditions
+        VCONV = SQRT(DTHVM)
+        endif
+! Mahrt and Sun low-res correction
+        VSGD = 0.32 * (max(dx/5000.-1.,0.))**.33
+        WSPD(I)=SQRT(WSPD(I)*WSPD(I)+VCONV*VCONV+vsgd*vsgd)
+        WSPD(I)=AMAX1(WSPD(I),0.1)
+        BR(I)=GOVRTH(I)*ZA(I)*DTHVDZ/(WSPD(I)*WSPD(I))                        
+!  IF PREVIOUSLY UNSTABLE, DO NOT LET INTO REGIMES 1 AND 2
+        IF(MOL(I).LT.0.)BR(I)=AMIN1(BR(I),0.0)
+!jdf
+        RMOL(I)=-GOVRTH(I)*DTHVDZ*ZA(I)*KARMAN
+!jdf
+
+  260 CONTINUE                                                                   
+
+!                                                                                
+!-----DIAGNOSE BASIC PARAMETERS FOR THE APPROPRIATED STABILITY CLASS:            
+!                                                                                
+!                                                                                
+!     THE STABILITY CLASSES ARE DETERMINED BY BR (BULK RICHARDSON NO.)           
+!     AND HOL (HEIGHT OF PBL/MONIN-OBUKHOV LENGTH).                              
+!                                                                                
+!     CRITERIA FOR THE CLASSES ARE AS FOLLOWS:                                   
+!                                                                                
+!        1. BR .GE. 0.0;                                                         
+!               REPRESENTS NIGHTTIME STABLE CONDITIONS (REGIME=1),               
+!                                                                                
+!        3. BR .EQ. 0.0                                                          
+!               REPRESENTS FORCED CONVECTION CONDITIONS (REGIME=3),              
+!                                                                                
+!        4. BR .LT. 0.0                                                          
+!               REPRESENTS FREE CONVECTION CONDITIONS (REGIME=4).                
+!                                                                                
+!CCCCC                                                                           
+
+!$acc loop private(zl,zl10,zl2,zol0,zolzz,zol2,zol10)      
+      DO 320 I=its,ite
+!                                                                           
+      if (BR(I).gt.0) then
+        if (BR(I).gt.250.0) then
+        ZOL(I)=zolri(250.0,ZA(I),ZNT(I))
+        else
+        ZOL(I)=zolri(BR(I),ZA(I),ZNT(I))
+        endif
+      endif
+!
+      if (BR(I).lt.0) then
+       IF(UST(I).LT.0.001)THEN
+          ZOL(I)=BR(I)*GZ1OZ0(I)
+        ELSE
+        if (BR(I).lt.-250.0) then
+        ZOL(I)=zolri(-250.0,ZA(I),ZNT(I))
+        else
+        ZOL(I)=zolri(BR(I),ZA(I),ZNT(I))
+        endif
+       ENDIF
+      endif
+!
+! ... paj: compute integrated similarity functions.
+!
+        zolzz=ZOL(I)*(ZA(I)+ZNT(I))/ZA(I) ! (z+z0/L
+        zol10=ZOL(I)*(10.+ZNT(I))/ZA(I)   ! (10+z0)/L
+        zol2=ZOL(I)*(2.+ZNT(I))/ZA(I)     ! (2+z0)/L
+        zol0=ZOL(I)*ZNT(I)/ZA(I)          ! z0/L
+        ZL2=(2.)/ZA(I)*ZOL(I)             ! 2/L      
+        ZL10=(10.)/ZA(I)*ZOL(I)           ! 10/L
+
+        IF((XLAND(I)-1.5).LT.0.)THEN
+        ZL=(0.01)/ZA(I)*ZOL(I)   ! (0.01)/L     
+        ELSE
+        ZL=ZOL0                     ! z0/L
+        ENDIF
+
+        IF(BR(I).LT.0.)GOTO 310  ! go to unstable regime (class 4)
+        IF(BR(I).EQ.0.)GOTO 280  ! go to neutral regime (class 3)
+!                                                                                
+!-----CLASS 1; STABLE (NIGHTTIME) CONDITIONS:                                    
+!
+        REGIME(I)=1.
+!
+! ... paj: PSIM and PSIH. Follows Cheng and Brutsaert 2005 (CB05).
+!
+        PSIM(I)=psim_stable(zolzz)-psim_stable(zol0)
+        PSIH(I)=psih_stable(zolzz)-psih_stable(zol0)
+!
+        PSIM10(I)=psim_stable(zol10)-psim_stable(zol0)
+        PSIH10(I)=psih_stable(zol10)-psih_stable(zol0)
+!
+        PSIM2(I)=psim_stable(zol2)-psim_stable(zol0)
+        PSIH2(I)=psih_stable(zol2)-psih_stable(zol0)
+!
+! ... paj: preparations to compute PSIQ. Follows CB05+Carlson Boland JAM 1978.
+!
+        PQ(I)=psih_stable(ZOL(I))-psih_stable(zl)
+        PQ2(I)=psih_stable(zl2)-psih_stable(zl)
+        PQ10(I)=psih_stable(zl10)-psih_stable(zl)
+!
+!       1.0 over Monin-Obukhov length
+        RMOL(I)=ZOL(I)/ZA(I) 
+!                                                                                
+
+        GOTO 320                                                                 
+!                                                                                
+!-----CLASS 3; FORCED CONVECTION:                                                
+!                                                                                
+  280   REGIME(I)=3.                                                           
+        PSIM(I)=0.0                                                              
+        PSIH(I)=PSIM(I)                                                          
+        PSIM10(I)=0.                                                   
+        PSIH10(I)=PSIM10(I)                                           
+        PSIM2(I)=0.                                                  
+        PSIH2(I)=PSIM2(I)                                           
+!
+! paj: preparations to compute PSIQ.
+!
+        PQ(I)=PSIH(I)
+        PQ2(I)=PSIH2(I)
+        PQ10(I)=0.
+!
+        ZOL(I)=0.                                             
+        RMOL(I) = ZOL(I)/ZA(I)  
+
+        GOTO 320                                                                 
+!                                                                                
+!-----CLASS 4; FREE CONVECTION:                                                  
+!                                                                                
+  310   CONTINUE                                                                 
+        REGIME(I)=4.                                                           
+!
+! ... paj: PSIM and PSIH ...
+!
+        PSIM(I)=psim_unstable(zolzz)-psim_unstable(zol0)
+        PSIH(I)=psih_unstable(zolzz)-psih_unstable(zol0)
+!
+        PSIM10(I)=psim_unstable(zol10)-psim_unstable(zol0)
+        PSIH10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+!
+        PSIM2(I)=psim_unstable(zol2)-psim_unstable(zol0)
+        PSIH2(I)=psih_unstable(zol2)-psih_unstable(zol0)
+!
+! ... paj: preparations to compute PSIQ 
+!
+        PQ(I)=psih_unstable(ZOL(I))-psih_unstable(zl)
+        PQ2(I)=psih_unstable(zl2)-psih_unstable(zl)
+        PQ10(I)=psih_unstable(zl10)-psih_unstable(zl)
+!
+!---LIMIOT PSIH AND PSIM IN THE CASE OF THIN LAYERS AND HIGH ROUGHNESS            
+!---  THIS PREVENTS DENOMINATOR IN FLUXES FROM GETTING TOO SMALL                 
+        PSIH(I)=AMIN1(PSIH(I),0.9*GZ1OZ0(I))
+        PSIM(I)=AMIN1(PSIM(I),0.9*GZ1OZ0(I))
+        PSIH2(I)=AMIN1(PSIH2(I),0.9*GZ2OZ0(I))
+        PSIM10(I)=AMIN1(PSIM10(I),0.9*GZ10OZ0(I))
+!
+! AHW: mods to compute CK, CD
+        PSIH10(I)=AMIN1(PSIH10(I),0.9*GZ10OZ0(I))
+
+        RMOL(I) = ZOL(I)/ZA(I)  
+
+  320 CONTINUE                                                                   
+!                                                                                
+!-----COMPUTE THE FRICTIONAL VELOCITY:                                           
+!     ZA(1982) EQS(2.60),(2.61).                                                 
+!                                                                                
+!$acc loop private(zl,zl10,zl2,zol0,zolzz,zol2,zol10)      
+      DO 330 I=its,ite
+        DTG=THX(I)-THGB(I)                                                   
+        PSIX=GZ1OZ0(I)-PSIM(I)                                                   
+        PSIX10=GZ10OZ0(I)-PSIM10(I)
+
+!     LOWER LIMIT ADDED TO PREVENT LARGE FLHC IN SOIL MODEL
+!     ACTIVATES IN UNSTABLE CONDITIONS WITH THIN LAYERS OR HIGH Z0
+!       PSIT=AMAX1(GZ1OZ0(I)-PSIH(I),2.)
+       PSIT=GZ1OZ0(I)-PSIH(I)
+       PSIT2=GZ2OZ0(I)-PSIH2(I)
+!
+        IF((XLAND(I)-1.5).GE.0)THEN                                            
+          ZL=ZNT(I)                                                            
+        ELSE                                                                     
+          ZL=0.01                                                                
+        ENDIF                                                                    
+!
+        PSIQ=ALOG(KARMAN*UST(I)*ZA(I)/XKA+ZA(I)/ZL)-PQ(I)
+        PSIQ2=ALOG(KARMAN*UST(I)*2./XKA+2./ZL)-PQ2(I)
+
+! AHW: mods to compute CK, CD
+        PSIQ10=ALOG(KARMAN*UST(I)*10./XKA+10./ZL)-PQ10(I)
+
+! V3.7: using Fairall 2003 to compute z0q and z0t over water:
+!       adapted from module_sf_mynn.F
+        IF ( (XLAND(I)-1.5).GE.0. ) THEN
+              VISC=(1.32+0.009*(SCR3(I)-273.15))*1.E-5
+              RESTAR=UST(I)*ZNT(I)/VISC
+              Z0T = (5.5e-5)*(RESTAR**(-0.60))
+              Z0T = MIN(Z0T,1.0e-4)
+              Z0T = MAX(Z0T,2.0e-9)
+              Z0Q = Z0T
+
+              PSIQ=max(ALOG((ZA(I)+Z0Q)/Z0Q)-PSIH(I), 2.)
+              PSIT=max(ALOG((ZA(I)+Z0T)/Z0T)-PSIH(I), 2.)
+              PSIQ2=max(ALOG((2.+Z0Q)/Z0Q)-PSIH2(I), 2.)
+              PSIT2=max(ALOG((2.+Z0T)/Z0T)-PSIH2(I), 2.)
+              PSIQ10=max(ALOG((10.+Z0Q)/Z0Q)-PSIH10(I), 2.)
+        ENDIF
+
+        IF ( PRESENT_ISFTCFLX ) THEN
+           IF ( ISFTCFLX_.EQ.1 .AND. (XLAND(I)-1.5).GE.0. ) THEN
+! v3.1
+!             Z0Q = 1.e-4 + 1.e-3*(MAX(0.,UST(I)-1.))**2
+! hfip1
+!             Z0Q = 0.62*2.0E-5/UST(I) + 1.E-3*(MAX(0.,UST(I)-1.5))**2
+! v3.2
+              Z0Q = 1.e-4
+!
+! ... paj: recompute PSIH for z0q
+!
+           zolzz=ZOL(I)*(ZA(I)+z0q)/ZA(I)    ! (z+z0q)/L
+           zol10=ZOL(I)*(10.+z0q)/ZA(I)   ! (10+z0q)/L
+           zol2=ZOL(I)*(2.+z0q)/ZA(I)     ! (2+z0q)/L
+           zol0=ZOL(I)*z0q/ZA(I)          ! z0q/L
+!
+              if (ZOL(I).gt.0.) then
+              PSIH(I)=psih_stable(zolzz)-psih_stable(zol0)
+              PSIH10(I)=psih_stable(zol10)-psih_stable(zol0)
+              PSIH2(I)=psih_stable(zol2)-psih_stable(zol0)
+              else
+                if (ZOL(I).eq.0) then
+                PSIH(I)=0.
+                PSIH10(I)=0.
+                PSIH2(I)=0.
+                else
+                PSIH(I)=psih_unstable(zolzz)-psih_unstable(zol0)
+                PSIH10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+                PSIH2(I)=psih_unstable(zol2)-psih_unstable(zol0)
+                endif
+              endif
+!
+              PSIQ=ALOG((ZA(I)+z0q)/Z0Q)-PSIH(I)
+              PSIT=PSIQ
+              PSIQ2=ALOG((2.+z0q)/Z0Q)-PSIH2(I)
+              PSIQ10=ALOG((10.+z0q)/Z0Q)-PSIH10(I)
+              PSIT2=PSIQ2
+           ENDIF
+          IF ( ISFTCFLX_.EQ.2 .AND. (XLAND(I)-1.5).GE.0. ) THEN
+! AHW: Garratt formula: Calculate roughness Reynolds number
+!        Kinematic viscosity of air (linear approc to
+!                 temp dependence at sea level)
+! GZ0OZT and GZ0OZQ are based off formulas from Brutsaert (1975), which
+! Garratt (1992) used with values of k = 0.40, Pr = 0.71, and Sc = 0.60
+              VISC=(1.32+0.009*(SCR3(I)-273.15))*1.E-5
+!!            VISC=1.5E-5
+              RESTAR=UST(I)*ZNT(I)/VISC
+              GZ0OZT=0.40*(7.3*SQRT(SQRT(RESTAR))*SQRT(0.71)-5.)
+!
+! ... paj: compute PSIH for z0t for temperature ...
+!
+              z0t=ZNT(I)/exp(GZ0OZT)
+!
+           zolzz=ZOL(I)*(ZA(I)+z0t)/ZA(I)    ! (z+z0t)/L
+           zol10=ZOL(I)*(10.+z0t)/ZA(I)   ! (10+z0t)/L
+           zol2=ZOL(I)*(2.+z0t)/ZA(I)     ! (2+z0t)/L
+           zol0=ZOL(I)*z0t/ZA(I)          ! z0t/L
+!
+              if (ZOL(I).gt.0.) then
+              PSIH(I)=psih_stable(zolzz)-psih_stable(zol0)
+!ARom              PSIH10(I)=psih_stable(zol10)-psih_stable(zol0)
+              PSIH2(I)=psih_stable(zol2)-psih_stable(zol0)
+              else
+                if (ZOL(I).eq.0) then
+                PSIH(I)=0.
+!ARom                PSIH10(I)=0.
+                PSIH2(I)=0.
+                else
+                PSIH(I)=psih_unstable(zolzz)-psih_unstable(zol0)
+!ARom                PSIH10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+                PSIH2(I)=psih_unstable(zol2)-psih_unstable(zol0)
+                endif
+              endif
+!
+!              PSIT=GZ1OZ0(I)-PSIH(I)+RESTAR2
+!              PSIT2=GZ2OZ0(I)-PSIH2(I)+RESTAR2
+              PSIT=ALOG((ZA(I)+z0t)/Z0t)-PSIH(I)
+              PSIT2=ALOG((2.+z0t)/Z0t)-PSIH2(I)
+!
+              GZ0OZQ=0.40*(7.3*SQRT(SQRT(RESTAR))*SQRT(0.60)-5.)
+              z0q=ZNT(I)/exp(GZ0OZQ)
+!
+           zolzz=ZOL(I)*(ZA(I)+z0q)/ZA(I)    ! (z+z0q)/L
+           zol10=ZOL(I)*(10.+z0q)/ZA(I)   ! (10+z0q)/L
+           zol2=ZOL(I)*(2.+z0q)/ZA(I)     ! (2+z0q)/L
+           zol0=ZOL(I)*z0q/ZA(I)          ! z0q/L
+!
+              if (ZOL(I).gt.0.) then
+              PSIH(I)=psih_stable(zolzz)-psih_stable(zol0)
+              PSIH10(I)=psih_stable(zol10)-psih_stable(zol0)
+              PSIH2(I)=psih_stable(zol2)-psih_stable(zol0)
+              else
+                if (ZOL(I).eq.0) then
+                PSIH(I)=0.
+                PSIH10(I)=0.
+                PSIH2(I)=0.
+                else
+                PSIH(I)=psih_unstable(zolzz)-psih_unstable(zol0)
+                PSIH10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+                PSIH2(I)=psih_unstable(zol2)-psih_unstable(zol0)
+                endif
+              endif
+!
+              PSIQ=ALOG((ZA(I)+z0q)/Z0q)-PSIH(I)
+              PSIQ2=ALOG((2.+z0q)/Z0q)-PSIH2(I)
+              PSIQ10=ALOG((10.+z0q)/Z0q)-PSIH10(I)
+!              PSIQ=GZ1OZ0(I)-PSIH(I)+2.28*SQRT(SQRT(RESTAR))-2.
+!              PSIQ2=GZ2OZ0(I)-PSIH2(I)+2.28*SQRT(SQRT(RESTAR))-2.
+!              PSIQ10=GZ10OZ0(I)-PSIH(I)+2.28*SQRT(SQRT(RESTAR))-2.
+           ENDIF
+        ENDIF
+        IF(PRESENT_CXX) THEN
+           CK(I)=(karman/psix10)*(karman/psiq10)
+           CD(I)=(karman/psix10)*(karman/psix10)
+           CKA(I)=(karman/psix)*(karman/psiq)
+           CDA(I)=(karman/psix)*(karman/psix)
+        ENDIF
+        IF ( PRESENT_IZ0TLND ) THEN
+           IF ( IZ0TLND_.EQ.1 .AND. (XLAND(I)-1.5).LE.0. ) THEN
+              ZL=ZNT(I)
+!             CZIL RELATED CHANGES FOR LAND
+              VISC=(1.32+0.009*(SCR3(I)-273.15))*1.E-5
+              RESTAR=UST(I)*ZL/VISC
+!             Modify CZIL according to Chen & Zhang, 2009
+
+              CZIL = 10.0 ** ( -0.40 * ( ZL / 0.07 ) )
+!
+! ... paj: compute phish for z0t over land
+!
+              z0t=ZNT(I)/exp(CZIL*KARMAN*SQRT(RESTAR))
+!
+           zolzz=ZOL(I)*(ZA(I)+z0t)/ZA(I)    ! (z+z0t)/L
+           zol10=ZOL(I)*(10.+z0t)/ZA(I)   ! (10+z0t)/L
+           zol2=ZOL(I)*(2.+z0t)/ZA(I)     ! (2+z0t)/L
+           zol0=ZOL(I)*z0t/ZA(I)          ! z0t/L
+!
+              if (ZOL(I).gt.0.) then
+              PSIH(I)=psih_stable(zolzz)-psih_stable(zol0)
+!ARom              PSIH10(I)=psih_stable(zol10)-psih_stable(zol0)
+              PSIH2(I)=psih_stable(zol2)-psih_stable(zol0)
+              else
+                if (ZOL(I).eq.0) then
+                PSIH(I)=0.
+!ARom                PSIH10(I)=0.
+                PSIH2(I)=0.
+                else
+                PSIH(I)=psih_unstable(zolzz)-psih_unstable(zol0)
+!ARom                PSIH10(I)=psih_unstable(zol10)-psih_unstable(zol0)
+                PSIH2(I)=psih_unstable(zol2)-psih_unstable(zol0)
+                endif
+              endif
+!
+              PSIQ=ALOG((ZA(I)+z0t)/Z0t)-PSIH(I)
+              PSIQ2=ALOG((2.+z0t)/Z0t)-PSIH2(I)
+              PSIT=PSIQ
+              PSIT2=PSIQ2
+!
+!              PSIT=GZ1OZ0(I)-PSIH(I)+CZIL*KARMAN*SQRT(RESTAR)
+!              PSIQ=GZ1OZ0(I)-PSIH(I)+CZIL*KARMAN*SQRT(RESTAR)
+!              PSIT2=GZ2OZ0(I)-PSIH2(I)+CZIL*KARMAN*SQRT(RESTAR)
+!              PSIQ2=GZ2OZ0(I)-PSIH2(I)+CZIL*KARMAN*SQRT(RESTAR)
+
+           ENDIF
+        ENDIF
+! TO PREVENT OSCILLATIONS AVERAGE WITH OLD VALUE 
+        UST(I)=0.5*UST(I)+0.5*KARMAN*WSPD(I)/PSIX                                             
+! TKE coupling: compute UST without vconv for use in tke scheme
+        WSPDI(I)=SQRT(UX(I)*UX(I)+VX(I)*VX(I))
+        IF ( PRESENT_USTM ) THEN
+        USTM(I)=0.5*USTM(I)+0.5*KARMAN*WSPDI(I)/PSIX
+        ENDIF
+
+        U10(I)=UX(I)*PSIX10/PSIX                                    
+        V10(I)=VX(I)*PSIX10/PSIX                                   
+        TH2(I)=THGB(I)+DTG*PSIT2/PSIT                                
+        Q2(I)=QSFC(I)+(QX(I)-QSFC(I))*PSIQ2/PSIQ                   
+        T2(I) = TH2(I)*(PSFCPA(I)/P1000mb)**ROVCP                     
+!                                                                                
+        IF((XLAND(I)-1.5).LT.0.)THEN                                            
+          UST(I)=AMAX1(UST(I),0.001)
+        ENDIF                                                                    
+        MOL(I)=KARMAN*DTG/PSIT/PRT                              
+        DENOMQ(I)=PSIQ
+        DENOMQ2(I)=PSIQ2
+        DENOMT2(I)=PSIT2
+        FM(I)=PSIX
+        FH(I)=PSIT
+  330 CONTINUE                                                                   
+!                                                                                
+  335 CONTINUE                                                                   
+                                                                                  
+!-----COMPUTE THE SURFACE SENSIBLE AND LATENT HEAT FLUXES:                       
+      IF ( PRESENT_SCM_FORCE_FLUX ) THEN
+         IF (SCM_FORCE_FLUX_.EQ.1) GOTO 350
+      ENDIF
+      DO i=its,ite
+        QFX(i)=0.                                                              
+        HFX(i)=0.                                                              
+      ENDDO
+  350 CONTINUE                                                                   
+
+      IF (ISFFLX.EQ.0) GOTO 410                                                
+                                                                                 
+!-----OVER WATER, ALTER ROUGHNESS LENGTH (ZNT) ACCORDING TO WIND (UST).          
+                                                                                 
+      DO 360 I=its,ite
+        IF((XLAND(I)-1.5).GE.0)THEN                                            
+!         ZNT(I)=CZO*UST(I)*UST(I)/G+OZO                                   
+! Since V3.7 (ref: EC Physics document for Cy36r1)
+          ZNT(I)=CZO*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
+! COARE 3.5 (Edson et al. 2013)
+!         CZC = 0.0017*WSPD(I)-0.005
+!         CZC = min(CZC,0.028)
+!         ZNT(I)=CZC*UST(I)*UST(I)/G+0.11*1.5E-5/UST(I)
+! AHW: change roughness length, and hence the drag coefficients CK and CD
+          IF ( PRESENT_ISFTCFLX ) THEN
+             IF ( ISFTCFLX_.NE.0 ) THEN
+!               ZNT(I)=10.*exp(-9.*UST(I)**(-.3333))
+!               ZNT(I)=10.*exp(-9.5*UST(I)**(-.3333))
+!               ZNT(I)=ZNT(I) + 0.11*1.5E-5/AMAX1(UST(I),0.01)
+!               ZNT(I)=0.011*UST(I)*UST(I)/G+OZO
+!               ZNT(I)=MAX(ZNT(I),3.50e-5)
+! AHW 2012:
+                ZW  = MIN((UST(I)/1.06)**(0.3),1.0)
+                ZN1 = 0.011*UST(I)*UST(I)/G + OZO
+                ZN2 = 10.*exp(-9.5*UST(I)**(-.3333)) + &
+                       0.11*1.5E-5/AMAX1(UST(I),0.01)
+                ZNT(I)=(1.0-ZW) * ZN1 + ZW * ZN2
+                ZNT(I)=MIN(ZNT(I),2.85e-3)
+                ZNT(I)=MAX(ZNT(I),1.27e-7)
+             ENDIF
+          ENDIF
+! commented by ARom. ZL is not used anymore          
+!          ZL = ZNT(I)
+!        ELSE
+!          ZL = 0.01
+        ENDIF                                                                    
+        FLQC(I)=RHOX(I)*MAVAIL(I)*UST(I)*KARMAN/DENOMQ(I)
+!       FLQC(I)=RHOX(I)*MAVAIL(I)*UST(I)*KARMAN/(   &
+!               ALOG(KARMAN*UST(I)*ZA(I)/XKA+ZA(I)/ZL)-PSIH(I))
+        DTTHX=ABS(THX(I)-THGB(I))                                            
+        IF(DTTHX.GT.1.E-5)THEN                                                   
+          FLHC(I)=CPM(I)*RHOX(I)*UST(I)*MOL(I)/(THX(I)-THGB(I))          
+!         write(*,1001)FLHC(I),CPM(I),RHOX(I),UST(I),MOL(I),THX(I),THGB(I),I
+! 1001   format(f8.5,2x,f12.7,2x,f12.10,2x,f12.10,2x,f13.10,2x,f12.8,f12.8,2x,i3)
+        ELSE                                                                     
+          FLHC(I)=0.                                                             
+        ENDIF                                                                    
+  360 CONTINUE                                                                   
+
+!                                                                                
+!-----COMPUTE SURFACE MOIST FLUX:                                                
+!                                                                                
+!     IF(IDRY.EQ.1)GOTO 390                                                
+!                                                                                
+     IF ( PRESENT_SCM_FORCE_FLUX ) THEN
+        IF (SCM_FORCE_FLUX_.EQ.1) GOTO 405
+     ENDIF
+
+      DO 370 I=its,ite
+        QFX(I)=FLQC(I)*(QSFC(I)-QX(I))                                     
+        QFX(I)=AMAX1(QFX(I),0.)                                            
+        LH(I)=XLV*QFX(I)
+  370 CONTINUE                                                                 
+                                                                                
+!-----COMPUTE SURFACE HEAT FLUX:                                                 
+!                                                                                
+  390 CONTINUE                                                                 
+      DO 400 I=its,ite
+        IF(XLAND(I)-1.5.GT.0.)THEN                                           
+          HFX(I)=FLHC(I)*(THGB(I)-THX(I)) 
+!         IF ( PRESENT(ISFTCFLX) ) THEN
+!            IF ( ISFTCFLX.NE.0 ) THEN
+! AHW: add dissipative heating term (commented out in 3.6.1)
+!               HFX(I)=HFX(I)+RHOX(I)*USTM(I)*USTM(I)*WSPDI(I)
+!            ENDIF
+!         ENDIF 
+        ELSEIF(XLAND(I)-1.5.LT.0.)THEN                                       
+          HFX(I)=FLHC(I)*(THGB(I)-THX(I))                                
+          HFX(I)=AMAX1(HFX(I),-250.)                                       
+        ENDIF                                                                  
+  400 CONTINUE                                                                 
+
+  405 CONTINUE                                                                 
+         
+      DO I=its,ite
+! IF commented bt ARom. not used          
+!         IF((XLAND(I)-1.5).GE.0)THEN
+!           ZL=ZNT(I)
+!         ELSE
+!           ZL=0.01
+!         ENDIF
+!v3.1.1
+!         CHS(I)=UST(I)*KARMAN/(ALOG(KARMAN*UST(I)*ZA(I) &
+!                /XKA+ZA(I)/ZL)-PSIH(I))
+         CHS(I)=UST(I)*KARMAN/DENOMQ(I)
+!        GZ2OZ0(I)=ALOG(2./ZNT(I))
+!        PSIM2(I)=-10.*GZ2OZ0(I)
+!        PSIM2(I)=AMAX1(PSIM2(I),-10.)
+!        PSIH2(I)=PSIM2(I)
+! v3.1.1
+!         CQS2(I)=UST(I)*KARMAN/(ALOG(KARMAN*UST(I)*2.0  &
+!               /XKA+2.0/ZL)-PSIH2(I))
+!         CHS2(I)=UST(I)*KARMAN/(GZ2OZ0(I)-PSIH2(I))
+         CQS2(I)=UST(I)*KARMAN/DENOMQ2(I)
+         CHS2(I)=UST(I)*KARMAN/DENOMT2(I)
+      ENDDO
+                                                                        
+  410 CONTINUE                                                                   
+!jdf
+!     DO I=its,ite
+!       IF(UST(I).GE.0.1) THEN
+!         RMOL(I)=RMOL(I)*(-FLHC(I))/(UST(I)*UST(I)*UST(I))
+!       ELSE
+!         RMOL(I)=RMOL(I)*(-FLHC(I))/(0.1*0.1*0.1)
+!       ENDIF
+!     ENDDO
+!jdf
+#ifdef _OPENACC
+   ENDDO ! J loop
+#endif
+!$acc end kernels
+!$acc end data
+!       
+
+   END SUBROUTINE SFCLAYREV1D
+
+!====================================================================
+   SUBROUTINE sfclayrevinit
+
+    INTEGER                   ::      N
+    REAL                      ::      zolf
+
+    DO N=0,1000
+! stable function tables
+       zolf = float(n)*0.01
+       psim_stab(n)=psim_stable_full(zolf)
+       psih_stab(n)=psih_stable_full(zolf)
+ 
+! unstable function tables
+       zolf = -float(n)*0.01
+       psim_unstab(n)=psim_unstable_full(zolf)
+       psih_unstab(n)=psih_unstable_full(zolf)
+
+    ENDDO
+!$acc update device(psim_unstab,psih_unstab,psim_stab,psih_stab)
+   END SUBROUTINE sfclayrevinit
+
+      function zolri(ri,z,z0)      
+!$acc routine seq
+!$acc routine(zolri2) seq
+!
+      if (ri.lt.0.)then
+        x1=-5.
+        x2=0.
+      else
+        x1=0.
+        x2=5.
+      endif
+!
+      fx1=zolri2(x1,ri,z,z0)
+      fx2=zolri2(x2,ri,z,z0)
+      Do While (abs(x1 - x2) > 0.01)
+      if(abs(fx2).lt.abs(fx1))then
+        x1=x1-fx1/(fx2-fx1)*(x2-x1)
+        fx1=zolri2(x1,ri,z,z0)
+        zolri=x1
+      else
+        x2=x2-fx2/(fx2-fx1)*(x2-x1)
+        fx2=zolri2(x2,ri,z,z0)
+        zolri=x2
+      endif
+!
+      enddo
+!
+
+      return
+      end function
+
+!
+! -----------------------------------------------------------------------
+!
+      function zolri2(zol2,ri2,z,z0)
+!$acc routine seq
+!$acc routine(psim_unstable) seq
+!$acc routine(psih_unstable) seq
+!$acc routine(psim_stable) seq
+!$acc routine(psih_stable) seq
+!
+      if(zol2*ri2 .lt. 0.)zol2=0.  ! limit zol2 - must be same sign as ri2
+!
+      zol20=zol2*z0/z ! z0/L
+      zol3=zol2+zol20 ! (z+z0)/L
+!
+      if (ri2.lt.0) then
+      psix2=log((z+z0)/z0)-(psim_unstable(zol3)-psim_unstable(zol20))
+      psih2=log((z+z0)/z0)-(psih_unstable(zol3)-psih_unstable(zol20))
+      else
+      psix2=log((z+z0)/z0)-(psim_stable(zol3)-psim_stable(zol20))
+      psih2=log((z+z0)/z0)-(psih_stable(zol3)-psih_stable(zol20))
+      endif
+!
+      zolri2=zol2*psih2/psix2**2-ri2
+!
+      return
+      end function
+!
+! ... integrated similarity functions ...
+!
+      function psim_stable_full(zolf)
+!$acc routine seq
+        psim_stable_full=-6.1*log(zolf+(1+zolf**2.5)**(1./2.5))
+      return
+      end function
+
+      function psih_stable_full(zolf)
+!$acc routine seq
+        psih_stable_full=-5.3*log(zolf+(1+zolf**1.1)**(1./1.1))
+      return
+      end function
+      
+      function psim_unstable_full(zolf)
+!$acc routine seq
+        x=(1.-16.*zolf)**.25
+        psimk=2*ALOG(0.5*(1+X))+ALOG(0.5*(1+X*X))-2.*ATAN(X)+2.*ATAN(1.)
+!
+        ym=(1.-10.*zolf)**0.33
+        psimc=(3./2.)*log((ym**2.+ym+1.)/3.)-sqrt(3.)*ATAN((2.*ym+1)/sqrt(3.))+4.*ATAN(1.)/sqrt(3.)
+!
+        psim_unstable_full=(psimk+zolf**2*(psimc))/(1+zolf**2.)
+
+      return
+      end function
+
+      function psih_unstable_full(zolf)
+!$acc routine seq
+        y=(1.-16.*zolf)**.5
+        psihk=2.*log((1+y)/2.)
+!
+        yh=(1.-34.*zolf)**0.33
+        psihc=(3./2.)*log((yh**2.+yh+1.)/3.)-sqrt(3.)*ATAN((2.*yh+1)/sqrt(3.))+4.*ATAN(1.)/sqrt(3.)
+!
+        psih_unstable_full=(psihk+zolf**2*(psihc))/(1+zolf**2.)
+
+      return
+      end function
+
+! look-up table functions
+      function psim_stable(zolf)
+!$acc routine seq
+!$acc routine(psim_stable_full) seq
+      integer :: nzol
+      real    :: rzol
+        nzol = int(zolf*100.)
+        rzol = zolf*100. - nzol
+        if(nzol+1 .le. 1000)then
+           psim_stable = psim_stab(nzol) + rzol*(psim_stab(nzol+1)-psim_stab(nzol))
+        else
+           psim_stable = psim_stable_full(zolf)
+        endif
+      return
+      end function
+
+      function psih_stable(zolf)
+!$acc routine seq
+!$acc routine(psih_stable_full) seq
+      integer :: nzol
+      real    :: rzol
+        nzol = int(zolf*100.)
+        rzol = zolf*100. - nzol
+        if(nzol+1 .le. 1000)then
+           psih_stable = psih_stab(nzol) + rzol*(psih_stab(nzol+1)-psih_stab(nzol))
+        else
+           psih_stable = psih_stable_full(zolf)
+        endif
+      return
+      end function
+      
+      function psim_unstable(zolf)
+!$acc routine seq
+!$acc routine(psim_unstable_full) seq
+      integer :: nzol
+      real    :: rzol
+        nzol = int(-zolf*100.)
+        rzol = -zolf*100. - nzol
+        if(nzol+1 .le. 1000)then
+           psim_unstable = psim_unstab(nzol) + rzol*(psim_unstab(nzol+1)-psim_unstab(nzol))
+        else
+           psim_unstable = psim_unstable_full(zolf)
+        endif
+      return
+      end function
+
+      function psih_unstable(zolf)
+!$acc routine seq
+!$acc routine(psih_unstable_full) seq
+      integer :: nzol
+      real    :: rzol
+        nzol = int(-zolf*100.)
+        rzol = -zolf*100. - nzol
+        if(nzol+1 .le. 1000)then
+           psih_unstable = psih_unstab(nzol) + rzol*(psih_unstab(nzol+1)-psih_unstab(nzol))
+        else
+           psih_unstable = psih_unstable_full(zolf)
+        endif
+      return
+      end function
+
+!-------------------------------------------------------------------          
+
+END MODULE module_sf_sfclayrev
+
+!
+! ----------------------------------------------------------
+!
+
+

--- a/src/fromNVIDIA/module_sf_slab.F
+++ b/src/fromNVIDIA/module_sf_slab.F
@@ -1,0 +1,572 @@
+!WRF:MODEL_LAYER:PHYSICS
+!
+MODULE module_sf_slab
+
+   !---SPECIFY CONSTANTS AND LAYERS FOR SOIL MODEL
+   !---SOIL DIFFUSION CONSTANT SET (M^2/S)
+
+   REAL, PARAMETER :: DIFSL=5.e-7
+
+   !---FACTOR TO MAKE SOIL STEP MORE CONSERVATIVE
+
+   REAL , PARAMETER :: SOILFAC=1.25
+
+CONTAINS
+
+!----------------------------------------------------------------
+   SUBROUTINE SLAB(T3D,QV3D,P3D,FLHC,FLQC,                      &
+                   PSFC,XLAND,TMN,HFX,QFX,LH,TSK,QSFC,CHKLOWQ,  &
+                   GSW,GLW,CAPG,THC,SNOWC,EMISS,MAVAIL,         &
+                   DELTSM,ROVCP,XLV,DTMIN,IFSNOW,               &
+                   SVP1,SVP2,SVP3,SVPT0,EP2,                    &
+                   KARMAN,EOMEG,STBOLT,                         &
+                   TSLB,ZS,DZS,num_soil_layers,radiation,       &
+                   P1000mb,                                     &
+                   ids,ide, jds,jde, kds,kde,                   &
+                   ims,ime, jms,jme, kms,kme,                   &
+                   its,ite, jts,jte, kts,kte                    )
+!----------------------------------------------------------------
+    IMPLICIT NONE
+!----------------------------------------------------------------
+!                                                                        
+!     SUBROUTINE SLAB CALCULATES THE GROUND TEMPERATURE TENDENCY 
+!     ACCORDING TO THE RESIDUAL OF THE SURFACE ENERGY BUDGET           
+!     (BLACKADAR, 1978B).                                              
+!                                                                      
+!     CHANGES:                                                         
+!          FOR SOIL SUB-TIMESTEPS UPDATE SURFACE HFX AND QFX AS TG     
+!          CHANGES TO PREVENT POSSIBLE INSTABILITY FOR LONG MODEL      
+!          STEPS (DT > ~200 SEC).                                      
+!                                                                      
+!          PUT SNOW COVER CHECK ON SOIL SUB-TIMESTEPS                  
+!                                                                      
+!          MAKE UPPER LIMIT ON SOIL SUB-STEP LENGTH MORE CONSERVATIVE  
+!                                                                      
+!----------------------------------------------------------------          
+!-- T3D         temperature (K)
+!-- QV3D        3D water vapor mixing ratio (Kg/Kg)
+!-- P3D         3D pressure (Pa)
+!-- FLHC        exchange coefficient for heat (m/s)
+!-- FLQC        exchange coefficient for moisture (m/s)
+!-- PSFC        surface pressure (Pa)
+!-- XLAND       land mask (1 for land, 2 for water)
+!-- TMN         soil temperature at lower boundary (K)
+!-- HFX         upward heat flux at the surface (W/m^2)
+!-- QFX         upward moisture flux at the surface (kg/m^2/s)
+!-- LH          latent heat flux at the surface (W/m^2)
+!-- TSK         surface temperature (K)
+!-- GSW         downward short wave flux at ground surface (W/m^2)      
+!-- GLW         downward long wave flux at ground surface (W/m^2)
+!-- CAPG        heat capacity for soil (J/K/m^3)
+!-- THC         thermal inertia (Cal/cm/K/s^0.5)
+!-- SNOWC       flag indicating snow coverage (1 for snow cover)
+!-- EMISS       surface emissivity (between 0 and 1)
+!-- DELTSM      time step (second)
+!-- ROVCP       R/CP
+!-- XLV         latent heat of melting (J/kg)
+!-- DTMIN       time step (minute)
+!-- IFSNOW      ifsnow=1 for snow-cover effects
+!-- SVP1        constant for saturation vapor pressure (kPa)
+!-- SVP2        constant for saturation vapor pressure (dimensionless)
+!-- SVP3        constant for saturation vapor pressure (K)
+!-- SVPT0       constant for saturation vapor pressure (K)
+!-- EP1         constant for virtual temperature (R_v/R_d - 1) (dimensionless)
+!-- EP2         constant for specific humidity calculation 
+!               (R_d/R_v) (dimensionless)
+!-- KARMAN      Von Karman constant
+!-- EOMEG       angular velocity of earth's rotation (rad/s)
+!-- STBOLT      Stefan-Boltzmann constant (W/m^2/K^4)
+!-- TSLB        soil temperature in 5-layer model
+!-- ZS          depths of centers of soil layers
+!-- DZS         thicknesses of soil layers
+!-- num_soil_layers   the number of soil layers
+!-- ids         start index for i in domain
+!-- ide         end index for i in domain
+!-- jds         start index for j in domain
+!-- jde         end index for j in domain
+!-- kds         start index for k in domain
+!-- kde         end index for k in domain
+!-- ims         start index for i in memory
+!-- ime         end index for i in memory
+!-- jms         start index for j in memory
+!-- jme         end index for j in memory
+!-- kms         start index for k in memory
+!-- kme         end index for k in memory
+!-- its         start index for i in tile
+!-- ite         end index for i in tile
+!-- jts         start index for j in tile
+!-- jte         end index for j in tile
+!-- kts         start index for k in tile
+!-- kte         end index for k in tile
+!----------------------------------------------------------------
+   INTEGER,  INTENT(IN   )   ::     ids,ide, jds,jde, kds,kde,  &
+                                    ims,ime, jms,jme, kms,kme,  &
+                                    its,ite, jts,jte, kts,kte
+
+   INTEGER, INTENT(IN)       ::     num_soil_layers
+   LOGICAL, INTENT(IN)       ::     radiation
+
+   INTEGER,  INTENT(IN   )   ::     IFSNOW
+
+!
+   REAL,     INTENT(IN   )   ::     DTMIN,XLV,ROVCP,DELTSM
+
+   REAL,     INTENT(IN )     ::     SVP1,SVP2,SVP3,SVPT0
+   REAL,     INTENT(IN )     ::     EP2,KARMAN,EOMEG,STBOLT
+   REAL,     INTENT(IN )     ::     P1000mb
+
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ), &
+             INTENT(INOUT)   :: TSLB
+
+   REAL,     DIMENSION(1:num_soil_layers), INTENT(IN)::ZS,DZS
+
+   REAL,    DIMENSION( ims:ime, kms:kme, jms:jme )            , &
+            INTENT(IN   )    ::                           QV3D, &
+                                                           P3D, &
+                                                           T3D
+!
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN   )    ::                          SNOWC, &
+                                                         XLAND, &
+                                                         EMISS, &
+                                                        MAVAIL, &
+                                                           TMN, &
+                                                           GSW, &
+                                                           GLW, &
+                                                           THC
+
+!CHKLOWQ is declared as memory size
+!
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(INOUT)    ::                            HFX, &
+                                                           QFX, &
+                                                            LH, &
+                                                          CAPG, &
+                                                           TSK, &
+                                                          QSFC, &
+                                                       CHKLOWQ
+
+   REAL,     DIMENSION( ims:ime, jms:jme )                    , &
+             INTENT(IN   )               ::               PSFC
+!
+   REAL,    DIMENSION( ims:ime, jms:jme ), INTENT(INOUT) ::     &
+                                                          FLHC, &
+                                                          FLQC
+
+! LOCAL VARS
+
+!   REAL,     DIMENSION( its:ite ) ::                      QV1D, &
+!                                                           P1D, &
+!                                                           T1D
+
+   INTEGER ::  I,J
+   CHARACTER(len=1024) :: msg
+
+!   DO J=jts,jte
+
+!      DO i=its,ite
+!         T1D(i) =T3D(i,1,j)
+!         QV1D(i)=QV3D(i,1,j)
+!         P1D(i) =P3D(i,1,j)
+!      ENDDO
+
+! the indices to the PSFC argument in the following call look
+! wrong; however, it is correct to call with its (and not ims)
+! because of the way PSFC is defined in SLAB1D. Whether *that*
+! is a good idea or not, this commenter cannot comment. JM
+
+!$acc data pcreate(T3D,QV3D,P3D,FLHC,FLQC,PSFC,XLAND,TMN,HFX,      &
+!$acc               QFX,TSK,QSFC,CHKLOWQ,LH,GSW,GLW,CAPG,THC,       &
+!$acc               SNOWC,EMISS,TSLB,ZS,DZS,MAVAIL)   
+!$acc update device(PSFC,TMN,      &
+!$acc               QSFC,CHKLOWQ,LH,GSW,GLW,CAPG,THC,       &
+!$acc               SNOWC,EMISS,TSLB,ZS,DZS)   
+      CALL SLAB2D(T3D,QV3D,P3D,FLHC,FLQC,       &
+           PSFC,XLAND,TMN,HFX,      &
+           QFX,TSK,QSFC,CHKLOWQ,    &
+           LH,GSW,GLW,                     &
+           CAPG,THC,SNOWC,EMISS,    &
+           MAVAIL,DELTSM,ROVCP,XLV,DTMIN,IFSNOW,         &
+           SVP1,SVP2,SVP3,SVPT0,EP2,KARMAN,EOMEG,STBOLT,        &
+           TSLB,ZS,DZS,num_soil_layers,radiation,      &
+           P1000mb,                                             &
+           ids,ide, jds,jde, kds,kde,                           &
+           ims,ime, jms,jme, kms,kme,                           &
+           its,ite, jts,jte, kts,kte                            )
+
+!   ENDDO
+!!$acc update host(TSLB,LH,CAPG,TSK,QSFC,CHKLOWQ,FLHC,FLQC)
+!$acc update host(TSLB,HFX,QFX,LH,CAPG,TSK,QSFC,CHKLOWQ)
+!$acc end data
+
+   END SUBROUTINE SLAB
+
+!----------------------------------------------------------------
+   SUBROUTINE SLAB2D(T3D,QV3D,P3D,FLHC,FLQC,                  &
+                   PSFCPA,XLAND,TMN,HFX,QFX,TSK,QSFC,CHKLOWQ,   &
+                   LH,GSW,GLW,CAPG,THC,SNOWC,EMISS,MAVAIL,      &
+                   DELTSM,ROVCP,XLV,DTMIN,IFSNOW,               &
+                   SVP1,SVP2,SVP3,SVPT0,EP2,                    &
+                   KARMAN,EOMEG,STBOLT,                         &
+                   TSLB2D,ZS,DZS,num_soil_layers,radiation,     &
+                   P1000mb,                                     &
+                   ids,ide, jds,jde, kds,kde,                   &
+                   ims,ime, jms,jme, kms,kme,                   &
+                   its,ite, jts,jte, kts,kte                    )
+!----------------------------------------------------------------
+    IMPLICIT NONE
+!----------------------------------------------------------------
+!                                                                        
+!     SUBROUTINE SLAB CALCULATES THE GROUND TEMPERATURE TENDENCY 
+!     ACCORDING TO THE RESIDUAL OF THE SURFACE ENERGY BUDGET           
+!     (BLACKADAR, 1978B).                                              
+!                                                                      
+!     CHANGES:                                                         
+!          FOR SOIL SUB-TIMESTEPS UPDATE SURFACE HFX AND QFX AS TG     
+!          CHANGES TO PREVENT POSSIBLE INSTABILITY FOR LONG MODEL      
+!          STEPS (DT > ~200 SEC).                                      
+!                                                                      
+!          PUT SNOW COVER CHECK ON SOIL SUB-TIMESTEPS                  
+!                                                                      
+!          MAKE UPPER LIMIT ON SOIL SUB-STEP LENGTH MORE CONSERVATIVE  
+!                                                                      
+!----------------------------------------------------------------          
+
+   INTEGER,  INTENT(IN   )   ::     ids,ide, jds,jde, kds,kde,  &
+                                    ims,ime, jms,jme, kms,kme,  &
+                                    its,ite, jts,jte, kts,kte
+
+   INTEGER , INTENT(IN)      ::     num_soil_layers
+   LOGICAL,  INTENT(IN   )   ::     radiation
+
+   INTEGER,  INTENT(IN   )   ::     IFSNOW
+!
+   REAL,     INTENT(IN   )   ::     DTMIN,XLV,ROVCP,DELTSM
+
+   REAL,     INTENT(IN )     ::     SVP1,SVP2,SVP3,SVPT0
+   REAL,     INTENT(IN )     ::     EP2,KARMAN,EOMEG,STBOLT
+   REAL,     INTENT(IN )     ::     P1000mb
+
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers, jms:jme ),          &
+             INTENT(INOUT)   :: TSLB2D
+
+   REAL,     DIMENSION(1:num_soil_layers), INTENT(IN)::ZS,DZS
+
+!
+   REAL,    DIMENSION( ims:ime,jms:jme )                      , &
+            INTENT(INOUT)    ::                            HFX, &
+                                                           QFX, &
+                                                            LH, &
+                                                          CAPG, &
+                                                           TSK, &
+                                                          QSFC, &
+                                                       CHKLOWQ
+!
+   REAL,    DIMENSION( ims:ime,jms:jme )                      , &
+            INTENT(IN   )    ::                          SNOWC, &
+                                                         XLAND, &
+                                                         EMISS, &
+                                                        MAVAIL, &
+                                                           TMN, &
+                                                           GSW, &
+                                                           GLW, &
+                                                           THC
+!
+   REAL,    DIMENSION( ims:ime, kms:kme, jms:jme )            , &
+            INTENT(IN   )    ::                           QV3D, &
+                                                           P3D, &
+                                                           T3D
+!
+   REAL,     DIMENSION( ims:ime,jms:jme )                     , &
+             INTENT(IN   )               ::             PSFCPA
+
+!
+   REAL,    DIMENSION( ims:ime,jms:jme ), INTENT(INOUT) ::      &
+                                                          FLHC, &
+                                                          FLQC
+! LOCAL VARS
+
+   REAL,    DIMENSION( its:ite,jts:jte )  ::   QS,TG0,RNET,DTHGDT
+!   REAL,    DIMENSION( its:ite )          ::            DTHGDT, &
+!                                                           TG0, &
+!                                                         THTMN, &
+!                                                          XLD1, &
+!                                                         TSCVN, &
+!                                                          OLTG, &
+!                                                        UPFLUX, &
+!                                                            HM, &
+!                                                          RNET, &
+!                                                         XINET, &
+!                                                            QS, &
+!                                                         DTSDT
+!
+!   REAL, DIMENSION( its:ite, num_soil_layers )        :: FLUX
+!
+   INTEGER :: I,K,J,NSOIL,ITSOIL,L,NK,RADSWTCH
+   REAL    :: PS,PS1,XLDCOL,TSKX,RNSOIL,RHOG1,RHOG2,RHOG3,LAMDAG
+   REAL    :: THG,ESG,QSG,HFXT,QFXT,CS,CSW,LAMG(4),THCON,PL,DTSDT_I
+   REAL    :: THX_I,TSCVN_I,UPFLUX_I,HM_I,XINET_I,FLUX_L, FLUX_LP
+ 
+!----------------------------------------------------------------------          
+!-----DETERMINE IF ANY POINTS IN COLUMN ARE LAND (RATHER THAN OCEAN)             
+!       POINTS.  IF NOT, SKIP DOWN TO THE PRINT STATEMENTS SINCE OCEAN           
+!       SURFACE TEMPERATURES ARE NOT ALLOWED TO CHANGE.                          
+!                                                                                
+! from sfcrad   
+!----------------------------------------------------------------------
+   DATA CSW/4.183E6/
+!   DATA LAMG/1.407E-8, -1.455E-5, 6.290E-3, 0.16857/
+
+      IF (radiation) then
+        RADSWTCH=1
+      ELSE
+        RADSWTCH=0
+      ENDIF
+
+
+!$acc data create(QS,TG0,RNET,DTHGDT)
+!$acc kernels
+   DO J=jts,jte
+!
+!-----THE SLAB THERMAL CAPACITY CAPG(I) ARE DEPENDENT ON:
+!     THC(I) - SOIL THERMAL INERTIAL, ONLY.
+!
+      DO I=its,ite
+         CAPG(I,J)=3.298E6*THC(I,J)
+         IF(num_soil_layers .gt. 1)THEN
+
+! CAPG REPRESENTS SOIL HEAT CAPACITY (J/K/M^3) WHEN DIFSL=5.E-7 (M^2/S)
+! TO GIVE A CORRECT THERMAL INERTIA (=CAPG*DIFSL^0.5)
+
+            CAPG(I,J)=5.9114E7*THC(I,J)
+         ENDIF
+      ENDDO
+!        
+      XLDCOL=2.0                                                                 
+!$acc loop seq
+      DO 10 I=its,ite
+        XLDCOL=AMIN1(XLDCOL,XLAND(I,J))                                          
+   10 CONTINUE                                                                   
+!                                                                                
+      IF(XLDCOL.GT.1.5)GOTO 90                                                   
+!                                                                                
+!                                                                                
+!-----CONVERT SLAB TEMPERATURE TO POTENTIAL TEMPERATURE AND                      
+!     SET XLD1(I) = 0. FOR OCEAN POINTS:                                         
+!                                                                                
+!                                                                                
+!      DO 20 I=its,ite
+!        IF((XLAND(I,J)-1.5).GE.0)THEN                                            
+!          XLD1(I)=0.                                                             
+!        ELSE                                                                     
+!          XLD1(I)=1.                                                             
+!        ENDIF                                                                    
+!   20 CONTINUE                                                                   
+!                                                                                
+!-----CONVERT 'TSK(THETAG)' TO 'TG' FOR 'IUP' CALCULATION ....                   
+!       IF WE ARE USING THE BLACKADAR MULTI-LEVEL (HIGH-RESOLUTION)              
+!       PBL MODEL                                                                
+!                                                                                
+      DO 50 I=its,ite
+!        IF(XLD1(I).LT.0.5)GOTO 50                                                
+        IF((XLAND(I,J)-1.5).GE.0)GOTO 50                                                
+
+! PS cmb
+        PS=(PSFCPA(I,J)/1000.)
+
+! TSK is Temperature at gound sfc
+!       TG0(I)=TSK(I,J)*(PS*0.01)**ROVCP                                         
+        TG0(I,J)=TSK(I,J)
+   50 CONTINUE  
+!                                                                                
+!-----COMPUTE THE SURFACE ENERGY BUDGET:                                         
+!                                                                                
+!     IF(ISOIL.EQ.1)NSOIL=1                                                      
+      IF(num_soil_layers .gt. 1)NSOIL=1                                                      
+
+
+      DO 70 I=its,ite
+!        IF(XLD1(I).LT.0.5)GOTO 70
+        IF((XLAND(I,J)-1.5).GE.0)GOTO 70
+        THX_I = T3D(I,1,J)*((P1000mb*0.001/(P3D(I,1,J)/1000.))**ROVCP)
+!        OLTG(I)=TSK(I,J)*(100./PSFC(I))**ROVCP
+!        OLTG(I)=TSK(I,J)*(P1000mb*0.001/PSFC(I))**ROVCP
+        UPFLUX_I=RADSWTCH*STBOLT*TG0(I,J)**4                            
+        XINET_I=EMISS(I,J)*(GLW(I,J)-UPFLUX_I)    
+        RNET(I,J)=GSW(I,J)+XINET_I                                                
+        HM_I=1.18*EOMEG*(TG0(I,J)-TMN(I,J))                                       
+!       MOISTURE FLUX CALCULATED HERE (OVERWRITES SFC LAYER VALUE FOR LAND)
+                ESG=SVP1*EXP(SVP2*(TG0(I,J)-SVPT0)/(TG0(I,J)-SVP3))
+                QSG=EP2*ESG/((PSFCPA(I,J)/1000.)-ESG)
+                THG=TSK(I,J)*(100./(PSFCPA(I,J)/1000.))**ROVCP
+                HFX(I,J)=FLHC(I,J)*(THG-THX_I)
+                QFX(I,J)=FLQC(I,J)*(QSG-QV3D(I,1,J))
+                LH(I,J)=QFX(I,J)*XLV
+        QS(I,J)=HFX(I,J)+QFX(I,J)*XLV                                
+!       IF(ISOIL.EQ.0)THEN                                                       
+        IF(num_soil_layers .EQ. 1)THEN                                                       
+          DTHGDT(I,J)=(RNET(I,J)-QS(I,J))/CAPG(I,J)-HM_I                              
+        ELSE
+          DTHGDT(I,J)=0.                                                           
+        ENDIF                                                                    
+   70 CONTINUE                       
+
+!     IF(ISOIL.EQ.1)THEN                                                         
+      IF(num_soil_layers .gt. 1)THEN                                                         
+        NSOIL=1+IFIX(SOILFAC*4*DIFSL/DZS(1)*DELTSM/DZS(1))   
+        RNSOIL=1./FLOAT(NSOIL)                                                   
+!                                                                                
+!     SOIL SUB-TIMESTEP                                                          
+!                                                                                
+        DO I=its,ite
+          THX_I = T3D(I,1,J)*((P1000mb*0.001/(P3D(I,1,J)/1000.))**ROVCP)
+          DO ITSOIL=1,NSOIL                                                        
+             DO L=1,num_soil_layers-1
+!              IF(XLD1(I).LT.0.5)GOTO 75                                          
+              IF((XLAND(I,J)-1.5).GE.0)GOTO 75                                          
+              IF(L.EQ.1.AND.ITSOIL.GT.1)THEN                                     
+!                PS1=(PSFC(I)*0.01)**ROVCP    
+                PS1=(PSFCPA(I,J)/P1000mb)**ROVCP    
+
+! for rk scheme A and B are the same
+                PS=(PSFCPA(I,J)/1000.)
+                THG=TSLB2D(I,1,J)/PS1                                              
+                ESG=SVP1*EXP(SVP2*(TSLB2D(I,1,J)-SVPT0)/(TSLB2D(I,1,J) & 
+                    -SVP3))                                                      
+                QSG=EP2*ESG/(PS-ESG)                                             
+!     UPDATE FLUXES FOR NEW GROUND TEMPERATURE                                   
+                HFXT=FLHC(I,J)*(THG-THX_I)                                     
+                QFXT=FLQC(I,J)*(QSG-QV3D(I,1,J))
+                QS(I,J)=HFXT+QFXT*XLV                                
+!     SUM HFX AND QFX OVER SOIL TIMESTEPS                                        
+                HFX(I,J)=HFX(I,J)+HFXT                                           
+                QFX(I,J)=QFX(I,J)+QFXT                                           
+              ENDIF                                                              
+              IF(L.eq.1) THEN
+                FLUX_L = RNET(I,J)-QS(I,J)
+              ELSE
+                FLUX_L =-DIFSL*CAPG(I,J)*(TSLB2D(I,L,J)-TSLB2D(I,L-1,J))/( &
+                         ZS(L)-ZS(L-1))
+              ENDIF
+              FLUX_LP = -DIFSL*CAPG(I,J)*(TSLB2D(I,L+1,J)-TSLB2D(I,L,J))/( &
+                        ZS(L+1)-ZS(L))
+!              FLUX(I,1)=RNET(I,J)-QS(I,J)                                            
+!              FLUX(I,L+1)=-DIFSL*CAPG(I,J)*(TSLB2D(I,L+1,J)-TSLB2D(I,L,J))/( & 
+!                          ZS(L+1)-ZS(L))                                         
+!              DTSDT(I)=-(FLUX(I,L+1)-FLUX(I,L))/(DZS(L)*CAPG(I,J))               
+              DTSDT_I=-(FLUX_LP-FLUX_L)/(DZS(L)*CAPG(I,J))               
+              TSLB2D(I,L,J)=TSLB2D(I,L,J)+DTSDT_I*DELTSM*RNSOIL                     
+              IF(IFSNOW.EQ.1.AND.L.EQ.1)THEN                              
+                IF((SNOWC(I,J).GT.0..AND.TSLB2D(I,1,J).GT.273.16))THEN             
+                  TSLB2D(I,1,J)=273.16                                             
+                ENDIF                                                            
+              ENDIF                                                              
+              IF(L.EQ.1)DTHGDT(I,J)=DTHGDT(I,J)+RNSOIL*DTSDT_I                      
+              IF(ITSOIL.EQ.NSOIL.AND.L.EQ.1)THEN                                 
+!     AVERAGE HFX AND QFX OVER SOIL TIMESTEPS FOR OUTPUT TO PBL                  
+                HFX(I,J)=HFX(I,J)*RNSOIL                                         
+                QFX(I,J)=QFX(I,J)*RNSOIL                                         
+                LH(I,J)=QFX(I,J)*XLV
+              ENDIF                                                              
+   75         CONTINUE                                                           
+            ENDDO                                                                
+          ENDDO                                                                  
+        ENDDO                                                                    
+      ENDIF                                                                      
+!                                                                                
+      DO 80 I=its,ite
+!        IF(XLD1(I).LT.0.5) GOTO 80                                                
+        IF((XLAND(I,J)-1.5).GE.0) GOTO 80                                                
+        TSKX=TG0(I,J)+DELTSM*DTHGDT(I,J)                                             
+
+! TSK is temperature
+!       TSK(I,J)=TSKX*(100./PS1)**ROVCP                                          
+        TSK(I,J)=TSKX
+   80 CONTINUE                                                                   
+
+
+!                                                                                
+!-----MODIFY THE THE GROUND TEMPERATURE IF THE SNOW COVER EFFECTS ARE            
+!     CONSIDERED: LIMIT THE GROUND TEMPERATURE UNDER 0 C.                        
+!                                                                                
+      IF(IFSNOW.NE.0) THEN        
+      DO 85 I=its,ite
+!        IF(XLD1(I).LT.0.5)GOTO 85                                                
+        IF((XLAND(I,J)-1.5).GE.0)GOTO 85                                                
+!       PS1=(PSFC(I)*0.01)**ROVCP             
+!       TSCVN(I)=TSK(I,J)*PS1                                            
+        TSCVN_I=TSK(I,J)
+        IF((SNOWC(I,J).GT.0..AND.TSCVN_I.GT.273.16))THEN                        
+          TSCVN_I=273.16                                                        
+        ELSE                                                                     
+          TSCVN_I=TSCVN_I                                                      
+        ENDIF                                                                    
+!       TSK(I,J)=TSCVN(I)/PS1                                                    
+        TSK(I,J)=TSCVN_I
+   85 CONTINUE            
+      ENDIF
+
+   90 CONTINUE                                                                   
+      ENDDO
+!$acc end kernels      
+!                                                                                
+
+!$acc  kernels      
+      DO J=jts,jte
+      DO I=its,ite
+! QSFC and CHKLOWQ needed by Eta PBL
+! WA added check for flqc = 0 to accomodate TEMF (and others?)
+        if ( FLQC(I,J) .ne. 0.) then
+           QSFC(I,J)=QV3D(I,1,J)+QFX(I,J)/FLQC(I,J)
+        else
+           QSFC(I,J) = QV3D(I,1,J)
+        end if
+        CHKLOWQ(I,J)=MAVAIL(I,J)
+      ENDDO
+!                                                                                
+!  140 CONTINUE                                                                   
+      ENDDO
+!$acc end kernels      
+!$acc end data
+   END SUBROUTINE SLAB2D
+
+!================================================================
+   SUBROUTINE slabinit(TSK,TMN,                                 &
+                       TSLB,ZS,DZS,num_soil_layers,             &
+                       allowed_to_read, start_of_simulation,    &
+                       ids,ide, jds,jde, kds,kde,               &
+                       ims,ime, jms,jme, kms,kme,               &
+                       its,ite, jts,jte, kts,kte                )
+!----------------------------------------------------------------
+   IMPLICIT NONE
+!----------------------------------------------------------------
+   LOGICAL , INTENT(IN)      ::      allowed_to_read
+   LOGICAL , INTENT(IN)      ::      start_of_simulation
+   INTEGER, INTENT(IN   )    ::      ids,ide, jds,jde, kds,kde, &
+                                     ims,ime, jms,jme, kms,kme, &
+                                     its,ite, jts,jte, kts,kte
+
+   INTEGER, INTENT(IN   )    ::      num_soil_layers
+!   
+   REAL,     DIMENSION( ims:ime , 1:num_soil_layers , jms:jme ), INTENT(INOUT) :: TSLB
+
+   REAL,     DIMENSION(1:num_soil_layers), INTENT(IN)  ::  ZS,DZS
+
+   REAL,    DIMENSION( ims:ime, jms:jme )                     , &
+            INTENT(IN)    ::                               TSK, &
+                                                           TMN
+
+!  LOCAR VAR
+
+   INTEGER                   ::      L,J,I,itf,jtf
+   CHARACTER*1024 message
+
+!----------------------------------------------------------------
+ 
+   itf=min0(ite,ide-1)
+   jtf=min0(jte,jde-1)
+
+   END SUBROUTINE slabinit
+!-------------------------------------------------------------------          
+
+END MODULE module_sf_slab

--- a/src/fromNVIDIA/notes
+++ b/src/fromNVIDIA/notes
@@ -1,0 +1,35 @@
+slab.F and module_sf_slab.F
+---------------------------
+
+   Incompatable arguments
+
+ysu.F and module_bl_ysu.F
+-------------------------
+
+   Incompatable arguments
+
+thompson.F and module_mp_thompson.F
+-----------------------------------
+  
+   Missing module_domain
+
+sfclay.F and module_sfc_sfclayrev.F
+-----------------------------------
+  
+   Change in name of the module
+
+module_bl_gwdo.F
+module_sf_noahdrv.F
+-------------------
+
+   Does not appear to be a corresponding file in current version of CM1
+
+module_ra_rrtmg_lw.f90 versus module_ra_rrtmg_lwf.F
+---------------------------------------------------
+
+   Size of integers and reals are not set properly
+
+module_ra_rrtmg_sw.f90 versus module_ra_rrtmg_swf.F
+---------------------------------------------------
+
+   Size of integers and reals are not set properly


### PR DESCRIPTION
This PR adds multiple files provided by NVIDIA.  These files represent WRF physics that have been ported to the GPU that may be of interest to the CM1 community.  The purpose of this PR is to make these physics packages available for initial review.  If they are deemed of interest to the CM1 community subsequent PR's will involve the integration of these files into the codebase.   Note the that use of the subdirectory 'fromNVIDIA' is a temporary construct whose only aim is to prevent these files from accidentally being prematurely compiled into CM1.