### PR TITLE
Add missing dependency of comm lib

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -400,7 +400,7 @@ module_mp_jensen_ishmael.o: input.o module_ra_etc.o
 mp_driver.o: constants.o input.o misclibs.o kessler.o goddard.o thompson.o lfoice.o morrison.o module_mp_nssl_2mom.o module_mp_p3.o module_mp_jensen_ishmael.o
 param.o: constants.o input.o init_terrain.o bc.o comm.o bcast.o thompson.o morrison.o module_mp_nssl_2mom.o goddard.o lfoice.o module_mp_p3.o module_mp_jensen_ishmael.o ib_module.o eddy_recycle.o lsnudge.o
 parcel.o: constants.o input.o cm1libs.o misclibs.o bc.o comm.o writeout_nc.o
-droplet.o: constants.o input.o cm1libs.o bc.o comm_droplet.o parcel.o mersennetwister_mod.o
+droplet.o: constants.o input.o cm1libs.o bc.o comm.o comm_droplet.o parcel.o mersennetwister_mod.o
 pdef.o: input.o bc.o comm.o
 pdcomp.o: constants.o input.o adv.o poiss.o ib_module.o
 poiss.o: input.o singleton.o

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -38,6 +38,7 @@
           timestats,time_droplet,mytime,ierr,time_droplet_reduce,maxx,maxy,maxz, &
           ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest,myid,nparcelsLocal,nparcelsactive
       use constants
+      use comm_module
       use comm_droplet_module
       use misclibs
       use parcel_module


### PR DESCRIPTION
This PR fixes a bug in this PR #83 that misses the dependency of **comm** lib in the `Makefile` and `droplet.F` code.

Now the code builds correctly and the verification result is unchanged.