### PR TITLE
Fix a potential compiler bug for CUDA-aware MPI call

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -45,7 +45,6 @@ DM            =
 OMP           =
 DP            =
 OPTS          =
-OPTS_M        =
 CPP           =
 OUTPUTINC     =
 OUTPUTLIB     =
@@ -78,34 +77,27 @@ endif
 #-----------------------------------------------------------------------------
 ifeq (${FC},nvfortran)
     OPTS         += -Mfree -Ktrap=none -Mautoinline -Minline=reshape -Kieee -Mnofma
-    OPTS_M       += -Mfree -Ktrap=none -Mautoinline -Minline=reshape -Kieee -Mnofma
     CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${DEBUG_L},true)
          OPTS    += -g -O0
-         OPTS_M  += -g -O0
          DM      += -D_B4B
     else
          OPTS    += -g -O2
-         OPTS_M  += -g -O2
     endif
     ifeq (${USE_DOUBLE_L},true)
          OPTS    += -r8
-         OPTS_M  += -r8
          DP      += -DDP
     endif
     ifeq (${USE_OPENMP_L},true)
          OPTS    += -mp
-         OPTS_M  += -mp
          OMP     += -DOPENMP
     endif
     ifeq (${USE_OPENACC_L},true)
         ifeq (${DEBUG_L},true)
             ifeq (${GPU_TYPE_L},a100)
                 OPTS += -acc -gpu=cc80,lineinfo,nofma,autocompare,math_uniform
-                OPTS_M += -acc -gpu=cc80,lineinfo,nofma,autocompare,math_uniform
             else
                 OPTS += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform
-                OPTS_M += -acc -gpu=cc70,lineinfo,nofma,autocompare,math_uniform
             endif
         else
             # Potentially interesting non-default compiler flags:: 
@@ -113,10 +105,8 @@ ifeq (${FC},nvfortran)
             #     -Mpcast         Enables the use of PCAST functionality
             ifeq (${GPU_TYPE_L},a100)
                 OPTS += -acc -gpu=cc80,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
-                OPTS_M += -acc -gpu=cc80,lineinfo,nofma,math_uniform,managed -Mpcast -Minfo=accel
             else
                 OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
-                OPTS_M += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
             endif
         endif
         DM       += -D_OPENACC
@@ -213,7 +203,6 @@ $(info $$DEBUG_L is [${DEBUG_L}])
 $(info $$USE_MPI_L is [${USE_MPI_L}])
 $(info $$FC is [${FC}])
 $(info $$OPTS is [${OPTS}])
-$(info $$OPTS_M is [${OPTS_M}])
 $(info $$CPP is [${CPP}])
 $(info $$OMP is [${OMP}])
 $(info $$DM is [${DM}])
@@ -222,7 +211,8 @@ $(info $$DM is [${DM}])
 #-- You shouldn't need to change anything below here
 #-----------------------------------------------------------------------------
 
-SRC   = constants.F \
+SRC   = cm1.F \
+	constants.F \
 	mersennetwister_mod.F \
 	input.F \
 	adv.F \
@@ -307,24 +297,17 @@ SRC   = constants.F \
 	module_bl_myjpbl.F \
 	module_sf_myjsfc.F
 
-SRC_M = cm1.F
-
 #SRC_NVTX = nvtx_mod.F
 SRC_NVTX = 
 
 OBJS = $(addsuffix .o, $(basename $(SRC)))
-OBJS_M = $(addsuffix .o, $(basename $(SRC_M)))
 OBJS_OPENACC = $(addsuffix .o, $(basename $(SRC_NVTX)))
 
-FFLAGS  = $(OPTS)
+FFLAGS = $(OPTS)
 ifeq (${USE_OPENACC_L},true)
 ifeq (${USE_CUDAMEM_L},true)
-FFLAGS_M = $(OPTS_M) -L/glade/u/apps/opt/nvhpc/22.2/Linux_x86_64/22.2/cuda/11.6/lib64 -lcudart
-else
-FFLAGS_M = $(OPTS_M)
+FFLAGS = $(OPTS) -L/glade/u/apps/opt/nvhpc/22.2/Linux_x86_64/22.2/cuda/11.6/lib64 -lcudart
 endif
-else
-FFLAGS_M = $(OPTS)
 endif
 AR      = ar cru
 
@@ -334,9 +317,9 @@ AR      = ar cru
 all : cm1
 
 #			$(FC) $(OBJS) $(FFLAGS) $(OUTPUTINC) $(OUTPUTLIB) $(LINKOPTS) -o ../run/cm1.exe
-cm1:			$(OBJS) $(OBJS_M)
-			$(FC) $(LINKOPTS) $(FFLAGS) $(FFLAGS_M) $(OBJS) ${OBJS_M} $(OUTPUTINC) $(OUTPUTLIB) -o ../run/cm1.exe
-			$(AR) onefile.F $(SRC) $(SRC_M)
+cm1:			$(OBJS)
+			$(FC) $(LINKOPTS) $(FFLAGS) $(OBJS) $(OUTPUTINC) $(OUTPUTLIB) -o ../run/cm1.exe
+			$(AR) onefile.F $(SRC)
 			mv onefile.F ../run
 
 %.f90: %.F
@@ -344,9 +327,6 @@ cm1:			$(OBJS) $(OBJS_M)
 
 $(OBJS): %.o: %.f90
 			$(FC) $(FFLAGS) $(OUTPUTINC) -c $<
-
-$(OBJS_M): %.o: %.f90
-			$(FC) $(FFLAGS_M) $(OUTPUTINC) -c $<
 
 code:
 			$(AR) onefile.F $(SRC)

--- a/src/Makefile
+++ b/src/Makefile
@@ -116,7 +116,7 @@ ifeq (${FC},nvfortran)
                 OPTS_M += -acc -gpu=cc80,lineinfo,nofma,math_uniform,managed -Mpcast -Minfo=accel
             else
                 OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
-                OPTS_M += -acc -gpu=cc70,lineinfo,nofma,math_uniform,managed -Mpcast -Minfo=accel
+                OPTS_M += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
             endif
         endif
         DM       += -D_OPENACC

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -3283,15 +3283,13 @@
 #endif
 
 #ifdef MPI
-      !!$acc host_data use_device(tmass,clw,cli,plw,pli)
-      !$acc update host(tmass,clw,cli,plw,pli)
+      !$acc host_data use_device(tmass,clw,cli,plw,pli)
       call MPI_ALLREDUCE(MPI_IN_PLACE,tmass,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,clw  ,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,cli  ,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,plw  ,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,pli  ,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-      !$acc update device(tmass,clw,cli,plw,pli)
-      !!$acc end host_data
+      !$acc end host_data
 #endif
       !$acc parallel loop gang vector default(present)
       do k=1,nk
@@ -9779,11 +9777,9 @@
         !$acc end parallel
 
 #ifdef MPI
-        !!$acc host_data use_device(savg)
-        !$acc update host(savg)
+        !$acc host_data use_device(savg)
         call MPI_ALLREDUCE(MPI_IN_PLACE,savg,nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-        !$acc update device(savg)
-        !!$acc end host_data
+        !$acc end host_data
 #endif
 
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
@@ -9812,11 +9808,9 @@
         !$acc end parallel
 
 #ifdef MPI
-        !!$acc host_data use_device(savg)
-        !$acc update host(savg)
+        !$acc host_data use_device(savg)
         call MPI_ALLREDUCE(MPI_IN_PLACE,savg,nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-        !$acc update device(savg)
-        !!$acc end host_data
+        !$acc end host_data
 #endif
 
         call write3d(savg,trecs,trecw,vargrid,nvar,varname,vardesc,varunit)
@@ -10264,9 +10258,9 @@
     !$acc end parallel
 
 #ifdef MPI
-    !$acc update host(ubar)
+    !$acc host_data use_device(ubar)
     call MPI_ALLREDUCE(MPI_IN_PLACE,ubar,nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-    !$acc update device(ubar)
+    !$acc end host_data
 #endif
 
     temd = 1.0d0/dble(nx*ny)
@@ -10377,9 +10371,9 @@
     !$acc end parallel
 
 #ifdef MPI
-    !$acc update host(vbar)
+    !$acc host_data use_device(vbar)
     call MPI_ALLREDUCE(MPI_IN_PLACE,vbar,nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-    !$acc update device(vbar)
+    !$acc end host_data 
 #endif
 
     temd = 1.0d0/dble(nx*ny)
@@ -10468,7 +10462,7 @@
     !-------------------------------------------------------
 
 #ifdef MPI
-    !$acc update host(ufr,ufs,ufd,vfr,vfs,vfd)
+    !$acc host_data use_device(ufr,ufs,ufd,vfr,vfs,vfd)
     call MPI_ALLREDUCE(MPI_IN_PLACE,ufr,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
     call MPI_ALLREDUCE(MPI_IN_PLACE,ufs,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
     call MPI_ALLREDUCE(MPI_IN_PLACE,ufd,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
@@ -10476,7 +10470,7 @@
     call MPI_ALLREDUCE(MPI_IN_PLACE,vfr,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
     call MPI_ALLREDUCE(MPI_IN_PLACE,vfs,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
     call MPI_ALLREDUCE(MPI_IN_PLACE,vfd,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-    !$acc update device(ufr,ufs,ufd,vfr,vfs,vfd)
+    !$acc end host_data
 #endif
 
     temd = 1.0d0/dble(nx*ny)
@@ -10610,9 +10604,9 @@
     !$acc end parallel
 
 #ifdef MPI
-    !$acc update host(sbar)
+    !$acc host_data use_device(sbar)
     call MPI_ALLREDUCE(MPI_IN_PLACE,sbar(2),(nk-1),MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-    !$acc update device(sbar)
+    !$acc end host_data 
 #endif
 
     temd = 1.0d0/dble(nx*ny)
@@ -10746,11 +10740,11 @@
       ENDIF
 
 #ifdef MPI
-      !$acc update host(sfr,sfs,sfd)
+      !$acc host_data use_device(sfr,sfs,sfd)
       call MPI_ALLREDUCE(MPI_IN_PLACE,sfr,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,sfs,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,sfd,nk+1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-      !$acc update device(sfr,sfs,sfd)
+      !$acc end host_data 
 #endif
 
       temd = 1.0d0/dble(nx*ny)
@@ -10913,9 +10907,9 @@
     !$acc end parallel
 
 #ifdef MPI
-    !$acc update host(savg)
+    !$acc host_data use_device(savg)
     call MPI_ALLREDUCE(MPI_IN_PLACE,savg(1),k2,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-    !$acc update device(savg)
+    !$acc end host_data 
 #endif
 
     !$acc parallel loop gang vector default(present)
@@ -10973,9 +10967,9 @@
     enddo
     !$acc end parallel
 #ifdef MPI
-    !$acc update host(savg)
+    !$acc host_data use_device(savg)
     call MPI_ALLREDUCE(MPI_IN_PLACE,savg,k2,MPI_DOUBLE_PRECISION,MPI_MAX,MPI_COMM_WORLD,ierr)
-    !$acc update device(savg)
+    !$acc end host_data 
 #endif
 
     end subroutine getmax
@@ -11029,9 +11023,9 @@
     !$acc end parallel
 
 #ifdef MPI
-    !$acc update host(savg)
+    !$acc host_data use_device(savg)
     call MPI_ALLREDUCE(MPI_IN_PLACE,savg,k2,MPI_DOUBLE_PRECISION,MPI_MIN,MPI_COMM_WORLD,ierr)
-    !$acc update device(savg)
+    !$acc end host_data 
 #endif
 
     end subroutine getmin

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3130,8 +3130,7 @@
 !! May need some kind of sync-barrier here.
       enddo
 
-      !$acc update host (cfl,imaxt,jmaxt,kmaxt)
-
+      !$acc update host(cfl,imaxt,jmaxt,kmaxt)
       fmax=cfl(1)
       imax=imaxt(1)
       jmax=jmaxt(1)
@@ -3142,14 +3141,12 @@
       mmax(2)=myid
       call MPI_ALLREDUCE(mmax,nmax,1,MPI_2REAL,MPI_MAXLOC,   &
                          MPI_COMM_WORLD,ierr)
-      !!$acc update device(mmax)
       loc=nint(nmax(2))
       imax=imax+(myi1-1)
       jmax=jmax+(myj1-1)
       call MPI_BCAST(imax,1,MPI_INTEGER,loc,MPI_COMM_WORLD,ierr)
       call MPI_BCAST(jmax,1,MPI_INTEGER,loc,MPI_COMM_WORLD,ierr)
       call MPI_BCAST(kmax,1,MPI_INTEGER,loc,MPI_COMM_WORLD,ierr)
-      !!$acc update device(imax,jmax,kmax)
       fmax=nmax(1)
       if(myid.eq.0)then
 #endif
@@ -3169,7 +3166,6 @@
 #ifdef MPI
       endif
 #endif
-
 
       print *,'calccfl: fmax is: ',fmax
       if(fmax.ge.1.50) stopit=.true.

--- a/src/solve1.F
+++ b/src/solve1.F
@@ -677,6 +677,7 @@
                 uref = 11.096
               endif
 
+              !$acc update host(zh)
               k = 1
               do while( zh(1,1,k).lt.zref )
                 k = k+1
@@ -685,6 +686,7 @@
               k1 = k-1
               k2 = k
 
+              !$acc update host(uavg)
               umod = uavg(k1)+(uavg(k2)-uavg(k1))*(zref-zh(1,1,k2))/(zh(1,1,k1)-zh(1,1,k2))
 
               oldval = ulspg(1)
@@ -696,11 +698,8 @@
             endif
 
 #ifdef MPI
-            !$acc update host(newval)
             call MPI_BCAST( newval  ,1,MPI_REAL   ,0,MPI_COMM_WORLD,ierr)
-            !$acc update device(newval)
 #endif
-            
 
             !$acc parallel loop gang vector default(present)
             do k=kb,ke

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -1791,11 +1791,11 @@
         ENDIF
 
 #ifdef MPI
-        !$acc update host(dumk3,dumk4)
+        !$acc host_data use_device(dumk3,dumk4)
         call MPI_IALLREDUCE(mpi_in_place,dumk3,nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,reqp1,ierr)
         call MPI_IALLREDUCE(mpi_in_place,dumk4,nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,reqp2,ierr)
+        !$acc end host_data
 #endif
-        !print *,'solve2: point #18'
 
         dopf = .true.
 
@@ -2120,7 +2120,6 @@
 #ifdef MPI
         call mpi_wait(reqp1,mpi_status_ignore,ierr)
         call mpi_wait(reqp2,mpi_status_ignore,ierr)
-        !$acc update device(dumk3,dumk4)
 #endif
         temq1 = 0.0
         temq2 = 0.0

--- a/src/testcase_simple_phys.F
+++ b/src/testcase_simple_phys.F
@@ -227,9 +227,9 @@
       !$acc end parallel
 
 #ifdef MPI
-      !$acc update host(cavg)
+      !$acc host_data use_device(cavg)
       call MPI_ALLREDUCE(MPI_IN_PLACE,cavg(kb,1),(ke-kb+1)*3       ,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-      !$acc update device(cavg)
+      !$acc end host_data
 #endif
 
       temd = 1.0d0/( dble(maxx-minx)*dble(maxy-miny) )
@@ -316,9 +316,9 @@
       !$acc end parallel
 
 #ifdef MPI
-      !acc update host(cavg)
+      !$acc host_data use_device(cavg)
       call MPI_ALLREDUCE(MPI_IN_PLACE,cavg(kb,1),(ke-kb+1)*(3+numq),MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-      !$acc update device(cavg) 
+      !$acc end host_data
 #endif
 
       temd = 1.0d0/( dble(maxx-minx)*dble(maxy-miny) )

--- a/src/turb.F
+++ b/src/turb.F
@@ -5446,11 +5446,11 @@
 
         !print *,'t2pcode: point #5'
 #ifdef MPI
-        !$acc update host(t13avg,t23avg,rfavg)
+        !$acc host_data use_device(t13avg,t23avg,rfavg)
         call MPI_ALLREDUCE(MPI_IN_PLACE,t13avg,ntwk-1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
         call MPI_ALLREDUCE(MPI_IN_PLACE,t23avg,ntwk-1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
         call MPI_ALLREDUCE(MPI_IN_PLACE,rfavg ,ntwk-1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-        !$acc update device(t13avg,t23avg,rfavg)
+        !$acc end host_data 
 #endif
 
   !
@@ -5634,10 +5634,10 @@
       !$acc end parallel
 
 #ifdef MPI
-      !$acc update host(cavg)
+      !$acc host_data use_device(cavg)
       call MPI_ALLREDUCE(MPI_IN_PLACE,cavg(1,1),nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
       call MPI_ALLREDUCE(MPI_IN_PLACE,cavg(1,2),nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-      !$acc update device(cavg)
+      !$acc end host_data 
 #endif
 
       temd = 1.0/dble(nx*ny)
@@ -5693,9 +5693,9 @@
     !$acc end parallel
 
 #ifdef MPI
-      !$acc update host(spavg)
+      !$acc host_data use_device(spavg)
       call MPI_ALLREDUCE(MPI_IN_PLACE,spavg,ntwk-1,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-      !$acc update device(spavg)
+      !$acc end host_data
 #endif
 
     !$acc parallel default(present)

--- a/src/writeout.F
+++ b/src/writeout.F
@@ -2198,11 +2198,9 @@
       !$acc end parallel
 
 #ifdef MPI
-        !!$acc host_data use_device(doit)
-        !$acc update host(dumk1)
+        !$acc host_data use_device(dumk1)
         call MPI_ALLREDUCE(MPI_IN_PLACE,dumk1(1),nk,MPI_DOUBLE_PRECISION,MPI_SUM,MPI_COMM_WORLD,ierr)
-        !$acc update device(dumk1)
-        !!$acc end host_data
+        !$acc end host_data
 #endif
       print *,'domaindiag: after mpi_allreduce '
       !$acc parallel default(present) private(k)

--- a/src/writeout.F
+++ b/src/writeout.F
@@ -239,10 +239,7 @@
       IF( numprocs.gt.nlim )THEN
         doit = .false.
         IF( myid.ge.nlim )THEN
-          !$acc update host(doit)
-          !!$acc host_data use_device(doit)
           call MPI_IRECV(doit,1,mpi_logical,myid-nlim,999999,MPI_COMM_WORLD,reqs,ierr)
-          !!$acc end host_data
           call MPI_WAIT(reqs,status,ierr)
         ENDIF
       ENDIF
@@ -8196,10 +8193,7 @@
       IF( numprocs.gt.nlim )THEN
         doit = .true.
         IF( myid+nlim .le. (numprocs-1) )THEN
-          !!$acc host_data use_device(doit)
-          !$acc update host(doit)
           call MPI_ISEND(doit,1,mpi_logical,myid+nlim,999999,MPI_COMM_WORLD,reqs,ierr)
-          !!$acc end host_data
           call MPI_WAIT(reqs,status,ierr)
         ENDIF
       ENDIF
@@ -8552,10 +8546,7 @@
         enddo
         enddo
 
-        !!$acc host_data use_device(dat1)
-        !!$acc update host(dat1)
         call MPI_ISEND(dat1(1,1),d3i*d3j,MPI_REAL,nodemaster,tag,MPI_COMM_WORLD,reqs,ierr)
-        !!$acc end host_data
         call MPI_WAIT(reqs,MPI_STATUS_IGNORE,ierr)
 
         tag = tag+2
@@ -8589,7 +8580,6 @@
 
       ! begin nodemaster section (not proc 0):
 
-      !!$acc update host(dat3)
       tag = 1
       DO k=numk1,numk2
 
@@ -8662,7 +8652,6 @@
 #endif
 
       ! begin proc 0:
-      !!$acc update host(dat3)
       tag = 1
       
       ! start receives from all other processors on a node:


### PR DESCRIPTION
This PR fixes a potential compiler bug while invoking the `mpi_allreduce` for communication.

**Issue:**
- It turns out that the `!$acc update host` and `!$acc update device` directives around an `MPI_ALLREDUCE` call do not work properly and produce a wrong result in a GPU run unless the managed memory is used.

**Solution:**
- use the "!$acc host_data use_device" directive
- specify the array bounds explicitly in the "!$acc update host" and "!$acc update device" directives

Both solutions work so far and we decide to go with the first option since it enables the CUDA-aware MPI communication. No managed memory is needed for the new GPU run.

**Verification result:**

GPU run with managed memory (from https://github.com/george-bryan/CM1/pull/88):
- Identical variables: 44
- variables with red_diff > 1.e-6: 29
- variables with red_diff <= 1.e-6: 13
- four variables with largest error: KSVMAX, KSHMAX, VOR2KM, VOR1KM

GPU run without managed memory:
- Identical variables: 44
- variables with red_diff > 1.e-6: 29
- variables with red_diff <= 1.e-6: 13
- four variables with largest error: KSVMAX, KSHMAX, VOR2KM, VOR1KM