### PR TITLE
Add gpudirect

### DIFF
--- a/src/comm.F
+++ b/src/comm.F
@@ -8376,9 +8376,6 @@
       !$acc declare present(w) &
       !$acc present(ww1,ww2,we1,we2,ws1,ws2,wn1,wn2)
 
-#ifndef _GPUDIRECT17
-      if(Debug) print *,'comm_1w_start_GPU:'
-#endif
       nr = 0
 !-----
 
@@ -8388,15 +8385,10 @@
         ! receive east
         if(ibe.eq.0)then
           nr = nr+1
-#ifdef _GPUDIRECT17
           !$acc host_data use_device(we2)
           call mpi_irecv(we2,cw1we,MPI_REAL,myeast,tag1,   &
                         MPI_COMM_WORLD,reqs(nr),ierr)
           !$acc end host_data
-#else
-          call mpi_irecv(we2,cw1we,MPI_REAL,myeast,tag1,   &
-                        MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
         endif
 
 !-----
@@ -8407,15 +8399,10 @@
         ! receive west
         if(ibw.eq.0)then
           nr = nr+1
-#ifdef _GPUDIRECT17
           !$acc host_data use_device(ww2)
           call mpi_irecv(ww2,cw1we,MPI_REAL,mywest,tag2,   &
                         MPI_COMM_WORLD,reqs(nr),ierr)
           !$acc end host_data
-#else
-          call mpi_irecv(ww2,cw1we,MPI_REAL,mywest,tag2,   &
-                        MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
         endif
 
 !-----
@@ -8426,15 +8413,10 @@
         ! receive north
         if(ibn.eq.0)then
           nr = nr+1
-#ifdef _GPUDIRECT17
           !$acc host_data use_device(wn2)
           call mpi_irecv(wn2,cw1sn,MPI_REAL,mynorth,tag3,   &
                         MPI_COMM_WORLD,reqs(nr),ierr)
           !$acc end host_data
-#else
-          call mpi_irecv(wn2,cw1sn,MPI_REAL,mynorth,tag3,   &
-                        MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
         endif
 
 !-----
@@ -8445,15 +8427,10 @@
         ! receive south
         if(ibs.eq.0)then
           nr = nr+1
-#ifdef _GPUDIRECT17
           !$acc host_data use_device(ws2)
           call mpi_irecv(ws2,cw1sn,MPI_REAL,mysouth,tag4,   &
                         MPI_COMM_WORLD,reqs(nr),ierr)
           !$acc end host_data
-#else
-          call mpi_irecv(ws2,cw1sn,MPI_REAL,mysouth,tag4,   &
-                        MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
         endif
 
 !------------------------------------------------
@@ -8472,16 +8449,10 @@
           enddo
           enddo
           nr = nr+1
-#ifdef _GPUDIRECT17
           !$acc host_data use_device(ww1)
           call mpi_isend(ww1,cw1we,MPI_REAL,mywest,tag1,   &
                          MPI_COMM_WORLD,reqs(nr),ierr)
           !$acc end host_data
-#else
-          !$acc update host(ww1)
-          call mpi_isend(ww1,cw1we,MPI_REAL,mywest,tag1,   &
-                         MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
         endif
 
         ! send east
@@ -8494,16 +8465,10 @@
           enddo
           enddo
           nr = nr+1
-#ifdef _GPUDIRECT17
           !$acc host_data use_device(we1)
           call mpi_isend(we1,cw1we,MPI_REAL,myeast,tag2,   &
                          MPI_COMM_WORLD,reqs(nr),ierr)
           !$acc end host_data
-#else
-          !$acc update host(we1)
-          call mpi_isend(we1,cw1we,MPI_REAL,myeast,tag2,   &
-                         MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
         endif
 
         ! send south
@@ -8516,16 +8481,10 @@
           enddo
           enddo
           nr = nr+1
-#ifdef _GPUDIRECT17
           !$acc host_data use_device(ws1)
           call mpi_isend(ws1,cw1sn,MPI_REAL,mysouth,tag3,   &
                          MPI_COMM_WORLD,reqs(nr),ierr)
           !$acc end host_data
-#else
-          !$acc update host(ws1)
-          call mpi_isend(ws1,cw1sn,MPI_REAL,mysouth,tag3,   &
-                         MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
         endif
 
         ! send north
@@ -8538,16 +8497,10 @@
           enddo
           enddo
           nr = nr+1
-#ifdef _GPUDIRECT17
           !$acc host_data use_device(wn1)
           call mpi_isend(wn1,cw1sn,MPI_REAL,mynorth,tag4,   &
                          MPI_COMM_WORLD,reqs(nr),ierr)
           !$acc end host_data
-#else
-          !$acc update host(wn1)
-          call mpi_isend(wn1,cw1sn,MPI_REAL,mynorth,tag4,   &
-                         MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
         endif
 
 !-----
@@ -8612,9 +8565,6 @@
         nn = nn + 1
 
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT17
-        !$acc update device(we2)
-#endif
         !$omp parallel do default(shared) private(j,k)
         !$acc parallel loop gang vector default(present) private(j,k)
         do k=2,nk
@@ -8623,9 +8573,6 @@
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT17
-        !$acc update device(ww2)
-#endif
         !$omp parallel do default(shared) private(j,k)
         !$acc parallel loop gang vector default(present) private(j,k)
         do k=2,nk
@@ -8634,9 +8581,6 @@
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT17
-        !$acc update device(wn2)
-#endif
         !$omp parallel do default(shared) private(i,k)
         !$acc parallel loop gang vector default(present) private(i,k)
         do k=2,nk
@@ -8645,9 +8589,6 @@
         enddo
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT17
-        !$acc update device(ws2)
-#endif
         !$omp parallel do default(shared) private(i,k)
         !$acc parallel loop gang vector default(present) private(i,k)
         do k=2,nk
@@ -8976,11 +8917,6 @@
       logical, parameter :: Debug = .FALSE.
 
 !------------------------------------------------
-#ifndef _GPUDIRECT18
-!print *, "comm_2d_start_GPU: Im called"
-      if(Debug) print *,'comm_2d_start_GPU:'
-#endif
-
       nr = 0
 
       nf=nf+1
@@ -8990,15 +8926,10 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT18
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,cmp*nj,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,cmp*nj,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -9009,15 +8940,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT18
         !$acc host_data use_device(newwest)
         call mpi_irecv(newwest,cmp*nj,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,cmp*nj,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -9028,15 +8954,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT18
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,ni*cmp,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,ni*cmp,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -9047,15 +8968,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT18
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,ni*cmp,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,ni*cmp,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -9074,16 +8990,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT18
         !$acc host_data use_device(west)
         call mpi_isend(west,cmp*nj,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,cmp*nj,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -9098,16 +9008,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT18
         !$acc host_data use_device(east)
         call mpi_isend(east,cmp*nj,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,cmp*nj,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -9122,16 +9026,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT18
         !$acc host_data use_device(north)
         call mpi_isend(north,ni*cmp,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,ni*cmp,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -9146,16 +9044,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT18
         !$acc host_data use_device(south)
         call mpi_isend(south,ni*cmp,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,ni*cmp,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -9242,9 +9134,6 @@
       integer i,j,nn,nr,index
 
 !-------------------------------------------------------------------
-#ifndef _GPUDIRECT18
-if(Debug) print *, "comm_2dew_end_GPU: Im called"
-#endif
 
       nr = 0
       if(ibe.eq.0)then
@@ -9263,9 +9152,6 @@ if(Debug) print *, "comm_2dew_end_GPU: Im called"
       enddo
 
       if(ibe.eq.0)then
-#ifndef _GPUDIRECT18
-        !$acc update device(neweast)
-#endif
         !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
         !$omp parallel do default(shared) private(i,j)
         do j=1,nj
@@ -9276,9 +9162,6 @@ if(Debug) print *, "comm_2dew_end_GPU: Im called"
       endif
 
       if(ibw.eq.0)then
-#ifndef _GPUDIRECT18
-        !$acc update device(newwest)
-#endif
         !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
         !$omp parallel do default(shared) private(i,j)
         do j=1,nj
@@ -9408,9 +9291,6 @@ if(Debug) print *, "comm_2dew_end_GPU: Im called"
       logical, parameter :: Debug = .FALSE.
 
 !-------------------------------------------------------------------
-#ifndef _GPUDIRECT18
-if(Debug) print *, "comm_2dns_end_GPU: Im called"
-#endif
 
       nr1 = 0
       if(ibe.eq.0)then
@@ -9436,9 +9316,6 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
       enddo
 
       if(ibs.eq.0)then
-#ifndef _GPUDIRECT18
-        !$acc update device(newsouth)
-#endif
         !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
         !$omp parallel do default(shared) private(i,j)
         do j=1,cmp
@@ -9449,9 +9326,6 @@ if(Debug) print *, "comm_2dns_end_GPU: Im called"
       endif
 
       if(ibn.eq.0)then
-#ifndef _GPUDIRECT18
-        !$acc update device(newnorth)
-#endif
         !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
         !$omp parallel do default(shared) private(i,j)
         do j=1,cmp
@@ -10372,9 +10246,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug = .FALSE.
 
-#ifndef _GPUDIRECT19
-      if(Debug) print *,'getcorneru3_GPU:'
-#endif
       count=cmp*cmp*nk
       nr1 = 0
       index_nw = -1
@@ -10387,15 +10258,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT19
         !$acc host_data use_device(nw2)
         call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_nw = nr1
       endif
 
@@ -10405,15 +10271,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT19
         !$acc host_data use_device(sw2)
         call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_sw = nr1
       endif
 
@@ -10423,15 +10284,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT19
         !$acc host_data use_device(ne2)
         call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_ne = nr1
       endif
 
@@ -10441,15 +10297,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT19
         !$acc host_data use_device(se2)
         call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_se = nr1
       endif
 
@@ -10469,16 +10320,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT19
         !$acc host_data use_device(se1)
         call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(se1)
-        call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
@@ -10491,16 +10336,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT19
         !$acc host_data use_device(ne1)
         call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(ne1)
-        call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
@@ -10513,16 +10352,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT19
         !$acc host_data use_device(sw1)
         call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(sw1)
-        call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
@@ -10535,16 +10368,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT19
         !$acc host_data use_device(nw1)
         call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(nw1)
-        call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -10558,9 +10385,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         nn = nn + 1
 
       if( index.eq.index_nw )then
-#ifndef _GPUDIRECT19
-        !$acc update device(nw2)
-#endif
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -10570,9 +10394,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif( index.eq.index_sw )then
-#ifndef _GPUDIRECT19
-        !$acc update device(sw2) 
-#endif
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -10582,9 +10403,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif( index.eq.index_ne )then
-#ifndef _GPUDIRECT19
-        !$acc update device(ne2)
-#endif
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -10594,9 +10412,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif( index.eq.index_se )then
-#ifndef _GPUDIRECT19
-        !$acc update device(se2)
-#endif
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,cmp

--- a/src/comm.F
+++ b/src/comm.F
@@ -1777,9 +1777,6 @@
       !$acc present(west,newwest,east,neweast) 
 
 !------------------------------------------------
-#ifndef _GPUDIRECT06
-      if(Debug) print *,'comm_2we_start_GPU:'
-#endif
       nr = 0
 
       nf=nf+1
@@ -1787,15 +1784,10 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT06
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,cs2we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,cs2we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -1806,15 +1798,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT06
         !$acc host_data use_device(neweast)
         call mpi_irecv(newwest,cs2we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,cs2we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -1833,16 +1820,10 @@
         enddo
         enddo
         nr = nr+1
-#ifdef _GPUDIRECT06
         !$acc host_data use_device(west)
         call mpi_isend(west,cs2we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,cs2we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -1859,16 +1840,10 @@
         enddo
         enddo
         nr = nr+1
-#ifdef _GPUDIRECT06
         !$acc host_data use_device(east)
         call mpi_isend(east,cs2we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,cs2we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -1920,9 +1895,6 @@
         nn = nn + 1
 
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT06
-        !$acc update device(neweast)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
@@ -1933,9 +1905,6 @@
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT06
-        !$acc update device(newwest)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
@@ -1992,9 +1961,6 @@
       !$acc declare present(s) &
       !$acc present(south,newsouth,north,newnorth)
 
-#ifndef _GPUDIRECT07
-      !if(Debug) print *,'comm_2sn_start_GPU:'
-#endif
 !----------
       nr = 0
 
@@ -2003,15 +1969,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT07
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,cs2sn,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,cs2sn,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -2022,15 +1983,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT07
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,cs2sn,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,cs2sn,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -2050,16 +2006,10 @@
         enddo
         nr = nr+1
 
-#ifdef _GPUDIRECT07
         !$acc host_data use_device(north)
         call mpi_isend(north,cs2sn,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,cs2sn,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -2076,16 +2026,10 @@
         enddo
         enddo
         nr = nr+1
-#ifdef _GPUDIRECT07
         !$acc host_data use_device(south)
         call mpi_isend(south,cs2sn,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,cs2sn,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -2137,9 +2081,6 @@
         nn = nn + 1
 
       if(index.eq.index_south)then
-#ifndef _GPUDIRECT07
-        !$acc update device(newsouth)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
@@ -2150,9 +2091,6 @@
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT07
-        !$acc update device(newnorth) 
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk

--- a/src/comm.F
+++ b/src/comm.F
@@ -1,5 +1,37 @@
 #undef _GPUDIRECT
 
+
+#define _GPUDIRECT01
+#define _GPUDIRECT02
+#define _GPUDIRECT03
+#define _GPUDIRECT04
+#define _GPUDIRECT05
+#define _GPUDIRECT06
+#define _GPUDIRECT07
+
+#undef _GPUDIRECT08
+
+#define _GPUDIRECT09
+#define _GPUDIRECT10
+#define _GPUDIRECT11
+#define _GPUDIRECT12
+
+
+#undef _GPUDIRECT13
+#undef _GPUDIRECT14
+
+#undef _GPUDIRECT15
+#undef _GPUDIRECT16
+!17: minor impact
+!18: does not enter
+
+#define _GPUDIRECT17
+#define _GPUDIRECT18
+#define _GPUDIRECT19
+#define _GPUDIRECT20
+#define _GPUDIRECT21
+#define _GPUDIRECT22
+
 #ifdef _GPUDIRECT
 
 #define _GPUDIRECT01

--- a/src/comm.F
+++ b/src/comm.F
@@ -3,18 +3,11 @@
 
 
 #undef _GPUDIRECT08
-
-#undef _GPUDIRECT13
 #undef _GPUDIRECT14
-
 #undef _GPUDIRECT15
 #undef _GPUDIRECT16
 
 #ifdef _GPUDIRECT
-
-
-#define _GPUDIRECT13
-
 
 ! 06,08,14 generates an runtime ERROR
 #undef _GPUDIRECT08 
@@ -23,9 +16,6 @@
 !Activating the following directive generates incorrect results.
 #define _GPUDIRECT15
 #define _GPUDIRECT16
-
-
-
 
 #endif
 
@@ -6182,23 +6172,15 @@
 !------------------------------------------------
 
       nr = 0
-#ifndef _GPUDIRECT13
-      if(Debug) print *,'comm_1s2d_start_GPU:'
-#endif
       nf=nf+1
       tag1=nf
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT13
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,nj,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,nj,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -6209,15 +6191,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT13
         !$acc host_data use_device(newwest)
         call mpi_irecv(newwest,nj,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,nj,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -6228,15 +6205,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT13
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,ni,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,ni,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -6247,15 +6219,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT13
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,ni,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,ni,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -6272,16 +6239,10 @@
           west(j)=s(1,j)
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT13
         !$acc host_data use_device(west)
         call mpi_isend(west,nj,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,nj,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -6295,16 +6256,10 @@
           east(j)=s(ni,j)
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT13
         !$acc host_data use_device(east)
         call mpi_isend(east,nj,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,nj,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -6318,16 +6273,10 @@
           north(i)=s(i,nj)
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT13
         !$acc host_data use_device(north)
         call mpi_isend(north,ni,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,ni,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -6342,16 +6291,10 @@
         enddo
         nr = nr + 1
 
-#ifdef _GPUDIRECT13
         !$acc host_data use_device(south)
         call mpi_isend(south,ni,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,ni,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -6585,36 +6528,24 @@
         nn = nn + 1
 
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT13
-        !$acc update device(neweast)
-#endif
         !$omp parallel do default(shared) private(j)
         !$acc parallel loop default(present) private(j)
         do j=1,nj
           s(ni+1,j)=neweast(j)
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT13
-        !$acc update device(newwest)
-#endif
         !$omp parallel do default(shared) private(j)
         !$acc parallel loop default(present) private(j)
         do j=1,nj
           s(0,j)=newwest(j)
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT13
-        !$acc update device(newsouth)
-#endif
         !$omp parallel do default(shared) private(i)
         !$acc parallel loop default(present) private(i)
         do i=1,ni
           s(i,0)=newsouth(i)
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT13
-        !$acc update device(newnorth)
-#endif
         !$omp parallel do default(shared) private(i)
         !$acc parallel loop default(present) private(i)
         do i=1,ni

--- a/src/comm.F
+++ b/src/comm.F
@@ -4,10 +4,6 @@
 
 #undef _GPUDIRECT08
 
-#define _GPUDIRECT11
-#define _GPUDIRECT12
-
-
 #undef _GPUDIRECT13
 #undef _GPUDIRECT14
 
@@ -26,8 +22,6 @@
 #ifdef _GPUDIRECT
 
 
-#define _GPUDIRECT11
-#define _GPUDIRECT12
 #define _GPUDIRECT13
 
 #define _GPUDIRECT17
@@ -4678,23 +4672,15 @@
 
       nr = 0
 
-#ifndef _GPUDIRECT11
-      if(Debug) print *,'comm_3v_start_GPU'
-#endif
       nv=nv+1
       tag1=2000+nv
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT11
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,cv3we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,cv3we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4705,15 +4691,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT11
         !$acc host_data use_device(newwest)
         call mpi_irecv(newwest,cv3we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,cv3we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4724,15 +4705,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT11
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,cs3sn,MPI_REAL,mynorth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,cs3sn,MPI_REAL,mynorth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4743,15 +4719,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT11
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,cs3sn,MPI_REAL,mysouth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,cs3sn,MPI_REAL,mysouth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -4772,16 +4743,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT11
         !$acc host_data use_device(west)
         call mpi_isend(west,cv3we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,cv3we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4797,16 +4762,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT11
         !$acc host_data use_device(east)
         call mpi_isend(east,cv3we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,cv3we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -4823,16 +4782,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT11
         !$acc host_data use_device(south)
         call mpi_isend(south,cs3sn,MPI_REAL,mysouth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,cs3sn,MPI_REAL,mysouth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4849,16 +4802,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT11
         !$acc host_data use_device(north)
         call mpi_isend(north,cs3sn,MPI_REAL,mynorth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,cs3sn,MPI_REAL,mynorth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -5147,9 +5094,6 @@
         nn = nn + 1
  
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT11
-        !$acc update device(neweast)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
@@ -5160,9 +5104,6 @@
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT11
-        !$acc update device(newwest)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
@@ -5173,9 +5114,6 @@
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT11
-        !$acc update device(newnorth)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
@@ -5186,9 +5124,6 @@
         enddo
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT11
-        !$acc update device(newsouth)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
@@ -5510,23 +5445,15 @@
 !------------------------------------------------
 
       nr = 0
-#ifndef _GPUDIRECT12
-      if(Debug) print *,'comm_3w_start_GPU:'
-#endif
       nw=nw+1
       tag1=3000+nw
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT12
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,cw3we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,cw3we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -5537,15 +5464,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT12
         !$acc host_data use_device(newwest)
         call mpi_irecv(newwest,cw3we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,cw3we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -5556,15 +5478,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT12
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,cw3sn,MPI_REAL,mynorth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,cw3sn,MPI_REAL,mynorth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -5575,15 +5492,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT12
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,cw3sn,MPI_REAL,mysouth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,cw3sn,MPI_REAL,mysouth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -5604,16 +5516,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT12
         !$acc host_data use_device(west)
         call mpi_isend(west,cw3we,MPI_REAL,mywest,tag1,    &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,cw3we,MPI_REAL,mywest,tag1,    &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -5630,16 +5536,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT12
         !$acc host_data use_device(east)
         call mpi_isend(east,cw3we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,cw3we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -5656,16 +5556,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT12
         !$acc host_data use_device(south)
         call mpi_isend(south,cw3sn,MPI_REAL,mysouth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,cw3sn,MPI_REAL,mysouth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -5682,16 +5576,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT12
         !$acc host_data use_device(north)
         call mpi_isend(north,cw3sn,MPI_REAL,mynorth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,cw3sn,MPI_REAL,mynorth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -5977,9 +5865,6 @@
         nn = nn + 1
  
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT12
-        !$acc update device(neweast)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=2,nk
@@ -5990,9 +5875,6 @@
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT12
-        !$acc update device(newwest)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=2,nk
@@ -6003,9 +5885,6 @@
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT12
-        !$acc update device(newnorth)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=2,nk
@@ -6016,9 +5895,6 @@
         enddo
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT12
-        !$acc update device(newsouth)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=2,nk

--- a/src/comm.F
+++ b/src/comm.F
@@ -9,27 +9,11 @@
 
 #undef _GPUDIRECT15
 #undef _GPUDIRECT16
-!17: minor impact
-!18: does not enter
-
-#define _GPUDIRECT17
-#define _GPUDIRECT18
-#define _GPUDIRECT19
-#define _GPUDIRECT20
-#define _GPUDIRECT21
-#define _GPUDIRECT22
 
 #ifdef _GPUDIRECT
 
 
 #define _GPUDIRECT13
-
-#define _GPUDIRECT17
-#define _GPUDIRECT18
-#define _GPUDIRECT19
-#define _GPUDIRECT20
-#define _GPUDIRECT21
-#define _GPUDIRECT22
 
 
 ! 06,08,14 generates an runtime ERROR
@@ -10648,9 +10632,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug = .FALSE.
 
-#ifndef _GPUDIRECT20
-      if(Debug) print *,'getcornerv3_GPU:'
-#endif
       count=cmp*cmp*nk
       nr1 = 0
       index_nw = -1
@@ -10663,15 +10644,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT20
         !$acc host_data use_device(nw2)
         call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_nw = nr1
       endif
 
@@ -10681,15 +10657,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT20
         !$acc host_data use_device(sw2)
         call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_sw = nr1
       endif
 
@@ -10699,15 +10670,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT20
         !$acc host_data use_device(ne2)
         call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_ne = nr1
       endif
 
@@ -10717,15 +10683,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT20
         !$acc host_data use_device(se2)
         call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_se = nr1
       endif
 
@@ -10745,16 +10706,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT20
         !$acc host_data use_device(se1)
         call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(se1)
-        call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
@@ -10767,16 +10722,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT20
         !$acc host_data use_device(ne1)
         call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(ne1)
-        call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
@@ -10789,16 +10738,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT20
         !$acc host_data use_device(sw1)
         call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(sw1)
-        call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
@@ -10811,16 +10754,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT20
         !$acc host_data use_device(nw1)
         call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(nw1)
-        call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -10834,9 +10771,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         nn = nn + 1
 
       if( index.eq.index_nw )then
-#ifndef _GPUDIRECT20
-        !$acc update device(nw2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -10846,9 +10780,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif( index.eq.index_sw )then
-#ifndef _GPUDIRECT20
-        !$acc update device(sw2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -10858,9 +10789,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif( index.eq.index_ne )then
-#ifndef _GPUDIRECT20
-        !$acc update device(ne2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -10870,9 +10798,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif( index.eq.index_se )then
-#ifndef _GPUDIRECT20
-        !$acc update device(se2)
-#endif
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -11111,9 +11036,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug = .FALSE.
 
-#ifndef _GPUDIRECT21
-      if(Debug) print *,'getcornerw3_GPU:'
-#endif
       count=cmp*cmp*nkp1
       nr1 = 0
       index_nw = -1
@@ -11126,15 +11048,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT21
         !$acc host_data use_device(nw2)
         call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_nw = nr1
       endif
 
@@ -11144,15 +11061,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT21
         !$acc host_data use_device(sw2)
         call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_sw = nr1
       endif
 
@@ -11162,15 +11074,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT21
         !$acc host_data use_device(ne2)
         call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_ne = nr1
       endif
 
@@ -11180,15 +11087,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr1 = nr1+1
-#ifdef _GPUDIRECT21
         !$acc host_data use_device(se2)
         call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-#endif
         index_se = nr1
       endif
 
@@ -11208,16 +11110,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT21
         !$acc host_data use_device(se1)
         call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(se1)
-        call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
@@ -11230,16 +11126,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT21
         !$acc host_data use_device(ne1)
         call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(ne1)
-        call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
@@ -11252,16 +11142,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT21
         !$acc host_data use_device(sw1)
         call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(sw1)
-        call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
@@ -11274,16 +11158,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr2 = nr2+1
-#ifdef _GPUDIRECT21
         !$acc host_data use_device(nw1)
         call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
-#else
-        !$acc update host(nw1)
-        call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -11297,9 +11175,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         nn = nn + 1
 
       if( index.eq.index_nw )then
-#ifndef _GPUDIRECT21
-        !$acc update device(nw2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nkp1
         do j=1,cmp
@@ -11309,9 +11184,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif( index.eq.index_sw )then
-#ifndef _GPUDIRECT21
-        !$acc update device(sw2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nkp1
         do j=1,cmp
@@ -11321,9 +11193,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif( index.eq.index_ne )then
-#ifndef _GPUDIRECT21
-        !$acc update device(ne2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nkp1
         do j=1,cmp
@@ -11333,9 +11202,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif( index.eq.index_se )then
-#ifndef _GPUDIRECT21
-        !$acc update device(se2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nkp1
         do j=1,cmp
@@ -11390,9 +11256,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
  
 !------------------------------------------------
 !$acc data create(west,newwest,east,neweast,south,newsouth,north,newnorth,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-#ifndef _GPUDIRECT22
-      if(Debug) print *,'comm_1s_tend_halo_GPU:'
-#endif
 
       nr = 0
 
@@ -11402,15 +11265,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,2*cs1we,MPI_DOUBLE_PRECISION,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,2*cs1we,MPI_DOUBLE_PRECISION,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -11421,15 +11279,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(newwest)
         call mpi_irecv(newwest,2*cs1we,MPI_DOUBLE_PRECISION,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,2*cs1we,MPI_DOUBLE_PRECISION,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -11440,15 +11293,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,2*cs1sn,MPI_DOUBLE_PRECISION,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,2*cs1sn,MPI_DOUBLE_PRECISION,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -11459,15 +11307,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,2*cs1sn,MPI_DOUBLE_PRECISION,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,2*cs1sn,MPI_DOUBLE_PRECISION,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -11488,16 +11331,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(west)
         call mpi_isend(west,2*cs1we,MPI_DOUBLE_PRECISION,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,2*cs1we,MPI_DOUBLE_PRECISION,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -11514,16 +11351,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(east)
         call mpi_isend(east,2*cs1we,MPI_DOUBLE_PRECISION,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east) 
-        call mpi_isend(east,2*cs1we,MPI_DOUBLE_PRECISION,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -11540,16 +11371,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(north)
         call mpi_isend(north,2*cs1sn,MPI_DOUBLE_PRECISION,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,2*cs1sn,MPI_DOUBLE_PRECISION,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -11566,16 +11391,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(south)
         call mpi_isend(south,2*cs1sn,MPI_DOUBLE_PRECISION,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,2*cs1sn,MPI_DOUBLE_PRECISION,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !---------------------------------------------------------------------
@@ -11609,9 +11428,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         nn = nn + 1
  
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT22
-        !$acc update device(neweast)
-#endif
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
 !$acc parallel loop gang vector collapse(2) default(present) private(j,k)
@@ -11622,9 +11438,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT22
-        !$acc update device(newwest)
-#endif
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
 !$acc parallel loop gang vector collapse(2) default(present) private(j,k)
@@ -11635,9 +11448,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT22
-        !$acc update device(newsouth)
-#endif
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
 !$acc parallel loop gang vector collapse(2) default(present) private(i,k)
@@ -11648,9 +11458,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT22
-        !$acc update device(newnorth)
-#endif
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
 !$acc parallel loop gang vector collapse(2) default(present) private(i,k)
@@ -11701,15 +11508,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(nw2)
         call mpi_irecv(nw2,2*2*nk,MPI_DOUBLE_PRECISION,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(nw2,2*2*nk,MPI_DOUBLE_PRECISION,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_nw = nr
       endif
 
@@ -11719,15 +11521,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(sw2)
         call mpi_irecv(sw2,2*2*nk,MPI_DOUBLE_PRECISION,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(sw2,2*2*nk,MPI_DOUBLE_PRECISION,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_sw = nr
       endif
 
@@ -11737,15 +11534,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(ne2)
         call mpi_irecv(ne2,2*2*nk,MPI_DOUBLE_PRECISION,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(ne2,2*2*nk,MPI_DOUBLE_PRECISION,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_ne = nr
       endif
 
@@ -11755,15 +11547,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(se2)
         call mpi_irecv(se2,2*2*nk,MPI_DOUBLE_PRECISION,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(se2,2*2*nk,MPI_DOUBLE_PRECISION,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_se = nr
       endif
 
@@ -11779,16 +11566,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
 
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(se1)
         call mpi_isend(se1,2*2*nk,MPI_DOUBLE_PRECISION,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(5),ierr)
         !$acc end host_data
-#else
-        !$acc update host(se1)
-        call mpi_isend(se1,2*2*nk,MPI_DOUBLE_PRECISION,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(5),ierr)
-#endif
       endif
  
 !-----
@@ -11802,16 +11583,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         enddo
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(ne1)
         call mpi_isend(ne1,2*2*nk,MPI_DOUBLE_PRECISION,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(6),ierr)
         !$acc end host_data
-#else
-        !$acc update host(ne1)
-        call mpi_isend(ne1,2*2*nk,MPI_DOUBLE_PRECISION,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(6),ierr)
-#endif
       endif
  
 !-----
@@ -11825,16 +11600,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         enddo
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(sw1)
         call mpi_isend(sw1,2*2*nk,MPI_DOUBLE_PRECISION,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(7),ierr)
         !$acc end host_data
-#else
-        !$acc update host(sw1)
-        call mpi_isend(sw1,2*2*nk,MPI_DOUBLE_PRECISION,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(7),ierr)
-#endif
       endif
  
 !-----
@@ -11848,16 +11617,10 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         enddo
-#ifdef _GPUDIRECT22
         !$acc host_data use_device(nw1)
         call mpi_isend(nw1,2*2*nk,MPI_DOUBLE_PRECISION,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(8),ierr)
         !$acc end host_data
-#else
-        !$acc update host(nw1)
-        call mpi_isend(nw1,2*2*nk,MPI_DOUBLE_PRECISION,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(8),ierr)
-#endif
       endif
  
 !-----
@@ -11868,9 +11631,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         nn = nn + 1
 
       if(index.eq.index_nw)then
-#ifndef _GPUDIRECT22
-      !$acc update device(nw2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,2
@@ -11880,9 +11640,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif(index.eq.index_sw)then
-#ifndef _GPUDIRECT22
-      !$acc update device(sw2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,2
@@ -11892,9 +11649,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif(index.eq.index_ne)then
-#ifndef _GPUDIRECT22
-      !$acc update device(ne2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,2
@@ -11904,9 +11658,6 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
       elseif(index.eq.index_se)then
-#ifndef _GPUDIRECT22
-      !$acc update device(se2)
-#endif
 !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
         do k=1,nk
         do j=1,2

--- a/src/comm.F
+++ b/src/comm.F
@@ -1,8 +1,6 @@
 #undef _GPUDIRECT
 
 
-#define _GPUDIRECT04
-#define _GPUDIRECT05
 #define _GPUDIRECT06
 #define _GPUDIRECT07
 
@@ -31,8 +29,6 @@
 
 #ifdef _GPUDIRECT
 
-#define _GPUDIRECT04
-#define _GPUDIRECT05
 
 #define _GPUDIRECT07
 #define _GPUDIRECT09
@@ -1142,9 +1138,6 @@
       logical, parameter :: Debug =.FALSE.
 
 !-----
-#ifndef _GPUDIRECT04
-      if(Debug) print *,'getcornerw_GPU:'
-#endif
       nr = 0
       index_nw = -1
       index_sw = -1
@@ -1157,15 +1150,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT04
         !$acc host_data use_device(nw2)
         call mpi_irecv(nw2,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(nw2,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_nw = nr
       endif
 
@@ -1176,15 +1164,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT04
         !$acc host_data use_device(sw2)
         call mpi_irecv(sw2,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(sw2,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_sw = nr
       endif
 
@@ -1195,15 +1178,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT04
         !$acc host_data use_device(ne2)
         call mpi_irecv(ne2,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(ne2,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_ne = nr
       endif
 
@@ -1214,15 +1192,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT04
         !$acc host_data use_device(se2)
         call mpi_irecv(se2,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(se2,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_se = nr
       endif
 
@@ -1240,16 +1213,10 @@
           se1(k)=w(ni,1,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT04
         !$acc host_data use_device(se1)
         call mpi_isend(se1,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(se1)
-        call mpi_isend(se1,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -1264,16 +1231,10 @@
           ne1(k)=w(ni,nj,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT04
         !$acc host_data use_device(ne1)
         call mpi_isend(ne1,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(ne1)
-        call mpi_isend(ne1,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -1288,16 +1249,10 @@
           sw1(k)=w(1,1,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT04
         !$acc host_data use_device(sw1)
         call mpi_isend(sw1,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(sw1)
-        call mpi_isend(sw1,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -1312,16 +1267,10 @@
           nw1(k)=w(1,nj,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT04
         !$acc host_data use_device(nw1)
         call mpi_isend(nw1,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(nw1)
-        call mpi_isend(nw1,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----------------------------------------------------------------------
@@ -1332,36 +1281,24 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-#ifndef _GPUDIRECT04
-        !$acc update device(nw2)
-#endif
         !$acc parallel loop gang vector default(present) private(k)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           w(0,nj+1,k)=nw2(k)
         enddo
       elseif(index.eq.index_sw)then
-#ifndef _GPUDIRECT04
-        !$acc update device(sw2)
-#endif
         !$acc parallel loop gang vector default(present) private(k)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           w(0,0,k)=sw2(k)
         enddo
       elseif(index.eq.index_ne)then
-#ifndef _GPUDIRECT04
-        !$acc update device(ne2)
-#endif
         !$acc parallel loop gang vector default(present) private(k)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           w(ni+1,nj+1,k)=ne2(k)
         enddo
       elseif(index.eq.index_se)then
-#ifndef _GPUDIRECT04
-        !$acc update device(se2)
-#endif
         !$acc parallel loop gang vector default(present) private(k)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
@@ -1606,9 +1543,6 @@
       logical, parameter :: Debug =.FALSE.
 
 !-----
-#ifndef _GPUDIRECT05
-      if(Debug) print *,'getcorner3_GPU:'
-#endif
       nr = 0
       index_nw = -1
       index_sw = -1
@@ -1621,15 +1555,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT05
         !$acc host_data use_device(nw2)
         call mpi_irecv(nw2,cmp*cmp*nk,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(nw2,cmp*cmp*nk,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_nw = nr
       endif
 
@@ -1639,15 +1568,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT05
         !$acc host_data use_device(sw2)
         call mpi_irecv(sw2,cmp*cmp*nk,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(sw2,cmp*cmp*nk,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_sw = nr
       endif
 
@@ -1657,15 +1581,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT05
         !$acc host_data use_device(ne2)
         call mpi_irecv(ne2,cmp*cmp*nk,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(ne2,cmp*cmp*nk,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_ne = nr
       endif
 
@@ -1675,15 +1594,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT05
         !$acc host_data use_device(se2)
         call mpi_irecv(se2,cmp*cmp*nk,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(se2,cmp*cmp*nk,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_se = nr
       endif
 
@@ -1699,16 +1613,10 @@
         enddo
         enddo
         enddo
-#ifdef _GPUDIRECT05
         !$acc host_data use_device(se1)
         call mpi_isend(se1,cmp*cmp*nk,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(5),ierr)
         !$acc end host_data
-#else
-        !$acc update host(se1)
-        call mpi_isend(se1,cmp*cmp*nk,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(5),ierr)
-#endif
       endif
 
 !-----
@@ -1723,16 +1631,10 @@
         enddo
         enddo
         enddo
-#ifdef _GPUDIRECT05
         !$acc host_data use_device(ne1)
         call mpi_isend(ne1,cmp*cmp*nk,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(6),ierr)
         !$acc end host_data
-#else
-        !$acc update host(ne1)
-        call mpi_isend(ne1,cmp*cmp*nk,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(6),ierr)
-#endif
       endif
 
 !-----
@@ -1747,16 +1649,10 @@
         enddo
         enddo
         enddo
-#ifdef _GPUDIRECT05
         !$acc host_data use_device(sw1)
         call mpi_isend(sw1,cmp*cmp*nk,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(7),ierr)
         !$acc end host_data
-#else
-        !$acc update host(sw1)
-        call mpi_isend(sw1,cmp*cmp*nk,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(7),ierr)
-#endif
       endif
 
 !-----
@@ -1771,16 +1667,10 @@
         enddo
         enddo
         enddo
-#ifdef _GPUDIRECT05
         !$acc host_data use_device(nw1)
         call mpi_isend(nw1,cmp*cmp*nk,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(8),ierr)
         !$acc end host_data
-#else
-        !$acc update host(nw1)
-        call mpi_isend(nw1,cmp*cmp*nk,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(8),ierr)
-#endif
       endif
 
 !-----
@@ -1791,9 +1681,6 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-#ifndef _GPUDIRECT05
-        !$acc update device(nw2)
-#endif
 !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -1804,9 +1691,6 @@
         enddo
         enddo
       elseif(index.eq.index_sw)then
-#ifndef _GPUDIRECT05
-        !$acc update device(sw2)
-#endif
 !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -1817,9 +1701,6 @@
         enddo
         enddo
       elseif(index.eq.index_ne)then
-#ifndef _GPUDIRECT05
-        !$acc update device(ne2)
-#endif
 !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -1830,9 +1711,6 @@
         enddo
         enddo
       elseif(index.eq.index_se)then
-#ifndef _GPUDIRECT05
-        !$acc update device(se2)
-#endif
 !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
         do j=1,cmp
@@ -1847,7 +1725,7 @@
       enddo
 
 !-----
-      !JMD REVISIT
+      !JMD-KLUDGE REVISIT
       !JMD I am confused here.  Why are we updating the buffers here... I don't
       !JMD think this is needed
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then

--- a/src/comm.F
+++ b/src/comm.F
@@ -1,8 +1,6 @@
 #undef _GPUDIRECT
 
 
-#define _GPUDIRECT02
-#define _GPUDIRECT03
 #define _GPUDIRECT04
 #define _GPUDIRECT05
 #define _GPUDIRECT06
@@ -33,8 +31,6 @@
 
 #ifdef _GPUDIRECT
 
-#define _GPUDIRECT02
-#define _GPUDIRECT03
 #define _GPUDIRECT04
 #define _GPUDIRECT05
 
@@ -525,9 +521,6 @@
       logical, parameter :: Debug =.FALSE.
 
 !-----
-#ifndef _GPUDIRECT02
-      if(Debug) print *,'getcornert_GPU:'
-#endif
       nr = 0
       index_nw = -1
       index_sw = -1
@@ -539,15 +532,10 @@
 
       if(ibw.eq.0 .and. ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT02
         !$acc host_data use_device(nw2)
         call mpi_irecv(nw2,nkp1,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(nw2,nkp1,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_nw = nr
       endif
 
@@ -557,15 +545,10 @@
 
       if(ibw.eq.0 .and. ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT02
         !$acc host_data use_device(sw2)
         call mpi_irecv(sw2,nkp1,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(sw2,nkp1,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_sw = nr
       endif
 
@@ -575,15 +558,10 @@
 
       if(ibe.eq.0 .and. ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT02
         !$acc host_data use_device(ne2)
         call mpi_irecv(ne2,nkp1,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(ne2,nkp1,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_ne = nr
       endif
 
@@ -593,15 +571,10 @@
 
       if(ibe.eq.0 .and. ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT02
         !$acc host_data use_device(se2)
         call mpi_irecv(se2,nkp1,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(se2,nkp1,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_se = nr
       endif
 
@@ -616,16 +589,10 @@
           se1(k)=t(ni,1,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT02
         !$acc host_data use_device(se1)
         call mpi_isend(se1,nkp1,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(se1)
-        call mpi_isend(se1,nkp1,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -637,16 +604,10 @@
           ne1(k)=t(ni,nj,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT02
         !$acc host_data use_device(ne1)
         call mpi_isend(ne1,nkp1,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(ne1)
-        call mpi_isend(ne1,nkp1,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -658,16 +619,10 @@
           sw1(k)=t(1,1,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT02
         !$acc host_data use_device(sw1)
         call mpi_isend(sw1,nkp1,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(sw1)
-        call mpi_isend(sw1,nkp1,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -679,16 +634,10 @@
           nw1(k)=t(1,nj,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT02
         !$acc host_data use_device(nw1)
         call mpi_isend(nw1,nkp1,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(nw1)
-        call mpi_isend(nw1,nkp1,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -699,36 +648,24 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-#ifndef _GPUDIRECT02
-        !$acc update device(nw2)
-#endif
         !$omp parallel do default(shared) private(k)
         !$acc parallel loop default(present) private(k)
         do k=1,nkp1
           t(0,nj+1,k)=nw2(k)
         enddo
       elseif(index.eq.index_sw)then
-#ifndef _GPUDIRECT02
-        !$acc update device(sw2)
-#endif
         !$omp parallel do default(shared) private(k)
         !$acc parallel loop default(present) private(k)
         do k=1,nkp1
           t(0,0,k)=sw2(k)
         enddo
       elseif(index.eq.index_ne)then
-#ifndef _GPUDIRECT02
-        !$acc update device(ne2)
-#endif
         !$omp parallel do default(shared) private(k)
         !$acc parallel loop default(present) private(k)
         do k=1,nkp1
           t(ni+1,nj+1,k)=ne2(k)
         enddo
       elseif(index.eq.index_se)then
-#ifndef _GPUDIRECT02
-        !$acc update device(se2)
-#endif
         !$omp parallel do default(shared) private(k)
         !$acc parallel loop default(present) private(k)
         do k=1,nkp1
@@ -998,9 +935,6 @@
 
 !-----
 
-#ifndef _GPUDIRECT03
-      if(Debug) print *,'getcornerv_GPU:'
-#endif
       nr = 0
       index_nw = -1
       index_sw = -1
@@ -1014,15 +948,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT03
         !$acc host_data use_device(nw2)
         call mpi_irecv(nw2,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(nw2,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_nw = nr
       endif
 
@@ -1033,15 +962,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT03
         !$acc host_data use_device(sw2)
         call mpi_irecv(sw2,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(sw2,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_sw = nr
       endif
 
@@ -1052,15 +976,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT03
         !$acc host_data use_device(ne2)
         call mpi_irecv(ne2,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(ne2,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_ne = nr
       endif
 
@@ -1071,15 +990,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT03
         !$acc host_data use_device(se2)
         call mpi_irecv(se2,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(se2,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_se = nr
       endif
 
@@ -1097,16 +1011,10 @@
           se1(k)=v(ni,2,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT03
         !$acc host_data use_device(se1)
         call mpi_isend(se1,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(se1)
-        call mpi_isend(se1,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -1121,16 +1029,10 @@
           ne1(k)=v(ni,nj,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT03
         !$acc host_data use_device(ne1)
         call mpi_isend(ne1,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(ne1)
-        call mpi_isend(ne1,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -1145,16 +1047,10 @@
           sw1(k)=v(1,2,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT03
         !$acc host_data use_device(sw1)
         call mpi_isend(sw1,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(sw1)
-        call mpi_isend(sw1,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -1169,16 +1065,10 @@
           nw1(k)=v(1,nj,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT03
         !$acc host_data use_device(nw1)
         call mpi_isend(nw1,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(nw1)
-        call mpi_isend(nw1,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----------------------------------------------------------------------
@@ -1189,36 +1079,24 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-#ifndef _GPUDIRECT03
-        !$acc update device(nw2)
-#endif
         !$acc parallel loop gang vector default(present) private(k)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           v(0,nj+2,k)=nw2(k)
         enddo
       elseif(index.eq.index_sw)then
-#ifndef _GPUDIRECT03
-        !$acc update device(sw2)
-#endif
         !$acc parallel loop gang vector default(present) private(k)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           v(0,0,k)=sw2(k)
         enddo
       elseif(index.eq.index_ne)then
-#ifndef _GPUDIRECT03
-        !$acc update device(ne2)
-#endif
         !$acc parallel loop gang vector default(present) private(k)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           v(ni+1,nj+2,k)=ne2(k)
         enddo
       elseif(index.eq.index_se)then
-#ifndef _GPUDIRECT03
-        !$acc update device(se2)
-#endif
         !$acc parallel loop gang vector default(present) private(k)
         !$omp parallel do default(shared) private(k)
         do k=1,nk

--- a/src/comm.F
+++ b/src/comm.F
@@ -1,13 +1,9 @@
 #undef _GPUDIRECT
 
 
-#define _GPUDIRECT06
-#define _GPUDIRECT07
 
 #undef _GPUDIRECT08
 
-#define _GPUDIRECT09
-#define _GPUDIRECT10
 #define _GPUDIRECT11
 #define _GPUDIRECT12
 
@@ -30,9 +26,6 @@
 #ifdef _GPUDIRECT
 
 
-#define _GPUDIRECT07
-#define _GPUDIRECT09
-#define _GPUDIRECT10
 #define _GPUDIRECT11
 #define _GPUDIRECT12
 #define _GPUDIRECT13
@@ -46,7 +39,6 @@
 
 
 ! 06,08,14 generates an runtime ERROR
-#undef _GPUDIRECT06  
 #undef _GPUDIRECT08 
 #undef _GPUDIRECT14
 
@@ -3145,9 +3137,6 @@
       !$acc present(south,newsouth,north,newnorth)
 !------------------------------------------------
 
-#ifndef _GPUDIRECT09
-      if(Debug) print *,'comm_3t_start_GPU:'
-#endif
       nr = 0
 
       nf=nf+1
@@ -3156,15 +3145,10 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT09
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,ct3we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,ct3we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -3175,15 +3159,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT09
         !$acc host_data use_device(newwest)
         call mpi_irecv(newwest,ct3we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,ct3we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -3194,15 +3173,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT09
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,ct3sn,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,ct3sn,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -3213,15 +3187,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT09
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,ct3sn,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,ct3sn,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -3242,16 +3211,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT09
         !$acc host_data use_device(west)
         call mpi_isend(west,ct3we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,ct3we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -3268,16 +3231,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT09
         !$acc host_data use_device(east)
         call mpi_isend(east,ct3we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,ct3we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -3294,16 +3251,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT09
         !$acc host_data use_device(north)
         call mpi_isend(north,ct3sn,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,ct3sn,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -3320,16 +3271,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT09
         !$acc host_data use_device(south)
         call mpi_isend(south,ct3sn,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,ct3sn,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -3614,9 +3559,6 @@
         nn = nn + 1
 
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT09
-        !$acc update device(neweast)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nkp1
@@ -3627,9 +3569,6 @@
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT09
-        !$acc update device(newwest)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nkp1
@@ -3640,9 +3579,6 @@
         enddo
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT09
-        !$acc update device(newsouth)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nkp1
@@ -3653,9 +3589,6 @@
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT09
-        !$acc update device(newnorth)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nkp1
@@ -3974,23 +3907,15 @@
 !------------------------------------------------
 
       nr = 0
-#ifndef _GPUDIRECT10
-      if(Debug) print *,'comm_3u_start_GPU'
-#endif
       nu=nu+1
       tag1=1000+nu
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT10
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,cs3we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,cs3we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4001,15 +3926,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT10
         !$acc host_data use_device(newwest)
         call mpi_irecv(newwest,cs3we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,cs3we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4020,15 +3940,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT10
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,cu3sn,MPI_REAL,mynorth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,cu3sn,MPI_REAL,mynorth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4039,15 +3954,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT10
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,cu3sn,MPI_REAL,mysouth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,cu3sn,MPI_REAL,mysouth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -4068,16 +3978,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT10
         !$acc host_data use_device(west)
         call mpi_isend(west,cs3we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,cs3we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4094,17 +3998,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT10
         !$acc host_data use_device(east)
         call mpi_isend(east,cs3we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,cs3we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
-
       endif
 
 !----------
@@ -4121,16 +4018,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT10
         !$acc host_data use_device(south)
         call mpi_isend(south,cu3sn,MPI_REAL,mysouth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,cu3sn,MPI_REAL,mysouth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4147,16 +4038,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT10
         !$acc host_data use_device(north)
         call mpi_isend(north,cu3sn,MPI_REAL,mynorth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,cu3sn,MPI_REAL,mynorth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -4443,9 +4328,6 @@
         nn = nn + 1
  
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT10
-        !$acc update device(neweast)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
@@ -4456,9 +4338,6 @@
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT10
-        !$acc update device(newwest)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
@@ -4469,9 +4348,6 @@
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT10
-        !$acc update device(newnorth)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk
@@ -4482,9 +4358,6 @@
         enddo
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT10
-        !$acc update device(newsouth)
-#endif
         !$omp parallel do default(shared) private(i,j,k)
         !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
         do k=1,nk

--- a/src/comm.F
+++ b/src/comm.F
@@ -1,7 +1,6 @@
 #undef _GPUDIRECT
 
 
-#define _GPUDIRECT01
 #define _GPUDIRECT02
 #define _GPUDIRECT03
 #define _GPUDIRECT04
@@ -34,7 +33,6 @@
 
 #ifdef _GPUDIRECT
 
-#define _GPUDIRECT01
 #define _GPUDIRECT02
 #define _GPUDIRECT03
 #define _GPUDIRECT04
@@ -336,22 +334,14 @@
 !      !$acc update host(s)
 !------------------------------------------------------------------
 
-#ifndef _GPUDIRECT01
-      if(Debug) print *,'getcorner_GPU: '
-#endif
       tag1=5001
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT01
         !$acc host_data use_device(nw2)
         call mpi_irecv(nw2,nk,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(nw2,nk,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_nw = nr
       endif
 
@@ -361,15 +351,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT01
         !$acc host_data use_device(sw2)
         call mpi_irecv(sw2,nk,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(sw2,nk,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_sw = nr
       endif
 
@@ -379,15 +364,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT01
         !$acc host_data use_device(ne2)
         call mpi_irecv(ne2,nk,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(ne2,nk,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_ne = nr
       endif
 
@@ -397,15 +377,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-#ifdef _GPUDIRECT01
         !$acc host_data use_device(se2)
         call mpi_irecv(se2,nk,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(se2,nk,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-#endif
         index_se = nr
       endif
 
@@ -421,16 +396,10 @@
           se1(k)=s(ni,1,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT01
         !$acc host_data use_device(se1)
         call mpi_isend(se1,nk,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(se1)
-        call mpi_isend(se1,nk,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -443,16 +412,10 @@
           ne1(k)=s(ni,nj,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT01
         !$acc host_data use_device(ne1)
         call mpi_isend(ne1,nk,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(ne1)
-        call mpi_isend(ne1,nk,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -465,16 +428,10 @@
           sw1(k)=s(1,1,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT01
         !$acc host_data use_device(sw1)
         call mpi_isend(sw1,nk,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(sw1)
-        call mpi_isend(sw1,nk,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -487,16 +444,10 @@
           nw1(k)=s(1,nj,k)
         enddo
         nrb = nrb + 1
-#ifdef _GPUDIRECT01
         !$acc host_data use_device(nw1)
         call mpi_isend(nw1,nk,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
-#else
-        !$acc update host(nw1)
-        call mpi_isend(nw1,nk,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-#endif
       endif
 
 !-----
@@ -507,9 +458,6 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-#ifndef _GPUDIRECT01
-        !$acc update device(nw2)
-#endif
 !$acc parallel loop gang vector default(present) private(k)
 !$omp parallel do default(shared)   &
 !$omp private(k)
@@ -517,9 +465,6 @@
           s(0,nj+1,k)=nw2(k)
         enddo
       elseif(index.eq.index_sw)then
-#ifndef _GPUDIRECT01
-        !$acc update device(sw2)
-#endif
 !$acc parallel loop gang vector default(present) private(k)
 !$omp parallel do default(shared)   &
 !$omp private(k)
@@ -527,9 +472,6 @@
           s(0,0,k)=sw2(k)
         enddo
       elseif(index.eq.index_ne)then
-#ifndef _GPUDIRECT01
-        !$acc update device(ne2)
-#endif
 !$acc parallel loop gang vector default(present) private(k)
 !$omp parallel do default(shared)   &
 !$omp private(k)
@@ -537,9 +479,6 @@
           s(ni+1,nj+1,k)=ne2(k)
         enddo
       elseif(index.eq.index_se)then
-#ifndef _GPUDIRECT01
-        !$acc update device(se2)
-#endif
 !$acc parallel loop gang vector default(present) private(k)
 !$omp parallel do default(shared)   &
 !$omp private(k)


### PR DESCRIPTION
This commit eliminates a number of _GPUDIRECT if-def blocks.  The elimination indicates that GPU-direct is now by default in a number of subroutines.   Note that four subroutines in comm.F still do not have GPU-direct enabled by default as they still have bugs that have not yet been resolved.  The correctness statistics are unchanged 

44 stat variables are identical.
29 stat variables show a mean relative difference > 1e-06
13 stat variables show a mean relative difference <= 1e-06