### PR TITLE
Syntax errors for directives identify by CCE

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -180,15 +180,20 @@ endif
 #  Cray compiler
 #-----------------------------------------------------------------------------
 ifeq (${FC},ftn)
-    OPTS         += -O3 -Ovector3 -Oscalar3 -Othread3
-    LINKOPTS     += -lfast_mv
-    CPP          += cpp -C -P -traditional
+    OPTS         += -O2 -Ovector2 -Oscalar2 -Othread2
+    #LINKOPTS     += -lfast_mv
+    CPP          += cpp -C -P -traditional -Wno-invalid-pp-token -ffreestanding
     ifeq (${USE_OPENMP_L},true)
         OPTS     += -h omp
         OMP      += -DOPENMP
     else
         OPTS     += -h noomp
     endif
+    ifeq (${USE_OPENACC_L},true)
+        OPTS     += -h acc
+        DM       += -D_OPENACC
+    endif
+
 endif
 
 #-----------------------------------------------------------------------------

--- a/src/adv_routines.F
+++ b/src/adv_routines.F
@@ -3384,8 +3384,7 @@
 
   IF( stag.eq.1 )THEN
 
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k),
+    !$omp parallel do default(shared) private(i,j,k)
     !$acc parallel loop gang vector collapse(3) default(present)
     DO j=1,nj
       do k=3,nk-1

--- a/src/bc.F
+++ b/src/bc.F
@@ -1585,7 +1585,6 @@
             radbcs(i,k)=avgs
           enddo
         enddo
-        !$acc end parallel
       endif
 
       if(ibn.eq.1.and.nbc.eq.2)then
@@ -1605,7 +1604,6 @@
             radbcn(i,k)=avgn
           enddo
         enddo
-        !$acc end parallel
       endif
 
       if(timestats.ge.1) time_bc=time_bc+mytime()
@@ -1646,7 +1644,6 @@
         temout(k) = 0.0d0
         temin(k)  = 0.0d0
       enddo
-      !$acc end parallel
 
       if(wbc.eq.2.and.ibw.eq.1)then
         i=1
@@ -1694,7 +1691,6 @@
         fluxout = fluxout + temout(k)
         fluxin  = fluxin  + temin(k)
       enddo
-      !$acc end parallel
 
 #ifdef MPI
       tem=0.0d0
@@ -1721,7 +1717,6 @@
           endif
         enddo
         enddo
-        !$acc end parallel
       endif
 
       if(ebc.eq.2.and.ibe.eq.1)then
@@ -1736,7 +1731,6 @@
           endif
         enddo
         enddo
-        !$acc end parallel
       endif
 
       !$acc end data
@@ -1815,7 +1809,6 @@
         fluxout = fluxout + temout(k)
         fluxin  = fluxin  + temin(k)
       enddo
-      !$acc end parallel
 
 #ifdef MPI
       tem=0.0d0

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -10274,7 +10274,7 @@
 
   !----------------------
 
-      !$omp parallel default(shared) private(i,j,k,wbar) reduction(+:ufrt,ufdt)
+      !$omp parallel do default(shared) private(i,j,k,wbar) reduction(+:ufrt,ufdt)
       !$acc parallel default(present) reduction(+:ufrt,ufdt)
       !$acc loop gang 
       do k=2,nk

--- a/src/interp_routines.F
+++ b/src/interp_routines.F
@@ -369,8 +369,8 @@
 
       !----
 
-    !$omp parallel do default(shared) private(i,j,k,wbar,cc1,cc2)
     k = 3
+    !$omp parallel do default(shared) private(i,j,k,wbar,cc1,cc2)
     !$acc parallel loop gang vector collapse(2) default(present) private(i,j,wbar)
     DO j=j1,j2
       !dir$ vector always
@@ -639,7 +639,7 @@
         i2=ni+1
       endif
 
-    !$omp parallel do default(shared) private(i,j,k,wbar) private(i,j,k,wbar)
+    !$omp parallel do default(shared) private(i,j,k,wbar)
     !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,wbar)
     DO k=4,nk-2
       do j=1,nj

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -3308,9 +3308,9 @@
 
       if(nx.gt.1.and.ny.gt.1)then
         ! 3d:
-        !$omp parallel do default(shared) private(i,j,k,tem1,tem2,tem3)
         !$acc parallel default(present) private(i,j,k,tem1,tem2,tem3) reduction(max:kstmp) 
         ks(1)=0.0
+        !$omp parallel do default(shared) private(i,j,k,tem1,tem2,tem3)
         !$acc loop gang 
         do k=2,nk
            kstmp = 0.0
@@ -3331,9 +3331,9 @@
         !$acc end parallel
       elseif(nx.gt.1)then
         ! 2d (including axisymm):
-        !$omp parallel do default(shared) private(i,j,tem1,tem2,tem3)
         !$acc parallel default(present) private(i,j,k,tem1,tem2,tem3) reduction(max:kstmp) 
         ks(1)=0.0
+        !$omp parallel do default(shared) private(i,j,tem1,tem2,tem3)
         !$acc loop gang
         do k=2,nk
           kstmp = 0.0
@@ -3833,7 +3833,6 @@
           ENDIF
         enddo
       enddo
-!$acc end parallel
 
       vmax = 0.0
 
@@ -3903,7 +3902,6 @@
         enddo
         enddo
       enddo
-      !$acc end parallel
 
 #ifdef MPI
       var=0.0d0
@@ -4150,7 +4148,6 @@
         ep=ep+foo3(k)
         le=le+foo4(k)
       enddo
-      !$acc end parallel
       !$acc end data
  
       ek=ek*(dx*dy*dz)

--- a/src/param.F
+++ b/src/param.F
@@ -5075,7 +5075,7 @@
       qd_subl  = 0
 
       ! dbz (new for cm1r19)
-      IF( output_dbz.eq.1 .or. restart_file_dbz .or. prcl_dbz )THEN
+      IF( output_dbz.eq.1 .or. restart_file_dbz .or. (prcl_dbz .eq. 1) )THEN
         ibdq = ib
         iedq = ie
         jbdq = jb

--- a/src/sfcphys.F
+++ b/src/sfcphys.F
@@ -548,7 +548,7 @@
 
 
       !$acc declare &
-      !$acc present(psfc,tsk,th0,tha,qa,tsk,znt,za) &
+      !$acc present(psfc,tsk,th0,tha,qa,znt,za) &
       !$acc present(dsxy,s1,thflux,qvflux,rf,cd,hpbl) &
       !$acc present(qsfc,gz1oz0,wspd,br,hfx,qfx) &
       !$acc present(cda,psim,psih,zol,mol,fm,fh,th2,q2,t2)

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -623,9 +623,8 @@
             !JMD ENDIF
         ELSE
           ! psolver=1,4,5:
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
             print *, 'Here 8 -- Not being executed'
+            !$omp parallel do default(shared) private(i,j,k)
             !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
             do k=1,nk
             do j=1,nj

--- a/src/testcase_simple_phys.F
+++ b/src/testcase_simple_phys.F
@@ -370,7 +370,6 @@
         kzi(i,j) = 0  ! initilize this to zero 
       enddo
       enddo
-      !$acc end parallel
 
       !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k,n)
       do k=1,nk
@@ -384,7 +383,6 @@
         enddo
         !----
       enddo
-      !$acc end parallel
 
       do n=nql1,nql2
       !$acc parallel default(present)

--- a/src/turbtend.F
+++ b/src/turbtend.F
@@ -2938,10 +2938,10 @@
         enddo
         enddo
 
-        !$acc parallel loop gang vector default(present) private(i,j)
+        !$acc parallel default(present)
         do k=(nk-1),2,-1
 
-        !$omp parallel default(shared) private(i,j)
+        !$omp parallel do default(shared) private(i,j)
         !$acc loop gang vector collapse(2)
         do j=1,nj
         do i=1,ni


### PR DESCRIPTION
This PR resolves a number of issues with the OMP and ACC directives that were identified by the CCE compiler.  It also reduces the default level of compiler optimization level for the CCE compiler from O3 to O2 because the O3 level takes a very long time to compile.  