### PR TITLE
Fix the broken GPU code with droplet injection function

### DIFF
--- a/src/droplet.F
+++ b/src/droplet.F
@@ -563,6 +563,7 @@
 ! Requires inputting the current 10-meter wind speed
    
    if ( .not. use_wall_bc ) then  
+      s10_xym = 0.0
       !$acc parallel loop gang vector reduction(+:s10_xym)
       do j=1,nj
          do i=1,ni

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -535,8 +535,6 @@
 
     nparcelsLocalActive = nparcelsLocalActive + sum(Arrive) - sum(Depart)
 
-    !$acc update device(pdata,pdata_locind)
-
     ! free up the memory for temporary variables
 
     deallocate(holes_ind)
@@ -565,6 +563,8 @@
 ! Requires inputting the current 10-meter wind speed
    
    if ( .not. use_wall_bc ) then  
+      !$acc update host (s10)
+
       s10_xym = 0.0
       do j=1,nj
          do i=1,ni
@@ -584,6 +584,8 @@
          write(*,'(a8,3i)')  'DHR1:',myid,np_tmp,nparcelsLocalActive
       end if
    end if
+
+   !$acc update device(pdata,pdata_locind)
 
    end subroutine droplet_driver
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -563,14 +563,13 @@
 ! Requires inputting the current 10-meter wind speed
    
    if ( .not. use_wall_bc ) then  
-      !$acc update host (s10)
-
-      s10_xym = 0.0
+      !$acc parallel loop gang vector reduction(+:s10_xym)
       do j=1,nj
          do i=1,ni
             s10_xym = s10_xym + s10(i,j)
          end do
       end do
+      !$acc end parallel
 #ifdef MPI
       call mpi_allreduce(mpi_in_place,s10_xym,1,mpi_real,mpi_sum,mpi_comm_world,ierr)
 #endif

--- a/src/input.F
+++ b/src/input.F
@@ -167,7 +167,7 @@
       !$acc                 prx,pry,prz,prsig,ngxy,ngz,ptype,pru,prv,prw,     &
       !$acc                 prt,prqv,prprs,prrho,nparcelsLocal,mywest,        &
       !$acc                 myeast,mynorth,mysouth,myne,myse,mysw,mynw,       &
-      !$acc                 prmult)
+      !$acc                 prmult,pract)
 
 !-----------------------------------------------------------------------
 

--- a/src/param.F
+++ b/src/param.F
@@ -6253,7 +6253,7 @@
       if(dowr) write(outfile,*)
 
       !$acc update device (prvpx,prvpy,prvpz,prrp,prms,prtp,prx, &
-      !$acc                pry,prz,prsig,prmult)
+      !$acc                pry,prz,prsig,prmult,pract)
 
 !--------------------------------------------------------------
 !  Get identity


### PR DESCRIPTION
This PR fixes the broken GPU code due to the changes from this PR #100.

By using the namelist `namelist.restC`, the verification result on Casper looks below:

**CPU (intel, 2 MPI ranks) vs. GPU (nvhpc, 2 MPI ranks + 2 V100 GPUs)**

_Stat output comparision_
- Identical variables: 59
- variables with rel_diff > 1.e-6: 24
- variables with rel_diff <= 1.e-6: 3
- four variables with largest error: PPMIN, PPMAX, DIVMIN, DIVMAX

_Droplet 0th-order diagnostic comparision_
- Identical variables: 12
- variable with rel_diff > 1.e-6: 0
- variable with rel_diff <= 1.e-6: 0

_Droplet 1st-order diagnostic comparision_
- Identical variables: 512
- variable with rel_diff > 1.e-6: 0
- variable with rel_diff <= 1.e-6: 0

--------------------------------------------------------------------------------

**Note** that if we use the droplet injection function, the total number of droplets at the end of simulation varies when we use different number of MPI ranks. Thus in the verification test, we need to use the same number of MPI ranks for both CPU and GPU runs.