### PR TITLE
Paper mods2: added load-imbalance timers

### DIFF
--- a/run/gust.ngpu8.sh
+++ b/run/gust.ngpu8.sh
@@ -12,4 +12,4 @@ module load nvhpc cuda cray-mpich
 export MPICH_GPU_SUPPORT_ENABLED=1
 export MPICH_GPU_MANAGED_MEMORY_SUPPORT_ENABLED=1
 # mpiexec -n 8 -ppn 4 get_local_rank ./cm1.exe --namelist namelist.small.gpu >& gust.ngpu8.small.512x512.log
-mpiexec -n 8 -ppn 4 get_local_rank ./cm1.exe --namelist namelist.figureE.gpu >& gust.ngpu8.figureE.512x512.log
+mpiexec -n 8 -ppn 4 get_local_rank ./gpu.exe --namelist namelist.figureE.gpu >& gust.ngpu8.figureE.512x512c.log

--- a/run/gust.ngpu8.sh
+++ b/run/gust.ngpu8.sh
@@ -11,4 +11,5 @@ module load nvhpc cuda cray-mpich
 
 export MPICH_GPU_SUPPORT_ENABLED=1
 export MPICH_GPU_MANAGED_MEMORY_SUPPORT_ENABLED=1
-mpiexec -n 8 -ppn 4 get_local_rank ./cm1.exe --namelist namelist.small.gpu >& gust.ngpu8.small.512x512.log
+# mpiexec -n 8 -ppn 4 get_local_rank ./cm1.exe --namelist namelist.small.gpu >& gust.ngpu8.small.512x512.log
+mpiexec -n 8 -ppn 4 get_local_rank ./cm1.exe --namelist namelist.figureE.gpu >& gust.ngpu8.figureE.512x512.log

--- a/run/gust.node8.sh
+++ b/run/gust.node8.sh
@@ -7,17 +7,12 @@
 #PBS -A UNDM0006
 
 
-module purge
-module load nvhpc
-module load cray-mpich
-module load ncarcompilers
-module unload cuda
+module --force purge
+module load ncarenv/23.03
+module load nvhpc/23.1
+module load ncarcompilers/0.8.0
+module load cray-mpich/8.1.25
 
-export PALS_NRANKS=1024
-export PALS_PPN=128
-export PALS_DEPTH=1
-export PALS_CPU_BIND=depth
-
-#mpiexec ./cm1.exe --namelist namelist.figureE.cpu >& node=8.figureE.512x512.log
+mpiexec -n 1024 ./cpu.exe --namelist namelist.figureE.cpu >& gust.node8.figureE.512x512c.log
 #mpiexec ./cpu.exe --namelist namelist.figureD.cpu >& node=8.figureD.256.log
-mpiexec ./cm1.exe --namelist namelist.figureA.cpu >& gust.node8.figureA.256.log
+#mpiexec ./cm1.exe --namelist namelist.figureA.cpu >& gust.node8.figureA.256.log

--- a/run/namelist.figureE.cpu
+++ b/run/namelist.figureE.cpu
@@ -82,7 +82,8 @@
  npt       =  1,
  pdtra     =  1,
  iprcl     =  1,  !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
- nparcels  =  8000000,  !I do at least 1000 just to get a variety
+ nparcelsInit = 36000000,   ! initial number of particles over the whole domain
+ nparcelsMax  = 40000000,   ! the total allowable number of particles over the whole domain
  /
 
  &param3

--- a/run/namelist.figureE.gpu
+++ b/run/namelist.figureE.gpu
@@ -82,7 +82,8 @@
  npt       =  1,
  pdtra     =  1,
  iprcl     =  1,  !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
- nparcels  =  8000000,  !I do at least 1000 just to get a variety
+ nparcelsInit = 36000000,   ! initial number of particles over the whole domain
+ nparcelsMax  = 36000000,   ! the total allowable number of particles over the whole domain
  /
 
  &param3

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,7 +104,7 @@ ifeq (${FC},nvfortran)
             #     -Minfo=accel    Provides verbose output for accelerator compilation phase
             #     -Mpcast         Enables the use of PCAST functionality
             ifeq (${GPU_TYPE_L},a100)
-                OPTS += -acc -gpu=cc80,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
+                OPTS += -acc -gpu=cc80,lineinfo,nofma,math_uniform -Minfo=accel
             else
                 OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
             endif
@@ -352,6 +352,7 @@ bcast.o:
 cm1.o: constants.o input.o param.o base.o init3d.o misclibs.o solve1.o solve2.o solve3.o diff2.o turb.o statpack.o writeout.o restart.o radiation_driver.o radtrns3d.o domaindiag.o azimavg.o hifrq.o parcel.o init_physics.o init_surface.o mp_driver.o ib_module.o eddy_recycle.o lsnudge.o nvtx_mod.o
 cm1libs.o: input.o constants.o
 comm.o: input.o bc.o
+comm_droplet.o: input.o constants.o
 diff2.o: constants.o input.o
 domaindiag.o: constants.o input.o interp_routines.o cm1libs.o getcape.o sfcphys.o turb.o lsnudge.o writeout_nc.o
 eddy_recycle.o: constants.o input.o

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -4062,7 +4062,7 @@ end module cuda_rt
                     time_mpu2+time_mpv2+time_mpw2+time_mpp2+                &
                     time_mps1+time_mps3+time_mpq1+time_mptk1+                         &
                     time_mps2+time_mps4+time_mpq2+time_mptk2+time_mpb+                &
-                    time_dpc+time_droplet_reduce+time_parceli_reduce+                 &
+                    time_dpc+time_droplet_reduce+time_parceli_reduce+time_lb+         &
 #endif
                     time_advs+time_advu+time_advv+time_advw+                &
                     time_phys_H2D + time_phys_D2H
@@ -4387,6 +4387,10 @@ end module cuda_rt
         time_droplet = sum/float(numprocs)
 
         sum = 0.0
+        call MPI_REDUCE(time_lb ,sum,1,MPI_REAL,MPI_SUM,0,MPI_COMM_WORLD,ierr)
+        time_lb = sum/float(numprocs)
+
+        sum = 0.0
         call MPI_REDUCE(time_droplet_inject ,sum,1,MPI_REAL,MPI_SUM,0,MPI_COMM_WORLD,ierr)
         time_droplet_inject = sum/float(numprocs)
 
@@ -4473,7 +4477,7 @@ end module cuda_rt
                   time_mpu2+time_mpv2+time_mpw2+time_mpp2+                &
                   time_mps1+time_mps3+time_mpq1+time_mptk1+                     &
                   time_mps2+time_mps4+time_mpq2+time_mptk2+time_mpb+            &
-                  time_dpc+time_droplet_reduce+                                    &
+                  time_dpc+time_droplet_reduce+time_lb+                         &
 #endif
                   time_advs+time_advu+time_advv+time_advw+                &
                   time_phys_H2D+time_phys_D2H
@@ -4567,6 +4571,7 @@ end module cuda_rt
       write(outfile,100) 'parceli ',time_parceli,time_parceli/time_solve
       write(outfile,100) 'droplet ',time_droplet,time_droplet/time_solve
       write(outfile,100) 'dropletI',time_droplet_inject,time_droplet_inject/time_solve
+      write(outfile,100) 'load-imb',time_lb,time_lb/time_solve
       if( dodomaindiag )  &
       write(outfile,100) 'domndiag',time_diag,time_diag/time_solve
       if( doazimavg )  &

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -4054,7 +4054,7 @@ end module cuda_rt
                     time_misc21+time_misc22+time_misc23+ &
                     time_write+time_restart+time_ttend+time_cor+time_fall+  &
                     time_satadj+time_dbz+time_sfcphys+                      &
-                    time_parcels+time_parceli+time_droplet+                 &
+                    time_parcels+time_parceli+time_droplet+time_droplet_inject+ &
                     time_rad+time_pbl+time_swath+time_pdef+time_prsrho+     &
                     time_diag+time_azimavg+time_hifrq+time_ercyl+           &
 #ifdef MPI
@@ -4381,9 +4381,14 @@ end module cuda_rt
         sum = 0.0
         call MPI_REDUCE(time_parceli ,sum,1,MPI_REAL,MPI_SUM,0,MPI_COMM_WORLD,ierr)
         time_parceli = sum/float(numprocs)
+
         sum = 0.0
         call MPI_REDUCE(time_droplet ,sum,1,MPI_REAL,MPI_SUM,0,MPI_COMM_WORLD,ierr)
         time_droplet = sum/float(numprocs)
+
+        sum = 0.0
+        call MPI_REDUCE(time_droplet_inject ,sum,1,MPI_REAL,MPI_SUM,0,MPI_COMM_WORLD,ierr)
+        time_droplet_inject = sum/float(numprocs)
 
         sum = 0.0
         call MPI_REDUCE(time_droplet_reduce ,sum,1,MPI_REAL,MPI_SUM,0,MPI_COMM_WORLD,ierr)
@@ -4460,7 +4465,7 @@ end module cuda_rt
                   time_bcs+time_bcs2+time_bcst+ &
                   time_write+time_restart+time_ttend+time_cor+time_fall+  &
                   time_satadj+time_dbz+time_sfcphys+                      &
-                  time_parcels+time_parceli+time_droplet+                 &
+                  time_parcels+time_parceli+time_droplet+time_droplet_inject+  &
                   time_rad+time_pbl+time_swath+time_pdef+time_prsrho+     &
                   time_diag+time_azimavg+time_hifrq+time_ercyl+           &
 #ifdef MPI
@@ -4561,6 +4566,7 @@ end module cuda_rt
       write(outfile,100) 'parcels ',time_parcels,time_parcels/time_solve
       write(outfile,100) 'parceli ',time_parceli,time_parceli/time_solve
       write(outfile,100) 'droplet ',time_droplet,time_droplet/time_solve
+      write(outfile,100) 'dropletI',time_droplet_inject,time_droplet_inject/time_solve
       if( dodomaindiag )  &
       write(outfile,100) 'domndiag',time_diag,time_diag/time_solve
       if( doazimavg )  &

--- a/src/comm.F
+++ b/src/comm.F
@@ -57,7 +57,16 @@
   public :: comm_1s2d_start,comm_1s2d_end
   public :: getcorneru3,getcornerv3,getcorner3_2d,getcorner
 
+  public :: sync
+
   CONTAINS
+
+! Synchronization routine 
+     subroutine sync()
+      use mpi
+      integer :: ierr
+      call MPI_BARRIER (MPI_COMM_WORLD,ierr)
+     end subroutine
 
 !-----------------------------------------------------------------------
 !  message passing routines

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -20,7 +20,7 @@
 
   ! set this variable to ".true." to rebounce the particles
   ! falling off the bottom (i.e., conserve the total droplet number)
-  logical, parameter :: use_wall_bc = .false.
+  logical, parameter :: use_wall_bc = .true.
 
   !For testing: set this parameter to ".false." to make droplet injection deterministic (not random)
   logical, parameter :: random_droplets = .true.
@@ -2441,12 +2441,6 @@
       !Set the parameters of the two lognormals:
       real :: rmin,rmax,rmin10,rmax10
 
-      !JMD The following is an expensive operation. Need to port the
-      !JMD injection loop to GPU to eliminate the need to perform this
-      !JMD update.
-      !$acc update host(pdata)
-      if(timestats.ge.1) time_phys_D2H=time_phys_D2H+mytime()
-
       rmin10 = log10(2e-06)
       rmax10 = log10(500e-06)
       dh = 0.0242
@@ -2582,11 +2576,6 @@
 
       end do
       if(timestats.ge.1) time_droplet=time_droplet+mytime()
-      !JMD The following is an expensive operation. Need to port the
-      !JMD previous loop to GPU to eliminate the need to perform this
-      !JMD update.
-      !$acc update device(pdata)
-      if(timestats.ge.1) time_phys_H2D=time_phys_H2D+mytime()
 
       !Then once the new droplets have been added, update nparcelsLocalActive
       nparcelsLocalActive = nparcelsLocalActive + my_reintro

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -2493,8 +2493,6 @@
 
       my_reintro = floor(xrange*yrange*dt*totdrops/drop_mult)      !Number of droplets to be produced by this MPI task
 
-      !JMD my_reintro = 10
-
 
 #ifdef MPI
       call mpi_allreduce(my_reintro+nparcelsLocalActive,tot_after_reintro,1,mpi_int,mpi_sum,mpi_comm_world,ierr)

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -2177,7 +2177,6 @@
                 v1(2) = rt_zeros(2)
 
         end do
-        !print *,'gauss_newton_2d: iterations: ',iterations
       !These indicate that this failed -- set flag = 1 to send to LV solver
       if (iterations == iteration_max) flag = 1
       if ((rt_zeros(1) .ne. rt_zeros(1)) .OR. rt_zeros(1)<0 .OR. (rt_zeros(2) .ne. rt_zeros(2)) .OR. rt_zeros(2)<0) flag = 1

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -39,8 +39,9 @@
           kmt,npvals,npvars,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,bbc,tbc,imove,zt,rzt, &
           umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
           prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult,prms,przs,pru,prv,prw,prt,prqv,prprs,prrho, &
-          timestats,time_droplet,mytime,ierr,time_droplet_reduce,maxx,maxy,maxz, &
-          ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest,myid,nparcelsLocal,nparcelsLocalActive
+          timestats,time_droplet,time_droplet_inject, mytime,ierr,time_droplet_reduce,maxx,maxy,maxz, &
+          ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest,myid,nparcelsLocal,nparcelsLocalActive, &
+          time_phys_H2D,time_phys_D2H
       use constants
       use comm_module
       use comm_droplet_module
@@ -306,6 +307,10 @@
     num100 = 0
     num1000 = 0
 
+    !print *,'HOST: nparcelsLocalActive: ',nparcelsLocalActive
+    !!$acc parallel
+    !print *,'DEVICE: nparcelsLocalActive: ',nparcelsLocalActive
+    !!$acc end parallel
 #ifdef _B4B01F
     !$acc update &
     !$acc host(pdata,xf,yf,zf,zh,sigma,sigmaf, &
@@ -428,8 +433,11 @@
     !$acc end parallel
 
     !$acc end data
+    if(timestats.ge.1) time_droplet=time_droplet+mytime()
 
     !$acc update host(pdata,pdata_locind)
+
+    if(timestats.ge.1) time_phys_D2H=time_phys_D2H+mytime()
 
     numvec(1) = num100
     numvec(2) = num1000
@@ -446,7 +454,6 @@
 
     if (myid==0) write(*,*) 'num100,num1000 = ',numvec(1),numvec(2)
 
-    if(timestats.ge.1) time_droplet=time_droplet+mytime()
 
 !----------------------------------------------------------------------
 !  remove the "holes" due to droplets which fell out: collapse pdata and adjust nparcelsLocalActive
@@ -481,6 +488,8 @@
    end do
 
    deallocate(holes_fallout_ind)
+
+    if(timestats.ge.1) time_droplet=time_droplet+mytime()
 
 !----------------------------------------------------------------------
 !  communicate data  (for MPI runs)
@@ -535,13 +544,15 @@
 
     nparcelsLocalActive = nparcelsLocalActive + sum(Arrive) - sum(Depart)
 
+    if(timestats.ge.1) time_droplet_reduce=time_droplet_reduce+mytime()
+
     !$acc update device(pdata,pdata_locind)
+    if(timestats.ge.1) time_phys_H2D=time_phys_H2D+mytime()
 
     ! free up the memory for temporary variables
 
     deallocate(holes_ind)
 
-    if(timestats.ge.1) time_droplet_reduce=time_droplet_reduce+mytime()
 #endif
 
 
@@ -566,6 +577,7 @@
    
    if ( .not. use_wall_bc ) then  
       s10_xym = 0.0
+      !$acc parallel loop gang vector reduction(+:s10_xym)
       do j=1,nj
          do i=1,ni
             s10_xym = s10_xym + s10(i,j)
@@ -584,6 +596,9 @@
          write(*,'(a8,3i)')  'DHR1:',myid,np_tmp,nparcelsLocalActive
       end if
    end if
+
+   if(timestats.ge.1) time_droplet_inject=time_droplet_inject+mytime()
+  
 
    end subroutine droplet_driver
 
@@ -2165,6 +2180,7 @@
                 v1(2) = rt_zeros(2)
 
         end do
+        !print *,'gauss_newton_2d: iterations: ',iterations
       !These indicate that this failed -- set flag = 1 to send to LV solver
       if (iterations == iteration_max) flag = 1
       if ((rt_zeros(1) .ne. rt_zeros(1)) .OR. rt_zeros(1)<0 .OR. (rt_zeros(2) .ne. rt_zeros(2)) .OR. rt_zeros(2)<0) flag = 1
@@ -2390,7 +2406,7 @@
       use input, only : nparcelsLocal,npvals,myid,ni,nj,ib,ie,jb,je, &
                         prx,pry,prz,pru,prv,prw,prvpx,prvpy,prvpz,prrp,prtp,prms,pract, &
                         prmult,prt,prrho,prprs,prqv,nparcelsLocalActive,numprocs,nparcelsMax, &
-                        injectHMax
+                        time_phys_H2D,time_phys_D2H,time_droplet,timestats,mytime,injectHMax
       use constants
       use MersenneTwister_mod
 #ifdef MPI
@@ -2423,6 +2439,12 @@
       !implementing the Andreas 1998 sea spray generation function
       !Set the parameters of the two lognormals:
       real :: rmin,rmax,rmin10,rmax10
+
+      !JMD The following is an expensive operation. Need to port the
+      !JMD injection loop to GPU to eliminate the need to perform this
+      !JMD update.
+      !$acc update host(pdata)
+      if(timestats.ge.1) time_phys_D2H=time_phys_D2H+mytime()
 
       rmin10 = log10(2e-06)
       rmax10 = log10(500e-06)
@@ -2480,7 +2502,7 @@
 
       my_reintro = floor(xrange*yrange*dt*totdrops/drop_mult)      !Number of droplets to be produced by this MPI task
 
-      my_reintro = 10
+      !JMD my_reintro = 10
 
 
 #ifdef MPI
@@ -2558,6 +2580,12 @@
         pdata(np,prrho) = 0.0
 
       end do
+      if(timestats.ge.1) time_droplet=time_droplet+mytime()
+      !JMD The following is an expensive operation. Need to port the
+      !JMD previous loop to GPU to eliminate the need to perform this
+      !JMD update.
+      !$acc update device(pdata)
+      if(timestats.ge.1) time_phys_H2D=time_phys_H2D+mytime()
 
       !Then once the new droplets have been added, update nparcelsLocalActive
       nparcelsLocalActive = nparcelsLocalActive + my_reintro

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -20,7 +20,7 @@
 
   ! set this variable to ".true." to rebounce the particles
   ! falling off the bottom (i.e., conserve the total droplet number)
-  logical, parameter :: use_wall_bc = .true.
+  logical, parameter :: use_wall_bc = .false.
 
   !For testing: set this parameter to ".false." to make droplet injection deterministic (not random)
   logical, parameter :: random_droplets = .true.
@@ -307,10 +307,6 @@
     num100 = 0
     num1000 = 0
 
-    !print *,'HOST: nparcelsLocalActive: ',nparcelsLocalActive
-    !!$acc parallel
-    !print *,'DEVICE: nparcelsLocalActive: ',nparcelsLocalActive
-    !!$acc end parallel
 #ifdef _B4B01F
     !$acc update &
     !$acc host(pdata,xf,yf,zf,zh,sigma,sigmaf, &

--- a/src/input.F
+++ b/src/input.F
@@ -246,7 +246,7 @@
            time_droplet_inject, time_parceli_reduce, &
            time_rad,time_pbl,time_swath,time_pdef,      &
            time_prsrho,time_restart,time_poiss,time_diag,            &
-           time_azimavg,time_hifrq,time_ercyl
+           time_azimavg,time_hifrq,time_ercyl,time_lb
       integer count_last
 
 !-----------------------------------------------------------------------

--- a/src/input.F
+++ b/src/input.F
@@ -167,7 +167,7 @@
       !$acc                 prx,pry,prz,prsig,ngxy,ngz,ptype,pru,prv,prw,     &
       !$acc                 prt,prqv,prprs,prrho,nparcelsLocal,mywest,        &
       !$acc                 myeast,mynorth,mysouth,myne,myse,mysw,mynw,       &
-      !$acc                 prmult)
+      !$acc                 prmult,pract)
 
 !-----------------------------------------------------------------------
 
@@ -243,7 +243,7 @@
            time_mps1,time_mps3,time_mpq1,time_mptk1,                 &
            time_mps2,time_mps4,time_mpq2,time_mptk2,time_mpb,time_dpc,        &
            time_parcels,time_parceli,time_droplet,time_droplet_reduce, &
-           time_parceli_reduce, &
+           time_droplet_inject, time_parceli_reduce, &
            time_rad,time_pbl,time_swath,time_pdef,      &
            time_prsrho,time_restart,time_poiss,time_diag,            &
            time_azimavg,time_hifrq,time_ercyl

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -4474,7 +4474,7 @@
           time_misc17,time_misc18,time_misc19,time_misc20,time_misc21,time_misc22, &
           time_misc23,time_integ,time_rdamp,time_divx,time_write,time_nvtx,time_restart, &
           time_ttend,time_cor,time_fall,time_satadj,time_sfcphys,time_parcels,time_parceli, &
-          time_droplet,time_droplet_reduce,time_parceli_reduce,time_rad,time_pbl,time_swath, &
+          time_droplet,time_droplet_reduce,time_droplet_inject, time_parceli_reduce,time_rad,time_pbl,time_swath, &
           time_pdef,time_prsrho,time_diag,time_azimavg,time_hifrq,time_ercyl,time_mpu1, &
           time_mpv1,time_mpw1,time_mpp1,time_mpu2,time_mpv2,time_mpw2,time_mpp2,time_mps1, &
           time_mps3,time_mpq1,time_mptk1,time_mptk2,time_mps2,time_mps4,time_mpq2,time_mpb, &
@@ -4543,6 +4543,7 @@
       time_parceli=0.0
       time_droplet=0.0
       time_droplet_reduce=0.0
+      time_droplet_inject=0.0
       time_parceli_reduce=0.0
       time_rad=0.0
       time_pbl=0.0

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -4478,7 +4478,7 @@
           time_pdef,time_prsrho,time_diag,time_azimavg,time_hifrq,time_ercyl,time_mpu1, &
           time_mpv1,time_mpw1,time_mpp1,time_mpu2,time_mpv2,time_mpw2,time_mpp2,time_mps1, &
           time_mps3,time_mpq1,time_mptk1,time_mptk2,time_mps2,time_mps4,time_mpq2,time_mpb, &
-          time_dpc
+          time_dpc,time_lb
 
 
       implicit none
@@ -4573,6 +4573,7 @@
       time_mpq2=0.0
       time_mpb=0.0
       time_dpc=0.0
+      time_lb=0.0
 #endif
 
       end subroutine set_time_to_zero

--- a/src/param.F
+++ b/src/param.F
@@ -6253,7 +6253,7 @@
       if(dowr) write(outfile,*)
 
       !$acc update device (prvpx,prvpy,prvpz,prrp,prms,prtp,prx, &
-      !$acc                pry,prz,prsig,prmult)
+      !$acc                pry,prz,prsig,prmult,pract)
 
 !--------------------------------------------------------------
 !  Get identity

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1853,14 +1853,14 @@
 !!!101     format(i6.6)
 
         if(dowr) write(outfile,*) string
-        open(unit=61,file=string,form='unformatted',access='direct',   &
-             recl=4*npvals*nparcelstot,status='unknown')
+!JMD        open(unit=61,file=string,form='unformatted',access='direct',   &
+!JMD             recl=4*npvals*nparcelstot,status='unknown')
 
         if(dowr) write(outfile,*)
         if(dowr) write(outfile,*) '  pdata prec = ',prec
 
 #ifdef MPI
-        write(61,rec=prec) ((rbuf(np,n),np=0,nparcelstot-1),n=0,npvals-1)
+!JMD        write(61,rec=prec) ((rbuf(np,n),np=0,nparcelstot-1),n=0,npvals-1)
 #else
         write(61,rec=prec) ((pdata(np,n),np=1,nparcelstot),n=1,npvals)
 #endif

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -701,7 +701,7 @@
           qd_dbz,rdx,rdy,nx,ny,myi,myj,nodex,nodey,myid,nip1,njp1,nkp1,axisymm,nnc1, &
           umove,vmove,prth,prt,prqsl,prqsi,prvpg,prb,prprs,prrho,prpt1,prqv,prq1,prnc1, &
           prkm,prkh,prtke,prdbz,przv,prx,pry,prz,prtime,prq2,prnc2,prznt,prust,pru,prv, &
-          prw,prsig,time_parceli_reduce,terrain_flag
+          prw,prsig,time_parceli_reduce,time_lb,terrain_flag
       use constants
       use cm1libs , only : rslf,rsif
       use bc_module, only: bcu2_GPU, bcv2_GPU, bcw2_GPU
@@ -963,14 +963,14 @@
 !  (may not parallelize correctly if this is not done)
 
 #ifdef MPI
-      !!$acc update device(u3d,v3d,w3d)
+      call sync()
+      if(timestats.ge.1) time_lb=time_lb+mytime()
       call getcorneru_GPU(u3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-      call bcu2_GPU(u3d)
       call getcornerv_GPU(v3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-      call bcv2_GPU(v3d)
       call getcornerw_GPU(w3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+      call bcu2_GPU(u3d)
+      call bcv2_GPU(v3d)
       call bcw2_GPU(w3d)
-      !!$acc update host(u3d,v3d,w3d)
 #endif
 
 !----------------------------------------------------------------------

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1853,14 +1853,14 @@
 !!!101     format(i6.6)
 
         if(dowr) write(outfile,*) string
-!JMD        open(unit=61,file=string,form='unformatted',access='direct',   &
-!JMD             recl=4*npvals*nparcelstot,status='unknown')
+        open(unit=61,file=string,form='unformatted',access='direct',   &
+             recl=4*npvals*nparcelstot,status='unknown')
 
         if(dowr) write(outfile,*)
         if(dowr) write(outfile,*) '  pdata prec = ',prec
 
 #ifdef MPI
-!JMD        write(61,rec=prec) ((rbuf(np,n),np=0,nparcelstot-1),n=0,npvals-1)
+        write(61,rec=prec) ((rbuf(np,n),np=0,nparcelstot-1),n=0,npvals-1)
 #else
         write(61,rec=prec) ((pdata(np,n),np=1,nparcelstot),n=1,npvals)
 #endif

--- a/src/pdef.F
+++ b/src/pdef.F
@@ -14,7 +14,7 @@
 
       subroutine pdefx1(xh,arh1,arh2,uh,rho0,gz,rgz,rru,advx,dum,mass,s0,s,dt,flag,west,newwest,east,neweast,reqs_s)
       use input, only: ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,cmp,jmp,kmp,ni,nj,nk,&
-          wbc,ebc,ibw,ibe,rdx,axisymm,terrain_flag,timestats,time_pdef,mytime
+          wbc,ebc,ibw,ibe,rdx,axisymm,terrain_flag,timestats,time_pdef,time_lb,mytime
       use bc_module, only: bcs_GPU
       use comm_module
       implicit none
@@ -111,6 +111,8 @@
 
         call bcs_GPU(dum)
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_2we_start_GPU(dum,west(1,1,1),newwest(1,1,1),east(1,1,1),neweast(1,1,1),reqs_s)
 #endif
 
@@ -289,7 +291,7 @@
 
       subroutine pdefy1(vh,rho0,gz,rgz,rrv,advy,dum,mass,s0,s,dt,flag,south,newsouth,north,newnorth,reqs_s)
       use input, only: ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,cmp,imp,jmp,kmp,ni,nj,nk,&
-          sbc,nbc,ibs,ibn,rdy,axisymm,terrain_flag,timestats,time_pdef,mytime,smeps
+          sbc,nbc,ibs,ibn,rdy,axisymm,terrain_flag,timestats,time_pdef,mytime,smeps,time_lb
       use bc_module, only: bcs_GPU
       use comm_module
       implicit none
@@ -370,6 +372,8 @@
 
         call bcs_GPU(dum)
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_2sn_start_GPU(dum,south(1,1,1),newsouth(1,1,1),north(1,1,1),newnorth(1,1,1),reqs_s)
 #endif
 

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -158,7 +158,7 @@
           psolver,dolsw,nqc,nqi,nnci,nncc,zt,rzt,rdx,rdy,rdz,smeps,advwenov,advwenos, &
           time_misc13,time_misc14,time_misc15,time_misc16,time_misc17,time_misc18,time_misc19, &
           time_misc20,time_misc21,time_misc22,time_buoyan,time_advs,time_divx,time_cor, &
-          time_advu,time_integ,time_prsrho,time_cflq,mytime,cm1setup,iusetke,sgsmodel,doimpl, &
+          time_advu,time_integ,time_prsrho,time_cflq,time_lb,mytime,cm1setup,iusetke,sgsmodel,doimpl, &
           iinit,ptype,wbc,ebc,sbc,nbc,icor,betaplane,nudgeobc,alphobc,iprcl,apmasscon, &
           ibw,ibe,ibs,ibn,imoist,irdamp,hrdamp,irbc,rdalpha,iptra,lspgrad,ierr,fcor,vmove, &
           umove,hurr_rad,difforder,idiff,nqv,eqtset,idiss,rterm,iice,nql1,nql2,nqs1,nqs2, &
@@ -599,6 +599,8 @@
         call bcs_GPU(t11)
         !print *,'solve2: after call to bcs_GPU(t11) #1'
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_1s_start_GPU(t11,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
 #endif
 
@@ -1040,6 +1042,8 @@
         !print *,'solve2: point #6'
 #ifdef MPI
         IF(nrk.ge.2)THEN
+          call sync()
+          if(timestats.ge.1) time_lb=time_lb+mytime()
           call comm_1s_end_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
           call getcorner_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
           call bcs2_GPU(rho)
@@ -1140,6 +1144,8 @@
         !print *,'solve2: before bcs_GPU #2'
         call bcs_GPU(dum6)
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_1s_start_GPU(dum6,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
         call comm_1s_end_GPU(  dum6,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
 #endif
@@ -1198,6 +1204,8 @@
 
 #ifdef MPI
       IF(nrk.ge.2)THEN
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_1s_end_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
       ENDIF
 #endif
@@ -1252,6 +1260,8 @@
 
 !--------------------------------------------------------------------
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_1s_end_GPU(t11,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
 #endif
 !--------------------------------------------------------------------
@@ -1494,6 +1504,8 @@
         !print *,'solve2: point #13'
 #ifdef MPI
         IF(nrk.ge.2)THEN
+          call sync()
+          if(timestats.ge.1) time_lb=time_lb+mytime()
           call comm_3s_end_GPU(th3d,rw31,rw32,re31,re32,   &
                                 rs31,rs32,rn31,rn32,reqs_y)
         ENDIF
@@ -1615,6 +1627,8 @@
         !print *,'solve2: point #15'
 #ifdef MPI
       if( nrk.ge.2 )then
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_3s_end_GPU(q3d(ib,jb,kb,n)  &
                        ,qw31(1,1,1,n),qw32(1,1,1,n),qe31(1,1,1,n),qe32(1,1,1,n)     &
                        ,qs31(1,1,1,n),qs32(1,1,1,n),qn31(1,1,1,n),qn32(1,1,1,n)     &
@@ -1811,20 +1825,22 @@
       !print *,'solve2: point #19'
 
       call bcu_GPU(u3d)
+      call bcv_GPU(v3d)
+      call bcw_GPU(w3d,1)
 #ifdef MPI
+      call sync()
+      if(timestats.ge.1) time_lb=time_lb+mytime()
       call comm_3u_start_GPU(u3d,uw31,uw32,ue31,ue32,   &
                              us31,us32,un31,un32,reqs_u)
-#endif
-      call bcv_GPU(v3d)
-#ifdef MPI
       call comm_3v_start_GPU(v3d,vw31,vw32,ve31,ve32,   &
                              vs31,vs32,vn31,vn32,reqs_v)
 #endif
-      call bcw_GPU(w3d,1)
       if(terrain_flag) then 
         call bcwsfc(gz,dzdx,dzdy,u3d,v3d,w3d)
       endif
 #ifdef MPI
+      call sync()
+      if(timestats.ge.1) time_lb=time_lb+mytime()
       call comm_3w_start_GPU(w3d,ww31,ww32,we31,we32,   &
                              ws31,ws32,wn31,wn32,reqs_w)
 #endif
@@ -1832,19 +1848,13 @@
         !call flush(6)
         !print *,'solve2: before bcs_GPU #3'
         call bcs_GPU(rho)
-#ifdef MPI
-        call comm_1s_start_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
-#endif
-        !call flush(6)
-        !print *,'solve2: before bcs_GPU #4'
         call bcs_GPU(pp3d)
-#ifdef MPI
-        call comm_1s_start_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
-#endif
-        !call flush(6)
-        !print *,'solve2: before bcs_GPU #5'
         call bcs_GPU(th3d)
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
+        call comm_1s_start_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
+        call comm_1s_start_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
         call comm_3s_start_GPU(th3d,rw31,rw32,re31,re32,   &
                                 rs31,rs32,rn31,rn32,reqs_y)
 #endif
@@ -1884,6 +1894,8 @@
 
 #ifdef MPI
         IF(nrk.ge.2)THEN
+          call sync()
+          if(timestats.ge.1) time_lb=time_lb+mytime()
           call comm_3t_end_GPU(tke3d,tkw1,tkw2,tke1,tke2,   &
                                  tks1,tks2,tkn1,tkn2,reqs_tk)
         ENDIF
@@ -1940,6 +1952,8 @@
 
           call bcw_GPU(tke3d,1)
 #ifdef MPI
+          call sync()
+          if(timestats.ge.1) time_lb=time_lb+mytime()
           call comm_3t_start_GPU(tke3d,tkw1,tkw2,tke1,tke2,   &
                                    tks1,tks2,tkn1,tkn2,reqs_tk)
 #endif
@@ -1980,15 +1994,13 @@
         ENDIF
         if(timestats.ge.1) time_misc21=time_misc21+mytime()
 
-        !call flush(6)
-        !print *,'solve2: before bcs_GPU #7'
         call bcs_GPU(qke3d)
-        !print *,'solve2: point #22'
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_3s_start_GPU(qke3d,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_tk)
         call comm_3s_end_GPU(  qke3d,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_tk)
 #endif
-        !print *,'solve2: point #22'
         weps = 10.0*epsilon
         diffit = 0
         if( idiff.eq.1 .and. difforder.eq.6 ) diffit = 1
@@ -2063,6 +2075,8 @@
         !print *,'solve2: point #23'
 #ifdef MPI
           IF(nrk.ge.2)THEN
+            call sync()
+            if(timestats.ge.1) time_lb=time_lb+mytime()
             call comm_3s_end_GPU(pt3d(ib,jb,kb,n),                           &
                   tw1(1,1,1,n),tw2(1,1,1,n),te1(1,1,1,n),te2(1,1,1,n),   &
                   ts1(1,1,1,n),ts2(1,1,1,n),tn1(1,1,1,n),tn2(1,1,1,n),   &
@@ -2080,7 +2094,7 @@
                  flag,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,rdsf,c1,c2,rho,rr,diffit, &
                  .false.,ibdq,iedq,jbdq,jedq,kbdq,kedq,nqdiag,qdiag,1,1,1,              &
                  1,1,1,wprof,dumk1,dumk2,hadvordrs,vadvordrs,kbdy,bndy,hflxw,hflxe,hflxs,hflxn,out3d)
-      print *,'solve2: after advs'
+      !print *,'solve2: after advs'
 
       !$omp parallel do default(shared) private(i,j,k)
       !$acc parallel loop gang vector collapse(3) default(present)
@@ -2093,12 +2107,11 @@
       enddo
       if(timestats.ge.1) time_integ=time_integ+mytime()
 
-        !print *,'solve2: point #25'
       IF(nrk.le.2)THEN
-        !call flush(6)
-        !print *,'solve2: before bcs_GPU #8'
         call bcs_GPU(pt3d(ib,jb,kb,n))
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_3s_start_GPU(pt3d(ib,jb,kb,n)   &
                      ,tw1(1,1,1,n),tw2(1,1,1,n),te1(1,1,1,n),te2(1,1,1,n)     &
                      ,ts1(1,1,1,n),ts2(1,1,1,n),tn1(1,1,1,n),tn2(1,1,1,n)     &
@@ -2205,6 +2218,8 @@
         endif
         call bcs_GPU(pt3d(ib,jb,kb,n))
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_3s_start_GPU(pt3d(ib,jb,kb,n)   &
                      ,tw1(1,1,1,n),tw2(1,1,1,n),te1(1,1,1,n),te2(1,1,1,n)     &
                      ,ts1(1,1,1,n),ts2(1,1,1,n),tn1(1,1,1,n),tn2(1,1,1,n)     &

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -153,7 +153,7 @@
           jedk,kbdk,kedk,nkdiag,ibdp,iedp,jbdp,jedp,kbdp,kedp,npdiag,ib2d,ie2d,jb2d,je2d, &
           nout2d,ib3d,ie3d,jb3d,je3d,kb3d,ke3d,nout3d,nf,nu,nv,nw,testcase,myid,timestats, &
           psolver,dolsw,nqc,nqi,nnci,nncc,mytime,cm1setup,iusetke,sgsmodel,doimpl,iinit,ptype, &
-          time_prsrho,time_microphy,time_parcels,time_integ,time_dpc,time_poiss,time_swath, & 
+          time_prsrho,time_microphy,time_parcels,time_integ,time_dpc,time_poiss,time_swath,time_lb, & 
           ibw,ibe,ibs,ibn,imoist,irdamp,hrdamp,irbc,rdalpha,iptra,lspgrad,ierr,fcor,vmove, &
           umove,hurr_rad,difforder,idiff,nqv,eqtset,idiss,rterm,iice,nql1,nql2,nqs1,nqs2, &
           axisymm,dx,dy,dz,rdz,bbc,terrain_flag,radopt,use_pbl,tsmall,qsmall,dohturb,dovturb, &
@@ -359,12 +359,11 @@
       !print *,'solve3: point #1'
 !Begin:  message passing
           call bcs_GPU(pp3d)
-#ifdef MPI
-          call comm_1s_start_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
-#endif
-
           call bcs_GPU(th3d)
 #ifdef MPI
+          call sync()
+          if(timestats.ge.1) time_lb=time_lb+mytime()
+          call comm_1s_start_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
           call comm_3s_start_GPU(th3d,rw31,rw32,re31,re32,   &
                                   rs31,rs32,rn31,rn32,reqs_y)
 #endif
@@ -387,6 +386,8 @@
 
       call bcs_GPU(rho)
 #ifdef MPI
+      call sync()
+      if(timestats.ge.1) time_lb=time_lb+mytime()
       call comm_1s_start_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
 #endif
       !print *,'solve3: point #4'
@@ -405,13 +406,12 @@
       if(timestats.ge.1) time_prsrho=time_prsrho+mytime()
 
 
-        call bcs_GPU(rr)
+      call bcs_GPU(rr)
+      call bcs_GPU(rf)
 #ifdef MPI
+      call sync()
+      if(timestats.ge.1) time_lb=time_lb+mytime()
       call comm_1s_start_GPU(rr,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
-#endif
-
-        call bcs_GPU(rf)
-#ifdef MPI
       call comm_1s_start_GPU(rf,p3w1,p3w2,p3e1,p3e2,p3s1,p3s2,p3n1,p3n2,reqs_p3)
 #endif
       !print *,'solve3: point #5'
@@ -447,6 +447,8 @@
         endif
         call bcs_GPU(ppx)
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_1s_start_GPU(ppx,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
 #endif
 
@@ -557,6 +559,8 @@
       !call maxmin2dhalo(ni,nj,w3d(ib,jb,13),text1,text2)
 
 #ifdef MPI
+      call sync()
+      if(timestats.ge.1) time_lb=time_lb+mytime()
       call comm_3u_end_GPU(u3d,uw31,uw32,ue31,ue32,   &
                            us31,us32,un31,un32,reqs_u)
       call comm_3v_end_GPU(v3d,vw31,vw32,ve31,ve32,   &
@@ -568,10 +572,10 @@
 #ifdef MPI
       if(   sgsmodel.eq.5 .or. sgsmodel.eq.6 )then
         call getcorneru_GPU(u3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call bcu2_GPU(u3d)
         call getcornerv_GPU(v3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call bcv2_GPU(v3d)
         call getcornerw_GPU(w3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call bcu2_GPU(u3d)
+        call bcv2_GPU(v3d)
         call bcw2_GPU(w3d)
       endif
 #endif
@@ -660,15 +664,13 @@
         if(timestats.ge.1) time_parcels=time_parcels+mytime()
         ! bc/comms:
         call bcu_GPU(rru)
-#ifdef MPI
-        call comm_3u_start_GPU(rru,uw31,uw32,ue31,ue32,us31,us32,un31,un32,reqs_u)
-#endif
         call bcv_GPU(rrv)
-#ifdef MPI
-        call comm_3v_start_GPU(rrv,vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,reqs_v)
-#endif
         call bcw_GPU(rrw,1)
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
+        call comm_3u_start_GPU(rru,uw31,uw32,ue31,ue32,us31,us32,un31,un32,reqs_u)
+        call comm_3v_start_GPU(rrv,vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,reqs_v)
         call comm_3w_start_GPU(rrw,ww31,ww32,we31,we32,ws31,ws32,wn31,wn32,reqs_w)
 #endif
       ENDIF
@@ -732,6 +734,8 @@
 
       if( cm1setup.eq.1 .and. iusetke )then
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_3t_end_GPU(tke3d,tkw1,tkw2,tke1,tke2,   &
                                tks1,tks2,tkn1,tkn2,reqs_tk)
 #endif
@@ -779,6 +783,8 @@
 !----------
 
 #ifdef MPI
+      call sync()
+      if(timestats.ge.1) time_lb=time_lb+mytime()
       call comm_1s_end_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
       call comm_3s_end_GPU(th3d,rw31,rw32,re31,re32,rs31,rs32,rn31,rn32,reqs_y)
 #endif
@@ -826,6 +832,8 @@
 
 #ifdef MPI
         !-----
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_1s_end_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
         call getcorner_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
         call bcs2_GPU(rho)
@@ -1008,6 +1016,8 @@
           if(timestats.ge.1) time_parcels=time_parcels+mytime()
           !print *,'solve3: after call to droplet_driver' 
 #ifdef MPI
+          call sync()
+          if(timestats.ge.1) time_lb=time_lb+mytime()
           call comm_1s_tend_halo_GPU(dpten(ib,jb,kb,1))
           call comm_1s_tend_halo_GPU(dpten(ib,jb,kb,2))
 #else
@@ -1045,12 +1055,12 @@
             enddo
             if(timestats.ge.1) time_parcels=time_parcels+mytime()
             call bcs_GPU(th3d)
-#ifdef MPI
-            call comm_3s_start_GPU(th3d,rw31,rw32,re31,re32,   &
-                                    rs31,rs32,rn31,rn32,reqs_y)
-#endif
             call bcs_GPU(q3d(ib,jb,kb,nqv))
 #ifdef MPI
+            call sync()
+            if(timestats.ge.1) time_lb=time_lb+mytime()
+            call comm_3s_start_GPU(th3d,rw31,rw32,re31,re32,   &
+                                    rs31,rs32,rn31,rn32,reqs_y)
             call comm_3s_start_GPU(q3d(ib,jb,kb,nqv)  &
                        ,qw31(1,1,1,nqv),qw32(1,1,1,nqv),qe31(1,1,1,nqv),qe32(1,1,1,nqv)     &
                        ,qs31(1,1,1,nqv),qs32(1,1,1,nqv),qn31(1,1,1,nqv),qn32(1,1,1,nqv)     &

--- a/src/sound.F
+++ b/src/sound.F
@@ -23,14 +23,14 @@
                         bndy,kbdy,                                        &
                         pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
       use input, only: ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,rmp,imp,jmp,kmp, &
-          ni,nj,nk,nsound,psolver,terrain_flag,rdx,rdy,rdz,axisymm,timestats,time_sound, &
+          ni,nj,nk,nsound,psolver,terrain_flag,rdx,rdy,rdz,axisymm,timestats,time_sound,time_lb, &
           mytime,irbc,ibw,ibe,ibs,ibn,wbc,ebc,sbc,nbc,roflux,convinit,convtime,nx,ny,myid, &
           zdeep,lamx,lamy,xcent,ycent,aconv,wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound,alph
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge
       use bc_module, only: bcs_GPU, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
           ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn
-      use comm_module, only : comm_1s_start_GPU,comm_1p_end_GPU
+      use comm_module, only : comm_1s_start_GPU,comm_1p_end_GPU,sync
       use ib_module
       implicit none
 
@@ -832,6 +832,8 @@
 !          call flush(6)
           call bcs_GPU(ppd)
 #ifdef MPI
+          call sync()
+          if(timestats.ge.1) time_lb=time_lb+mytime()
           !$acc update host(ppd)
           call comm_1s_start_GPU(ppd,pw1,pw2,pe1,pe2,   &
                                  ps1,ps2,pn1,pn2,reqs_p)

--- a/src/soundcb.F
+++ b/src/soundcb.F
@@ -26,12 +26,12 @@
           ibph,ieph,jbph,jeph,kbph,keph,ni,nj,nk,nsound,terrain_flag,rdx,rdy,rdz, &
           axisymm,timestats,time_sound,mytime,irbc,ibw,ibe,ibs,ibn,wbc,ebc,sbc,nbc, &
           roflux,convinit,convtime,nx,ny,myid,zdeep,lamx,lamy,xcent,ycent,aconv, &
-          wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound
+          wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound,time_lb
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge,getdiv
       use bc_module, only : bcs_GPU, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
           ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn
-      use comm_module, only : comm_1p_end_GPU,comm_1s_start_GPU,comm_1s_end_GPU
+      use comm_module, only : comm_1p_end_GPU,comm_1s_start_GPU,comm_1s_end_GPU,sync
       use ib_module
       implicit none
 
@@ -507,6 +507,8 @@
         IF( n.lt.nloop )THEN
           call bcs_GPU(ppd)
 #ifdef MPI
+          call sync()
+          if(timestats.ge.1) time_lb=time_lb+mytime()
           call comm_1s_start_GPU(ppd,pw1,pw2,pe1,pe2,   &
                                  ps1,ps2,pn1,pn2,reqs_p)
 #endif
@@ -589,6 +591,8 @@
       if(timestats.ge.1) time_sound=time_sound+mytime()
       call bcs_GPU(phi2)
 #ifdef MPI
+      call sync()
+      if(timestats.ge.1) time_lb=time_lb+mytime()
       call comm_1s_start_GPU(phi2,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
       call comm_1s_end_GPU(  phi2,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
 #endif

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -26,12 +26,12 @@
       use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,rmp,imp,jmp,kmp,         &
           ni,nj,nk,nsound,psolver,terrain_flag,rdx,rdy,rdz,axisymm,timestats,time_sound,   &
           mytime,irbc,ibw,ibe,ibs,ibn,wbc,ebc,sbc,nbc,roflux,convinit,convtime,nx,ny,myid, &
-          zdeep,lamx,lamy,xcent,ycent,aconv,wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound
+          zdeep,lamx,lamy,xcent,ycent,aconv,wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound,time_lb
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge
       use bc_module, only : bcp, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
           ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn
-      use comm_module, only : comm_1p_start_GPU,comm_1p_end_GPU
+      use comm_module, only : comm_1p_start_GPU,comm_1p_end_GPU,sync
       use maxmin_module
       use ib_module
       implicit none
@@ -986,6 +986,8 @@
           ! 210613: call bcp, only set 1 row/column
           call bcp(ppd)
 #ifdef MPI
+          call sync()
+          if(timestats.ge.1) time_lb=time_lb+mytime()
           call comm_1p_start_GPU(ppd,pw1,pw2,pe1,pe2,   &
                                  ps1,ps2,pn1,pn2,reqs_p)
 #endif

--- a/src/turb.F
+++ b/src/turb.F
@@ -2487,17 +2487,6 @@
 
     ENDIF
      
-!    if( nstep.eq.0 .and. myid.eq.0 )then
-!      !$acc update host (grdscl)
-!      print *
-!      print *,'  zf,grdscl:'
-!      i = 1
-!      j = 1
-!      do k=2,nk
-!        print *,k,(zf(i,j,k)-zf(i,j,1)),grdscl(i,j,k)
-!      enddo
-!    endif
-
       if(timestats.ge.1) time_turb=time_turb+mytime()
 
 !------------------------------------------------------------

--- a/src/turb.F
+++ b/src/turb.F
@@ -69,7 +69,7 @@
           ib2d,ie2d,jb2d,je2d,nout2d,ib3d,ie3d,jb3d,je3d,kb3d,ke3d,nout3d,nbudget,nqs1,nqs2,nql1,nql2, &
           nnci,nncc,nqv,nqc,nqi,dx,dy,dz,umove,vmove,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,bbc,tbc, &
           terrain_flag,mytime,iice,sfcmodel,sgsmodel,myid,cm1setup,testcase,ipbl,idiss,horizturb, &
-          time_turb,time_sfcphys,time_pbl,output_dissten,use_pbl,rdx,rdy,rdz,timestats,isfcflx, &
+          time_turb,time_sfcphys,time_pbl,time_lb,output_dissten,use_pbl,rdx,rdy,rdz,timestats,isfcflx, &
           output_def,output_nm,output_km,output_kh,output_sfcflx,imoist,oceanmodel,imove, &
           viscosity,sc_num,pr_num,smeps,dot2p,use_avg_sfc,use_avg_sfc,dowr,ptype,axisymm, &
           td_diss,td_pbl,pertflx,radopt,outfile,dodomaindiag,cnst_znt,isftcflx,iz0tlnd,adapt_dt, &
@@ -1043,27 +1043,21 @@
   IF( bbc.eq.3 )THEN
     !-------------!
     call bc2d_GPU(ust)
-#ifdef MPI
-    call comm_1s2d_start_GPU(ust,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
-                             us31(1,1,1),us32(1,1,1),un31(1,1,1),un32(1,1,1),reqs_s)
-#endif
     call bc2d_GPU(u1)
-#ifdef MPI
-    call comm_1s2d_start_GPU(u1 ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
-                             us31(1,1,2),us32(1,1,2),un31(1,1,2),un32(1,1,2),reqs_u)
-#endif
     call bc2d_GPU(v1)
-#ifdef MPI
-    call comm_1s2d_start_GPU(v1 ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
-                             us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
-#endif
     call bc2d_GPU(s1)
-#ifdef MPI
-    call comm_1s2d_start_GPU(s1 ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
-                             us31(1,1,4),us32(1,1,4),un31(1,1,4),un32(1,1,4),reqs_w)
-#endif
     call bc2d_GPU(znt)
 #ifdef MPI
+    call sync()
+    if(timestats.ge.1) time_lb=time_lb+mytime()
+    call comm_1s2d_start_GPU(ust,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
+                             us31(1,1,1),us32(1,1,1),un31(1,1,1),un32(1,1,1),reqs_s)
+    call comm_1s2d_start_GPU(u1 ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
+                             us31(1,1,2),us32(1,1,2),un31(1,1,2),un32(1,1,2),reqs_u)
+    call comm_1s2d_start_GPU(v1 ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
+                             us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
+    call comm_1s2d_start_GPU(s1 ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
+                             us31(1,1,4),us32(1,1,4),un31(1,1,4),un32(1,1,4),reqs_w)
     call comm_1s2d_start_GPU(znt,uw31(1,1,5),uw32(1,1,5),ue31(1,1,5),ue32(1,1,5),  &
                              us31(1,1,5),us32(1,1,5),un31(1,1,5),un32(1,1,5),reqs_p)
 #endif
@@ -1142,22 +1136,18 @@
   IF( tbc.eq.3 )THEN
     !-------------!
     call bc2d_GPU(ustt)
-#ifdef MPI
-    call comm_1s2d_start_GPU(ustt,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
-                              us31(1,1,1),us32(1,1,1),un31(1,1,1),un32(1,1,1),reqs_s)
-#endif
     call bc2d_GPU(ut)
-#ifdef MPI
-    call comm_1s2d_start_GPU(ut ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
-                             us31(1,1,2),us32(1,1,2),un31(1,1,2),un32(1,1,2),reqs_u)
-#endif
     call bc2d_GPU(vt)
-#ifdef MPI
-    call comm_1s2d_start_GPU(vt ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
-                             us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
-#endif
     call bc2d_GPU(st)
 #ifdef MPI
+    call sync()
+    if(timestats.ge.1) time_lb=time_lb+mytime()
+    call comm_1s2d_start_GPU(ustt,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
+                              us31(1,1,1),us32(1,1,1),un31(1,1,1),un32(1,1,1),reqs_s)
+    call comm_1s2d_start_GPU(ut ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
+                             us31(1,1,2),us32(1,1,2),un31(1,1,2),un32(1,1,2),reqs_u)
+    call comm_1s2d_start_GPU(vt ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
+                             us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
     call comm_1s2d_start_GPU(st ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
                              us31(1,1,4),us32(1,1,4),un31(1,1,4),un32(1,1,4),reqs_w)
 #endif
@@ -1167,18 +1157,15 @@
     !-------------!
     call comm_1s2d_end_GPU(ustt,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
                             us31(1,1,1),us32(1,1,1),un31(1,1,1),un32(1,1,1),reqs_s)
-    call bcs2_2d_GPU(ustt)
-
     call comm_1s2d_end_GPU(ut ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
                            us31(1,1,2),us32(1,1,2),un31(1,1,2),un32(1,1,2),reqs_u)
-    call bcs2_2d_GPU(ut )
-
     call comm_1s2d_end_GPU(vt ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
                            us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
-    call bcs2_2d_GPU(vt )
-
     call comm_1s2d_end_GPU(st ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
                            us31(1,1,4),us32(1,1,4),un31(1,1,4),un32(1,1,4),reqs_w)
+    call bcs2_2d_GPU(ustt)
+    call bcs2_2d_GPU(ut )
+    call bcs2_2d_GPU(vt )
     call bcs2_2d_GPU(st )
 
     !-------------!
@@ -1517,11 +1504,13 @@
 
       if( do_ib )then
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call getcorneru_GPU(ua,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call bcu2_GPU(ua)
         call getcornerv_GPU(va,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call bcv2_GPU(va)
         call getcornerw_GPU(wa,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call bcu2_GPU(ua)
+        call bcv2_GPU(va)
         call bcw2_GPU(wa)
 #endif
       endif
@@ -2274,11 +2263,11 @@
 
       if( use_pbl )then
         call bcs_GPU(upten)
-#ifdef MPI
-        call comm_1s_start_GPU(upten,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
-#endif
         call bcs_GPU(vpten)
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
+        call comm_1s_start_GPU(upten,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
         call comm_1s_start_GPU(vpten,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_p)
 #endif
         IF( axisymm.eq.1 )THEN
@@ -2323,7 +2312,7 @@
                          kvdw1,kvdw2,kvde1,kvde2,kvds1,kvds2,kvdn1,kvdn2)
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmt,ibc,iec,jbc,jec,kbc,kec, &
           ibt,iet,jbt,jet,kbt,ket,ib3d,ie3d,jb3d,je3d,kb3d,ke3d,nout3d,ni,nj,nk, &
-          dx,dy,dz,myid,timestats,time_turb,mytime,tconfig 
+          dx,dy,dz,myid,timestats,time_turb,time_lb,mytime,tconfig 
       use constants
       use bc_module, only: bcw_GPU, bct2_GPU
       use comm_module
@@ -2515,25 +2504,18 @@
 ! Set values at boundaries, start comms:
 
       call bcw_GPU(kmh,1)
-#ifdef MPI
-      call comm_1t_start_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
-                             khcs1,khcs2,khcn1,khcn2,reqs_khc)
-#endif
-
       call bcw_GPU(kmv,1)
-#ifdef MPI
-      call comm_1t_start_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
-                             kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
-#endif
-
       call bcw_GPU(khh,1)
-#ifdef MPI
-      call comm_1t_start_GPU(khh,khdw1,khdw2,khde1,khde2,   &
-                             khds1,khds2,khdn1,khdn2,reqs_khd)
-#endif
-
       call bcw_GPU(khv,1)
 #ifdef MPI
+      call sync()
+      if(timestats.ge.1) time_lb=time_lb+mytime()
+      call comm_1t_start_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
+                             khcs1,khcs2,khcn1,khcn2,reqs_khc)
+      call comm_1t_start_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
+                             kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
+      call comm_1t_start_GPU(khh,khdw1,khdw2,khde1,khde2,   &
+                             khds1,khds2,khdn1,khdn2,reqs_khd)
       call comm_1t_start_GPU(khv,kvdw1,kvdw2,kvde1,kvde2,   &
                              kvds1,kvds2,kvdn1,kvdn2,reqs_kvd)
 #endif
@@ -2543,14 +2525,14 @@
 #ifdef MPI
       call comm_1t_end_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
                            khcs1,khcs2,khcn1,khcn2,reqs_khc)
-      call bct2_GPU(kmh)
       call comm_1t_end_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
                            kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
-      call bct2_GPU(kmv)
       call comm_1t_end_GPU(khh,khdw1,khdw2,khde1,khde2,   &
                            khds1,khds2,khdn1,khdn2,reqs_khd)
       call comm_1t_end_GPU(khv,kvdw1,kvdw2,kvde1,kvde2,   &
                            kvds1,kvds2,kvdn1,kvdn2,reqs_kvd)
+      call bct2_GPU(kmh)
+      call bct2_GPU(kmv)
       call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
       call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
 #endif
@@ -2570,7 +2552,7 @@
                        kvcw1,kvcw2,kvce1,kvce2,kvcs1,kvcs2,kvcn1,kvcn2)
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmt,ibc,iec,jbc,jec,kbc,kec, &
           ibt,iet,jbt,jet,kbt,ket,ib3d,ie3d,jb3d,je3d,kb3d,ke3d,nout3d,ni,nj,nk, &
-          dx,dy,dz,myid,timestats,time_turb,mytime,tbc,bbc
+          dx,dy,dz,myid,timestats,time_turb,time_lb,mytime,tbc,bbc
       use constants
       use bc_module, only: bc2d_GPU, bcs2_2d_GPU
       use comm_module
@@ -2626,20 +2608,15 @@
 
         !-----
         call bc2d_GPU(tkea(ibt,jbt,1))
-        !call bc2d(tkea(ibt,jbt,1))
+        call bc2d_GPU(kmh(ibc,jbc,1))
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_1s2d_start_GPU(tkea(ibt,jbt,1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
                                              kvcs1(1,1),kvcs2(1,1),kvcn1(1,1),kvcn2(1,1),reqs_kvc)
-#endif
-        call bc2d_GPU(kmh(ibc,jbc,1))
-        !call bc2d(kmh(ibc,jbc,1))
-#ifdef MPI
         call comm_1s2d_start_GPU(kmh(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                             khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
         !-----
-!!$acc update host(tkea,kmh,kmv,khh,khv,zntmp,ust,ustt)              &
-!!$acc host(khcw1,khcw2,khce1,khce2,khcs1,khcs2,khcn1,khcn2)  &
-!!$acc host(kvcw1,kvcw2,kvce1,kvce2,kvcs1,kvcs2,kvcn1,kvcn2) 
         call comm_1s2d_end_GPU(tkea(ibt,jbt,1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
                                            kvcs1(1,1),kvcs2(1,1),kvcn1(1,1),kvcn2(1,1),reqs_kvc)
         call bcs2_2d_GPU(tkea(ibt,jbt,1))
@@ -2650,9 +2627,6 @@
         !-----
         call comm_2d_corner_GPU(tkea(ibt,jbt,1))
         call comm_2d_corner_GPU(kmh(ibc,jbc,1))
-!!$acc update device(tkea,kmh,kmv,khh,khv,zntmp,ust,ustt)              &
-!!$acc device(khcw1,khcw2,khce1,khce2,khcs1,khcs2,khcn1,khcn2)  &
-!!$acc device(kvcw1,kvcw2,kvce1,kvce2,kvcs1,kvcs2,kvcn1,kvcn2) 
         !-----
 #endif
 
@@ -2688,14 +2662,12 @@
 
         !-----
         call bc2d_GPU(tkea(ibt,jbt,nk+1))
-        !call bc2d(tkea(ibt,jbt,nk+1))
+        call bc2d_GPU(kmh(ibc,jbc,nk+1))
 #ifdef MPI
+        call sync()
+        if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_1s2d_start_GPU(tkea(ibt,jbt,nk+1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
                                                 kvcs1(1,1),kvcs2(1,1),kvcn1(1,1),kvcn2(1,1),reqs_kvc)
-#endif
-        call bc2d_GPU(kmh(ibc,jbc,nk+1))
-        !call bc2d(kmh(ibc,jbc,nk+1))
-#ifdef MPI
         call comm_1s2d_start_GPU(kmh(ibc,jbc,nk+1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                                khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
         !-----

--- a/src/turb.F
+++ b/src/turb.F
@@ -2498,16 +2498,16 @@
 
     ENDIF
      
-    !$acc update host (grdscl)
-    if( nstep.eq.0 .and. myid.eq.0 )then
-      print *
-      print *,'  zf,grdscl:'
-      i = 1
-      j = 1
-      do k=2,nk
-        print *,k,(zf(i,j,k)-zf(i,j,1)),grdscl(i,j,k)
-      enddo
-    endif
+!    if( nstep.eq.0 .and. myid.eq.0 )then
+!      !$acc update host (grdscl)
+!      print *
+!      print *,'  zf,grdscl:'
+!      i = 1
+!      j = 1
+!      do k=2,nk
+!        print *,k,(zf(i,j,k)-zf(i,j,1)),grdscl(i,j,k)
+!      enddo
+!    endif
 
       if(timestats.ge.1) time_turb=time_turb+mytime()
 


### PR DESCRIPTION
This PR removes some dead code that was commented out and adds a new timer that measures load imbalance in the model.  It also eliminates a device-to-host copy that was unnecessary.  Note that to accurately measure load imbalance, a number of communication operators were grouped together  This also reduces the number of cpp  #ifdef _MPI in the code.  