### PR TITLE
More bug fixes about droplet calculation

### DIFF
--- a/src/cm1.F
+++ b/src/cm1.F
@@ -604,10 +604,6 @@ end module cuda_rt
       ni = nx / nodex
       nj = ny / nodey
       nk = nz
-      nip1 = ni+1
-      njp1 = nj+1
-      nkp1 = nk+1
-      nkm1 = nk-1
 
       nimax = ni
       njmax = nj
@@ -777,6 +773,12 @@ end module cuda_rt
 
 !-----------------------------------------------
 #endif
+
+      ! Now they are known for MPI runs 
+      nip1 = ni+1
+      njp1 = nj+1
+      nkp1 = nk+1
+      nkm1 = nk-1
 
       call wenocheck
 

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -176,6 +176,7 @@
       logical, parameter :: use_truly_random_pert  =  .false.
 
       real :: tmpx, tmpy, tmpz
+      integer :: np_tmp
 
 !--------------------------
 
@@ -427,16 +428,17 @@
           tmpz = rand*injectHMax
 
           ! check if this parcel falls into this MPI region
-          if ( tmpx .ge. xf(1) .and. tmpx .le. xf(ni+1) .and. &
-               tmpy .ge. yf(1) .and. tmpy .le. yf(nj+1) ) then
+          ! if parcel is on a tile boundary, let the eastmost/northmost tile own it
+          if ( tmpx .ge. xf(1) .and. tmpx .lt. xf(ni+1) .and. &
+               tmpy .ge. yf(1) .and. tmpy .lt. yf(nj+1) ) then
 
              pdata(i,prx) = tmpx
              pdata(i,pry) = tmpy
              pdata(i,prz) = tmpz
 
-             if(MODULO(n,100)==0) then 
-               if(dowr) write(outfile,*) i,pdata(i,prx),pdata(i,pry),pdata(i,prz)
-             endif
+!             if(MODULO(n,100)==0) then 
+!               if(dowr) write(outfile,*) i,pdata(i,prx),pdata(i,pry),pdata(i,prz)
+!             endif
 
              if (prcl_droplet.eq.1) then
     
@@ -489,6 +491,20 @@
           end if    ! end of if statement for xf/yf check
 
         end do      ! end of loop for nparcelsInit
+
+#ifdef MPI
+        ! Sanity check
+        call mpi_allreduce(nparcelsLocalActive,np_tmp,1,mpi_int,mpi_sum,mpi_comm_world,ierr)
+        if ( np_tmp .ne. nparcelsInit ) then
+           print *
+           print *,'  Error: nparcelsInit does not equal np_tmp '
+           print *
+           print *,'  nparcelsInit = ',nparcelsInit
+           print *,'  np_tmp       = ',np_tmp
+           print *
+           stop 3333
+        end if
+#endif
 
         !Here also initialize the droplet histogram arrays
         call initialize_droplet_histograms


### PR DESCRIPTION
George found more bugs in the droplet-related calculations, which include:
- A better handling of droplet initialization for droplets that fall on the tile boundary.
- A bug fix for the **nip1** and **njp1** variables that are not initialized properly in an MPI run.
---
Then I performed the verification test on Gust with the `namelist_ASD.input` namelist and `input_sounding_ASD` file. I revised the namelist for the following options to improve the reproducibility of GPU code (no droplet injection for these runs):
```
dtl    =  0.5,
timax  =  600.0,
adapt_dt = 0,
```

When comparing 4 CPUs and 4 A100 GPUs, the verification results are identical with that in PR #115.

## Metric statistics
36 stat variables are identical.
42 stat variables show a mean relative difference > 1e-06
8 stat variables show a mean relative difference <= 1e-06
four variables with largest relative errors: VOR2KM, VOR1KM, PPMIN, DIVMIN

## Droplet 0th-order diagnostic comparison:
2 stat variables are identical.
4 stat variables show a mean relative difference > 1e-06
6 stat variables show a mean relative difference <= 1e-06
four variables with largest relative errors: radmin, radmax, radavg, qfavg

## Droplet 1st-order diagnostic comparison:
256 stat variables are identical.
0 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06