### PR TITLE
Duplicate code elimination in bc.F and comm.F

### DIFF
--- a/run/gust.verify.cpu.sh
+++ b/run/gust.verify.cpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 #PBS -N cm1
 #PBS -l select=1:ncpus=2:mpiprocs=2:ompthreads=1
-#PBS -l walltime=00:20:00
+#PBS -l walltime=00:40:00
 #PBS -j oe
 #PBS -q main
 #PBS -A UNDM0006

--- a/run/gust.verify.gpu.sh
+++ b/run/gust.verify.gpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #PBS -N cm1
 #PBS -l select=1:ncpus=2:mpiprocs=2:ngpus=2:mem=100gb
-#PBS -l walltime=00:20:00
+#PBS -l walltime=00:40:00
 #PBS -j oe
 #PBS -q main
 #PBS -A UNDM0006

--- a/src/anelp.F
+++ b/src/anelp.F
@@ -26,7 +26,7 @@
           zdeep,lamx,lamy,xcent,ycent,aconv,wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge
-      use bc_module, only: bcs_GPU, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
+      use bc_module, only: bcs, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
           ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn
       use poiss_module
       implicit none
@@ -248,7 +248,7 @@
                        cfb,cfa,cfc,d1,d2,pdt,lgbth,lgbph,rhs,trans,dttmp)
 
         !$acc data copy(phi2)
-        call bcs_GPU(phi2)
+        call bcs(phi2)
         !$acc end data
 
 !---------------------------------------------------------------------

--- a/src/azimavg.F
+++ b/src/azimavg.F
@@ -2605,7 +2605,7 @@
 
       use input
       use constants
-      use bc_module, only: bc2d_GPU, bcs2_2d_GPU
+      use bc_module, only: bc2d, bcs2_2d
 #ifdef MPI
       use comm_module
       use mpi
@@ -2644,15 +2644,13 @@
       ! by default, run del^2 diffusion 100 times:
       do n=1,100
 
-        !$acc data copy(dum1)
-        call bc2d_GPU(dum1(ib,jb,1))
-        !$acc end data
+        call bc2d(dum1(ib,jb,1),device=.false.)
 #ifdef MPI
         call comm_2d_start(dum1(ib,jb,1),west,newwest,east,neweast,   &
                                          south,newsouth,north,newnorth,reqs)
         call comm_2dew_end(dum1(ib,jb,1),west,newwest,east,neweast,reqs)
         call comm_2dns_end(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs)
-        call bcs2_2d_GPU(dum1(ib,jb,1),device=.false.)
+        call bcs2_2d(dum1(ib,jb,1),device=.false.)
         call comm_2d_corner(dum1(ib,jb,1))
 #endif
 
@@ -2675,15 +2673,13 @@
 
       enddo
 
-        !$acc data copy(dum1)
-        call bc2d_GPU(dum1(ib,jb,1))
-        !$acc end data
+        call bc2d(dum1(ib,jb,1),device=.false.)
 #ifdef MPI
         call comm_2d_start(dum1(ib,jb,1),west,newwest,east,neweast,   &
                                          south,newsouth,north,newnorth,reqs)
         call comm_2dew_end(dum1(ib,jb,1),west,newwest,east,neweast,reqs)
         call comm_2dns_end(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs)
-        call bcs2_2d_GPU(dum1(ib,jb,1),device=.false.)
+        call bcs2_2d(dum1(ib,jb,1),device=.false.)
         call comm_2d_corner(dum1(ib,jb,1))
 #endif
 

--- a/src/azimavg.F
+++ b/src/azimavg.F
@@ -2605,7 +2605,7 @@
 
       use input
       use constants
-      use bc_module, only: bc2d_GPU, bcs2_2d
+      use bc_module, only: bc2d_GPU, bcs2_2d_GPU
 #ifdef MPI
       use comm_module
       use mpi
@@ -2652,7 +2652,7 @@
                                          south,newsouth,north,newnorth,reqs)
         call comm_2dew_end(dum1(ib,jb,1),west,newwest,east,neweast,reqs)
         call comm_2dns_end(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs)
-        call bcs2_2d(dum1(ib,jb,1))
+        call bcs2_2d_GPU(dum1(ib,jb,1),device=.false.)
         call comm_2d_corner(dum1(ib,jb,1))
 #endif
 
@@ -2683,7 +2683,7 @@
                                          south,newsouth,north,newnorth,reqs)
         call comm_2dew_end(dum1(ib,jb,1),west,newwest,east,neweast,reqs)
         call comm_2dns_end(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs)
-        call bcs2_2d(dum1(ib,jb,1))
+        call bcs2_2d_GPU(dum1(ib,jb,1),device=.false.)
         call comm_2d_corner(dum1(ib,jb,1))
 #endif
 

--- a/src/base.F
+++ b/src/base.F
@@ -34,8 +34,8 @@
                       sw31,sw32,se31,se32,ss31,ss32,sn31,sn32)
       use input
       use constants
-      use bc_module, only: bcu_GPU, bcv_GPU, bcs_GPU, extrapbcs, &
-          bcu2_GPU, bcv2_GPU
+      use bc_module, only: bcu, bcv, bcs, extrapbcs, &
+          bcu2, bcv2
       use comm_module
       use goddard_module, only : T0K,T00K,RT0
       use cm1libs , only : rslf,rsif
@@ -2028,13 +2028,13 @@
 !  fill in ghost cells
 
       !$acc data copy(pi0,prs0,th0,qv0,qc0,qi0,rh0)
-      call bcs_GPU(pi0)
-      call bcs_GPU(prs0)
-      call bcs_GPU(th0)
-      call bcs_GPU(qv0)
-      call bcs_GPU(qc0)
-      call bcs_GPU(qi0)
-      call bcs_GPU(rh0)
+      call bcs(pi0)
+      call bcs(prs0)
+      call bcs(th0)
+      call bcs(qv0)
+      call bcs(qc0)
+      call bcs(qi0)
+      call bcs(rh0)
       !$acc end data
        
 
@@ -2129,7 +2129,7 @@
     enddo
 
       !$acc data copy(rho0)
-      call bcs_GPU(rho0)
+      call bcs(rho0)
       !$acc end data
 #ifdef MPI
       call comm_all_s(rho0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
@@ -2660,8 +2660,8 @@
 !  Fill in ghost cells
 
       !$acc data copy(u0,v0)
-      call bcu_GPU(u0)
-      call bcv_GPU(v0)
+      call bcu(u0)
+      call bcv(v0)
       !$acc end data
 
       !--------
@@ -2673,7 +2673,7 @@
       call getcorneru3(u0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
                           s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
       !$acc data copy(u0)
-      call bcu2_GPU(u0)
+      call bcu2(u0)
       !$acc end data
 #endif
 !$omp parallel do default(shared)   &
@@ -2693,7 +2693,7 @@
       call getcornerv3(v0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
                           s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
       !$acc data copy(v0)
-      call bcv2_GPU(v0)
+      call bcv2(v0)
       !$acc end data
 #endif
 !$omp parallel do default(shared)   &

--- a/src/base.F
+++ b/src/base.F
@@ -36,7 +36,7 @@
       use constants
       use bc_module, only: bcu, bcv, bcs, extrapbcs, &
           bcu2, bcv2
-      use comm_module, only: comm_all_s_GPU, getcorneru3,getcornerv3, &
+      use comm_module, only: comm_all_s_GPU,getcorneru3_GPU,getcornerv3_GPU, &
           comm_3u_start,comm_3u_end,comm_3v_start,comm_3v_end
       use goddard_module, only : T0K,T00K,RT0
       use cm1libs , only : rslf,rsif
@@ -2671,8 +2671,8 @@
                             us31,us32,un31,un32,reqs_u)
       call comm_3u_end(u0,uw31,uw32,ue31,ue32,   &
                           us31,us32,un31,un32,reqs_u)
-      call getcorneru3(u0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
-                          s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
+      call getcorneru3_GPU(u0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
+                          s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1),device=.false.)
       !$acc data copy(u0)
       call bcu2(u0)
       !$acc end data
@@ -2691,8 +2691,8 @@
                             vs31,vs32,vn31,vn32,reqs_v)
       call comm_3v_end(v0,vw31,vw32,ve31,ve32,   &
                           vs31,vs32,vn31,vn32,reqs_v)
-      call getcornerv3(v0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
-                          s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
+      call getcornerv3_GPU(v0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
+                          s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1),device=.false.)
       !$acc data copy(v0)
       call bcv2(v0)
       !$acc end data

--- a/src/base.F
+++ b/src/base.F
@@ -36,7 +36,8 @@
       use constants
       use bc_module, only: bcu, bcv, bcs, extrapbcs, &
           bcu2, bcv2
-      use comm_module
+      use comm_module, only: comm_all_s_GPU, getcorneru3,getcornerv3, &
+          comm_3u_start,comm_3u_end,comm_3v_start,comm_3v_end
       use goddard_module, only : T0K,T00K,RT0
       use cm1libs , only : rslf,rsif
       use turb_module , only : ramp_up_turb
@@ -2043,20 +2044,20 @@
       nu=0
       nv=0
       nw=0
-     call comm_all_s( pi0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
-      call comm_all_s(prs0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
-      call comm_all_s( th0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
-      call comm_all_s( qv0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
-      call comm_all_s( qc0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
-      call comm_all_s( qi0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
-      call comm_all_s( rh0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
+     call comm_all_s_GPU( pi0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
+      call comm_all_s_GPU(prs0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
+      call comm_all_s_GPU( th0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
+      call comm_all_s_GPU( qv0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
+      call comm_all_s_GPU( qc0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
+      call comm_all_s_GPU( qi0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
+      call comm_all_s_GPU( rh0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
 #endif
 
       !$acc data copy(pi0,prs0,th0,qv0,qc0,qi0,rh0)
@@ -2132,8 +2133,8 @@
       call bcs(rho0)
       !$acc end data
 #ifdef MPI
-      call comm_all_s(rho0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
+      call comm_all_s_GPU(rho0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+                         n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
 #endif
       !$acc data copy(rho0)
       call extrapbcs(rho0)

--- a/src/bc.F
+++ b/src/bc.F
@@ -9,15 +9,8 @@
   public :: restrict_openbc_sn, restrict_openbc_we
   public :: ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn, bcs_tend_halo
 
-  !CPU only 
-  public :: bcs
-
   !MPI + GPU enabled
   public :: bcs2_GPU, bct2_GPU, bcu2_GPU, bcv2_GPU, bcw2_GPU, bcs2_2d_gpu
-
-  !MPI CPU only 
-  public :: bcs2_2d
-
 
   CONTAINS
 
@@ -190,177 +183,9 @@
 
       end subroutine bcp
 
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine bcw(w,flag)
-      use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc,ngxy, &
-          ibw,ibe,ibs,ibn,ni,nj,nk,timestats,time_bc,mytime
-      implicit none
-
-      real, dimension(ib:ie,jb:je,kb:ke+1) :: w
-      integer flag
-
-      integer i,j,k
-
-!-----------------------------------------------------------------------
-!  west boundary condition
-
-!$omp parallel do default(shared) private(i,j,k)
-    DO k=2,nk
-
-#ifndef MPI
-      if(wbc.eq.1)then
-        do j=jb,je
-        do i=1,ngxy
-          w(1-i,j,k)=w(ni+1-i,j,k)
-        enddo
-        enddo
-      elseif(wbc.eq.2)then
-#else
-      if(ibw.eq.1.and.wbc.eq.2)then
-#endif
-        do j=0,nj+1
-        do i=1-ngxy,0
-          w(i,j,k)=w(1,j,k)
-        enddo
-        enddo
-#ifdef MPI
-      elseif(ibw.eq.1.and.(wbc.eq.3.or.wbc.eq.4))then
-#else
-      elseif(wbc.eq.3.or.wbc.eq.4)then
-#endif
-        do j=0,nj+1
-        do i=1,ngxy
-          w(1-i,j,k)=w(i,j,k)
-        enddo
-        enddo
-      endif
-
-!-----------------------------------------------------------------------
-!  east boundary condition
-
-#ifndef MPI
-      if(ebc.eq.1)then
-        do j=jb,je
-        do i=1,ngxy
-          w(ni+i,j,k)=w(i,j,k)
-        enddo
-        enddo
-      elseif(ebc.eq.2)then
-#else
-      if(ibe.eq.1.and.ebc.eq.2)then
-#endif
-        do j=0,nj+1
-        do i=ni+1,ni+ngxy
-          w(i,j,k)=w(ni,j,k)
-        enddo
-        enddo
-#ifdef MPI
-      elseif(ibe.eq.1.and.(ebc.eq.3.or.ebc.eq.4))then
-#else
-      elseif(ebc.eq.3.or.ebc.eq.4)then
-#endif
-        do j=0,nj+1
-        do i=1,ngxy
-          w(ni+i,j,k)=w(ni+1-i,j,k)
-        enddo
-        enddo
-      endif
-
-!-----------------------------------------------------------------------
-!  south boundary condition
-
-#ifndef MPI
-      if(sbc.eq.1)then
-        do j=1,ngxy
-        do i=ib,ie
-          w(i,1-j,k)=w(i,nj+1-j,k)
-        enddo
-        enddo
-      elseif(sbc.eq.2)then
-#else
-      if(ibs.eq.1.and.sbc.eq.2)then
-#endif
-        do j=1-ngxy,0
-        do i=0,ni+1
-          w(i,j,k)=w(i,1,k)
-        enddo
-        enddo
-#ifdef MPI
-      elseif(ibs.eq.1.and.(sbc.eq.3.or.sbc.eq.4))then
-#else
-      elseif(sbc.eq.3.or.sbc.eq.4)then
-#endif
-        do j=1,ngxy
-        do i=0,ni+1
-          w(i,1-j,k)=w(i,j,k)
-        enddo
-        enddo
-      endif
-
-!-----------------------------------------------------------------------
-!  north boundary condition
-
-#ifndef MPI
-      if(nbc.eq.1)then
-        do j=1,ngxy
-        do i=ib,ie
-          w(i,nj+j,k)=w(i,j,k)
-        enddo
-        enddo
-      elseif(nbc.eq.2)then
-#else
-      if(ibn.eq.1.and.nbc.eq.2)then
-#endif
-        do j=nj+1,nj+ngxy
-        do i=0,ni+1
-          w(i,j,k)=w(i,nj,k)
-        enddo
-        enddo
-#ifdef MPI
-      elseif(ibn.eq.1.and.(nbc.eq.3.or.nbc.eq.4))then
-#else
-      elseif(nbc.eq.3.or.nbc.eq.4)then
-#endif
-        do j=1,ngxy
-        do i=0,ni+1
-          w(i,nj+j,k)=w(i,nj+1-j,k)
-        enddo
-        enddo
-      endif
-
-    ENDDO
-
-!-----------------------------------------------------------------------
-!  top/bottom boundary condition
-
-    IF(flag.eq.1)THEN
-
-!$omp parallel do default(shared) private(i,j)
-      do j=0,nj+1
-      do i=0,ni+1
-        w(i,j, 1)=0.0
-        w(i,j,nk+1)=0.0
-      enddo
-      enddo
-
-    ENDIF
-
-!-----------------------------------------------------------------------
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-      end subroutine bcw
-
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
 
       subroutine bcwsfc(gz,dzdx,dzdy,u,v,w)
       use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ni,nj, &
@@ -509,138 +334,10 @@
 
 
 #ifdef MPI
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine bct2(t)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
-          ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
-          patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
-      implicit none
-
-      real t(ib:ie,jb:je,kb:ke+1)
-
-      integer i,j,k
-
-!---------------------------------------------------------
-!  This subroutine sets the corner points
-!---------------------------------------------------------
-
-      if(ibw.eq.1)then
-
-        if(patchsww)then
-          j=0
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-          do k=1,nk+1
-          do i=1-ngxy,0
-            t(i,j,k)=t(1,j,k)
-          enddo
-          enddo
-        endif
-
-        if(patchnww)then
-          j=nj+1
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-          do k=1,nk+1
-          do i=1-ngxy,0
-            t(i,j,k)=t(1,j,k)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(ibe.eq.1)then
-
-        if(patchsee)then
-          j=0
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-          do k=1,nk+1
-          do i=ni+1,ni+ngxy
-            t(i,j,k)=t(ni,j,k)
-          enddo
-          enddo
-        endif
-
-        if(patchnee)then
-          j=nj+1
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-          do k=1,nk+1
-          do i=ni+1,ni+ngxy
-            t(i,j,k)=t(ni,j,k)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(ibs.eq.1)then
-
-        if(patchsws)then
-          i=0
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-          do k=1,nk+1
-          do j=1-ngxy,0
-            t(i,j,k)=t(i,1,k)
-          enddo
-          enddo
-        endif
-
-        if(patchses)then
-          i=ni+1
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-          do k=1,nk+1
-          do j=1-ngxy,0
-            t(i,j,k)=t(i,1,k)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(ibn.eq.1)then
-
-        if(patchnwn)then
-          i=0
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-          do k=1,nk+1
-          do j=nj+1,nj+ngxy
-            t(i,j,k)=t(i,nj,k)
-          enddo
-          enddo
-        endif
-
-        if(patchnen)then
-          i=ni+1
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-          do k=1,nk+1
-          do j=nj+1,nj+ngxy
-            t(i,j,k)=t(i,nj,k)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-      end subroutine bct2
-
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
 
       subroutine bct2_GPU(t)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
@@ -1020,12 +717,9 @@
 
       end subroutine bcv2_GPU
 
-
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
 
       subroutine bcw2_GPU(w)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
@@ -1149,22 +843,24 @@
 
       end subroutine bcw2_GPU
 
-
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-
-      subroutine bcs2_2d(s)
+      subroutine bcs2_2d_GPU(s,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
           ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
           patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real s(ib:ie,jb:je)
+      logical, optional, intent(in) :: device
 
       integer i,j
+      logical :: openacc
+
+      !Setup GPU specific parameters
+      call SetGPUParams(openacc,device)
 
 !---------------------------------------------------------
 !  This subroutine sets the corner points
@@ -1173,6 +869,7 @@
       if(ibw.eq.1)then
 
         if(patchsww)then
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do j=-2,0
           do i=1-ngxy,0
           s(i,j)=s(1,j)
@@ -1181,6 +878,7 @@
         endif
 
         if(patchnww)then
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do j=nj+1,nj+3
           do i=1-ngxy,0
           s(i,j)=s(1,j)
@@ -1193,6 +891,7 @@
       if(ibe.eq.1)then
 
         if(patchsee)then
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do j=-2,0
           do i=ni+1,ni+ngxy
           s(i,j)=s(ni,j)
@@ -1201,6 +900,7 @@
         endif
 
         if(patchnee)then
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do j=nj+1,nj+3
           do i=ni+1,ni+ngxy
           s(i,j)=s(ni,j)
@@ -1213,6 +913,7 @@
       if(ibs.eq.1)then
 
         if(patchsws)then
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do j=1-ngxy,0
           do i=-2,0
           s(i,j)=s(i,1)
@@ -1221,6 +922,7 @@
         endif
 
         if(patchses)then
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do j=1-ngxy,0
           do i=ni+1,ni+3
           s(i,j)=s(i,1)
@@ -1233,6 +935,7 @@
       if(ibn.eq.1)then
 
         if(patchnwn)then
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do j=nj+1,nj+ngxy
           do i=-2,0
           s(i,j)=s(i,nj)
@@ -1241,117 +944,7 @@
         endif
 
         if(patchnen)then
-          do j=nj+1,nj+ngxy
-          do i=ni+1,ni+3
-          s(i,j)=s(i,nj)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-      end subroutine bcs2_2d
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine bcs2_2d_GPU(s)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
-          ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
-          patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
-      implicit none
-
-      real s(ib:ie,jb:je)
-
-      integer i,j
-
-!---------------------------------------------------------
-!  This subroutine sets the corner points
-!---------------------------------------------------------
-
-      if(ibw.eq.1)then
-
-        if(patchsww)then
-!$acc parallel loop gang vector collapse(2) default(present)
-          do j=-2,0
-          do i=1-ngxy,0
-          s(i,j)=s(1,j)
-          enddo
-          enddo
-        endif
-
-        if(patchnww)then
-!$acc parallel loop gang vector collapse(2) default(present)
-          do j=nj+1,nj+3
-          do i=1-ngxy,0
-          s(i,j)=s(1,j)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(ibe.eq.1)then
-
-        if(patchsee)then
-!$acc parallel loop gang vector collapse(2) default(present)
-          do j=-2,0
-          do i=ni+1,ni+ngxy
-          s(i,j)=s(ni,j)
-          enddo
-          enddo
-        endif
-
-        if(patchnee)then
-!$acc parallel loop gang vector collapse(2) default(present)
-          do j=nj+1,nj+3
-          do i=ni+1,ni+ngxy
-          s(i,j)=s(ni,j)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(ibs.eq.1)then
-
-        if(patchsws)then
-!$acc parallel loop gang vector collapse(2) default(present)
-          do j=1-ngxy,0
-          do i=-2,0
-          s(i,j)=s(i,1)
-          enddo
-          enddo
-        endif
-
-        if(patchses)then
-!$acc parallel loop gang vector collapse(2) default(present)
-          do j=1-ngxy,0
-          do i=ni+1,ni+3
-          s(i,j)=s(i,1)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(ibn.eq.1)then
-
-        if(patchnwn)then
-!$acc parallel loop gang vector collapse(2) default(present)
-          do j=nj+1,nj+ngxy
-          do i=-2,0
-          s(i,j)=s(i,nj)
-          enddo
-          enddo
-        endif
-
-        if(patchnen)then
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do j=nj+1,nj+ngxy
           do i=ni+1,ni+3
           s(i,j)=s(i,nj)
@@ -2371,193 +1964,20 @@
 
       end subroutine bc2d_GPU
 
-      subroutine bcs(s)
-      use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
-          ibw,ibe,ibs,ibn,timestats,time_bc,mytime
-      implicit none
-
-      real, dimension(ib:ie,jb:je,kb:ke) :: s
-
-      integer i,j,k
-
-!-----------------------------------------------------------------------
-!  west boundary condition
-
-
-#ifndef MPI
-      if(wbc.eq.1)then
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=jb,je
-        do i=1,ngxy
-          s(1-i,j,k)=s(ni+1-i,j,k)
-        enddo
-        enddo
-    ENDDO
-      elseif(wbc.eq.2)then
-#else
-      if(ibw.eq.1.and.wbc.eq.2)then
-#endif
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=0,nj+1
-        do i=1-ngxy,0
-          s(i,j,k)=s(1,j,k)
-        enddo
-        enddo
-    ENDDO
-#ifdef MPI
-      elseif(ibw.eq.1.and.(wbc.eq.3.or.wbc.eq.4))then
-#else
-      elseif(wbc.eq.3.or.wbc.eq.4)then
-#endif
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=0,nj+1
-        do i=1,ngxy
-          s(1-i,j,k)=s(i,j,k)
-        enddo
-        enddo
-    ENDDO
-      endif
-
-!-----------------------------------------------------------------------
-!  east boundary condition
-
-
-#ifndef MPI
-      if(ebc.eq.1)then
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=jb,je
-        do i=1,ngxy
-          s(ni+i,j,k)=s(i,j,k)
-        enddo
-        enddo
-    ENDDO
-      elseif(ebc.eq.2)then
-#else
-      if(ibe.eq.1.and.ebc.eq.2)then
-#endif
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=0,nj+1
-        do i=ni+1,ni+ngxy
-          s(i,j,k)=s(ni,j,k)
-        enddo
-        enddo
-    ENDDO
-#ifdef MPI
-      elseif(ibe.eq.1.and.(ebc.eq.3.or.ebc.eq.4))then
-#else
-      elseif(ebc.eq.3.or.ebc.eq.4)then
-#endif
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=0,nj+1
-        do i=1,ngxy
-          s(ni+i,j,k)=s(ni+1-i,j,k)
-        enddo
-        enddo
-    ENDDO
-      endif
-
-!-----------------------------------------------------------------------
-!  south boundary condition
-
-
-#ifndef MPI
-      if(sbc.eq.1)then
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=1,ngxy
-        do i=ib,ie
-          s(i,1-j,k)=s(i,nj+1-j,k)
-        enddo
-        enddo
-    ENDDO
-      elseif(sbc.eq.2)then
-#else
-      if(ibs.eq.1.and.sbc.eq.2)then
-#endif
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=1-ngxy,0
-        do i=0,ni+1
-          s(i,j,k)=s(i,1,k)
-        enddo
-        enddo
-    ENDDO
-#ifdef MPI
-      elseif(ibs.eq.1.and.(sbc.eq.3.or.sbc.eq.4))then
-#else
-      elseif(sbc.eq.3.or.sbc.eq.4)then
-#endif
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=1,ngxy
-        do i=0,ni+1
-          s(i,1-j,k)=s(i,j,k)
-        enddo
-        enddo
-    ENDDO
-      endif
-!-----------------------------------------------------------------------
-!  north boundary condition
-
-
-#ifndef MPI
-      if(nbc.eq.1)then
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=1,ngxy
-        do i=ib,ie
-          s(i,nj+j,k)=s(i,j,k)
-        enddo
-        enddo
-    ENDDO
-      elseif(nbc.eq.2)then
-#else
-      if(ibn.eq.1.and.nbc.eq.2)then
-#endif
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=nj+1,nj+ngxy
-        do i=0,ni+1
-          s(i,j,k)=s(i,nj,k)
-        enddo
-        enddo
-    ENDDO
-#ifdef MPI
-      elseif(ibn.eq.1.and.(nbc.eq.3.or.nbc.eq.4))then
-#else
-      elseif(nbc.eq.3.or.nbc.eq.4)then
-#endif
-    !$omp parallel do default(shared) private(i,j,k)
-    DO k=1,nk
-        do j=1,ngxy
-        do i=0,ni+1
-          s(i,nj+j,k)=s(i,nj+1-j,k)
-        enddo
-        enddo
-    ENDDO
-      endif
-!-----------------------------------------------------------------------
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-      end subroutine bcs
-
-      subroutine bcs_GPU(s)
+      subroutine bcs_GPU(s,device)
       use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
           ibw,ibe,ibs,ibn,timestats,time_bcs,mytime
       implicit none
 
       real, dimension(ib:ie,jb:je,kb:ke) :: s
+      logical, optional :: device
 
       integer i,j,k
+      logical :: openacc
 
-      !$acc data present(s)
+      call SetGPUParams(openacc,device)
+
+      !!$acc data present(s)
 
 !-----------------------------------------------------------------------
 !  west boundary condition
@@ -2565,8 +1985,7 @@
 #ifndef MPI
       if(wbc.eq.1)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(3)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
            do j=jb,je
               do i=1,ngxy
@@ -2574,14 +1993,12 @@
               end do
            end do
         end do
-        !$acc end parallel
       elseif(wbc.eq.2)then
 #else
       if(ibw.eq.1.and.wbc.eq.2)then
 #endif
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(3)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
            do j=0,nj+1
               do i=1-ngxy,0
@@ -2589,15 +2006,13 @@
               end do
            end do
         end do
-        !$acc end parallel
 #ifdef MPI
       elseif(ibw.eq.1.and.(wbc.eq.3.or.wbc.eq.4))then
 #else
       elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
        !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
+       !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
        do k=1,nk
           do j=0,nj+1
              do i=1,ngxy
@@ -2605,7 +2020,6 @@
              enddo
           enddo
        end do
-       !$acc end parallel
       endif
 
 !-----------------------------------------------------------------------
@@ -2614,8 +2028,7 @@
 #ifndef MPI
       if(ebc.eq.1)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(3)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
            do j=jb,je
               do i=1,ngxy
@@ -2623,14 +2036,12 @@
               end do
            end do
         end do
-        !$acc end parallel
       elseif(ebc.eq.2)then
 #else
       if(ibe.eq.1.and.ebc.eq.2)then
 #endif
        !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
+       !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
        do k=1,nk
           do j=0,nj+1
              do i=ni+1,ni+ngxy
@@ -2638,15 +2049,13 @@
              end do
           end do
        end do
-       !$acc end parallel
 #ifdef MPI
       elseif(ibe.eq.1.and.(ebc.eq.3.or.ebc.eq.4))then
 #else
       elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
        !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
+       !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
        do k=1,nk
           do j=0,nj+1
              do i=1,ngxy
@@ -2654,7 +2063,6 @@
              end do
           end do
        end do 
-       !$acc end parallel
       endif
 
 !-----------------------------------------------------------------------
@@ -2663,8 +2071,7 @@
 #ifndef MPI
       if(sbc.eq.1)then
        !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
+       !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
        do k=1,nk
           do j=1,ngxy
              do i=ib,ie
@@ -2672,14 +2079,12 @@
              end do
           end do
        end do 
-       !$acc end parallel
       elseif(sbc.eq.2)then
 #else
       if(ibs.eq.1.and.sbc.eq.2)then
 #endif
        !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
+       !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
        do k=1,nk
           do j=1-ngxy,0
              do i=0,ni+1
@@ -2687,15 +2092,13 @@
              end do
           end do
        end do 
-       !$acc end parallel
 #ifdef MPI
       elseif(ibs.eq.1.and.(sbc.eq.3.or.sbc.eq.4))then
 #else
       elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
        !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
+       !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
        do k=1,nk
           do j=1,ngxy
              do i=0,ni+1
@@ -2703,7 +2106,6 @@
              end do
           end do
        end do 
-       !$acc end parallel
       endif
 
 !-----------------------------------------------------------------------
@@ -2712,8 +2114,7 @@
 #ifndef MPI
       if(nbc.eq.1)then
        !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
+       !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
        do k=1,nk
           do j=1,ngxy
              do i=ib,ie
@@ -2721,14 +2122,12 @@
              end do
           end do
        end do 
-       !$acc end parallel
       elseif(nbc.eq.2)then
 #else
       if(ibn.eq.1.and.nbc.eq.2)then
 #endif
        !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present)
-       !$acc loop gang vector collapse(3)
+       !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
        do k=1,nk
           do j=nj+1,nj+ngxy
              do i=0,ni+1
@@ -2736,15 +2135,13 @@
              end do
           end do
        end do
-       !$acc end parallel
 #ifdef MPI
       elseif(ibn.eq.1.and.(nbc.eq.3.or.nbc.eq.4))then
 #else
       elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
        !$omp parallel do default(shared) private(i,j,k)
-       !$acc parallel default(present) private(i,j,k)
-       !$acc loop gang vector collapse(3)
+       !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
        do k=1,nk
           do j=1,ngxy
              do i=0,ni+1
@@ -2752,12 +2149,11 @@
              end do
           end do
        end do 
-       !$acc end parallel
       endif
 
 !-----------------------------------------------------------------------
 
-      !$acc end data
+      !!$acc end data
 
       if(timestats.ge.1) time_bcs=time_bcs+mytime()
 
@@ -3412,132 +2808,6 @@
       if(timestats.ge.1) time_bc=time_bc+mytime()
  
       end subroutine bcw_GPU
-
-#if 0
-
-   subroutine bcs2(s)
-      use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
-          ibw,ibe,ibs,ibn,timestats,time_bc,mytime,patchsww,patchnww, &
-          patchsee,patchnee,patchsws,patchses,patchnwn,patchnen
-      implicit none
-
-      real s(ib:ie,jb:je,kb:ke)
-
-      integer i,j,k
-
-!---------------------------------------------------------
-!  This subroutine sets the corner points
-!---------------------------------------------------------
-
-      if(ibw.eq.1)then
-
-        if(patchsww)then
-          j=0
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-          do k=1,nk
-          do i=1-ngxy,0
-            s(i,j,k)=s(1,j,k)
-          enddo
-          enddo
-        endif
-
-        if(patchnww)then
-          j=nj+1
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-          do k=1,nk
-          do i=1-ngxy,0
-            s(i,j,k)=s(1,j,k)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(ibe.eq.1)then
-
-        if(patchsee)then
-          j=0
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-          do k=1,nk
-          do i=ni+1,ni+ngxy
-            s(i,j,k)=s(ni,j,k)
-          enddo
-          enddo
-        endif
-
-        if(patchnee)then
-          j=nj+1
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-          do k=1,nk
-          do i=ni+1,ni+ngxy
-            s(i,j,k)=s(ni,j,k)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(ibs.eq.1)then
-
-        if(patchsws)then
-          i=0
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-          do k=1,nk
-          do j=1-ngxy,0
-            s(i,j,k)=s(i,1,k)
-          enddo
-          enddo
-        endif
-
-        if(patchses)then
-          i=ni+1
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-          do k=1,nk
-          do j=1-ngxy,0
-            s(i,j,k)=s(i,1,k)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(ibn.eq.1)then
-
-        if(patchnwn)then
-          i=0
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-          do k=1,nk
-          do j=nj+1,nj+ngxy
-            s(i,j,k)=s(i,nj,k)
-          enddo
-          enddo
-        endif
-
-        if(patchnen)then
-          i=ni+1
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-          do k=1,nk
-          do j=nj+1,nj+ngxy
-            s(i,j,k)=s(i,nj,k)
-          enddo
-          enddo
-        endif
-
-      endif
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-      end subroutine bcs2
-
-#endif
 
       subroutine bcs2_GPU(s,device)
       use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &

--- a/src/bc.F
+++ b/src/bc.F
@@ -4,13 +4,13 @@
   private
 
   !GPU enabled
-  public :: bc2d_GPU, bcu_GPU, bcv_GPU, bcw_GPU, bcs_GPU, bcp, bcwsfc
+  public :: bc2d, bcu, bcv, bcw, bcs, bcp, bcwsfc
   public :: radbcew, radbcns, radbcew4, radbcns4, extrapbcs
   public :: restrict_openbc_sn, restrict_openbc_we
   public :: ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn, bcs_tend_halo
 
   !MPI + GPU enabled
-  public :: bcs2_GPU, bct2_GPU, bcu2_GPU, bcv2_GPU, bcw2_GPU, bcs2_2d_gpu
+  public :: bcs2, bct2, bcu2, bcv2, bcw2, bcs2_2d
 
   CONTAINS
 
@@ -19,23 +19,26 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine bcp(p)
+      subroutine bcp(p,device)
       use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc, &
           ibw,ibe,ibs,ibn,ni,nj,nk,timestats,time_bc,mytime
       implicit none
 
       real, dimension(ib:ie,jb:je,kb:ke) :: p
+      logical, optional, intent(in) :: device
 
       integer i,j,k
+      logical :: openacc 
       !$acc declare present(p)
 
+      call SetGPUParams(openacc,device)
 !-----------------------------------------------------------------------
 !  west boundary condition
 
 #ifndef MPI
       if(wbc.eq.1)then
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=0,nj+1
           p(0,j,k)=p(ni,j,k)
@@ -46,7 +49,7 @@
       if(ibw.eq.1.and.wbc.eq.2)then
 #endif
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=0,nj+1
           p(0,j,k)=p(1,j,k)
@@ -58,7 +61,7 @@
       elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=0,nj+1
           p(0,j,k)=p(1,j,k)
@@ -72,7 +75,7 @@
 #ifndef MPI
       if(ebc.eq.1)then
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=0,nj+1
           p(ni+1,j,k)=p(1,j,k)
@@ -83,7 +86,7 @@
       if(ibe.eq.1.and.ebc.eq.2)then
 #endif
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=0,nj+1
           p(ni+1,j,k)=p(ni,j,k)
@@ -95,7 +98,7 @@
       elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=0,nj+1
           p(ni+1,j,k)=p(ni,j,k)
@@ -109,7 +112,7 @@
 #ifndef MPI
       if(sbc.eq.1)then
         !$omp parallel do default(shared) private(i,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=0,ni+1
           p(i,0,k)=p(i,nj,k)
@@ -120,7 +123,7 @@
       if(ibs.eq.1.and.sbc.eq.2)then
 #endif
         !$omp parallel do default(shared) private(i,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=0,ni+1
           p(i,0,k)=p(i,1,k)
@@ -132,7 +135,7 @@
       elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
         !$omp parallel do default(shared) private(i,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=0,ni+1
           p(i,0,k)=p(i,1,k)
@@ -146,7 +149,7 @@
 #ifndef MPI
       if(nbc.eq.1)then
         !$omp parallel do default(shared) private(i,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=0,ni+1
           p(i,nj+1,k)=p(i,1,k)
@@ -157,7 +160,7 @@
       if(ibn.eq.1.and.nbc.eq.2)then
 #endif
         !$omp parallel do default(shared) private(i,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=0,ni+1
           p(i,nj+1,k)=p(i,nj,k)
@@ -169,7 +172,7 @@
       elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
         !$omp parallel do default(shared) private(i,k)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=0,ni+1
           p(i,nj+1,k)=p(i,nj,k)
@@ -187,7 +190,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine bcwsfc(gz,dzdx,dzdy,u,v,w)
+      subroutine bcwsfc(gz,dzdx,dzdy,u,v,w,device)
       use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ni,nj, &
           timestats,time_bc,mytime
 
@@ -198,15 +201,17 @@
       real, intent(in), dimension(ib:ie+1,jb:je,kb:ke) :: u
       real, intent(in), dimension(ib:ie,jb:je+1,kb:ke) :: v
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: w
+      logical, optional, intent(in) :: device
 
-      !$acc declare present(gz,dzdx,dzdy,u,v,w)
 
       integer :: i,j
+      logical :: openacc
 
+      call SetGPUParams(openacc,device)
 !-----------------------------------------------------------------------
 
       !$omp parallel do default(shared) private(i,j)
-      !$acc parallel loop gang vector collapse(2) default(present) 
+      !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
       do j=0,nj+1
       do i=0,ni+1
         w(i,j,1) = 0.5*( ( u(i,j,1)+u(i+1,j,1) )*dzdx(i,j) &
@@ -240,12 +245,14 @@
 
 #ifndef MPI
 
+      call SetGPUParams(openacc,device)
+
 !-----------------------------------------------------------------------
 !  west boundary condition
 
       if(wbc.eq.1)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=1,nj
           s(1,j,k)=s(1,j,k)+s(ni+1,j,k)
@@ -258,7 +265,7 @@
 
       if(ebc.eq.1)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=1,nj
           s(ni,j,k)=s(ni,j,k)+s(0,j,k)
@@ -271,7 +278,7 @@
 
       if(sbc.eq.1)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=1,ni
           s(i,1,k)=s(i,1,k)+s(i,nj+1,k)
@@ -284,7 +291,7 @@
 
       if(nbc.eq.1)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=1,ni
           s(i,nj,k)=s(i,nj,k)+s(i,0,k)
@@ -309,20 +316,23 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine extrapbcs(s)
+      subroutine extrapbcs(s,device)
       use input, only : ib,ie,jb,je,kb,ke,nk,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
       implicit none
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
-      !$acc declare present(s)
+      logical, optional, intent(in) :: device
 
       integer :: i,j
+      logical :: openacc
 
       ! cm1r18 extrapolation formulation:
       ! assumes zh(0) is same as zf(1), and zh(nk+1) is same as zf(nk+1)
 
+      call SetGPUParams(openacc,device)
+
       !$omp parallel do default(shared) private(i,j)
-      !$acc parallel loop gang vector collapse(2) default(present)
+      !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
       do j=jb,je
       do i=ib,ie
         s(i,j,0)    = cgs1*s(i,j,1)+cgs2*s(i,j,2)+cgs3*s(i,j,3)
@@ -339,26 +349,29 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine bct2_GPU(t)
+      subroutine bct2(t,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
           ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
           patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
-      real t(ib:ie,jb:je,kb:ke+1)
+      real, intent(inout) ::  t(ib:ie,jb:je,kb:ke+1)
+      logical, optional, intent(in) :: device
 
       integer i,j,k
+      logical :: openacc
 
 !---------------------------------------------------------
 !  This subroutine sets the corner points
 !---------------------------------------------------------
+      call SetGPUParams(openacc,device)
 
       if(ibw.eq.1)then
 
         if(patchsww)then
           j=0
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk+1
           do i=1-ngxy,0
             t(i,j,k)=t(1,j,k)
@@ -368,8 +381,8 @@
 
         if(patchnww)then
           j=nj+1
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk+1
           do i=1-ngxy,0
             t(i,j,k)=t(1,j,k)
@@ -383,8 +396,8 @@
 
         if(patchsee)then
           j=0
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk+1
           do i=ni+1,ni+ngxy
             t(i,j,k)=t(ni,j,k)
@@ -394,8 +407,8 @@
 
         if(patchnee)then
           j=nj+1
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk+1
           do i=ni+1,ni+ngxy
             t(i,j,k)=t(ni,j,k)
@@ -409,8 +422,8 @@
 
         if(patchsws)then
           i=0
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk+1
           do j=1-ngxy,0
             t(i,j,k)=t(i,1,k)
@@ -420,8 +433,8 @@
 
         if(patchses)then
           i=ni+1
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk+1
           do j=1-ngxy,0
             t(i,j,k)=t(i,1,k)
@@ -435,8 +448,8 @@
 
         if(patchnwn)then
           i=0
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk+1
           do j=nj+1,nj+ngxy
             t(i,j,k)=t(i,nj,k)
@@ -446,8 +459,8 @@
 
         if(patchnen)then
           i=ni+1
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk+1
           do j=nj+1,nj+ngxy
             t(i,j,k)=t(i,nj,k)
@@ -459,23 +472,26 @@
 
       if(timestats.ge.1) time_bc=time_bc+mytime()
 
-      end subroutine bct2_GPU
+      end subroutine bct2
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine bcu2_GPU(u)
+      subroutine bcu2(u,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
           ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
           patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real u(ib:ie+1,jb:je,kb:ke)
+      logical, optional, intent(in) :: device
 
       integer i,j,k
+      logical :: openacc
 
+      call SetGPUParams(openacc,device)
 !---------------------------------------------------------
 !  This subroutine sets the corner points
 !---------------------------------------------------------
@@ -484,8 +500,8 @@
 
         if(patchsww)then
           j=0
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do i=1-ngxy,0
             u(i,j,k)=u(1,j,k)
@@ -495,8 +511,8 @@
 
         if(patchnww)then
           j=nj+1
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do i=1-ngxy,0
             u(i,j,k)=u(1,j,k)
@@ -510,8 +526,8 @@
 
         if(patchsee)then
           j=0
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do i=ni+2,ni+1+ngxy
             u(i,j,k)=u(ni+1,j,k)
@@ -521,8 +537,8 @@
 
         if(patchnee)then
           j=nj+1
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do i=ni+2,ni+1+ngxy
             u(i,j,k)=u(ni+1,j,k)
@@ -536,8 +552,8 @@
 
         if(patchsws)then
           i=0
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do j=1-ngxy,0
             u(i,j,k)=u(i,1,k)
@@ -547,8 +563,8 @@
 
         if(patchses)then
           i=ni+2
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do j=1-ngxy,0
             u(i,j,k)=u(i,1,k)
@@ -562,8 +578,8 @@
 
         if(patchnwn)then
           i=0
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do j=nj+1,nj+ngxy
             u(i,j,k)=u(i,nj,k)
@@ -573,8 +589,8 @@
 
         if(patchnen)then
           i=ni+2
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do j=nj+1,nj+ngxy
             u(i,j,k)=u(i,nj,k)
@@ -586,7 +602,7 @@
 
       if(timestats.ge.1) time_bc=time_bc+mytime()
 
-      end subroutine bcu2_GPU
+      end subroutine bcu2
 
 
 
@@ -595,16 +611,19 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine bcv2_GPU(v)
+      subroutine bcv2(v,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
           ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
           patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real v(ib:ie,jb:je+1,kb:ke)
+      logical, optional, intent(in) :: device
 
       integer i,j,k
+      logical :: openacc
 
+      call SetGPUParams(openacc,device)
 !---------------------------------------------------------
 !  This subroutine sets the corner points
 !---------------------------------------------------------
@@ -613,8 +632,8 @@
 
         if(patchsww)then
           j=0
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do i=1-ngxy,0
             v(i,j,k)=v(1,j,k)
@@ -624,8 +643,8 @@
 
         if(patchnww)then
           j=nj+2
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do i=1-ngxy,0
             v(i,j,k)=v(1,j,k)
@@ -639,8 +658,8 @@
 
         if(patchsee)then
           j=0
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do i=ni+1,ni+ngxy
             v(i,j,k)=v(ni,j,k)
@@ -650,8 +669,8 @@
 
         if(patchnee)then
           j=nj+2
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do i=ni+1,ni+ngxy
             v(i,j,k)=v(ni,j,k)
@@ -665,8 +684,8 @@
 
         if(patchsws)then
           i=0
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do j=1-ngxy,0
             v(i,j,k)=v(i,1,k)
@@ -676,8 +695,8 @@
 
         if(patchses)then
           i=ni+1
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do j=1-ngxy,0
             v(i,j,k)=v(i,1,k)
@@ -691,8 +710,8 @@
 
         if(patchnwn)then
           i=0
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do j=nj+2,nj+1+ngxy
             v(i,j,k)=v(i,nj+1,k)
@@ -702,8 +721,8 @@
 
         if(patchnen)then
           i=ni+1
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk
           do j=nj+2,nj+1+ngxy
             v(i,j,k)=v(i,nj+1,k)
@@ -715,22 +734,25 @@
 
       if(timestats.ge.1) time_bc=time_bc+mytime()
 
-      end subroutine bcv2_GPU
+      end subroutine bcv2
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine bcw2_GPU(w)
+      subroutine bcw2(w,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
           ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
           patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
       implicit none
 
       real w(ib:ie,jb:je,kb:ke+1)
+      logical, optional, intent(in) :: device
 
       integer i,j,k
+      logical :: openacc
 
+      call SetGPUParams(openacc,device)
 !---------------------------------------------------------
 !  This subroutine sets the corner points
 !---------------------------------------------------------
@@ -739,8 +761,8 @@
 
         if(patchsww)then
           j=0
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk+1
           do i=1-ngxy,0
             w(i,j,k)=w(1,j,k)
@@ -750,8 +772,8 @@
 
         if(patchnww)then
           j=nj+1
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk+1
           do i=1-ngxy,0
             w(i,j,k)=w(1,j,k)
@@ -765,8 +787,8 @@
 
         if(patchsee)then
           j=0
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk+1
           do i=ni+1,ni+ngxy
             w(i,j,k)=w(ni,j,k)
@@ -776,8 +798,8 @@
 
         if(patchnee)then
           j=nj+1
-!$omp parallel do default(shared) private(i,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk+1
           do i=ni+1,ni+ngxy
             w(i,j,k)=w(ni,j,k)
@@ -791,8 +813,8 @@
 
         if(patchsws)then
           i=0
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk+1
           do j=1-ngxy,0
             w(i,j,k)=w(i,1,k)
@@ -802,8 +824,8 @@
 
         if(patchses)then
           i=ni+1
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk+1
           do j=1-ngxy,0
             w(i,j,k)=w(i,1,k)
@@ -817,8 +839,8 @@
 
         if(patchnwn)then
           i=0
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk+1
           do j=nj+1,nj+ngxy
             w(i,j,k)=w(i,nj,k)
@@ -828,8 +850,8 @@
 
         if(patchnen)then
           i=ni+1
-!$omp parallel do default(shared) private(j,k)
-!$acc parallel loop gang vector collapse(2) default(present)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
           do k=1,nk+1
           do j=nj+1,nj+ngxy
             w(i,j,k)=w(i,nj,k)
@@ -841,13 +863,13 @@
 
       if(timestats.ge.1) time_bc=time_bc+mytime()
 
-      end subroutine bcw2_GPU
+      end subroutine bcw2
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine bcs2_2d_GPU(s,device)
+      subroutine bcs2_2d(s,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ngxy, &
           ibw,ibe,ibs,ibn,patchsww,patchnww,patchsee,patchnee, &
           patchsws,patchses,patchnwn,patchnen,timestats,time_bc,mytime
@@ -956,7 +978,7 @@
 
       if(timestats.ge.1) time_bc=time_bc+mytime()
 
-      end subroutine bcs2_2d_GPU
+      end subroutine bcs2_2d
 
 #endif
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -964,7 +986,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine radbcew(radbcw,radbce,ua)
+      subroutine radbcew(radbcw,radbce,ua,device)
       use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc,ni,nj,nk, &
           ibw,ibe,ibs,ibn,timestats,time_bc,mytime
       use constants
@@ -972,15 +994,17 @@
 
       real, dimension(jb:je,kb:ke) :: radbcw,radbce
       real, dimension(ib:ie+1,jb:je,kb:ke) :: ua
+      logical, optional, intent(in) :: device
  
       integer j,k
       real cbcw,cbce
+      logical :: openacc
 
-      !$acc declare present(radbcw,radbce,ua)
  
+      call SetGPUParams(openacc,device)
       if(ibw.eq.1.and.wbc.eq.2)then
         !$omp parallel do default(shared) private(j,k,cbcw)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=1,nj
           cbcw=ua(1,j,k)-cstar
@@ -995,7 +1019,7 @@
  
       if(ibe.eq.1.and.ebc.eq.2)then
         !$omp parallel do default(shared) private(j,k,cbce)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=1,nj
           cbce=ua(ni+1,j,k)+cstar
@@ -1020,7 +1044,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine radbcns(radbcs,radbcn,va)
+      subroutine radbcns(radbcs,radbcn,va,device)
       use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc,ni,nj,nk, &
           ibw,ibe,ibs,ibn,timestats,time_bc,mytime
 
@@ -1029,15 +1053,17 @@
 
       real, dimension(ib:ie,kb:ke) :: radbcs,radbcn
       real, dimension(ib:ie,jb:je+1,kb:ke) :: va
+      logical, optional, intent(in) :: device
  
       integer i,k
       real cbcs,cbcn
+      logical :: openacc
 
-      !$acc declare present(radbcs,radbcn,va)
 
+      call SetGPUParams(openacc,device)
       if(ibs.eq.1.and.sbc.eq.2)then
         !$omp parallel do default(shared) private(i,k,cbcs)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc) 
         do k=1,nk
         do i=1,ni
           cbcs=va(i,1,k)-cstar
@@ -1052,7 +1078,7 @@
  
       if(ibn.eq.1.and.nbc.eq.2)then
         !$omp parallel do default(shared) private(i,k,cbcn)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=1,ni
           cbcn=va(i,nj+1,k)+cstar
@@ -1077,7 +1103,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine radbcew4(ruf,radbcw,radbce,u1,u2,dt)
+      subroutine radbcew4(ruf,radbcw,radbce,u1,u2,dt,device)
       use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc,ni,nj,nk, &
           ibw,ibe,ibs,ibn,dx,timestats,time_bc,mytime
 
@@ -1088,16 +1114,18 @@
       real, dimension(jb:je,kb:ke) :: radbcw,radbce
       real, dimension(ib:ie+1,jb:je,kb:ke) :: u1,u2
       real dt
+      logical, optional, intent(in) :: device
 
       integer j,k
       real umax,avgw,avge,foo,cbcw,cbce
-      !$acc declare present(radbcw,radbce,u1,u2)
+      logical :: openacc
 
+      call SetGPUParams(openacc,device)
       umax=csmax
 
       if(ibw.eq.1.and.wbc.eq.2)then
        !$omp parallel do default(shared) private(j,k,foo,avgw,cbcw)
-       !$acc parallel loop gang vector default(present) private(j,k,foo,avgw,cbcw)
+       !$acc parallel loop gang vector default(present) private(j,k,foo,avgw,cbcw) if(openacc)
         do j=1,nj
           avgw=0.
           do k=1,nk
@@ -1116,7 +1144,7 @@
 
       if(ibe.eq.1.and.ebc.eq.2)then
         !$omp parallel do default(shared) private(j,k,foo,avge,cbce)
-        !$acc parallel loop gang vector default(present) private(j,k,foo,avge,cbce)
+        !$acc parallel loop gang vector default(present) private(j,k,foo,avge,cbce) if(openacc)
         do j=1,nj
           avge=0.
           do k=1,nk
@@ -1143,7 +1171,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine radbcns4(rvf,radbcs,radbcn,v1,v2,dt)
+      subroutine radbcns4(rvf,radbcs,radbcn,v1,v2,dt,device)
       use input, only : ib,ie,jb,je,kb,ke,wbc,ebc,sbc,nbc,ni,nj,nk, &
           ibw,ibe,ibs,ibn,dy,timestats,time_bc,mytime
       use constants
@@ -1153,17 +1181,19 @@
       real, dimension(ib:ie,kb:ke) :: radbcs,radbcn
       real, dimension(ib:ie,jb:je+1,kb:ke) :: v1,v2
       real dt
+      logical, optional, intent(in) :: device
 
       integer i,k
       real umax,avgs,avgn,foo,cbcs,cbcn
+      logical :: openacc
 
-      !$acc declare present(radbcs,radbcn,v1,v2)
 
+      call SetGPUParams(openacc,device)
       umax=csmax
 
       if(ibs.eq.1.and.sbc.eq.2)then
         !$omp parallel do default(shared) private(i,k,avgs,foo,cbcs)
-        !$acc parallel loop gang vector default(present) private(i,k,avgs,foo,cbcs)
+        !$acc parallel loop gang vector default(present) private(i,k,avgs,foo,cbcs) if(openacc)
         do i=1,ni
           avgs=0.
           do k=1,nk
@@ -1182,7 +1212,7 @@
 
       if(ibn.eq.1.and.nbc.eq.2)then
         !$omp parallel do default(shared) private(i,k,avgn,foo,cbcn)
-        !$acc parallel loop gang vector default(present) private(i,k,avgn,foo,cbcn)
+        !$acc parallel loop gang vector default(present) private(i,k,avgn,foo,cbcn) if(openacc)
         do i=1,ni
           avgn=0.
           do k=1,nk
@@ -1209,7 +1239,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine restrict_openbc_we(rvh,rmh,rho0,u3d)
+      subroutine restrict_openbc_we(rvh,rmh,rho0,u3d,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk, &
           wbc,ebc,sbc,nbc,ibw,ibe,ibs,ibn,time_bc, &
           ierr,timestats,mytime
@@ -1222,17 +1252,20 @@
       real, dimension(ib:ie,jb:je,kb:ke) :: rmh
       real, dimension(ib:ie,jb:je,kb:ke) :: rho0
       real, dimension(ib:ie+1,jb:je,kb:ke) :: u3d
+      logical, optional, intent(in) :: device
 
       integer i,j,k
       double precision :: fluxout,fluxin,tem,u1,t3
       double precision :: temp1,temp2
       double precision, dimension(nk) :: temout,temin
+      logical :: openacc
       !$acc declare present(rvh,rmh,rho0,u3d)
 
+      call SetGPUParams(openacc,device)
       !$acc data create(temout,temin)
 
       !$omp parallel do default(shared) private(k)
-      !$acc parallel loop gang vector default(present) 
+      !$acc parallel loop gang vector default(present) if(openacc)
       do k=1,nk
         temout(k) = 0.0d0
         temin(k)  = 0.0d0
@@ -1241,7 +1274,7 @@
       if(wbc.eq.2.and.ibw.eq.1)then
         i=1
         !$omp parallel do default(shared) private(j,k,temp1,temp2)
-        !$acc parallel default(present) reduction(+:temp1,temp2)
+        !$acc parallel default(present) reduction(+:temp1,temp2) if(openacc)
         !$acc loop gang
         do k=1,nk
           temp1 = temout(k)
@@ -1260,7 +1293,7 @@
       if(ebc.eq.2.and.ibe.eq.1)then
         i=ni+1
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel default(present) reduction(+:temp1,temp2)
+        !$acc parallel default(present) reduction(+:temp1,temp2) if(openacc)
         !$acc loop gang
         do k=1,nk
           temp1 = temout(k)
@@ -1279,7 +1312,7 @@
       fluxout = 0.0d0
       fluxin  = 0.0d0
 
-      !$acc parallel loop gang vector default(present) reduction(+:fluxout,fluxin)
+      !$acc parallel loop gang vector default(present) reduction(+:fluxout,fluxin) if(openacc)
       do k=1,nk
         fluxout = fluxout + temout(k)
         fluxin  = fluxin  + temin(k)
@@ -1301,7 +1334,7 @@
       if(wbc.eq.2.and.ibw.eq.1)then
         i=1
         !$omp parallel do default(shared) private(j,k,u1)
-        !$acc parallel loop gang vector collapse(2) default(present) 
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=1,nj
           u1=rho0(1,j,k)*u3d(i,j,k)
@@ -1315,7 +1348,7 @@
       if(ebc.eq.2.and.ibe.eq.1)then
         i=ni+1
         !$omp parallel do default(shared) private(j,k,u1)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do j=1,nj
           u1=rho0(ni,j,k)*u3d(i,j,k)
@@ -1338,7 +1371,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine restrict_openbc_sn(ruh,rmh,rho0,v3d)
+      subroutine restrict_openbc_sn(ruh,rmh,rho0,v3d,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk, &
           wbc,ebc,sbc,nbc,ibw,ibe,ibs,ibn,time_bc, &
           ierr,timestats,mytime
@@ -1351,15 +1384,18 @@
       real, dimension(ib:ie,jb:je,kb:ke) :: rmh
       real, dimension(ib:ie,jb:je,kb:ke) :: rho0
       real, dimension(ib:ie,jb:je+1,kb:ke) :: v3d
+      logical, optional, intent(in) :: device
 
       integer i,j,k
       double precision :: fluxout,fluxin,tem,u1,t3,tmp1,tmp2
       double precision, dimension(nk) :: temout,temin
+      logical :: openacc
 
+      call SetGPUParams(openacc,device)
       if(sbc.eq.2.and.ibs.eq.1)then
         j=1
 !$omp parallel do default(shared) private(i,k,tmp1,tmp2)
-        !$acc parallel default(present) reduction(+:tmp1,tmp2)
+        !$acc parallel default(present) reduction(+:tmp1,tmp2) if(openacc)
         !$acc loop gang
         do k=1,nk
         tmp1 = 0.D0
@@ -1378,7 +1414,7 @@
       if(nbc.eq.2.and.ibn.eq.1)then
         j=nj+1
 !$omp parallel do default(shared) private(i,k,tmp1,tmp2)
-        !$acc parallel default(present) reduction(+:tmp1,tmp2)
+        !$acc parallel default(present) reduction(+:tmp1,tmp2) if(openacc)
         !$acc loop gang
         do k=1,nk
         tmp1 = 0.D0
@@ -1397,7 +1433,7 @@
       fluxout = 0.0d0
       fluxin  = 0.0d0
 
-      !$acc parallel loop gang vector default(present) reduction(+:fluxout,fluxin)
+      !$acc parallel loop gang vector default(present) reduction(+:fluxout,fluxin) if(openacc)
       do k=1,nk
         fluxout = fluxout + temout(k)
         fluxin  = fluxin  + temin(k)
@@ -1418,9 +1454,8 @@
 
       if(sbc.eq.2.and.ibs.eq.1)then
         j=1
-!$omp parallel do default(shared) private(i,k,u1)
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(2)
+        !$omp parallel do default(shared) private(i,k,u1)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=1,ni
           u1=rho0(i,1,k)*v3d(i,j,k)
@@ -1429,14 +1464,12 @@
           endif
         enddo
         enddo
-        !$acc end parallel
       endif
 
       if(nbc.eq.2.and.ibn.eq.1)then
         j=nj+1
 !$omp parallel do default(shared) private(i,k,u1)
-        !$acc parallel default(present)
-        !$acc loop gang vector collapse(2)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nk
         do i=1,ni
           u1=rho0(i,nj,k)*v3d(i,j,k)
@@ -1445,7 +1478,6 @@
           endif
         enddo
         enddo
-        !$acc end parallel
       endif
 
       if(timestats.ge.1) time_bc=time_bc+mytime()
@@ -1458,7 +1490,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine ssopenbcw(uh,rds,sigma,rdsf,sigmaf,gz,rgzu,gx,radbcw,dum1,u3d,uten,dts)
+      subroutine ssopenbcw(uh,rds,sigma,rdsf,sigmaf,gz,rgzu,gx,radbcw,dum1,u3d,uten,dts,device)
       use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,ni,nj,nk, &
           cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,rdx,terrain_flag,timestats,time_bc,mytime
       implicit none
@@ -1473,17 +1505,18 @@
       real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: u3d
       real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: uten
       real, intent(in) :: dts
+      logical, optional, intent(in) :: device
 
       integer :: i,j,k
       real :: r1,r2
+      logical :: openacc
 
-      !$acc declare present(uh,rds,sigma,rdsf,sigmaf,gz,rgzu,gx, &
-      !$acc                 radbcw,dum1,u3d,uten)
+      call SetGPUParams(openacc,device)
 
           IF(.not.terrain_flag)THEN
             ! no terrain:
             !$omp parallel do default(shared) private(j,k)
-            !$acc parallel loop gang vector collapse(2) default(present)
+            !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
             do k=1,nk
             do j=1,nj
               u3d(1,j,k)=u3d(1,j,k)+dts*( -radbcw(j,k)       &
@@ -1495,6 +1528,7 @@
             ! with terrain:
             ! dum1 stores u at w points:
             !$omp parallel do default(shared) private(i,j,k,r1,r2)
+            !JMD what to do about nested directives
             !$acc parallel default(present)
             !$acc loop gang
             do j=1,nj
@@ -1522,7 +1556,7 @@
             !$acc end parallel
 
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(2) default(present)
+            !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
             do k=1,nk
             do j=1,nj
               u3d(1,j,k)=u3d(1,j,k)+dts*( -radbcw(j,k)*(                            &
@@ -1544,7 +1578,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine ssopenbce(uh,rds,sigma,rdsf,sigmaf,gz,rgzu,gx,radbce,dum1,u3d,uten,dts)
+      subroutine ssopenbce(uh,rds,sigma,rdsf,sigmaf,gz,rgzu,gx,radbce,dum1,u3d,uten,dts,device)
       use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,ni,nj,nk, &
           cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,rdx,terrain_flag,timestats,time_bc,mytime
       implicit none
@@ -1559,17 +1593,17 @@
       real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: u3d
       real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: uten
       real, intent(in) :: dts
+      logical, optional, intent(in) :: device
 
       integer :: i,j,k
       real :: r1,r2
+      logical :: openacc
 
-      !$acc declare present(uh,rds,sigma,rdsf,sigmaf,gz,rgzu,gx, &
-      !$acc                 radbce,dum1,u3d,uten)
-
+      call SetGPUParams(openacc,device)
           IF(.not.terrain_flag)THEN
             ! no terrain:
             !$omp parallel do default(shared) private(j,k)
-            !$acc parallel loop gang vector collapse(2) default(present)
+            !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
             do k=1,nk
             do j=1,nj
               u3d(ni+1,j,k)=u3d(ni+1,j,k)+dts*( -radbce(j,k)           &
@@ -1581,6 +1615,7 @@
             ! with terrain:
             ! dum1 stores u at w points:
             !$omp parallel do default(shared) private(i,j,k,r1,r2)
+            !JMD nested-openacc directives
             !$acc parallel default(present)
             !$acc loop gang
             do j=1,nj
@@ -1608,7 +1643,7 @@
             !$acc end parallel
 
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(2) default(present)
+            !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
             do k=1,nk
             do j=1,nj
               u3d(ni+1,j,k)=u3d(ni+1,j,k)+dts*( -radbce(j,k)*(                                &
@@ -1630,7 +1665,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine ssopenbcs(vh,rds,sigma,rdsf,sigmaf,gz,rgzv,gy,radbcs,dum1,v3d,vten,dts)
+      subroutine ssopenbcs(vh,rds,sigma,rdsf,sigmaf,gz,rgzv,gy,radbcs,dum1,v3d,vten,dts,device)
       use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,ni,nj,nk, &
           cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,rdy,terrain_flag,timestats,time_bc,mytime
       implicit none
@@ -1645,17 +1680,19 @@
       real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: v3d
       real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: vten
       real, intent(in) :: dts
+      logical, optional, intent(in) :: device
 
       integer :: i,j,k
       real :: r1,r2
+      logical :: openacc
 
-      !$acc declare present(vh,rds,sigma,rdsf,sigmaf,gz,rgzv,gy, &
-      !$acc                 radbcs,dum1,v3d,vten)
+
+      call SetGPUParams(openacc,device)
 
           IF(.not.terrain_flag)THEN
             ! no terrain:
             !$omp parallel do default(shared) private(i,k)
-            !$acc parallel loop gang vector collapse(2) default(present)
+            !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
             do k=1,nk
             do i=1,ni
               v3d(i,1,k)=v3d(i,1,k)+dts*( -radbcs(i,k)      &
@@ -1667,7 +1704,7 @@
             ! with terrain:
             ! dum1 stores v at w points:
             !$omp parallel do default(shared) private(i,j,k,r1,r2)
-            !$acc parallel default(present)
+            !$acc parallel default(present) if(openacc)
             !$acc loop gang 
             do j=1,2
               ! lowest model level:
@@ -1694,7 +1731,7 @@
             !$acc end parallel
 
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(2) default(present)
+            !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
             do k=1,nk
             do i=1,ni
               v3d(i,1,k)=v3d(i,1,k)+dts*( -radbcs(i,k)*(                            &
@@ -1716,7 +1753,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine ssopenbcn(vh,rds,sigma,rdsf,sigmaf,gz,rgzv,gy,radbcn,dum1,v3d,vten,dts)
+      subroutine ssopenbcn(vh,rds,sigma,rdsf,sigmaf,gz,rgzv,gy,radbcn,dum1,v3d,vten,dts,device)
       use input, only : ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,ktb,kte,ni,nj,nk, &
           cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,rdy,terrain_flag,timestats,time_bc,mytime
       implicit none
@@ -1731,17 +1768,17 @@
       real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: v3d
       real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: vten
       real, intent(in) :: dts
+      logical, optional, intent(in) :: device
 
       integer :: i,j,k
       real :: r1,r2
+      logical :: openacc
 
-      !$acc declare present(vh,rds,sigma,rdsf,sigmaf,gz,rgzv,gy, &
-      !$acc                 radbcn,dum1,v3d,vten)
-
+      call SetGPUParams(openacc,device)
           IF(.not.terrain_flag)THEN
             ! no terrain:
             !$omp parallel do default(shared) private(i,k)
-            !$acc parallel loop gang vector collapse(2) default(present)
+            !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
             do k=1,nk
             do i=1,ni
               v3d(i,nj+1,k)=v3d(i,nj+1,k)+dts*( -radbcn(i,k)        &
@@ -1753,7 +1790,8 @@
             ! with terrain:
             ! dum1 stores v at w points:
             !$omp parallel do default(shared) private(i,j,k,r1,r2)
-            !$acc parallel default(present)
+            !JMD nested openacc 
+            !$acc parallel default(present) if(openacc)
             !$acc loop gang
             do j=nj,nj+1
               ! lowest model level:
@@ -1780,7 +1818,7 @@
             !$acc end parallel
 
             !$omp parallel do default(shared) private(i,j,k)
-            !$acc parallel loop gang vector collapse(2) default(present)
+            !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
             do k=1,nk
             do i=1,ni
               v3d(i,nj+1,k)=v3d(i,nj+1,k)+dts*( -radbcn(i,k)*(                                &
@@ -1795,28 +1833,31 @@
       if(timestats.ge.1) time_bc=time_bc+mytime()
 
       end subroutine ssopenbcn
+
 !GPU================================================================================================
 !GPU ported subroutine below here 
 !GPU================================================================================================
 
-      subroutine bc2d_GPU(s)
+      subroutine bc2d(s,device)
       use input, only : ib,ie,jb,je,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
           ibw,ibe,ibs,ibn,timestats,time_bc,mytime 
       implicit none
 
       real, dimension(ib:ie,jb:je) :: s
+      logical, intent(in), optional :: device
 
       integer i,j
+      logical :: openacc
 
-      !$acc declare present(s)
 
+      call SetGPUParams(openacc,device)
 !-----------------------------------------------------------------------
 !  west boundary condition
 
 #ifndef MPI
       if(wbc.eq.1)then
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=jb,je
         do i=1,ngxy
           s(1-i,j)=s(ni+1-i,j)
@@ -1827,7 +1868,7 @@
       if(ibw.eq.1.and.wbc.eq.2)then
 #endif
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=jb,je
         do i=1-ngxy,0
           s(i,j)=s(1,j)
@@ -1839,7 +1880,7 @@
       elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=jb,je
         do i=1,ngxy
           s(1-i,j)=s(i,j)
@@ -1853,7 +1894,7 @@
 #ifndef MPI
       if(ebc.eq.1)then
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=jb,je
         do i=1,ngxy
           s(ni+i,j)=s(i,j)
@@ -1864,7 +1905,7 @@
       if(ibe.eq.1.and.ebc.eq.2)then
 #endif
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=jb,je
         do i=ni+1,ni+ngxy
           s(i,j)=s(ni,j)
@@ -1876,7 +1917,7 @@
       elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=jb,je
         do i=1,ngxy
           s(ni+i,j)=s(ni+1-i,j)
@@ -1890,7 +1931,7 @@
 #ifndef MPI
       if(sbc.eq.1)then
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,ngxy
         do i=ib,ie
           s(i,1-j)=s(i,nj+1-j)
@@ -1901,7 +1942,7 @@
       if(ibs.eq.1.and.sbc.eq.2)then
 #endif
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1-ngxy,0
         do i=ib,ie
           s(i,j)=s(i,1)
@@ -1913,7 +1954,7 @@
       elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,ngxy
         do i=ib,ie
           s(i,1-j)=s(i,j)
@@ -1927,7 +1968,7 @@
 #ifndef MPI
       if(nbc.eq.1)then
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,ngxy
         do i=ib,ie
           s(i,nj+j)=s(i,j)
@@ -1938,7 +1979,7 @@
       if(ibn.eq.1.and.nbc.eq.2)then
 #endif
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=nj+1,nj+ngxy
         do i=ib,ie
           s(i,j)=s(i,nj)
@@ -1950,7 +1991,7 @@
       elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
         !$omp parallel do default(shared) private(i,j)
-        !$acc parallel loop gang vector collapse(2) default(present)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,ngxy
         do i=ib,ie
           s(i,nj+j)=s(i,nj+1-j)
@@ -1962,9 +2003,9 @@
 
       if(timestats.ge.1) time_bc=time_bc+mytime()
 
-      end subroutine bc2d_GPU
+      end subroutine bc2d
 
-      subroutine bcs_GPU(s,device)
+      subroutine bcs(s,device)
       use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
           ibw,ibe,ibs,ibn,timestats,time_bcs,mytime
       implicit none
@@ -1976,9 +2017,6 @@
       logical :: openacc
 
       call SetGPUParams(openacc,device)
-
-      !!$acc data present(s)
-
 !-----------------------------------------------------------------------
 !  west boundary condition
 
@@ -2157,27 +2195,27 @@
 
       if(timestats.ge.1) time_bcs=time_bcs+mytime()
 
-      end subroutine bcs_GPU
+      end subroutine bcs
 
-      subroutine bcu_GPU(u)
+      subroutine bcu(u,device)
       use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
           ibw,ibe,ibs,ibn,timestats,time_bc,mytime
       implicit none
 
       real, dimension(ib:ie+1,jb:je,kb:ke) :: u
+      logical, optional, intent(in) :: device
 
       integer i,j,k  
+      logical :: openacc
 
-      !$acc data present(u)
-
+      call SetGPUParams(openacc,device)
 !-----------------------------------------------------------------------
 !  west boundary condition
 
 #ifndef MPI
     if(wbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       do k=1,nk
          do j=jb,je
             do i=1,ngxy
@@ -2185,14 +2223,12 @@
             end do
          end do
       end do
-      !$acc end parallel
     elseif(wbc.eq.2)then
 #else
     if(ibw.eq.1.and.wbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       do k=1,nk
          do j=0,nj+1
             do i=1-ngxy,0
@@ -2200,15 +2236,13 @@
             end do
          end do
       end do
-      !$acc end parallel
 #ifdef MPI
     elseif(ibw.eq.1.and.(wbc.eq.3.or.wbc.eq.4))then
 #else
     elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(2)
+      !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
       do k=1,nk
          do j=0,nj+1
             u(1,j,k)=0.
@@ -2218,7 +2252,6 @@
             end do
          end do
       end do
-      !$acc end parallel
     endif
 
 !-----------------------------------------------------------------------
@@ -2227,8 +2260,7 @@
 #ifndef MPI
     if(ebc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       do k=1,nk
          do j=jb,je
             do i=1,ngxy
@@ -2236,14 +2268,12 @@
             end do
          end do
       end do
-      !$acc end parallel
     elseif(ebc.eq.2)then
 #else
     if(ibe.eq.1.and.ebc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       do k=1,nk
          do j=0,nj+1
             do i=ni+2,ni+1+ngxy
@@ -2251,15 +2281,13 @@
             end do
          end do
       end do
-      !$acc end parallel
 #ifdef MPI
     elseif(ibe.eq.1.and.(ebc.eq.3.or.ebc.eq.4))then
 #else
     elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(2)
+      !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
       do k=1,nk
          do j=0,nj+1
             u(ni+1,j,k)=0.0
@@ -2269,7 +2297,6 @@
             end do
         end do
       end do
-      !$acc end parallel
     endif
 
 !-----------------------------------------------------------------------
@@ -2278,8 +2305,7 @@
 #ifndef MPI
     if(sbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       do k=1,nk
          do j=1,ngxy
             do i=ib,ie+1
@@ -2287,14 +2313,12 @@
             end do
          end do
       end do
-      !$acc end parallel
     elseif(sbc.eq.2)then
 #else
     if(ibs.eq.1.and.sbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       do k=1,nk
          do j=1-ngxy,0
             do i=0,ni+2
@@ -2302,15 +2326,13 @@
             end do
          end do
       end do
-      !$acc end parallel
 #ifdef MPI
     elseif(ibs.eq.1.and.(sbc.eq.3.or.sbc.eq.4))then
 #else
     elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       do k=1,nk
          do j=1,ngxy
             do i=0,ni+2
@@ -2318,7 +2340,6 @@
             end do
          end do
       end do
-      !$acc end parallel
     endif
 
 !-----------------------------------------------------------------------
@@ -2327,8 +2348,7 @@
 #ifndef MPI
     if(nbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       do k=1,nk
          do j=1,ngxy
             do i=ib,ie+1
@@ -2336,14 +2356,12 @@
             end do
         end do
       end do
-      !$acc end parallel
     elseif(nbc.eq.2)then
 #else
     if(ibn.eq.1.and.nbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       do k=1,nk
          do j=nj+1,nj+ngxy
             do i=0,ni+2
@@ -2351,15 +2369,13 @@
             end do
          end do
       end do
-      !$acc end parallel
 #ifdef MPI
     elseif(ibn.eq.1.and.(nbc.eq.3.or.nbc.eq.4))then
 #else
     elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel default(present)
-      !$acc loop gang vector collapse(3)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       do k=1,nk
          do j=1,ngxy
             do i=0,ni+2
@@ -2367,27 +2383,27 @@
             end do
          end do
       end do
-      !$acc end parallel
     endif
 
-    !$acc end data
 
 !-----------------------------------------------------------------------
 
       if(timestats.ge.1) time_bc=time_bc+mytime()
  
-      end subroutine bcu_GPU
+      end subroutine bcu
 
-      subroutine bcv_GPU(v)
+      subroutine bcv(v,device)
       use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
           ibw,ibe,ibs,ibn,timestats,time_bc,mytime,axisymm
       implicit none
 
       real, dimension(ib:ie,jb:je+1,kb:ke) :: v
+      logical, optional, intent(in) :: device
  
       integer i,j,k
-      !$acc declare present(v)
+      logical :: openacc
 
+      call SetGPUParams(openacc,device)
 !-----------------------------------------------------------------------
 !  south boundary condition
 
@@ -2395,7 +2411,7 @@
 #ifndef MPI
     if(sbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=1,ngxy
         do i=ib,ie
@@ -2408,7 +2424,7 @@
     if(ibs.eq.1.and.sbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=1-ngxy,0
         do i=0,ni+1
@@ -2422,7 +2438,7 @@
     elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=1,ngxy
         do i=0,ni+1
@@ -2430,7 +2446,7 @@
         enddo
         enddo
       ENDDO
-      !$acc parallel loop gang vector collapse(2) default(present)
+      !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
       DO k=1,nk
         do i=0,ni+1
           v(i,   1,k)=0.
@@ -2443,7 +2459,7 @@
 
     IF(axisymm.eq.1)THEN
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(2) default(present)
+      !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
       DO k=1,nk
         do i=ib,ie
           v(i,2,k)=v(i,1,k)
@@ -2454,7 +2470,7 @@
 #ifndef MPI
     if(nbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=1,ngxy
         do i=ib,ie
@@ -2467,7 +2483,7 @@
     if(ibn.eq.1.and.nbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=nj+2,nj+1+ngxy
         do i=0,ni+1
@@ -2481,7 +2497,7 @@
     elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=1,ngxy
         do i=0,ni+1
@@ -2489,7 +2505,7 @@
         enddo
         enddo
       ENDDO
-      !$acc parallel loop gang vector collapse(2) default(present)
+      !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
       DO k=1,nk
         do i=0,ni+1
           v(i,nj+1,k)=0.
@@ -2503,7 +2519,7 @@
 #ifndef MPI
     if(wbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=jb,je+1
         do i=1,ngxy
@@ -2516,7 +2532,7 @@
     if(ibw.eq.1.and.wbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=0,nj+2
         do i=1-ngxy,0
@@ -2530,7 +2546,7 @@
     elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=0,nj+2
         do i=1,ngxy
@@ -2542,7 +2558,7 @@
 
     IF(axisymm.eq.1)THEN
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=0,nj+2
         do i=1,ngxy
@@ -2558,7 +2574,7 @@
 #ifndef MPI
     if(ebc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=jb,je+1
         do i=1,ngxy
@@ -2571,7 +2587,7 @@
     if(ibe.eq.1.and.ebc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=0,nj+2
         do i=ni+1,ni+ngxy
@@ -2585,7 +2601,7 @@
     elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=1,nk
         do j=0,nj+2
         do i=1,ngxy
@@ -2600,19 +2616,22 @@
 
     if(timestats.ge.1) time_bc=time_bc+mytime()
  
-      end subroutine bcv_GPU
+      end subroutine bcv
 
-      subroutine bcw_GPU(w,flag)
+      subroutine bcw(w,flag,device)
       use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
           ibw,ibe,ibs,ibn,timestats,time_bc,mytime
       implicit none
 
       real, dimension(ib:ie,jb:je,kb:ke+1) :: w
       integer flag
+      logical, optional, intent(in) :: device
  
       integer i,j,k
+      logical :: openacc
       !$acc declare present(w)
 
+      call SetGPUParams(openacc,device)
 !-----------------------------------------------------------------------
 !  west boundary condition
 
@@ -2620,7 +2639,7 @@
 #ifndef MPI
     if(wbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=jb,je
         do i=1,ngxy
@@ -2633,7 +2652,7 @@
     if(ibw.eq.1.and.wbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=0,nj+1
         do i=1-ngxy,0
@@ -2647,7 +2666,7 @@
     elseif(wbc.eq.3.or.wbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=0,nj+1
         do i=1,ngxy
@@ -2663,7 +2682,7 @@
 #ifndef MPI
     if(ebc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=jb,je
         do i=1,ngxy
@@ -2676,7 +2695,7 @@
     if(ibe.eq.1.and.ebc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=0,nj+1
         do i=ni+1,ni+ngxy
@@ -2690,7 +2709,7 @@
     elseif(ebc.eq.3.or.ebc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=0,nj+1
         do i=1,ngxy
@@ -2706,7 +2725,7 @@
 #ifndef MPI
     if(sbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=1,ngxy
         do i=ib,ie
@@ -2719,7 +2738,7 @@
     if(ibs.eq.1.and.sbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=1-ngxy,0
         do i=0,ni+1
@@ -2733,7 +2752,7 @@
     elseif(sbc.eq.3.or.sbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=1,ngxy
         do i=0,ni+1
@@ -2749,7 +2768,7 @@
 #ifndef MPI
     if(nbc.eq.1)then
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=1,ngxy
         do i=ib,ie
@@ -2762,7 +2781,7 @@
     if(ibn.eq.1.and.nbc.eq.2)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=nj+1,nj+ngxy
         do i=0,ni+1
@@ -2776,7 +2795,7 @@
     elseif(nbc.eq.3.or.nbc.eq.4)then
 #endif
       !$omp parallel do default(shared) private(i,j,k)
-      !$acc parallel loop gang vector collapse(3) default(present)
+      !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
       DO k=2,nk
         do j=1,ngxy
         do i=0,ni+1
@@ -2793,7 +2812,7 @@
     IF(flag.eq.1)THEN
 
       !$omp parallel do default(shared) private(i,j)
-      !$acc parallel loop gang vector collapse(2) default(present)
+      !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
       do j=0,nj+1
       do i=0,ni+1
         w(i,j, 1)=0.0
@@ -2807,15 +2826,15 @@
 
       if(timestats.ge.1) time_bc=time_bc+mytime()
  
-      end subroutine bcw_GPU
+      end subroutine bcw
 
-      subroutine bcs2_GPU(s,device)
+      subroutine bcs2(s,device)
       use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
           ibw,ibe,ibs,ibn,timestats,time_bcs2,mytime,patchsww,patchnww, &
           patchsee,patchnee,patchsws,patchses,patchnwn,patchnen
       implicit none
 
-      real s(ib:ie,jb:je,kb:ke)
+      real, intent(inout) ::  s(ib:ie,jb:je,kb:ke)
       logical, optional :: device
 
       integer i,j,k
@@ -2933,7 +2952,7 @@
       
       if(timestats.ge.1) time_bcs2=time_bcs2+mytime()
 
-      end subroutine bcs2_GPU
+      end subroutine bcs2
 
       subroutine SetGPUParams(openacc,device)
 

--- a/src/bc.F
+++ b/src/bc.F
@@ -10,7 +10,7 @@
   public :: ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn, bcs_tend_halo
 
   !CPU only 
-  public :: bcs, bcs2
+  public :: bcs
 
   !MPI + GPU enabled
   public :: bcs2_GPU, bct2_GPU, bcu2_GPU, bcv2_GPU, bcw2_GPU, bcs2_2d_gpu
@@ -3413,6 +3413,7 @@
  
       end subroutine bcw_GPU
 
+#if 0
 
    subroutine bcs2(s)
       use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
@@ -3536,17 +3537,21 @@
 
       end subroutine bcs2
 
-      subroutine bcs2_GPU(s)
+#endif
+
+      subroutine bcs2_GPU(s,device)
       use input, only : ib,ie,jb,je,kb,ke,ngxy,ni,nj,nk,wbc,ebc,sbc,nbc, &
           ibw,ibe,ibs,ibn,timestats,time_bcs2,mytime,patchsww,patchnww, &
           patchsee,patchnee,patchsws,patchses,patchnwn,patchnen
       implicit none
 
       real s(ib:ie,jb:je,kb:ke)
+      logical, optional :: device
 
       integer i,j,k
+      logical :: openacc
 
-      !$acc data present(s)
+      call SetGPUParams(openacc,device)
 
 !---------------------------------------------------------
 !  This subroutine sets the corner points
@@ -3556,8 +3561,8 @@
 
         if(patchsww)then
           j=0
-!$omp parallel do default(shared)  private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared)  private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk
              do i=1-ngxy,0
                 s(i,j,k)=s(1,j,k)
@@ -3567,8 +3572,8 @@
 
         if(patchnww)then
           j=nj+1
-!$omp parallel do default(shared) private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk
              do i=1-ngxy,0
                 s(i,j,k)=s(1,j,k)
@@ -3582,8 +3587,8 @@
 
         if(patchsee)then
           j=0
-!$omp parallel do default(shared) private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk
              do i=ni+1,ni+ngxy
                 s(i,j,k)=s(ni,j,k)
@@ -3593,8 +3598,8 @@
 
         if(patchnee)then
           j=nj+1
-!$omp parallel do default(shared) private(i,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(i,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk
              do i=ni+1,ni+ngxy
                 s(i,j,k)=s(ni,j,k)
@@ -3608,8 +3613,8 @@
 
         if(patchsws)then
           i=0
-!$omp parallel do default(shared) private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk
              do j=1-ngxy,0
                 s(i,j,k)=s(i,1,k)
@@ -3619,8 +3624,8 @@
 
         if(patchses)then
           i=ni+1
-!$omp parallel do default(shared) private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk
              do j=1-ngxy,0
                 s(i,j,k)=s(i,1,k)
@@ -3634,8 +3639,8 @@
 
         if(patchnwn)then
           i=0
-!$omp parallel do default(shared) private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk
              do j=nj+1,nj+ngxy
                 s(i,j,k)=s(i,nj,k)
@@ -3645,8 +3650,8 @@
 
         if(patchnen)then
           i=ni+1
-!$omp parallel do default(shared) private(j,k)
-          !$acc parallel loop gang vector default(present) collapse(2)
+          !$omp parallel do default(shared) private(j,k)
+          !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
           do k=1,nk
              do j=nj+1,nj+ngxy
                 s(i,j,k)=s(i,nj,k)
@@ -3656,10 +3661,26 @@
 
       endif
       
-      !$acc end data
-
       if(timestats.ge.1) time_bcs2=time_bcs2+mytime()
 
       end subroutine bcs2_GPU
+
+      subroutine SetGPUParams(openacc,device)
+
+         logical, intent(inout) :: openacc
+         logical, optional :: device
+
+      if(present(device)) then
+         if(device) then
+            openacc = .true.
+         else
+            openacc = .false.
+         endif
+      else
+         openacc = .true.
+      endif
+
+      end subroutine SetGPUParams
+
 
   END MODULE bc_module

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -414,7 +414,6 @@ end module cuda_rt
                   endif
           end select
       end do 
-      print *, 'Using the namelist input file: ', namelist_input
 
 !----------------------------------------------------------------------
 !  For arbitrary 3d output array:  
@@ -458,10 +457,10 @@ end module cuda_rt
 #ifdef _OPENACC
       ndev = acc_get_num_devices(acc_device_nvidia)
       idev = mod(myid,ndev)
-      print *,'myid: ',myid
-      print *,'numprocs: ',numprocs
-      print *,'Total # of GPU: ',ndev 
-      print *,'Using GPU: ',idev 
+      write(*,*) 'numprocs: ',numprocs
+      write(*,*) 'Total # of GPU: ',ndev 
+      write(*,*) 'Using GPU: ',idev 
+      call flush(6)
       
       call acc_set_device_num(idev,acc_device_nvidia)
 #endif

--- a/src/comm.F
+++ b/src/comm.F
@@ -2070,164 +2070,6 @@
       if(timestats.ge.1) time_mps4=time_mps4+mytime() 
       end subroutine comm_2sn_end_GPU
 
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-      subroutine comm_3s_start(s,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
-          myeast,mywest,mysouth,mynorth,nf,cs3we,cs3sn,timestats,time_mps1, &
-          mytime,ierr
-      use mpi
-      implicit none
- 
-      real s(ib:ie,jb:je,kb:ke)
-      real west(cmp,nj,nk),newwest(cmp,nj,nk)
-      real east(cmp,nj,nk),neweast(cmp,nj,nk)
-      real south(ni,cmp,nk),newsouth(ni,cmp,nk)
-      real north(ni,cmp,nk),newnorth(ni,cmp,nk)
-      integer reqs(8)
- 
-      integer i,j,k,nr
-      integer tag1,tag2,tag3,tag4
- 
-!------------------------------------------------
-
-      nr = 0
-
-      nf=nf+1
-      tag1=nf
-
-      ! receive east
-      if(ibe.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(neweast,cs3we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nf=nf+1
-      tag2=nf
-
-      ! receive west
-      if(ibw.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newwest,cs3we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nf=nf+1
-      tag3=nf
-
-      ! receive south
-      if(ibs.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newsouth,cs3sn,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nf=nf+1
-      tag4=nf
-
-      ! receive north
-      if(ibn.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newnorth,cs3sn,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr = 4
-
-      ! send west
-      if(ibw.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj
-        do i=1,cmp
-          west(i,j,k)=s(i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(west,cs3we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
-
- 
-      ! send east
-      if(ibe.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj
-        do i=1,cmp
-          east(i,j,k)=s(ni-cmp+i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(east,cs3we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
- 
-      ! send north
-      if(ibn.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni
-          north(i,j,k)=s(i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(north,cs3sn,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
- 
-      ! send south
-      if(ibs.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni
-          south(i,j,k)=s(i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(south,cs3sn,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
- 
-      if(timestats.ge.1) time_mps1=time_mps1+mytime()
-
-      end subroutine comm_3s_start
-
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -2416,256 +2258,6 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
- 
-      subroutine comm_3s_end(s,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
-          wbc,ebc,nbc,sbc,myeast,mywest,mysouth,mynorth,nf,cs3we,cs3sn,timestats, &
-          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen, &
-          time_bc,time_mps2,mytime,ierr
-      use mpi
-      implicit none
- 
-      real s(ib:ie,jb:je,kb:ke)
-      real west(cmp,nj,nk),newwest(cmp,nj,nk)
-      real east(cmp,nj,nk),neweast(cmp,nj,nk)
-      real south(ni,cmp,nk),newsouth(ni,cmp,nk)
-      real north(ni,cmp,nk),newnorth(ni,cmp,nk)
-      integer reqs(8)
- 
-      integer i,j,k,nn,nr,index
-      integer :: index_east,index_west,index_south,index_north
-      integer, dimension(mpi_status_size,8) :: status1
-
-!-------------------------------------------------------------------
-
-      index_east = -1
-      index_west = -1
-      index_south = -1
-      index_north = -1
-
-      nr = 0
-      if(ibe.eq.0)then
-        nr = nr + 1
-        index_east = nr
-      endif
-      if(ibw.eq.0)then
-        nr = nr + 1
-        index_west = nr
-      endif
-      if(ibs.eq.0)then
-        nr = nr + 1
-        index_south = nr
-      endif
-      if(ibn.eq.0)then
-        nr = nr + 1
-        index_north = nr
-      endif
-
-    nn = 1
-    do while( nn .le. nr )
-      call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
-      nn = nn + 1
- 
-      if(index.eq.index_east)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj
-        do i=1,cmp
-          s(ni+i,j,k)=neweast(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_west)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj
-        do i=1,cmp
-          s(i-cmp,j,k)=newwest(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_south)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni
-          s(i,j-cmp,k)=newsouth(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_north)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni
-          s(i,nj+j,k)=newnorth(i,j,k)
-        enddo
-        enddo
-        enddo
-      endif
-
-    enddo
-
-      if(timestats.ge.1) time_mps2=time_mps2+mytime()
- 
-!----------
-!  patch for corner
- 
-      if( (ebc.eq.2.or.wbc.eq.2).and.(sbc.eq.1.or.nbc.eq.1) )then
- 
-        if(ibw.eq.1)then
-
-          if(p2tchsww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(0,0,k)=s(1,0,k)
-            enddo
-          endif
-
-          if(p2tchnww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(0,nj+1,k)=s(1,nj+1,k)
-            enddo
-          endif
-
-        endif
-
-        if(ibe.eq.1)then
- 
-          if(p2tchsee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(ni+1,0,k)=s(ni,0,k)
-            enddo
-          endif
- 
-          if(p2tchnee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(ni+1,nj+1,k)=s(ni,nj+1,k)
-            enddo
-          endif
- 
-        endif
- 
-      endif
-
-      if( (ebc.eq.1.or.wbc.eq.1).and.(sbc.eq.2.or.nbc.eq.2) )then
- 
-        if(ibs.eq.1)then
- 
-          if(p2tchsws)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(0,0,k)=s(0,1,k)
-            enddo
-          endif
- 
-          if(p2tchses)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(ni+1,0,k)=s(ni+1,1,k)
-            enddo
-          endif
- 
-        endif
- 
-        if(ibn.eq.1)then
- 
-          if(p2tchnwn)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(0,nj+1,k)=s(0,nj,k)
-            enddo
-          endif
- 
-          if(p2tchnen)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(ni+1,nj+1,k)=s(ni+1,nj,k)
-            enddo
-          endif
- 
-        endif
- 
-      endif
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-!----------
-
-      nr = 0
-
-      if(ibw.eq.0)then
-        nr = nr+1
-      endif
-      if(ibe.eq.0)then
-        nr = nr+1
-      endif
-      if(ibn.eq.0)then
-        nr = nr+1
-      endif
-      if(ibs.eq.0)then
-        nr = nr+1
-      endif
-
-    if( nr.ge.1 )then
-      call MPI_WAITALL(nr,reqs(5:5+nr-1),status1(1:mpi_status_size,5:5+nr-1),ierr)
-    endif
-
-      if(timestats.ge.1) time_mps2=time_mps2+mytime()
-
-!-----------------------------------------------------------
- 
-      end subroutine comm_3s_end
-
-      subroutine SetMsgParams(openacc,gdirect,device,gpudirect)
-
-         logical, intent(inout) :: openacc, gdirect
-         logical, optional :: device,gpudirect
-
-      if(present(device)) then 
-         if(device) then 
-            openacc = .true.
-            if(present(gpudirect)) then 
-               gdirect = gpudirect
-            else
-               gdirect = .true.
-            endif
-         else
-            openacc = .false.
-            gdirect = .false.
-         endif
-      else
-         openacc = .true.
-         if(present(gpudirect)) then 
-            gdirect = gpudirect
-         else
-            gdirect = .true.
-         endif
-      endif
-
-      end subroutine SetMsgParams
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
  
       subroutine comm_3s_end_GPU(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs,gpudirect,device)
@@ -9488,6 +9080,7 @@
 
       end subroutine getcorner3_2d
 
+
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -9497,7 +9090,7 @@
                               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
 
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt
-      use bc_module, only: bcs2
+      use bc_module, only: bcs2_GPU
       implicit none
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
@@ -9506,13 +9099,14 @@
       real, intent(inout), dimension(cmp,cmp,kmt+1) :: n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2
       integer, intent(inout), dimension(rmp) :: reqs_s
 
-      call comm_3s_start(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s)
-      call comm_3s_end(  s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s)
+      call comm_3s_start_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
+      call comm_3s_end_GPU( s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
       call getcorner3(s,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),   &
                         s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
-      call bcs2(s)
+      call bcs2_GPU(s,device=.false.)
 
       end subroutine comm_all_s
+
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -9530,9 +9124,6 @@
       real, intent(inout), dimension(cmp,cmp,kmt+1) :: n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2
       integer, intent(inout), dimension(rmp) :: reqs_s
       logical, parameter :: Debug = .FALSE.
-
-!      real, dimension(cmp,jmp,kmp)   :: sw31b,sw32b,se31b,se32b
-!      real, dimension(imp,cmp,kmp)   :: ss31b,ss32b,sn31b,sn32b
 
 
       !$acc data present (s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32, &
@@ -11401,5 +10992,35 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 #endif
+
+
+      subroutine SetMsgParams(openacc,gdirect,device,gpudirect)
+
+         logical, intent(inout) :: openacc, gdirect
+         logical, optional :: device,gpudirect
+
+      if(present(device)) then
+         if(device) then
+            openacc = .true.
+            if(present(gpudirect)) then
+               gdirect = gpudirect
+            else
+               gdirect = .true.
+            endif
+         else
+            openacc = .false.
+            gdirect = .false.
+         endif
+      else
+         openacc = .true.
+         if(present(gpudirect)) then
+            gdirect = gpudirect
+         else
+            gdirect = .true.
+         endif
+      endif
+
+      end subroutine SetMsgParams
+
 
   END MODULE comm_module

--- a/src/comm.F
+++ b/src/comm.F
@@ -1,24 +1,3 @@
-#undef _GPUDIRECT
-
-
-
-#undef _GPUDIRECT08
-#undef _GPUDIRECT14
-#undef _GPUDIRECT15
-#undef _GPUDIRECT16
-
-#ifdef _GPUDIRECT
-
-! 06,08,14 generates an runtime ERROR
-#undef _GPUDIRECT08 
-#undef _GPUDIRECT14
-
-!Activating the following directive generates incorrect results.
-#define _GPUDIRECT15
-#define _GPUDIRECT16
-
-#endif
-
   MODULE comm_module
 
   implicit none
@@ -49,7 +28,7 @@
   public :: comm_2d_start, comm_2dns_end,comm_2dew_end
   public :: comm_2d_corner,comm_all_s
   public :: comm_1s_start,comm_1s_end
-  public :: comm_3s_start,comm_3s_end
+!  public :: comm_3s_start,comm_3s_end
   public :: comm_3t_start,comm_3t_end
   public :: comm_3u_start,comm_3u_end
   public :: comm_3v_start,comm_3v_end
@@ -2254,7 +2233,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       subroutine comm_3s_start_GPU(s,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
+                                 south,newsouth,north,newnorth,reqs,gpudirect,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
           myeast,mywest,mysouth,mynorth,nf,cs3we,cs3sn,timestats,time_mps1, &
           mytime,ierr
@@ -2267,34 +2246,32 @@
       real south(ni,cmp,nk),newsouth(ni,cmp,nk)
       real north(ni,cmp,nk),newnorth(ni,cmp,nk)
       integer reqs(8)
+      logical, optional :: gpudirect
+      logical, optional :: device
  
       integer i,j,k,nr
       integer tag1,tag2,tag3,tag4
       logical, parameter :: Debug =.FALSE.
-      !$acc declare present(s) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc
+      logical :: gdirect
+      !!$acc declare present(s) &
+      !!$acc present(west,newwest,east,neweast) &
+      !!$acc present(south,newsouth,north,newnorth)
  
-!------------------------------------------------
-#ifndef _GPUDIRECT08
-      if(Debug) print *,'comm_3s_start_GPU:'
-#endif
-      nr = 0
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
+!------------------------------------------------
+      nr = 0
       nf=nf+1
       tag1=nf
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT08
-        !$acc host_data use_device(neweast)
+        !$acc host_data use_device(neweast) if(gdirect)
         call mpi_irecv(neweast,cs3we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,cs3we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -2305,15 +2282,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT08
-        !$acc host_data use_device(newwest)
+        !$acc host_data use_device(newwest) if(gdirect)
         call mpi_irecv(newwest,cs3we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,cs3we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -2324,15 +2296,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT08
-        !$acc host_data use_device(newsouth)
+        !$acc host_data use_device(newsouth) if(gdirect)
         call mpi_irecv(newsouth,cs3sn,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,cs3sn,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -2343,15 +2310,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT08
-        !$acc host_data use_device(newnorth)
+        !$acc host_data use_device(newnorth) if(gdirect)
         call mpi_irecv(newnorth,cs3sn,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,cs3sn,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -2363,7 +2325,7 @@
       ! send west
       if(ibw.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -2372,16 +2334,11 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT08
-        !$acc host_data use_device(west) 
+        !$acc update host(west) if(openacc .and. (.not. gdirect))
+        !$acc host_data use_device(west) if(gdirect)
         call mpi_isend(west,cs3we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,cs3we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -2390,7 +2347,7 @@
       ! send east
       if(ibe.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -2399,16 +2356,11 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT08
-        !$acc host_data use_device(east) 
+        !$acc update host(east) if(openacc .and. (.not. gdirect))
+        !$acc host_data use_device(east) if(gdirect)
         call mpi_isend(east,cs3we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,cs3we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -2417,7 +2369,7 @@
       ! send north
       if(ibn.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -2426,16 +2378,11 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT08
-        !$acc host_data use_device(north) 
+        !$acc update host(north) if(openacc .and. (.not. gdirect))
+        !$acc host_data use_device(north) if(gdirect)
         call mpi_isend(north,cs3sn,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,cs3sn,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -2444,7 +2391,7 @@
       ! send south
       if(ibs.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -2453,16 +2400,11 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT08
-        !$acc host_data use_device(south) 
+        !$acc update host(south) if(openacc .and. (.not. gdirect))
+        !$acc host_data use_device(south) if(gdirect)
         call mpi_isend(south,cs3sn,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,cs3sn,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -2692,6 +2634,33 @@
  
       end subroutine comm_3s_end
 
+      subroutine SetMsgParams(openacc,gdirect,device,gpudirect)
+
+         logical, intent(inout) :: openacc, gdirect
+         logical, optional :: device,gpudirect
+
+      if(present(device)) then 
+         if(device) then 
+            openacc = .true.
+            if(present(gpudirect)) then 
+               gdirect = gpudirect
+            else
+               gdirect = .true.
+            endif
+         else
+            openacc = .false.
+            gdirect = .false.
+         endif
+      else
+         openacc = .true.
+         if(present(gpudirect)) then 
+            gdirect = gpudirect
+         else
+            gdirect = .true.
+         endif
+      endif
+
+      end subroutine SetMsgParams
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -2699,7 +2668,7 @@
  
  
       subroutine comm_3s_end_GPU(s,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
+                               south,newsouth,north,newnorth,reqs,gpudirect,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
           wbc,ebc,nbc,sbc,myeast,mywest,mysouth,mynorth,nf,cs3we,cs3sn,timestats, &
           p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen, &
@@ -2713,13 +2682,22 @@
       real south(ni,cmp,nk),newsouth(ni,cmp,nk)
       real north(ni,cmp,nk),newnorth(ni,cmp,nk)
       integer reqs(8)
+      logical, optional :: gpudirect
+      logical, optional :: device
  
       integer i,j,k,nn,nr,index
       integer :: index_east,index_west,index_south,index_north
       integer, dimension(mpi_status_size,8) :: status1
-      !$acc declare present(s) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc
+      logical :: gdirect
+      !!$acc declare present(s) &
+      !!$acc present(west,newwest,east,neweast) &
+      !!$acc present(south,newsouth,north,newnorth)
+
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
+
 
 !-------------------------------------------------------------------
 
@@ -2751,11 +2729,9 @@
       nn = nn + 1
  
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT08
-        !$acc update device(neweast)
-#endif
+        !$acc update device(neweast) if(openacc .and. (.not. gdirect))
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -2764,11 +2740,9 @@
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT08
-        !$acc update device(newwest)
-#endif
+        !$acc update device(newwest) if(openacc .and. (.not. gdirect))
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -2777,11 +2751,9 @@
         enddo
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT08
-        !$acc update device(newsouth)
-#endif
+        !$acc update device(newsouth) if(openacc .and. (.not. gdirect))
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -2790,11 +2762,9 @@
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT08
-        !$acc update device(newnorth)
-#endif
+        !$acc update device(newnorth) if(openacc .and. (.not. gdirect))
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -2817,7 +2787,7 @@
 
           if(p2tchsww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) private(k) if(openacc)
             do k=1,nk
               s(0,0,k)=s(1,0,k)
             enddo
@@ -2825,7 +2795,7 @@
 
           if(p2tchnww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) private(k) if(openacc)
             do k=1,nk
               s(0,nj+1,k)=s(1,nj+1,k)
             enddo
@@ -2837,7 +2807,7 @@
  
           if(p2tchsee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) private(k) if(openacc)
             do k=1,nk
               s(ni+1,0,k)=s(ni,0,k)
             enddo
@@ -2845,7 +2815,7 @@
  
           if(p2tchnee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) private(k) if(openacc)
             do k=1,nk
               s(ni+1,nj+1,k)=s(ni,nj+1,k)
             enddo
@@ -2861,7 +2831,7 @@
  
           if(p2tchsws)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) private(k) if(openacc)
             do k=1,nk
               s(0,0,k)=s(0,1,k)
             enddo
@@ -2869,7 +2839,7 @@
  
           if(p2tchses)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) private(k) if(openacc)
             do k=1,nk
               s(ni+1,0,k)=s(ni+1,1,k)
             enddo
@@ -2881,7 +2851,7 @@
  
           if(p2tchnwn)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) private(k) if(openacc)
             do k=1,nk
               s(0,nj+1,k)=s(0,nj,k)
             enddo
@@ -2889,7 +2859,7 @@
  
           if(p2tchnen)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) private(k) if(openacc)
             do k=1,nk
               s(ni+1,nj+1,k)=s(ni+1,nj,k)
             enddo
@@ -2926,8 +2896,6 @@
 !-----------------------------------------------------------
  
       end subroutine comm_3s_end_GPU
-
-
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -6831,24 +6799,15 @@
 !------------------------------------------------
 
       nr = 0
-#ifndef _GPUDIRECT14
-      if(Debug) print *,'comm_1s_start_GPU:'
-#endif
       nf=nf+1
       tag1=nf
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_start_GPU: point #1'
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,cs1we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,cs1we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -6859,16 +6818,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_start_GPU: point #2'
         !$acc host_data use_device(newwest)
         call mpi_irecv(newwest,cs1we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,cs1we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -6879,16 +6832,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_start_GPU: point #3'
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,cs1sn,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,cs1sn,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -6899,16 +6846,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_start_GPU: point #4'
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,cs1sn,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,cs1sn,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -6927,17 +6868,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_start_GPU: point #5'
         !$acc host_data use_device(west)
         call mpi_isend(west,cs1we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,cs1we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -6952,17 +6886,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_start_GPU: point #6'
         !$acc host_data use_device(east)
         call mpi_isend(east,cs1we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,cs1we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -6977,17 +6904,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_start_GPU: point #7'
         !$acc host_data use_device(north)
         call mpi_isend(north,cs1sn,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,cs1sn,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
  
 !----------
@@ -7002,17 +6922,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_start_GPU: point #8'
         !$acc host_data use_device(south)
         call mpi_isend(south,cs1sn,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,cs1sn,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7294,10 +7207,6 @@
         nn = nn + 1
  
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_end_GPU: point #1'
-        !$acc update device(neweast)
-#endif
         !$omp parallel do default(shared) private(j,k)
         !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
         do k=1,nk
@@ -7306,10 +7215,6 @@
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_end_GPU: point #2'
-        !$acc update device(newwest)
-#endif
         !$omp parallel do default(shared) private(j,k)
         !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
         do k=1,nk
@@ -7318,10 +7223,6 @@
         enddo
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_end_GPU: point #3'
-        !$acc update device(newsouth)
-#endif
         !$omp parallel do default(shared) private(i,k)
         !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
         do k=1,nk
@@ -7330,10 +7231,6 @@
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT14
-        if(Debug) print *,'comm_1s_end_GPU: point #4'
-        !$acc update device(newnorth)
-#endif
         !$omp parallel do default(shared) private(i,k)
         !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
         do k=1,nk
@@ -7493,25 +7390,15 @@
 !------------------------------------------------
 
       nr = 0
-#ifndef _GPUDIRECT15
-      if(Debug) print *,'comm_1p_start_GPU:'
-#endif
-
       nf=nf+1
       tag1=nf
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_start_GPU point #1'
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,cs1we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,cs1we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7522,16 +7409,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_start_GPU point #2'
         !$acc host_data use_device(newwest)
         call mpi_irecv(newwest,cs1we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,cs1we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7542,16 +7423,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_start_GPU point #3'
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,cs1sn,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,cs1sn,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7562,16 +7437,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_start_GPU point #4'
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,cs1sn,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,cs1sn,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -7591,17 +7460,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_start_GPU point #5'
         !$acc host_data use_device(west)
         call mpi_isend(west,cs1we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,cs1we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7617,17 +7479,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_start_GPU point #6'
         !$acc host_data use_device(east)
         call mpi_isend(east,cs1we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,cs1we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7643,17 +7498,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_start_GPU point #7'
         !$acc host_data use_device(north)
         call mpi_isend(north,cs1sn,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,cs1sn,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7669,17 +7517,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_start_GPU point #8'
         !$acc host_data use_device(south)
         call mpi_isend(south,cs1sn,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,cs1sn,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7743,10 +7584,6 @@
         nn = nn + 1
  
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_end_GPU: point #1'
-        !$acc update device(neweast)
-#endif
         !$omp parallel do default(shared) private(j,k)
         !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
         do k=1,nk
@@ -7755,10 +7592,6 @@
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_end_GPU: point #2'
-        !$acc update device(newwest)
-#endif
         !$omp parallel do default(shared) private(j,k)
         !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
         do k=1,nk
@@ -7767,10 +7600,6 @@
         enddo
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_end_GPU: point #3'
-        !$acc update device(newsouth)
-#endif
         !$omp parallel do default(shared) private(i,k)
         !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
         do k=1,nk
@@ -7779,10 +7608,6 @@
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT15
-        if(Debug) print *,'comm_1p_end_GPU: point #4'
-        !$acc update device(newnorth)
-#endif
         !$omp parallel do default(shared) private(i,k)
         !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
         do k=1,nk
@@ -7849,9 +7674,6 @@
 !------------------------------------------------
      
       nr = 0
-#ifndef _GPUDIRECT16
-      if(Debug) print *,'comm_1t_start_GPU:'
-#endif
       nf=nf+1
       tag1=nf
 
@@ -7859,15 +7681,10 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT16
         !$acc host_data use_device(neweast)
         call mpi_irecv(neweast,ct1we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(neweast,ct1we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7878,15 +7695,10 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT16
         !$acc host_data use_device(newwest)
         call mpi_irecv(newwest,ct1we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newwest,ct1we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7897,15 +7709,10 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT16
         !$acc host_data use_device(newsouth)
         call mpi_irecv(newsouth,ct1sn,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newsouth,ct1sn,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7916,15 +7723,10 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-#ifdef _GPUDIRECT16
         !$acc host_data use_device(newnorth)
         call mpi_irecv(newnorth,ct1sn,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        call mpi_irecv(newnorth,ct1sn,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !------------------------------------------------
@@ -7944,16 +7746,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT16
         !$acc host_data use_device(west)
         call mpi_isend(west,ct1we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(west)
-        call mpi_isend(west,ct1we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7969,16 +7765,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT16
         !$acc host_data use_device(east)
         call mpi_isend(east,ct1we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(east)
-        call mpi_isend(east,ct1we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -7994,16 +7784,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT16
         !$acc host_data use_device(north)
         call mpi_isend(north,ct1sn,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(north)
-        call mpi_isend(north,ct1sn,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -8019,16 +7803,10 @@
         enddo
         enddo
         nr = nr + 1
-#ifdef _GPUDIRECT16
         !$acc host_data use_device(south)
         call mpi_isend(south,ct1sn,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
-#else
-        !$acc update host(south)
-        call mpi_isend(south,ct1sn,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-#endif
       endif
 
 !----------
@@ -8093,9 +7871,6 @@
         nn = nn + 1
 
       if(index.eq.index_east)then
-#ifndef _GPUDIRECT16
-        !$acc update device(neweast)
-#endif
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
 !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
@@ -8105,9 +7880,6 @@
         enddo
         enddo
       elseif(index.eq.index_west)then
-#ifndef _GPUDIRECT16
-        !$acc update device(newwest)
-#endif
 !$omp parallel do default(shared)   &
 !$omp private(j,k)
 !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
@@ -8117,9 +7889,6 @@
         enddo
         enddo
       elseif(index.eq.index_south)then
-#ifndef _GPUDIRECT16
-        !$acc update device(newsouth)
-#endif
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
 !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
@@ -8129,9 +7898,6 @@
         enddo
         enddo
       elseif(index.eq.index_north)then
-#ifndef _GPUDIRECT16
-        !$acc update device(newnorth)
-#endif
 !$omp parallel do default(shared)   &
 !$omp private(i,k)
 !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
@@ -9438,8 +9204,10 @@
       tag1=5061
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
+        !$acc host_data use_device(s(0,nj+1))
         call mpi_irecv(s(0,nj+1),1,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
+        !$acc end host_data
       endif
 
 !-----
@@ -9448,8 +9216,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
+        !$acc host_data use_device(s(0,0))
         call mpi_irecv(s(0,0),1,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
+        !$acc end host_data
       endif
 
 !-----
@@ -9458,8 +9228,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
+        !$acc host_data use_device(s(ni+1,nj+1))
         call mpi_irecv(s(ni+1,nj+1),1,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
+        !$acc end host_data
       endif
 
 !-----
@@ -9468,8 +9240,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
+        !$acc host_data use_device(s(ni+1,0))
         call mpi_irecv(s(ni+1,0),1,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
+        !$acc end host_data
       endif
 
 !------------------------------------------------
@@ -9480,36 +9254,40 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nrb = nrb + 1
-        !$acc update host(s(ni,1))
+        !$acc host_data use_device(s(ni,1))
         call mpi_isend(s(ni,1),1,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
+        !$acc end host_data
       endif
 
 !-----
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nrb = nrb + 1
-        !$acc update host(s(ni,nj))
+        !$acc host_data use_device(s(ni,nj))
         call mpi_isend(s(ni,nj),1,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
+        !$acc end host_data
       endif
 
 !-----
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nrb = nrb + 1
-        !$acc update host(s(1,1))
+        !$acc host_data use_device(s(1,1))
         call mpi_isend(s(1,1),1,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
+        !$acc end host_data
       endif
 
 !-----
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nrb = nrb + 1
-         !$acc update host(s(1,nj))
+        !$acc host_data use_device(s(1,nj))
         call mpi_isend(s(1,nj),1,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
+        !$acc end host_data
       endif
 
 !------------------------------------------------
@@ -9527,20 +9305,6 @@
     if( nrb.ge.1 )then
       call MPI_WAITALL(nrb,reqs(5:5+nrb-1),status1(1:mpi_status_size,5:5+nrb-1),ierr)
     endif
-#ifdef _OPENACC
-    if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-      !$acc update device(s(ni+1,0))
-    endif
-    if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-      !$acc update device(s(ni+1,nj+1))
-    endif
-    if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-      !$acc update device(s(0,0))
-    endif
-    if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-      !$acc update device(s(0,nj+1))
-    endif
-#endif
 
 !-----
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
@@ -9767,13 +9531,16 @@
       integer, intent(inout), dimension(rmp) :: reqs_s
       logical, parameter :: Debug = .FALSE.
 
-      if(Debug) print *,'comm_all_s_GPU:'
+!      real, dimension(cmp,jmp,kmp)   :: sw31b,sw32b,se31b,se32b
+!      real, dimension(imp,cmp,kmp)   :: ss31b,ss32b,sn31b,sn32b
+
 
       !$acc data present (s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32, &
-      !$acc               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
+      !$acc               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2)
 
-      call comm_3s_start_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s)
-      call comm_3s_end_GPU(  s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s)
+
+      call comm_3s_start_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,gpudirect=.false.)
+      call comm_3s_end_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,gpudirect=.false.)
       call getcorner3_GPU(s,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),   &
                         s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
       call bcs2_GPU(s)
@@ -9873,10 +9640,8 @@
       logical, parameter :: Debug = .FALSE.
       integer :: i,j
       !$acc data present (s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32, &
-      !$acc               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2, &
-      !$acc               reqs_s)
+      !$acc               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2)
 
-if(Debug) print *, "prepcorners3_GPU: Im called"
 
       IF( comm.eq.1 )THEN
         call bcs_GPU(s)

--- a/src/comm.F
+++ b/src/comm.F
@@ -34,7 +34,7 @@
   public :: comm_3v_start,comm_3v_end
   public :: comm_3w_start,comm_3w_end
   public :: comm_1s2d_start,comm_1s2d_end
-  public :: getcorneru3,getcornerv3,getcorner3_2d,getcorner
+  public :: getcorneru3,getcornerv3,getcorner3_2d  
 
   public :: sync
 
@@ -75,181 +75,12 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 #ifdef MPI
-      subroutine getcorner(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
-          mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
-      use mpi
-      implicit none
- 
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
-      real, intent(inout), dimension(nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
- 
-      integer k,nn,nr,nrb,index
-      integer :: index_nw,index_sw,index_ne,index_se
-      integer reqs(8)
-      integer tag1,tag2,tag3,tag4
-      integer, dimension(mpi_status_size,8) :: status1
-
-!-----
-
-      nr = 0
-      index_nw = -1
-      index_sw = -1
-      index_ne = -1
-      index_se = -1
-
-!------------------------------------------------------------------
-
-      tag1=5001
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(nw2,nk,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-        index_nw = nr
-      endif
-
-!-----
-
-      tag2=5002
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(sw2,nk,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-        index_sw = nr
-      endif
-
-!-----
-
-      tag3=5003
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(ne2,nk,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-        index_ne = nr
-      endif
-
-!-----
-
-      tag4=5004
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(se2,nk,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-        index_se = nr
-      endif
-
-!------------------------------------------------------------------
-
-      nrb = 4
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-        do k=1,nk
-          se1(k)=s(ni,1,k)
-        enddo
-        nrb = nrb + 1
-        call mpi_isend(se1,nk,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-      endif
- 
-!-----
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-        do k=1,nk
-          ne1(k)=s(ni,nj,k)
-        enddo
-        nrb = nrb + 1
-        call mpi_isend(ne1,nk,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-      endif
- 
-!-----
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-        do k=1,nk
-          sw1(k)=s(1,1,k)
-        enddo
-        nrb = nrb + 1
-        call mpi_isend(sw1,nk,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-      endif
- 
-!-----
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-        do k=1,nk
-          nw1(k)=s(1,nj,k)
-        enddo
-        nrb = nrb + 1
-        call mpi_isend(nw1,nk,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-      endif
- 
-!-----
-
-      nn = 1
-      do while( nn .le. nr )
-        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
-
-      if(index.eq.index_nw)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-        do k=1,nk
-          s(0,nj+1,k)=nw2(k)
-        enddo
-      elseif(index.eq.index_sw)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-        do k=1,nk
-          s(0,0,k)=sw2(k)
-        enddo
-      elseif(index.eq.index_ne)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-        do k=1,nk
-          s(ni+1,nj+1,k)=ne2(k)
-        enddo
-      elseif(index.eq.index_se)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-        do k=1,nk
-          s(ni+1,0,k)=se2(k)
-        enddo
-      endif
-
-      enddo
-
-!-----
-
-    nrb = nrb-4
-
-    if( nrb.ge.1 )then
-      call MPI_WAITALL(nrb,reqs(5:5+nrb-1),status1(1:mpi_status_size,5:5+nrb-1),ierr)
-    endif
-
-!-----
-
-      if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-
-      end subroutine getcorner
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine getcorner_GPU(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      subroutine getcorner_GPU(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -257,6 +88,7 @@
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
       real, intent(inout), dimension(nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      logical, optional, intent(in) :: device,gpudirect
 
       integer k,nn,nr,nrb,index
       integer :: index_nw,index_sw,index_ne,index_se
@@ -264,6 +96,12 @@
       integer tag1,tag2,tag3,tag4
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug =.FALSE.
+      logical :: openacc, gdirect
+
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
+
 !-----
 
       nr = 0
@@ -271,14 +109,13 @@
       index_sw = -1
       index_ne = -1
       index_se = -1
-!      !$acc update host(s)
 !------------------------------------------------------------------
 
       tag1=5001
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(nw2)
+        !$acc host_data use_device(nw2) if(gdirect)
         call mpi_irecv(nw2,nk,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -291,7 +128,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(sw2)
+        !$acc host_data use_device(sw2) if(gdirect)
         call mpi_irecv(sw2,nk,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -304,7 +141,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(ne2)
+        !$acc host_data use_device(ne2) if(gdirect)
         call mpi_irecv(ne2,nk,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -317,7 +154,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(se2)
+        !$acc host_data use_device(se2) if(gdirect)
         call mpi_irecv(se2,nk,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -329,14 +166,13 @@
       nrb = 4
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$omp parallel do default(shared) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do k=1,nk
           se1(k)=s(ni,1,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(se1)
+        !$acc host_data use_device(se1) if(gdirect)
         call mpi_isend(se1,nk,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -345,14 +181,13 @@
 !-----
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$omp parallel do default(shared) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do k=1,nk
           ne1(k)=s(ni,nj,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(ne1)
+        !$acc host_data use_device(ne1) if(gdirect)
         call mpi_isend(ne1,nk,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -361,14 +196,13 @@
 !-----
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$omp parallel do default(shared) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do k=1,nk
           sw1(k)=s(1,1,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(sw1)
+        !$acc host_data use_device(sw1) if(gdirect)
         call mpi_isend(sw1,nk,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -377,14 +211,13 @@
 !-----
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$omp parallel do default(shared) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do k=1,nk
           nw1(k)=s(1,nj,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(nw1)
+        !$acc host_data use_device(nw1) if(gdirect)
         call mpi_isend(nw1,nk,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -398,30 +231,26 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$omp parallel do default(shared) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do k=1,nk
           s(0,nj+1,k)=nw2(k)
         enddo
       elseif(index.eq.index_sw)then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$omp parallel do default(shared)  private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do k=1,nk
           s(0,0,k)=sw2(k)
         enddo
       elseif(index.eq.index_ne)then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$omp parallel do default(shared) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do k=1,nk
           s(ni+1,nj+1,k)=ne2(k)
         enddo
       elseif(index.eq.index_se)then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$omp parallel do default(shared) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do k=1,nk
           s(ni+1,0,k)=se2(k)
         enddo

--- a/src/comm.F
+++ b/src/comm.F
@@ -23,12 +23,12 @@
   public :: getcorneru_GPU,getcornerv_GPU,getcornert_GPU,getcornerw_GPU,getcorner_GPU
   public :: getcorneru3_GPU,getcornerv3_GPU,getcornerw3_GPU
   public :: prepcorners3_GPU,prepcornert_GPU,prepcorners_GPU
+  public :: comm_all_s_GPU
 
   !CPU only routines
   public :: comm_2d_start, comm_2dns_end,comm_2dew_end
-  public :: comm_2d_corner,comm_all_s
+  public :: comm_2d_corner
   public :: comm_1s_start,comm_1s_end
-!  public :: comm_3s_start,comm_3s_end
   public :: comm_3t_start,comm_3t_end
   public :: comm_3u_start,comm_3u_end
   public :: comm_3v_start,comm_3v_end
@@ -1269,213 +1269,11 @@
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
       end subroutine getcornerw_GPU
 
-
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine getcorner3(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
-          cmp,nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
-      use mpi
-      implicit none
- 
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
-      real, intent(inout), dimension(cmp,cmp,nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
- 
-      integer :: i,j,k,nn,nr,index
-      integer :: index_nw,index_sw,index_ne,index_se
-      integer reqs(8)
-      integer tag1,tag2,tag3,tag4
-
-!-----
-
-      nr = 0
-      index_nw = -1
-      index_sw = -1
-      index_ne = -1
-      index_se = -1
-
-!------------------------------------------------------------------
-
-      tag1=5001
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(nw2,cmp*cmp*nk,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-        index_nw = nr
-      endif
-
-!-----
-
-      tag2=5002
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(sw2,cmp*cmp*nk,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-        index_sw = nr
-      endif
-
-!-----
-
-      tag3=5003
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(ne2,cmp*cmp*nk,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-        index_ne = nr
-      endif
-
-!-----
-
-      tag4=5004
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(se2,cmp*cmp*nk,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-        index_se = nr
-      endif
-
-!------------------------------------------------------------------
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-!!!          se1(i,j,k)=s(ni,1,k)
-          se1(i,j,k)=s(ni-cmp+i,j,k)
-        enddo
-        enddo
-        enddo
-        call mpi_isend(se1,cmp*cmp*nk,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(5),ierr)
-      endif
- 
-!-----
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-!!!          ne1(i,j,k)=s(ni,nj,k)
-          ne1(i,j,k)=s(ni-cmp+i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        call mpi_isend(ne1,cmp*cmp*nk,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(6),ierr)
-      endif
- 
-!-----
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-!!!          sw1(i,j,k)=s(1,1,k)
-          sw1(i,j,k)=s(i,j,k)
-        enddo
-        enddo
-        enddo
-        call mpi_isend(sw1,cmp*cmp*nk,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(7),ierr)
-      endif
- 
-!-----
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-!!!          nw1(i,j,k)=s(1,nj,k)
-          nw1(i,j,k)=s(i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        call mpi_isend(nw1,cmp*cmp*nk,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(8),ierr)
-      endif
- 
-!-----
-
-      nn = 1
-      do while( nn .le. nr )
-        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
-
-      if(index.eq.index_nw)then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-!!!          s(0,nj+1,k)=nw2(i,j,k)
-          s(-cmp+i,nj+j,k)=nw2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_sw)then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-!!!          s(0,0,k)=sw2(i,j,k)
-          s(-cmp+i,-cmp+j,k)=sw2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_ne)then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-!!!          s(ni+1,nj+1,k)=ne2(i,j,k)
-          s(ni+i,nj+j,k)=ne2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_se)then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-!!!          s(ni+1,0,k)=se2(i,j,k)
-          s(ni+i,-cmp+j,k)=se2(i,j,k)
-        enddo
-        enddo
-        enddo
-      endif
-
-      enddo
-
-!-----
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        call MPI_WAIT (reqs(5),MPI_STATUS_IGNORE,ierr)
-      endif
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        call MPI_WAIT (reqs(6),MPI_STATUS_IGNORE,ierr)
-      endif
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        call MPI_WAIT (reqs(7),MPI_STATUS_IGNORE,ierr)
-      endif
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        call MPI_WAIT (reqs(8),MPI_STATUS_IGNORE,ierr)
-      endif
-
-!-----
-
-      if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-
-      end subroutine getcorner3
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-      subroutine getcorner3_GPU(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      subroutine getcorner3_GPU(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           cmp,nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -1483,12 +1281,18 @@
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
       real, intent(inout), dimension(cmp,cmp,nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      logical, optional, intent(in) :: device,gpudirect
 
       integer :: i,j,k,nn,nr,index
       integer :: index_nw,index_sw,index_ne,index_se
       integer reqs(8)
       integer tag1,tag2,tag3,tag4
       logical, parameter :: Debug =.FALSE.
+      logical :: openacc,gdirect
+
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !-----
       nr = 0
@@ -1496,14 +1300,13 @@
       index_sw = -1
       index_ne = -1
       index_se = -1
-!      !$acc update host(s)
 !------------------------------------------------------------------
 
       tag1=5001
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(nw2)
+        !$acc host_data use_device(nw2) if(gdirect)
         call mpi_irecv(nw2,cmp*cmp*nk,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -1516,7 +1319,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(sw2)
+        !$acc host_data use_device(sw2) if(gdirect)
         call mpi_irecv(sw2,cmp*cmp*nk,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -1529,7 +1332,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(ne2)
+        !$acc host_data use_device(ne2) if(gdirect)
         call mpi_irecv(ne2,cmp*cmp*nk,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -1542,7 +1345,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(se2)
+        !$acc host_data use_device(se2) if(gdirect)
         call mpi_irecv(se2,cmp*cmp*nk,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -1552,7 +1355,7 @@
 !------------------------------------------------------------------
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-!$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -1561,7 +1364,7 @@
         enddo
         enddo
         enddo
-        !$acc host_data use_device(se1)
+        !$acc host_data use_device(se1) if(gdirect)
         call mpi_isend(se1,cmp*cmp*nk,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(5),ierr)
         !$acc end host_data
@@ -1570,7 +1373,7 @@
 !-----
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-!$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -1579,7 +1382,7 @@
         enddo
         enddo
         enddo
-        !$acc host_data use_device(ne1)
+        !$acc host_data use_device(ne1) if(gdirect)
         call mpi_isend(ne1,cmp*cmp*nk,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(6),ierr)
         !$acc end host_data
@@ -1588,7 +1391,7 @@
 !-----
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-!$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -1597,7 +1400,7 @@
         enddo
         enddo
         enddo
-        !$acc host_data use_device(sw1)
+        !$acc host_data use_device(sw1) if(gdirect)
         call mpi_isend(sw1,cmp*cmp*nk,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(7),ierr)
         !$acc end host_data
@@ -1606,7 +1409,7 @@
 !-----
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-!$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -1615,7 +1418,7 @@
         enddo
         enddo
         enddo
-        !$acc host_data use_device(nw1)
+        !$acc host_data use_device(nw1) if(gdirect)
         call mpi_isend(nw1,cmp*cmp*nk,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(8),ierr)
         !$acc end host_data
@@ -1629,7 +1432,7 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-!$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -1639,7 +1442,7 @@
         enddo
         enddo
       elseif(index.eq.index_sw)then
-!$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -1649,7 +1452,7 @@
         enddo
         enddo
       elseif(index.eq.index_ne)then
-!$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -1659,7 +1462,7 @@
         enddo
         enddo
       elseif(index.eq.index_se)then
-!$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -1673,27 +1476,20 @@
       enddo
 
 !-----
-      !JMD-KLUDGE REVISIT
-      !JMD I am confused here.  Why are we updating the buffers here... I don't
-      !JMD think this is needed
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         call MPI_WAIT (reqs(5),MPI_STATUS_IGNORE,ierr)
-        !$acc update device(se2)
       endif
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         call MPI_WAIT (reqs(6),MPI_STATUS_IGNORE,ierr)
-        !$acc update device(ne2)
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         call MPI_WAIT (reqs(7),MPI_STATUS_IGNORE,ierr)
-        !$acc update device(sw2)
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         call MPI_WAIT (reqs(8),MPI_STATUS_IGNORE,ierr)
-        !$acc update device(nw2)
       endif
 
 !-----
@@ -2096,9 +1892,6 @@
       logical, parameter :: Debug =.FALSE.
       logical :: openacc
       logical :: gdirect
-      !!$acc declare present(s) &
-      !!$acc present(west,newwest,east,neweast) &
-      !!$acc present(south,newsouth,north,newnorth)
  
       ! Set the GPU specific parameters to control communication
       call SetMsgParams(openacc,gdirect,device,gpudirect)
@@ -2282,14 +2075,9 @@
       integer, dimension(mpi_status_size,8) :: status1
       logical :: openacc
       logical :: gdirect
-      !!$acc declare present(s) &
-      !!$acc present(west,newwest,east,neweast) &
-      !!$acc present(south,newsouth,north,newnorth)
-
 
       ! Set the GPU specific parameters to control communication
       call SetMsgParams(openacc,gdirect,device,gpudirect)
-
 
 !-------------------------------------------------------------------
 
@@ -9080,39 +8868,12 @@
 
       end subroutine getcorner3_2d
 
-
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
-
-      subroutine comm_all_s(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                              n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
-
-      use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt
-      use bc_module, only: bcs2
-      implicit none
-
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
-      real, intent(inout), dimension(cmp,jmp,kmp)   :: sw31,sw32,se31,se32
-      real, intent(inout), dimension(imp,cmp,kmp)   :: ss31,ss32,sn31,sn32
-      real, intent(inout), dimension(cmp,cmp,kmt+1) :: n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2
-      integer, intent(inout), dimension(rmp) :: reqs_s
-
-      call comm_3s_start_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
-      call comm_3s_end_GPU( s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
-      call getcorner3(s,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),   &
-                        s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
-      call bcs2(s,device=.false.)
-
-      end subroutine comm_all_s
-
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       subroutine comm_all_s_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                              n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
+                              n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device)
 
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt
       use bc_module, only: bcs2
@@ -9123,20 +8884,17 @@
       real, intent(inout), dimension(imp,cmp,kmp)   :: ss31,ss32,sn31,sn32
       real, intent(inout), dimension(cmp,cmp,kmt+1) :: n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2
       integer, intent(inout), dimension(rmp) :: reqs_s
+      logical, optional, intent(in) :: device
       logical, parameter :: Debug = .FALSE.
 
-
-      !$acc data present (s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32, &
-      !$acc               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2)
-
-
-      call comm_3s_start_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,gpudirect=.false.)
-      call comm_3s_end_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,gpudirect=.false.)
+      call comm_3s_start_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s, &
+                device=device, gpudirect=.false.)
+      call comm_3s_end_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s, &
+                device=device,gpudirect=.false.)
       call getcorner3_GPU(s,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),   &
-                        s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
-      call bcs2(s)
+                s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1),device=device)
+      call bcs2(s,device=device)
 
-      !$acc end data
       end subroutine comm_all_s_GPU
 
 #endif

--- a/src/comm.F
+++ b/src/comm.F
@@ -34,7 +34,7 @@
   public :: comm_3v_start,comm_3v_end
   public :: comm_3w_start,comm_3w_end
   public :: comm_1s2d_start,comm_1s2d_end
-  public :: getcorneru3,getcornerv3,getcorner3_2d  
+  public :: getcorner3_2d  
 
   public :: sync
 
@@ -8903,12 +8903,12 @@
       end subroutine prepcornert_GPU
 
 #ifdef MPI
+
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-
-      subroutine getcorneru3(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      subroutine getcorneru3_GPU(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibn,ibs, &
           wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
@@ -8916,195 +8916,7 @@
 
       real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: u
       real, intent(inout), dimension(cmp,cmp,nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
-
-      integer :: i,j,k,nn,index
-      integer :: index_nw,index_sw,index_ne,index_se
-      integer reqs(8)
-      integer tag1,tag2,tag3,tag4,count,nr1,nr2
-      integer, dimension(mpi_status_size,8) :: status1
-
-      count=cmp*cmp*nk
-      nr1 = 0
-      index_nw = -1
-      index_sw = -1
-      index_ne = -1
-      index_se = -1
-
-!-----
-
-      tag1=5031
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_nw = nr1
-      endif
-
-!-----
-
-      tag2=5032
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_sw = nr1
-      endif
-
-!-----
-
-      tag3=5033
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_ne = nr1
-      endif
-
-!-----
-
-      tag4=5034
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_se = nr1
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr2 = 0
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          se1(i,j,k)=u(ni-cmp+i,j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          ne1(i,j,k)=u(ni-cmp+i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          sw1(i,j,k)=u(1+i,j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          nw1(i,j,k)=u(1+i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nn = 1
-      do while( nn .le. nr1 )
-
-        call MPI_WAITANY(nr1,reqs(1:nr1),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
-
-      if( index.eq.index_nw )then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          u(-cmp+i,nj+j,k)=nw2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif( index.eq.index_sw )then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          u(-cmp+i,-cmp+j,k)=sw2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif( index.eq.index_ne )then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          u(ni+1+i,nj+j,k)=ne2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif( index.eq.index_se )then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          u(ni+1+i,-cmp+j,k)=se2(i,j,k)
-        enddo
-        enddo
-        enddo
-      endif
-
-      enddo
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-    if( nr2.ge.1 )then
-      call MPI_WAITALL(nr2,reqs(5:5+nr2-1),status1(1:mpi_status_size,5:5+nr2-1),ierr)
-    endif
-
-!-----
-
-      if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-
-      end subroutine getcorneru3
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine getcorneru3_GPU(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibn,ibs, &
-          wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
-      use mpi
-      implicit none
-
-      real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: u
-      real, intent(inout), dimension(cmp,cmp,nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      logical, optional, intent(in) :: device,gpudirect
 
       integer :: i,j,k,nn,index
       integer :: index_nw,index_sw,index_ne,index_se
@@ -9112,6 +8924,11 @@
       integer tag1,tag2,tag3,tag4,count,nr1,nr2
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug = .FALSE.
+      logical :: openacc,gdirect
+
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
       count=cmp*cmp*nk
       nr1 = 0
@@ -9125,7 +8942,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr1 = nr1+1
-        !$acc host_data use_device(nw2)
+        !$acc host_data use_device(nw2) if(gdirect)
         call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
@@ -9138,7 +8955,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr1 = nr1+1
-        !$acc host_data use_device(sw2)
+        !$acc host_data use_device(sw2) if(gdirect)
         call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
@@ -9151,7 +8968,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr1 = nr1+1
-        !$acc host_data use_device(ne2)
+        !$acc host_data use_device(ne2) if(gdirect)
         call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
@@ -9164,7 +8981,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr1 = nr1+1
-        !$acc host_data use_device(se2)
+        !$acc host_data use_device(se2) if(gdirect)
         call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
@@ -9178,7 +8995,7 @@
       nr2 = 0
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9187,14 +9004,14 @@
         enddo
         enddo
         nr2 = nr2+1
-        !$acc host_data use_device(se1)
+        !$acc host_data use_device(se1) if(gdirect)
         call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
       endif
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9203,14 +9020,14 @@
         enddo
         enddo
         nr2 = nr2+1
-        !$acc host_data use_device(ne1)
+        !$acc host_data use_device(ne1) if(gdirect)
         call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9219,14 +9036,14 @@
         enddo
         enddo
         nr2 = nr2+1
-        !$acc host_data use_device(sw1)
+        !$acc host_data use_device(sw1) if(gdirect)
         call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9235,7 +9052,7 @@
         enddo
         enddo
         nr2 = nr2+1
-        !$acc host_data use_device(nw1)
+        !$acc host_data use_device(nw1) if(gdirect)
         call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
@@ -9252,7 +9069,7 @@
         nn = nn + 1
 
       if( index.eq.index_nw )then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9261,7 +9078,7 @@
         enddo
         enddo
       elseif( index.eq.index_sw )then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9270,7 +9087,7 @@
         enddo
         enddo
       elseif( index.eq.index_ne )then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc) 
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9279,7 +9096,7 @@
         enddo
         enddo
       elseif( index.eq.index_se )then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9304,13 +9121,11 @@
 
       end subroutine getcorneru3_GPU
 
-
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-
-      subroutine getcornerv3(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      subroutine getcornerv3_GPU(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibn,ibs, &
           wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
@@ -9318,195 +9133,7 @@
 
       real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: v
       real, intent(inout), dimension(cmp,cmp,nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
-
-      integer :: i,j,k,nn,index
-      integer :: index_nw,index_sw,index_ne,index_se
-      integer reqs(8)
-      integer tag1,tag2,tag3,tag4,count,nr1,nr2
-      integer, dimension(mpi_status_size,8) :: status1
-
-      count=cmp*cmp*nk
-      nr1 = 0
-      index_nw = -1
-      index_sw = -1
-      index_ne = -1
-      index_se = -1
-
-!-----
-
-      tag1=5041
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_nw = nr1
-      endif
-
-!-----
-
-      tag2=5042
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_sw = nr1
-      endif
-
-!-----
-
-      tag3=5043
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_ne = nr1
-      endif
-
-!-----
-
-      tag4=5044
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_se = nr1
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr2 = 0
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          se1(i,j,k)=v(ni-cmp+i,1+j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          ne1(i,j,k)=v(ni-cmp+i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          sw1(i,j,k)=v(i,1+j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          nw1(i,j,k)=v(i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nn = 1
-      do while( nn .le. nr1 )
-
-        call MPI_WAITANY(nr1,reqs(1:nr1),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
-
-      if( index.eq.index_nw )then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          v(-cmp+i,nj+1+j,k)=nw2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif( index.eq.index_sw )then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          v(-cmp+i,-cmp+j,k)=sw2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif( index.eq.index_ne )then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          v(ni+i,nj+1+j,k)=ne2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif( index.eq.index_se )then
-        do k=1,nk
-        do j=1,cmp
-        do i=1,cmp
-          v(ni+i,-cmp+j,k)=se2(i,j,k)
-        enddo
-        enddo
-        enddo
-      endif
-
-      enddo
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-    if( nr2.ge.1 )then
-      call MPI_WAITALL(nr2,reqs(5:5+nr2-1),status1(1:mpi_status_size,5:5+nr2-1),ierr)
-    endif
-
-!-----
-
-      if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-
-      end subroutine getcornerv3
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine getcornerv3_GPU(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibn,ibs, &
-          wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
-      use mpi
-      implicit none
-
-      real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: v
-      real, intent(inout), dimension(cmp,cmp,nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      logical, optional, intent(in) :: device, gpudirect
 
       integer :: i,j,k,nn,index
       integer :: index_nw,index_sw,index_ne,index_se
@@ -9514,6 +9141,12 @@
       integer tag1,tag2,tag3,tag4,count,nr1,nr2
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug = .FALSE.
+      logical :: gdirect,openacc
+
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
+
 
       count=cmp*cmp*nk
       nr1 = 0
@@ -9527,7 +9160,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr1 = nr1+1
-        !$acc host_data use_device(nw2)
+        !$acc host_data use_device(nw2) if(gdirect)
         call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
@@ -9540,7 +9173,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr1 = nr1+1
-        !$acc host_data use_device(sw2)
+        !$acc host_data use_device(sw2) if(gdirect)
         call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
@@ -9553,7 +9186,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr1 = nr1+1
-        !$acc host_data use_device(ne2)
+        !$acc host_data use_device(ne2) if(gdirect)
         call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
@@ -9566,7 +9199,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr1 = nr1+1
-        !$acc host_data use_device(se2)
+        !$acc host_data use_device(se2) if(gdirect)
         call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr1),ierr)
         !$acc end host_data
@@ -9580,7 +9213,7 @@
       nr2 = 0
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9589,14 +9222,14 @@
         enddo
         enddo
         nr2 = nr2+1
-        !$acc host_data use_device(se1)
+        !$acc host_data use_device(se1) if(gdirect)
         call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
       endif
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9605,14 +9238,14 @@
         enddo
         enddo
         nr2 = nr2+1
-        !$acc host_data use_device(ne1)
+        !$acc host_data use_device(ne1) if(gdirect)
         call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9621,14 +9254,14 @@
         enddo
         enddo
         nr2 = nr2+1
-        !$acc host_data use_device(sw1)
+        !$acc host_data use_device(sw1) if(gdirect)
         call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
       endif
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9637,7 +9270,7 @@
         enddo
         enddo
         nr2 = nr2+1
-        !$acc host_data use_device(nw1)
+        !$acc host_data use_device(nw1) if(gdirect)
         call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(4+nr2),ierr)
         !$acc end host_data
@@ -9654,7 +9287,7 @@
         nn = nn + 1
 
       if( index.eq.index_nw )then
-!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9663,7 +9296,7 @@
         enddo
         enddo
       elseif( index.eq.index_sw )then
-!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9672,7 +9305,7 @@
         enddo
         enddo
       elseif( index.eq.index_ne )then
-!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp
@@ -9681,7 +9314,7 @@
         enddo
         enddo
       elseif( index.eq.index_se )then
-        !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        !$acc parallel loop gang vector collapse(3) default(present) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,cmp

--- a/src/comm.F
+++ b/src/comm.F
@@ -9090,7 +9090,7 @@
                               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
 
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt
-      use bc_module, only: bcs2_GPU
+      use bc_module, only: bcs2
       implicit none
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
@@ -9103,7 +9103,7 @@
       call comm_3s_end_GPU( s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
       call getcorner3(s,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),   &
                         s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
-      call bcs2_GPU(s,device=.false.)
+      call bcs2(s,device=.false.)
 
       end subroutine comm_all_s
 
@@ -9115,7 +9115,7 @@
                               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
 
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt
-      use bc_module, only: bcs2_GPU
+      use bc_module, only: bcs2
       implicit none
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
@@ -9134,7 +9134,7 @@
       call comm_3s_end_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,gpudirect=.false.)
       call getcorner3_GPU(s,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),   &
                         s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
-      call bcs2_GPU(s)
+      call bcs2(s)
 
       !$acc end data
       end subroutine comm_all_s_GPU
@@ -9148,7 +9148,7 @@
                                pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,comm)
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt,ni,nj,nk, &
           tbc,bbc,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
-      use bc_module, only: bcs_GPU,bcs2_GPU
+      use bc_module, only: bcs,bcs2
       implicit none
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
@@ -9170,7 +9170,7 @@
 !--------------------------------------------!
 
       IF( comm.eq.1 )THEN
-        call bcs_GPU(s)
+        call bcs(s)
       ENDIF
 #ifdef MPI
       if(Debug) print *,'prepcorners_GPU point #1'
@@ -9181,7 +9181,7 @@
       if(Debug) print *,'prepcorners_GPU point #2'
       call getcorner_GPU(s,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
       if(Debug) print *,'prepcorners_GPU point #3'
-      call bcs2_GPU(s)
+      call bcs2(s)
       if(Debug) print *,'prepcorners_GPU point #4'
 #endif
 
@@ -9219,7 +9219,7 @@
                                 n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,comm)
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt,ni,nj,nk, &
           tbc,bbc,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
-      use bc_module, only: bcs_GPU
+      use bc_module, only: bcs
       implicit none
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
@@ -9235,7 +9235,7 @@
 
 
       IF( comm.eq.1 )THEN
-        call bcs_GPU(s)
+        call bcs(s)
 #ifdef MPI
         call comm_all_s_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
@@ -9279,7 +9279,7 @@
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,comm)
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt,ni,nj,nk, &
           tbc,bbc,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
-      use bc_module, only: bcw_GPU, bct2_GPU
+      use bc_module, only: bcw, bct2
       implicit none
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: t
@@ -9300,7 +9300,7 @@
 
       if(Debug) print *,'prepcornert_GPU'
       IF( comm.eq.1 )THEN
-        call bcw_GPU(t,0)
+        call bcw(t,0)
       ENDIF
 #ifdef MPI
       IF( comm.eq.1 )THEN
@@ -9308,7 +9308,7 @@
         call comm_1t_end_GPU(  t,tkw1(1,1,1),tkw2(1,1,1),tke1(1,1,1),tke2(1,1,1),tks1(1,1,1),tks2(1,1,1),tkn1(1,1,1),tkn2(1,1,1),reqs_p)
       ENDIF
       call getcornert_GPU(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      call bct2_GPU(t)
+      call bct2(t)
 #endif
 
       !$acc end data

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -3141,7 +3141,7 @@
             if (random_droplets) then
                ! initialize a new random number generator for each
                ! injected droplet
-               local_seed = int(29.*mtime) + (97*myid) + (7*j)
+               local_seed = floor(29.*mtime) + (97*myid) + (7*j)
                call new_RandomNumberSequence(randomNumbers, local_seed)
                rand = getRandomReal(randomNumbers)
                a = totdrops*rand

--- a/src/hifrq.F
+++ b/src/hifrq.F
@@ -54,7 +54,7 @@
     use constants
     use cm1libs , only : rslf,rsif
     use adv_module , only : advs
-    use bc_module, only: bcs
+    use bc_module, only: bcs_GPU
     use ib_module
 #ifdef NETCDF
     use writeout_nc_module , only : writehifrq_nc
@@ -934,10 +934,10 @@
 
       !c-c-c-c-c-c-c-c-c-c
 
-      call bcs(sadv)
+      call bcs_GPU(sadv,device=.false.)
 #ifdef MPI
-      call comm_3s_start(sadv,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s)
-      call comm_3s_end(  sadv,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s)
+      call comm_3s_start_GPU(sadv,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
+      call comm_3s_end_GPU(sadv,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
 #endif
 
     if( td_hadv.ge.1 .and. td_vadv.ge.1 )then

--- a/src/hifrq.F
+++ b/src/hifrq.F
@@ -54,7 +54,7 @@
     use constants
     use cm1libs , only : rslf,rsif
     use adv_module , only : advs
-    use bc_module, only: bcs_GPU
+    use bc_module, only: bcs
     use ib_module
 #ifdef NETCDF
     use writeout_nc_module , only : writehifrq_nc
@@ -934,7 +934,7 @@
 
       !c-c-c-c-c-c-c-c-c-c
 
-      call bcs_GPU(sadv,device=.false.)
+      call bcs(sadv,device=.false.)
 #ifdef MPI
       call comm_3s_start_GPU(sadv,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
       call comm_3s_end_GPU(sadv,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)

--- a/src/ib_module.F
+++ b/src/ib_module.F
@@ -31,7 +31,7 @@
         rmp,cmp,jmp,imp,ni,nj,nk,nx,ny,nz,dx,testcase,miny,maxy,minx,maxx,ierr, &
         myid,dowr,nf,nu,nv,nw,centerx,centery,dowr,outfile
     use constants
-    use bc_module, only: bc2d_GPU, bcs2_2d_GPU
+    use bc_module, only: bc2d, bcs2_2d
     use comm_module
 #ifdef MPI
     use mpi
@@ -185,9 +185,7 @@
 
     !---  DO NOT CHANGE ANYTHING BELOW HERE  ---!
 
-        !$acc data copy(zsfoo)
-        call bc2d_GPU(zsfoo)
-        !$acc end data
+        call bc2d(zsfoo,device=.false.)
 #ifdef MPI
       nf=0
       nu=0
@@ -198,8 +196,8 @@
       call comm_2dew_end(zsfoo,west,newwest,east,neweast,reqs_p)
       call comm_2dns_end(zsfoo,south,newsouth,north,newnorth,reqs_p)
       !$acc data copy(zsfoo)
-      call bcs2_2d_GPU(zsfoo)
-      call bc2d_GPU(zsfoo)
+      call bcs2_2d(zsfoo)
+      call bc2d(zsfoo)
       !$acc end data
       call getcorner3_2d(zsfoo)
 #endif

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -78,7 +78,7 @@
       use constants
       use misclibs
       use cm1libs , only : rslf,rsif
-      use bc_module, only: bcu_GPU, bcv_GPU, bcw_GPU, bcs_GPU
+      use bc_module, only: bcu, bcv, bcw, bcs
       use module_mp_nssl_2mom, only: ccn, lccn
       use poiss_module
       use parcel_module , only : getparcelzs
@@ -264,8 +264,8 @@
             tke3d = 1.0
           ENDIF
           !$acc data copy(tkea,tke3d)
-          call bcw_GPU(tkea,1)
-          call bcw_GPU(tke3d,1)
+          call bcw(tkea,1)
+          call bcw(tke3d,1)
           !$acc end data
       ENDIF
 
@@ -1318,11 +1318,11 @@
         ! all done, set some boundary conditions, calculate final pressure, etc:
 
         !$acc data copy(ua,va)
-        call bcu_GPU(ua)
-        call bcv_GPU(va)
+        call bcu(ua)
+        call bcv(va)
         !$acc end data
-        call bcs_GPU(ppi,device=.false.)
-        call bcs_GPU(tha,device=.false.)
+        call bcs(ppi,device=.false.)
+        call bcs(tha,device=.false.)
 
         call calcprs(pi0,prs,ppi)
 
@@ -2001,7 +2001,7 @@
 
         ENDIF
 
-        call bcs_GPU(ppi,device=.false.)
+        call bcs(ppi,device=.false.)
 
       ENDIF
 
@@ -2102,7 +2102,7 @@
         enddo
         enddo
 
-      call bcs_GPU(ppi,device=.false.)
+      call bcs(ppi,device=.false.)
 
   ENDIF  bsmod
 
@@ -2138,8 +2138,8 @@
       use input
       use constants
       use misclibs
-      use bc_module, only: bc2d_GPU, bcu_GPU, bcv_GPU, bcw_GPU, bcwsfc, bcs_GPU, &
-          bcs2_GPU, bcs2_2d_GPU
+      use bc_module, only: bc2d, bcu, bcv, bcw, bcwsfc, bcs, &
+          bcs2, bcs2_2d
       use comm_module
       use parcel_module , only : getparcelzs
       use ib_module
@@ -2224,34 +2224,34 @@
 !  Make sure boundary values are set properly
 
       !$acc data copy(ua,va,wa)
-      call bcu_GPU(ua)
-      call bcv_GPU(va)
-      call bcw_GPU(wa,1)
+      call bcu(ua)
+      call bcv(va)
+      call bcw(wa,1)
       !$acc end data
-      call bcs_GPU(ppi,device=.false.)
-      call bcs_GPU(tha,device=.false.)
+      call bcs(ppi,device=.false.)
+      call bcs(tha,device=.false.)
       if(imoist.eq.1)then
         do n=1,numq
-          call bcs_GPU(qa(ibm,jbm,kbm,n),device=.false.)
+          call bcs(qa(ibm,jbm,kbm,n),device=.false.)
         enddo
       endif
       if( cm1setup.eq.1 .and. iusetke )then
         !$acc data copy(tkea)
-        call bcw_GPU(tkea,1)
+        call bcw(tkea,1)
         !$acc end data
       endif
 
       if(iptra.eq.1)then
         do n=1,npt
-          call bcs_GPU(pta(ib,jb,kb,n),device=.false.)
+          call bcs(pta(ib,jb,kb,n),device=.false.)
         enddo
       endif
       
       !$acc data copy(u0,v0)
-      call bcu_GPU(u0)
-      call bcv_GPU(v0)
+      call bcu(u0)
+      call bcv(v0)
       !$acc end data
-      call bcs_GPU(th0,device=.false.)
+      call bcs(th0,device=.false.)
 
 #ifdef MPI
 !------------------------------------------------------------------
@@ -2332,7 +2332,7 @@
       if(terrain_flag)then
         !$acc data copyin(gz,dzdx,dzdy,ua,va) copy(wa)
         call bcwsfc(gz,dzdx,dzdy,ua,va,wa)
-        call bc2d_GPU(wa(ib,jb,1))
+        call bc2d(wa(ib,jb,1))
         !$acc end data
       endif
 
@@ -2343,14 +2343,14 @@
         enddo
         enddo
         !$acc data copy(tkea)
-        call bc2d_GPU(tkea(ibt,jbt,1))
+        call bc2d(tkea(ibt,jbt,1))
         !$acc end data
 #ifdef MPI
         call comm_1s2d_start(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
                                              ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s)
         call comm_1s2d_end(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
                                            ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s)
-        call bcs2_2d_GPU(tkea(ibt,jbt,1),device=.false.)
+        call bcs2_2d(tkea(ibt,jbt,1),device=.false.)
         call comm_2d_corner(tkea(ibt,jbt,1))
 #endif
       endif
@@ -2433,7 +2433,7 @@
       endif
 
       if( psolver.eq.6 )then
-        call bcs_GPU(phi1,device=.false.)
+        call bcs(phi1,device=.false.)
 #ifdef MPI
         call comm_1s_start(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         call comm_1s_end(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
@@ -2503,12 +2503,12 @@
   ENDIF
 
 
-        call bcs_GPU(rho,device=.false.)
+        call bcs(rho,device=.false.)
 #ifdef MPI
         call comm_1s_start(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         call comm_1s_end(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         !$acc data copy(rho)
-        call bcs2_GPU(rho)
+        call bcs2(rho)
         !$acc end data
         call getcorner(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
 #endif
@@ -2524,21 +2524,21 @@
         enddo
         enddo
 
-        call bcs_GPU(rr,device=.false.)
+        call bcs(rr,device=.false.)
 #ifdef MPI
         call comm_1s_start(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         call comm_1s_end(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         !$acc data copy(rr)
-        call bcs2_GPU(rr)
+        call bcs2(rr)
         !$acc end data
         call getcorner(rr,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
 #endif
-        call bcs_GPU(rf,device=.false.)
+        call bcs(rf,device=.false.)
 #ifdef MPI
         call comm_1s_start(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         call comm_1s_end(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         !$acc data copy(rf)
-        call bcs2_GPU(rf)
+        call bcs2(rf)
         !$acc end data
         call getcorner(rf,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
 #endif
@@ -2639,7 +2639,7 @@
 
       ENDIF
 
-      call bcs_GPU(ppx,device=.false.)
+      call bcs(ppx,device=.false.)
 #ifdef MPI
       call comm_1s_start(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
       call comm_1s_end(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -2510,7 +2510,7 @@
         !$acc data copy(rho)
         call bcs2(rho)
         !$acc end data
-        call getcorner(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call getcorner_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
 
       !$omp parallel do default(shared)  &
@@ -2531,7 +2531,7 @@
         !$acc data copy(rr)
         call bcs2(rr)
         !$acc end data
-        call getcorner(rr,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call getcorner_GPU(rr,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
         call bcs(rf,device=.false.)
 #ifdef MPI
@@ -2540,7 +2540,7 @@
         !$acc data copy(rf)
         call bcs2(rf)
         !$acc end data
-        call getcorner(rf,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call getcorner_GPU(rf,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
 
         ! meh 1 !

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -78,7 +78,7 @@
       use constants
       use misclibs
       use cm1libs , only : rslf,rsif
-      use bc_module, only: bcu_GPU, bcv_GPU, bcw_GPU, bcs
+      use bc_module, only: bcu_GPU, bcv_GPU, bcw_GPU, bcs_GPU
       use module_mp_nssl_2mom, only: ccn, lccn
       use poiss_module
       use parcel_module , only : getparcelzs
@@ -1321,8 +1321,8 @@
         call bcu_GPU(ua)
         call bcv_GPU(va)
         !$acc end data
-        call bcs(ppi)
-        call bcs(tha)
+        call bcs_GPU(ppi,device=.false.)
+        call bcs_GPU(tha,device=.false.)
 
         call calcprs(pi0,prs,ppi)
 
@@ -2001,7 +2001,7 @@
 
         ENDIF
 
-        call bcs(ppi)
+        call bcs_GPU(ppi,device=.false.)
 
       ENDIF
 
@@ -2102,7 +2102,7 @@
         enddo
         enddo
 
-      call bcs(ppi)
+      call bcs_GPU(ppi,device=.false.)
 
   ENDIF  bsmod
 
@@ -2138,8 +2138,8 @@
       use input
       use constants
       use misclibs
-      use bc_module, only: bc2d_GPU, bcu_GPU, bcv_GPU, bcw_GPU, bcwsfc, bcs, &
-          bcs2_GPU, bcs2_2d
+      use bc_module, only: bc2d_GPU, bcu_GPU, bcv_GPU, bcw_GPU, bcwsfc, bcs_GPU, &
+          bcs2_GPU, bcs2_2d_GPU
       use comm_module
       use parcel_module , only : getparcelzs
       use ib_module
@@ -2228,11 +2228,11 @@
       call bcv_GPU(va)
       call bcw_GPU(wa,1)
       !$acc end data
-      call bcs(ppi)
-      call bcs(tha)
+      call bcs_GPU(ppi,device=.false.)
+      call bcs_GPU(tha,device=.false.)
       if(imoist.eq.1)then
         do n=1,numq
-          call bcs(qa(ibm,jbm,kbm,n))
+          call bcs_GPU(qa(ibm,jbm,kbm,n),device=.false.)
         enddo
       endif
       if( cm1setup.eq.1 .and. iusetke )then
@@ -2243,7 +2243,7 @@
 
       if(iptra.eq.1)then
         do n=1,npt
-          call bcs(pta(ib,jb,kb,n))
+          call bcs_GPU(pta(ib,jb,kb,n),device=.false.)
         enddo
       endif
       
@@ -2251,7 +2251,7 @@
       call bcu_GPU(u0)
       call bcv_GPU(v0)
       !$acc end data
-      call bcs(th0)
+      call bcs_GPU(th0,device=.false.)
 
 #ifdef MPI
 !------------------------------------------------------------------
@@ -2276,22 +2276,22 @@
       call comm_3w_end(wa,ww31,ww32,we31,we32,   &
                           ws31,ws32,wn31,wn32,reqs_w)
 
-      call comm_3s_start(ppi,sw31,sw32,se31,se32,   &
-                             ss31,ss32,sn31,sn32,reqs_s)
-      call comm_3s_end(ppi,sw31,sw32,se31,se32,   &
-                           ss31,ss32,sn31,sn32,reqs_s)
+      call comm_3s_start_GPU(ppi,sw31,sw32,se31,se32,   &
+                             ss31,ss32,sn31,sn32,reqs_s,device=.false.)
+      call comm_3s_end_GPU(ppi,sw31,sw32,se31,se32,   &
+                           ss31,ss32,sn31,sn32,reqs_s,device=.false.)
 
-      call comm_3s_start(tha,sw31,sw32,se31,se32,   &
-                             ss31,ss32,sn31,sn32,reqs_s)
-      call comm_3s_end(tha,sw31,sw32,se31,se32,   &
-                           ss31,ss32,sn31,sn32,reqs_s)
+      call comm_3s_start_GPU(tha,sw31,sw32,se31,se32,   &
+                             ss31,ss32,sn31,sn32,reqs_s,device=.false.)
+      call comm_3s_end_GPU(tha,sw31,sw32,se31,se32,   &
+                           ss31,ss32,sn31,sn32,reqs_s,device=.false.)
 
       IF(imoist.eq.1)THEN
         do n=1,numq
-          call comm_3s_start(qa(ibm,jbm,kbm,n),sw31,sw32,se31,se32,   &
-                                               ss31,ss32,sn31,sn32,reqs_s)
-          call comm_3s_end(qa(ibm,jbm,kbm,n),sw31,sw32,se31,se32,   &
-                                             ss31,ss32,sn31,sn32,reqs_s)
+          call comm_3s_start_GPU(qa(ibm,jbm,kbm,n),sw31,sw32,se31,se32,   &
+                                             ss31,ss32,sn31,sn32,reqs_s,device=.false.)
+          call comm_3s_end_GPU(qa(ibm,jbm,kbm,n),sw31,sw32,se31,se32,   &
+                                             ss31,ss32,sn31,sn32,reqs_s,device=.false.)
         enddo
       ENDIF
 
@@ -2304,10 +2304,10 @@
 
       IF(iptra.eq.1)THEN
         do n=1,npt
-          call comm_3s_start(pta(ib,jb,kb,n),sw31,sw32,se31,se32,   &
-                                             ss31,ss32,sn31,sn32,reqs_s)
-          call comm_3s_end(pta(ib,jb,kb,n),sw31,sw32,se31,se32,   &
-                                           ss31,ss32,sn31,sn32,reqs_s)
+          call comm_3s_start_GPU(pta(ib,jb,kb,n),sw31,sw32,se31,se32,   &
+                                             ss31,ss32,sn31,sn32,reqs_s,device=.false.)
+          call comm_3s_end_GPU(pta(ib,jb,kb,n),sw31,sw32,se31,se32,   &
+                                           ss31,ss32,sn31,sn32,reqs_s,device=.false.)
         enddo
       ENDIF
 
@@ -2321,10 +2321,10 @@
       call comm_3v_end(v0,vw31,vw32,ve31,ve32,   &
                           vs31,vs32,vn31,vn32,reqs_v)
 
-      call comm_3s_start(th0,sw31,sw32,se31,se32,   &
-                             ss31,ss32,sn31,sn32,reqs_s)
-      call comm_3s_end(th0,sw31,sw32,se31,se32,   &
-                           ss31,ss32,sn31,sn32,reqs_s)
+      call comm_3s_start_GPU(th0,sw31,sw32,se31,se32,   &
+                             ss31,ss32,sn31,sn32,reqs_s,device=.false.)
+      call comm_3s_end_GPU(th0,sw31,sw32,se31,se32,   &
+                           ss31,ss32,sn31,sn32,reqs_s,device=.false.)
 
       call MPI_BARRIER (MPI_COMM_WORLD,ierr)
 
@@ -2350,7 +2350,7 @@
                                              ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s)
         call comm_1s2d_end(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
                                            ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s)
-        call bcs2_2d(tkea(ibt,jbt,1))
+        call bcs2_2d_GPU(tkea(ibt,jbt,1),device=.false.)
         call comm_2d_corner(tkea(ibt,jbt,1))
 #endif
       endif
@@ -2433,7 +2433,7 @@
       endif
 
       if( psolver.eq.6 )then
-        call bcs(phi1)
+        call bcs_GPU(phi1,device=.false.)
 #ifdef MPI
         call comm_1s_start(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         call comm_1s_end(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
@@ -2503,7 +2503,7 @@
   ENDIF
 
 
-        call bcs(rho)
+        call bcs_GPU(rho,device=.false.)
 #ifdef MPI
         call comm_1s_start(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         call comm_1s_end(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
@@ -2524,7 +2524,7 @@
         enddo
         enddo
 
-        call bcs(rr)
+        call bcs_GPU(rr,device=.false.)
 #ifdef MPI
         call comm_1s_start(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         call comm_1s_end(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
@@ -2533,7 +2533,7 @@
         !$acc end data
         call getcorner(rr,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
 #endif
-        call bcs(rf)
+        call bcs_GPU(rf,device=.false.)
 #ifdef MPI
         call comm_1s_start(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         call comm_1s_end(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
@@ -2639,7 +2639,7 @@
 
       ENDIF
 
-      call bcs(ppx)
+      call bcs_GPU(ppx,device=.false.)
 #ifdef MPI
       call comm_1s_start(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
       call comm_1s_end(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)

--- a/src/init_terrain.F
+++ b/src/init_terrain.F
@@ -17,7 +17,7 @@
 
       use input
       use constants
-      use bc_module, only: bc2d_GPU, bcs2_2d
+      use bc_module, only: bc2d_GPU, bcs2_2d_GPU
       use adv_routines , only : zsgrad
       use comm_module
 #ifdef MPI
@@ -169,7 +169,7 @@
                               south,newsouth,north,newnorth,reqs_p)
         call comm_2dew_end(zs,west,newwest,east,neweast,reqs_p)
         call comm_2dns_end(zs,south,newsouth,north,newnorth,reqs_p)
-        call bcs2_2d(zs)
+        call bcs2_2d_GPU(zs,device=.false.)
         !$acc data copy(zs)
         call bc2d_GPU(zs)
         !$acc end data
@@ -217,7 +217,7 @@
                                 south,newsouth,north,newnorth,reqs_p)
         call comm_2dew_end(dzdx,west,newwest,east,neweast,reqs_p)
         call comm_2dns_end(dzdx,south,newsouth,north,newnorth,reqs_p)
-        call bcs2_2d(dzdx)
+        call bcs2_2d_GPU(dzdx,device=.false.)
         !$acc data copy(dzdx)
         call bc2d_GPU(dzdx)
         !$acc end data
@@ -227,7 +227,7 @@
                                 south,newsouth,north,newnorth,reqs_p)
         call comm_2dew_end(dzdy,west,newwest,east,neweast,reqs_p)
         call comm_2dns_end(dzdy,south,newsouth,north,newnorth,reqs_p)
-        call bcs2_2d(dzdy)
+        call bcs2_2d_GPU(dzdy,device=.false.)
         !$acc data copy(dzdy)
         call bc2d_GPU(dzdy)
         !$acc end data
@@ -252,7 +252,7 @@
                                south,newsouth,north,newnorth,reqs_p)
         call comm_2dew_end(rgz,west,newwest,east,neweast,reqs_p)
         call comm_2dns_end(rgz,south,newsouth,north,newnorth,reqs_p)
-        call bcs2_2d(rgz)
+        call bcs2_2d_GPU(rgz,device=.false.)
         !$acc data copy(rgz)
         call bc2d_GPU(rgz)
         !$acc end data

--- a/src/init_terrain.F
+++ b/src/init_terrain.F
@@ -17,7 +17,7 @@
 
       use input
       use constants
-      use bc_module, only: bc2d_GPU, bcs2_2d_GPU
+      use bc_module, only: bc2d, bcs2_2d
       use adv_routines , only : zsgrad
       use comm_module
 #ifdef MPI
@@ -158,7 +158,7 @@
 !--------------------------------------------------------------
 
         !$acc data copy(zs)
-        call bc2d_GPU(zs)
+        call bc2d(zs)
         !$acc end data
 #ifdef MPI
         nf=0
@@ -169,9 +169,9 @@
                               south,newsouth,north,newnorth,reqs_p)
         call comm_2dew_end(zs,west,newwest,east,neweast,reqs_p)
         call comm_2dns_end(zs,south,newsouth,north,newnorth,reqs_p)
-        call bcs2_2d_GPU(zs,device=.false.)
+        call bcs2_2d(zs,device=.false.)
         !$acc data copy(zs)
-        call bc2d_GPU(zs)
+        call bc2d(zs)
         !$acc end data
         call getcorner3_2d(zs)
 #endif
@@ -208,8 +208,8 @@
 !  set boundary points
 
         !$acc data copy(dzdx,dzdy)
-        call bc2d_GPU(dzdx)
-        call bc2d_GPU(dzdy)
+        call bc2d(dzdx)
+        call bc2d(dzdy)
         !$acc end data
 
 #ifdef MPI
@@ -217,9 +217,9 @@
                                 south,newsouth,north,newnorth,reqs_p)
         call comm_2dew_end(dzdx,west,newwest,east,neweast,reqs_p)
         call comm_2dns_end(dzdx,south,newsouth,north,newnorth,reqs_p)
-        call bcs2_2d_GPU(dzdx,device=.false.)
+        call bcs2_2d(dzdx,device=.false.)
         !$acc data copy(dzdx)
-        call bc2d_GPU(dzdx)
+        call bc2d(dzdx)
         !$acc end data
         call getcorner3_2d(dzdx)
 
@@ -227,9 +227,9 @@
                                 south,newsouth,north,newnorth,reqs_p)
         call comm_2dew_end(dzdy,west,newwest,east,neweast,reqs_p)
         call comm_2dns_end(dzdy,south,newsouth,north,newnorth,reqs_p)
-        call bcs2_2d_GPU(dzdy,device=.false.)
+        call bcs2_2d(dzdy,device=.false.)
         !$acc data copy(dzdy)
-        call bc2d_GPU(dzdy)
+        call bc2d(dzdy)
         !$acc end data
         call getcorner3_2d(dzdy)
 #endif
@@ -245,16 +245,16 @@
         enddo
 
         !$acc data copy(rgz)
-        call bc2d_GPU(rgz)
+        call bc2d(rgz)
         !$acc end data
 #ifdef MPI
         call comm_2d_start(rgz,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs_p)
         call comm_2dew_end(rgz,west,newwest,east,neweast,reqs_p)
         call comm_2dns_end(rgz,south,newsouth,north,newnorth,reqs_p)
-        call bcs2_2d_GPU(rgz,device=.false.)
+        call bcs2_2d(rgz,device=.false.)
         !$acc data copy(rgz)
-        call bc2d_GPU(rgz)
+        call bc2d(rgz)
         !$acc end data
         call getcorner3_2d(rgz)
 #endif

--- a/src/param.F
+++ b/src/param.F
@@ -26,7 +26,7 @@
       use input
       use constants
       use init_terrain_module
-      use bc_module, only: bcs_GPU
+      use bc_module, only: bcs
       use comm_module
       use bcast_module
       use ib_module
@@ -8277,9 +8277,9 @@
       enddo
       enddo
       enddo
-      !$acc data copy(cc2,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
-      call bcs_GPU(cc2)
-      !$acc end data
+      !!$acc data copy(cc2,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
+      call bcs(cc2,device=.false.)
+      !!$acc end data
 #ifdef MPI
       call comm_all_s(cc2,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)

--- a/src/param.F
+++ b/src/param.F
@@ -27,7 +27,7 @@
       use constants
       use init_terrain_module
       use bc_module, only: bcs
-      use comm_module
+      use comm_module, only: comm_all_s_GPU,nabor
       use bcast_module
       use ib_module
       use eddy_recycle
@@ -8281,8 +8281,8 @@
       call bcs(cc2,device=.false.)
       !!$acc end data
 #ifdef MPI
-      call comm_all_s(cc2,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
-                          n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
+      call comm_all_s_GPU(cc2,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+                     n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
 #endif
 
       if(dowr) write(outfile,*)

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -704,7 +704,7 @@
           prw,prsig,time_parceli_reduce,time_lb,terrain_flag
       use constants
       use cm1libs , only : rslf,rsif
-      use bc_module, only: bcu2_GPU, bcv2_GPU, bcw2_GPU
+      use bc_module, only: bcu2, bcv2, bcw2
       use comm_module
 #ifdef MPI
       use mpi
@@ -968,9 +968,9 @@
       call getcorneru_GPU(u3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
       call getcornerv_GPU(v3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
       call getcornerw_GPU(w3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-      call bcu2_GPU(u3d)
-      call bcv2_GPU(v3d)
-      call bcw2_GPU(w3d)
+      call bcu2(u3d)
+      call bcv2(v3d)
+      call bcw2(w3d)
 #endif
 
 !----------------------------------------------------------------------

--- a/src/pdef.F
+++ b/src/pdef.F
@@ -15,7 +15,7 @@
       subroutine pdefx1(xh,arh1,arh2,uh,rho0,gz,rgz,rru,advx,dum,mass,s0,s,dt,flag,west,newwest,east,neweast,reqs_s)
       use input, only: ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,cmp,jmp,kmp,ni,nj,nk,&
           wbc,ebc,ibw,ibe,rdx,axisymm,terrain_flag,timestats,time_pdef,time_lb,mytime
-      use bc_module, only: bcs_GPU
+      use bc_module, only: bcs
       use comm_module
       implicit none
 
@@ -109,7 +109,7 @@
 
         if(timestats.ge.1) time_pdef=time_pdef+mytime()
 
-        call bcs_GPU(dum)
+        call bcs(dum)
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -292,7 +292,7 @@
       subroutine pdefy1(vh,rho0,gz,rgz,rrv,advy,dum,mass,s0,s,dt,flag,south,newsouth,north,newnorth,reqs_s)
       use input, only: ib,ie,jb,je,kb,ke,itb,ite,jtb,jte,cmp,imp,jmp,kmp,ni,nj,nk,&
           sbc,nbc,ibs,ibn,rdy,axisymm,terrain_flag,timestats,time_pdef,mytime,smeps,time_lb
-      use bc_module, only: bcs_GPU
+      use bc_module, only: bcs
       use comm_module
       implicit none
 
@@ -370,7 +370,7 @@
         endif
         if(timestats.ge.1) time_pdef=time_pdef+mytime()
 
-        call bcs_GPU(dum)
+        call bcs(dum)
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()

--- a/src/radiation_driver.F
+++ b/src/radiation_driver.F
@@ -130,7 +130,7 @@
           if(dowr) write(outfile,*) '  Calculating radiation tendency:'
           if(timestats.ge.1) time_rad=time_rad+mytime()
           !$acc data copy(prs)
-          call bcs_GPU(prs)
+          call bcs(prs)
           !$acc end data
           CALL zenangl( ni,nj,      zf(1,1,1),    &
                 rad2d(1,1,ncosz), rad2d(1,1,ncosss), radsw,              &

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -171,8 +171,8 @@
           qd_lsw,qd_hidiff,qd_vidiff,vd_cor,ud_cent,vd_cent,vd_hadv,wd_buoy,ud_pgrad,vd_pgrad, &
           wd_pgrad,td_div,kd_adv
       use constants
-      use bc_module, only: bc2d_GPU, bcs_GPU, bcu_GPU, bcv_GPU, bcw_GPU, bcwsfc, &
-                           radbcew4, radbcns4, bcs2_gpu 
+      use bc_module, only: bc2d, bcs, bcu, bcv, bcw, bcwsfc, &
+                           radbcew4, radbcns4, bcs2
       use comm_module
       use adv_module
       use maxmin_module
@@ -563,7 +563,6 @@
 
           ELSEIF(eqtset.eq.1)THEN
 
-            !print *,'before eqtset==1 loop'
             !$acc parallel loop gang vector collapse(3) default(present) 
             do k=1,nk
             do j=1,nj
@@ -595,9 +594,7 @@
         if(timestats.ge.1) time_buoyan=time_buoyan+mytime()
 
 !--------------------------------------------------------------------
-        !print *,'solve2: before call to bcs_GPU(t11) #1'
-        call bcs_GPU(t11)
-        !print *,'solve2: after call to bcs_GPU(t11) #1'
+        call bcs(t11)
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -619,7 +616,6 @@
         enddo
         enddo
         if(timestats.ge.1) time_misc14=time_misc14+mytime()
-        !print *,'solve2: point #2'
 !--------------------------------------------------------------------
         IF(nrk.ge.2)THEN
 #ifdef MPI
@@ -632,10 +628,9 @@
 #endif
           if(terrain_flag)then
             call bcwsfc(gz,dzdx,dzdy,u3d,v3d,w3d)
-            call bc2d_GPU(w3d(ib,jb,1))
+            call bc2d(w3d(ib,jb,1))
           endif
         ENDIF
-        !print *,'solve2: point #27'
 !--------------------------------------------------------------------
 !  Get rru,rrv,rrw,divx
 !  (NOTE:  do not change these arrays until after small steps)
@@ -734,9 +729,8 @@
     ENDIF
     if(timestats.ge.1) time_advs=time_advs+mytime()
 
-        !print *,'solve2: point #4'
         IF(terrain_flag)THEN
-          call bcw_GPU(rrw,0)
+          call bcw(rrw,0)
 #ifdef MPI
           call comm_1w_start_GPU(rrw,ww1,ww2,we1,we2,   &
                                  ws1,ws2,wn1,wn2,reqs_w)
@@ -744,7 +738,6 @@
                                ws1,ws2,wn1,wn2,reqs_w)
 #endif
         ENDIF
-        !print *,'solve2: point #5'
 
       IF(.not.terrain_flag)THEN
         IF(axisymm.eq.0)THEN
@@ -1039,17 +1032,15 @@
         ENDIF
 
 !--------------------------------------------------------------------
-        !print *,'solve2: point #6'
 #ifdef MPI
         IF(nrk.ge.2)THEN
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
           call comm_1s_end_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
           call getcorner_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-          call bcs2_GPU(rho)
+          call bcs2(rho)
         ENDIF
 #endif
-        !print *,'solve2: point #7'
 !--------------------------------------------------------------------
 !  advection:
           call advu(nrk   ,arh1,arh2,uh,xf,rxf,arf1,arf2,uf,vh,gz,rgz,gzu,mh,rho0,rr0,rf0,rrf0,dum1,dum2,dum3,dum4,dum5,dum6,dum7,divx, &
@@ -1137,12 +1128,9 @@
 
         ! dum6 stores buoyancy:
 
-        !print *,'solve2: point #8'
       termod1:  &
       IF( terrain_flag )THEN
-        !call flush(6)
-        !print *,'solve2: before bcs_GPU #2'
-        call bcs_GPU(dum6)
+        call bcs(dum6)
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -1197,7 +1185,6 @@
         enddo
 
       ENDIF  termod1
-        !print *,'solve2: point #9'
 
 !--------------------------------------------------------------------
 !  Pressure equation
@@ -1209,7 +1196,6 @@
         call comm_1s_end_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
       ENDIF
 #endif
-      !print *,'solve2: point #10'
 
       IF( psolver.le.3 )THEN
 
@@ -1442,7 +1428,6 @@
 !  on final RK step, get max CFL
 
         IF( nrk.eq.nrkmax )THEN
-          !print *,'solve2: before call to calccflquick'
           call calccflquick(dt,uh,vh,mh,u3d,v3d,w3d,reqc)
         ENDIF
 
@@ -1501,7 +1486,6 @@
 !--------------------------------------------------------------------
 !  THETA-equation
 
-        !print *,'solve2: point #13'
 #ifdef MPI
         IF(nrk.ge.2)THEN
           call sync()
@@ -1510,7 +1494,6 @@
                                 rs31,rs32,rn31,rn32,reqs_y)
         ENDIF
 #endif
-        !print *,'solve2: point #14'
 
         ! note: t11 stores 3d divergence
 
@@ -1580,7 +1563,6 @@
                    flag,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,rdsf,c1,c2,rho,rr,diffit, &
                    dotbud,ibdt,iedt,jbdt,jedt,kbdt,kedt,ntdiag,tdiag,td_hadv,td_vadv,td_lsw, &
                    td_hidiff,td_vidiff,td_hediff,wprof,dumk1,dumk2,hadvordrs,vadvordrs,kbdy,bndy,hflxw,hflxe,hflxs,hflxn,out3d)
-      !print *,'solve2: point #14.1'
 
       !$omp parallel do default(shared) private(i,j,k)
       !$acc parallel loop gang vector collapse(3) default(present)
@@ -1624,7 +1606,6 @@
         pdef = 0
       endif
 
-        !print *,'solve2: point #15'
 #ifdef MPI
       if( nrk.ge.2 )then
         call sync()
@@ -1635,7 +1616,6 @@
                        ,reqs_q(1,n) )
       endif
 #endif
-        !print *,'solve2: point #16'
 
       ! Note: epsilon = 1.0e-18
 !!!      weps = 0.01*epsilon
@@ -1822,11 +1802,10 @@
 !--------------------------------------------------------------------
 !  bcs and comms:
 
-      !print *,'solve2: point #19'
 
-      call bcu_GPU(u3d)
-      call bcv_GPU(v3d)
-      call bcw_GPU(w3d,1)
+      call bcu(u3d)
+      call bcv(v3d)
+      call bcw(w3d,1)
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -1845,11 +1824,9 @@
                              ws31,ws32,wn31,wn32,reqs_w)
 #endif
       IF(nrk.lt.nrkmax)THEN
-        !call flush(6)
-        !print *,'solve2: before bcs_GPU #3'
-        call bcs_GPU(rho)
-        call bcs_GPU(pp3d)
-        call bcs_GPU(th3d)
+        call bcs(rho)
+        call bcs(pp3d)
+        call bcs(th3d)
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -1860,7 +1837,7 @@
 #endif
         IF(imoist.eq.1)THEN
           do n=1,numq
-            call bcs_GPU(q3d(ib,jb,kb,n))
+            call bcs(q3d(ib,jb,kb,n))
 #ifdef MPI
             call comm_3s_start_GPU(q3d(ib,jb,kb,n)  &
                        ,qw31(1,1,1,n),qw32(1,1,1,n),qe31(1,1,1,n),qe32(1,1,1,n)     &
@@ -1870,7 +1847,6 @@
           enddo
         ENDIF
       ENDIF
-      !print *,'solve2: point #20'
 
 !--------------------------------------------------------------------
 !  TKE advection
@@ -1897,7 +1873,6 @@
                                  tks1,tks2,tkn1,tkn2,reqs_tk)
         ENDIF
 #endif
-      !print *,'solve2: point #20.1'
 
         if( dotdwrite .and. kd_adv.ge.1 )then
         if( nrk.eq.nrkmax )then
@@ -1947,7 +1922,7 @@
           call zero_out_w(bndy,kbdy,tke3d)
         ENDIF
 
-          call bcw_GPU(tke3d,1)
+          call bcw(tke3d,1)
 #ifdef MPI
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -1956,7 +1931,6 @@
 #endif
 
         ENDIF
-        !print *,'solve2: point #21'
 
 !--------------------------------------------------------------------
 !  qke advection (for PBL schemes with TKE)
@@ -1991,7 +1965,7 @@
         ENDIF
         if(timestats.ge.1) time_misc21=time_misc21+mytime()
 
-        call bcs_GPU(qke3d)
+        call bcs(qke3d)
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -2068,7 +2042,6 @@
       if(timestats.ge.1) time_misc22=time_misc22+mytime()
 
 
-        !print *,'solve2: point #23'
 #ifdef MPI
           IF(nrk.ge.2)THEN
             call sync()
@@ -2079,7 +2052,6 @@
                   reqs_t(1,n))
           ENDIF
 #endif
-        !print *,'solve2: point #24'
 
       weps = 1.0*epsilon
       diffit = 0
@@ -2090,7 +2062,6 @@
                  flag,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,rdsf,c1,c2,rho,rr,diffit, &
                  .false.,ibdq,iedq,jbdq,jedq,kbdq,kedq,nqdiag,qdiag,1,1,1,              &
                  1,1,1,wprof,dumk1,dumk2,hadvordrs,vadvordrs,kbdy,bndy,hflxw,hflxe,hflxs,hflxn,out3d)
-      !print *,'solve2: after advs'
 
       !$omp parallel do default(shared) private(i,j,k)
       !$acc parallel loop gang vector collapse(3) default(present)
@@ -2104,7 +2075,7 @@
       if(timestats.ge.1) time_integ=time_integ+mytime()
 
       IF(nrk.le.2)THEN
-        call bcs_GPU(pt3d(ib,jb,kb,n))
+        call bcs(pt3d(ib,jb,kb,n))
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -2209,7 +2180,7 @@
         if( pdtra.eq.1 ) then 
             call pdefq2_GPU(0.0,afoo,ruh,rvh,rmh,rho,pt3d(ib,jb,kb,n))
         endif
-        call bcs_GPU(pt3d(ib,jb,kb,n))
+        call bcs(pt3d(ib,jb,kb,n))
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -165,8 +165,8 @@
           output_rain,output_sws,output_svs,output_sps,output_srs,output_sgs,output_sus,output_shs
 
       use constants
-      use bc_module, only: bc2d_GPU, bcs_GPU, bcu_GPU, bcv_GPU, bcw_GPU, bcwsfc, &
-          bcs_tend_halo, bcs2_GPU, bcu2_GPU, bcv2_GPU, bcw2_GPU
+      use bc_module, only: bc2d, bcs, bcu, bcv, bcw, bcwsfc, &
+          bcs_tend_halo, bcs2, bcu2, bcv2, bcw2
       use comm_module
       use maxmin_module
       use adv_routines, only : movesfc
@@ -357,8 +357,8 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 !Begin:  message passing
-          call bcs_GPU(pp3d)
-          call bcs_GPU(th3d)
+          call bcs(pp3d)
+          call bcs(th3d)
 #ifdef MPI
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -369,7 +369,7 @@
 
       IF( imoist.eq.1 )THEN
           DO n=1,numq
-            call bcs_GPU(q3d(ib,jb,kb,n))
+            call bcs(q3d(ib,jb,kb,n))
 #ifdef MPI
             call comm_3s_start_GPU(q3d(ib,jb,kb,n)  &
                        ,qw31(1,1,1,n),qw32(1,1,1,n),qe31(1,1,1,n),qe32(1,1,1,n)     &
@@ -380,7 +380,7 @@
       ENDIF
 
 
-      call bcs_GPU(rho)
+      call bcs(rho)
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -401,8 +401,8 @@
       if(timestats.ge.1) time_prsrho=time_prsrho+mytime()
 
 
-      call bcs_GPU(rr)
-      call bcs_GPU(rf)
+      call bcs(rr)
+      call bcs(rf)
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -439,7 +439,7 @@
           enddo
           enddo
         endif
-        call bcs_GPU(ppx)
+        call bcs(ppx)
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -567,15 +567,15 @@
         call getcorneru_GPU(u3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
         call getcornerv_GPU(v3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
         call getcornerw_GPU(w3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call bcu2_GPU(u3d)
-        call bcv2_GPU(v3d)
-        call bcw2_GPU(w3d)
+        call bcu2(u3d)
+        call bcv2(v3d)
+        call bcw2(w3d)
       endif
 #endif
 
       if(terrain_flag)then
         call bcwsfc(gz,dzdx,dzdy,u3d,v3d,w3d)
-        call bc2d_GPU(w3d(ib,jb,1))
+        call bc2d(w3d(ib,jb,1))
       endif
 
 !----------
@@ -656,9 +656,9 @@
         ENDIF
         if(timestats.ge.1) time_parcels=time_parcels+mytime()
         ! bc/comms:
-        call bcu_GPU(rru)
-        call bcv_GPU(rrv)
-        call bcw_GPU(rrw,1)
+        call bcu(rru)
+        call bcv(rrv)
+        call bcw(rrw,1)
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -825,15 +825,15 @@
         if(timestats.ge.1) time_lb=time_lb+mytime()
         call comm_1s_end_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
         call getcorner_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call bcs2_GPU(rho)
+        call bcs2(rho)
         !-----
         call comm_1s_end_GPU(rr,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
         call getcorner_GPU(rr,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call bcs2_GPU(rr)
+        call bcs2(rr)
         !-----
         call comm_1s_end_GPU(rf,p3w1,p3w2,p3e1,p3e2,p3s1,p3s2,p3n1,p3n2,reqs_p3)
         call getcorner_GPU(rf,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call bcs2_GPU(rf)
+        call bcs2(rf)
         !-----
 #endif
 
@@ -872,9 +872,9 @@
         call getcornerv3_GPU(rrv,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
                              s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
         call getcornerw3_GPU(rrw,n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2)
-        call bcu2_GPU(rru)
-        call bcv2_GPU(rrv)
-        call bcw2_GPU(rrw)
+        call bcu2(rru)
+        call bcv2(rrv)
+        call bcw2(rrw)
 #endif
         prltrn:  &
         if(terrain_flag)then
@@ -1038,8 +1038,8 @@
             enddo
             enddo
             if(timestats.ge.1) time_parcels=time_parcels+mytime()
-            call bcs_GPU(th3d)
-            call bcs_GPU(q3d(ib,jb,kb,nqv))
+            call bcs(th3d)
+            call bcs(q3d(ib,jb,kb,nqv))
 #ifdef MPI
             call sync()
             if(timestats.ge.1) time_lb=time_lb+mytime()

--- a/src/sound.F
+++ b/src/sound.F
@@ -28,7 +28,7 @@
           zdeep,lamx,lamy,xcent,ycent,aconv,wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound,alph
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge
-      use bc_module, only: bcs_GPU, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
+      use bc_module, only: bcs, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
           ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn
       use comm_module, only : comm_1s_start_GPU,comm_1p_end_GPU,sync
       use ib_module
@@ -830,7 +830,7 @@
           if(timestats.ge.1) time_sound=time_sound+mytime()
           
 !          call flush(6)
-          call bcs_GPU(ppd)
+          call bcs(ppd)
 #ifdef MPI
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()

--- a/src/soundcb.F
+++ b/src/soundcb.F
@@ -29,7 +29,7 @@
           wnudge,t2_wnudge,zt,rzt,smeps,kdiv,csound,time_lb
       use constants
       use misclibs , only : convinitu,convinitv,get_wnudge,getdiv
-      use bc_module, only : bcs_GPU, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
+      use bc_module, only : bcs, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
           ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn
       use comm_module, only : comm_1p_end_GPU,comm_1s_start_GPU,comm_1s_end_GPU,sync
       use ib_module
@@ -505,7 +505,7 @@
       if(timestats.ge.1) time_sound=time_sound+mytime()
 
         IF( n.lt.nloop )THEN
-          call bcs_GPU(ppd)
+          call bcs(ppd)
 #ifdef MPI
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -589,7 +589,7 @@
 
 
       if(timestats.ge.1) time_sound=time_sound+mytime()
-      call bcs_GPU(phi2)
+      call bcs(phi2)
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -982,7 +982,7 @@
 
         IF( n.lt.nloop )THEN
           if(timestats.ge.1) time_sound=time_sound+mytime()
-!!!          call bcs(ppd)
+!!!          call bcs_GPU(ppd,device=.false.)
           ! 210613: call bcp, only set 1 row/column
           call bcp(ppd)
 #ifdef MPI

--- a/src/turb.F
+++ b/src/turb.F
@@ -77,7 +77,7 @@
           bl_mynn_edmf_mom,bl_mynn_edmf_tke,bl_mynn_mixscalars,bl_mynn_output,bl_mynn_cloudmix,bl_mynn_mixqt, &
           icloud_bl,spp_pbl,oml_gamma,grav_settling,initflag
       use constants
-      use bc_module, only: bc2d_GPU, bcw_GPU, bcs_GPU, bcu2_GPU, bcv2_GPU, bcw2_GPU, bcs2_2d_GPU
+      use bc_module, only: bc2d, bcw, bcs, bcu2, bcv2, bcw2, bcs2_2d
       use comm_module
       use misclibs , only : calcksquick
       use sfcphys_module
@@ -1042,11 +1042,11 @@
   bbc3b:  &
   IF( bbc.eq.3 )THEN
     !-------------!
-    call bc2d_GPU(ust)
-    call bc2d_GPU(u1)
-    call bc2d_GPU(v1)
-    call bc2d_GPU(s1)
-    call bc2d_GPU(znt)
+    call bc2d(ust)
+    call bc2d(u1)
+    call bc2d(v1)
+    call bc2d(s1)
+    call bc2d(znt)
 #ifdef MPI
     call sync()
     if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -1062,7 +1062,7 @@
                              us31(1,1,5),us32(1,1,5),un31(1,1,5),un32(1,1,5),reqs_p)
 #endif
   if( sfcmodel.eq.4 )then
-    call bc2d_GPU(mznt)
+    call bc2d(mznt)
 #ifdef MPI
     call comm_1s2d_start_GPU(mznt,uw31(1,1,6),uw32(1,1,6),ue31(1,1,6),ue32(1,1,6),  &
                               us31(1,1,6),us32(1,1,6),un31(1,1,6),un32(1,1,6),reqs_x)
@@ -1074,28 +1074,28 @@
     !-------------!
     call comm_1s2d_end_GPU(ust,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
                            us31(1,1,1),us32(1,1,1),un31(1,1,1),un32(1,1,1),reqs_s)
-    call bcs2_2d_GPU(ust)
+    call bcs2_2d(ust)
 
     call comm_1s2d_end_GPU(u1 ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
                            us31(1,1,2),us32(1,1,2),un31(1,1,2),un32(1,1,2),reqs_u)
-    call bcs2_2d_GPU(u1 )
+    call bcs2_2d(u1 )
 
     call comm_1s2d_end_GPU(v1 ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
                            us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
-    call bcs2_2d_GPU(v1 )
+    call bcs2_2d(v1 )
 
     call comm_1s2d_end_GPU(s1 ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
                            us31(1,1,4),us32(1,1,4),un31(1,1,4),un32(1,1,4),reqs_w)
-    call bcs2_2d_GPU(s1 )
+    call bcs2_2d(s1 )
 
     call comm_1s2d_end_GPU(znt,uw31(1,1,5),uw32(1,1,5),ue31(1,1,5),ue32(1,1,5),  &
                            us31(1,1,5),us32(1,1,5),un31(1,1,5),un32(1,1,5),reqs_p)
-    call bcs2_2d_GPU(znt)
+    call bcs2_2d(znt)
 
   if( sfcmodel.eq.4 )then
     call comm_1s2d_end_GPU(mznt,uw31(1,1,6),uw32(1,1,6),ue31(1,1,6),ue32(1,1,6),  &
                             us31(1,1,6),us32(1,1,6),un31(1,1,6),un32(1,1,6),reqs_x)
-    call bcs2_2d_GPU(mznt)
+    call bcs2_2d(mznt)
   endif
     !-------------!
 
@@ -1135,10 +1135,10 @@
   tbc3b:  &
   IF( tbc.eq.3 )THEN
     !-------------!
-    call bc2d_GPU(ustt)
-    call bc2d_GPU(ut)
-    call bc2d_GPU(vt)
-    call bc2d_GPU(st)
+    call bc2d(ustt)
+    call bc2d(ut)
+    call bc2d(vt)
+    call bc2d(st)
 #ifdef MPI
     call sync()
     if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -1163,10 +1163,10 @@
                            us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
     call comm_1s2d_end_GPU(st ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
                            us31(1,1,4),us32(1,1,4),un31(1,1,4),un32(1,1,4),reqs_w)
-    call bcs2_2d_GPU(ustt)
-    call bcs2_2d_GPU(ut )
-    call bcs2_2d_GPU(vt )
-    call bcs2_2d_GPU(st )
+    call bcs2_2d(ustt)
+    call bcs2_2d(ut )
+    call bcs2_2d(vt )
+    call bcs2_2d(st )
 
     !-------------!
 
@@ -1509,9 +1509,9 @@
         call getcorneru_GPU(ua,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
         call getcornerv_GPU(va,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
         call getcornerw_GPU(wa,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call bcu2_GPU(ua)
-        call bcv2_GPU(va)
-        call bcw2_GPU(wa)
+        call bcu2(ua)
+        call bcv2(va)
+        call bcw2(wa)
 #endif
       endif
 
@@ -2262,8 +2262,8 @@
       !c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c-c!
 
       if( use_pbl )then
-        call bcs_GPU(upten)
-        call bcs_GPU(vpten)
+        call bcs(upten)
+        call bcs(vpten)
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -2314,7 +2314,7 @@
           ibt,iet,jbt,jet,kbt,ket,ib3d,ie3d,jb3d,je3d,kb3d,ke3d,nout3d,ni,nj,nk, &
           dx,dy,dz,myid,timestats,time_turb,time_lb,mytime,tconfig 
       use constants
-      use bc_module, only: bcw_GPU, bct2_GPU
+      use bc_module, only: bcw, bct2
       use comm_module
       implicit none
 
@@ -2492,10 +2492,10 @@
 !------------------------------------------------------------
 ! Set values at boundaries, start comms:
 
-      call bcw_GPU(kmh,1)
-      call bcw_GPU(kmv,1)
-      call bcw_GPU(khh,1)
-      call bcw_GPU(khv,1)
+      call bcw(kmh,1)
+      call bcw(kmv,1)
+      call bcw(khh,1)
+      call bcw(khv,1)
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -2520,8 +2520,8 @@
                            khds1,khds2,khdn1,khdn2,reqs_khd)
       call comm_1t_end_GPU(khv,kvdw1,kvdw2,kvde1,kvde2,   &
                            kvds1,kvds2,kvdn1,kvdn2,reqs_kvd)
-      call bct2_GPU(kmh)
-      call bct2_GPU(kmv)
+      call bct2(kmh)
+      call bct2(kmv)
       call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
       call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
 #endif
@@ -2543,7 +2543,7 @@
           ibt,iet,jbt,jet,kbt,ket,ib3d,ie3d,jb3d,je3d,kb3d,ke3d,nout3d,ni,nj,nk, &
           dx,dy,dz,myid,timestats,time_turb,time_lb,mytime,tbc,bbc
       use constants
-      use bc_module, only: bc2d_GPU, bcs2_2d_GPU
+      use bc_module, only: bc2d, bcs2_2d
       use comm_module
       implicit none
 
@@ -2596,8 +2596,8 @@
         if(timestats.ge.1) time_turb=time_turb+mytime()
 
         !-----
-        call bc2d_GPU(tkea(ibt,jbt,1))
-        call bc2d_GPU(kmh(ibc,jbc,1))
+        call bc2d(tkea(ibt,jbt,1))
+        call bc2d(kmh(ibc,jbc,1))
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -2608,11 +2608,11 @@
         !-----
         call comm_1s2d_end_GPU(tkea(ibt,jbt,1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
                                            kvcs1(1,1),kvcs2(1,1),kvcn1(1,1),kvcn2(1,1),reqs_kvc)
-        call bcs2_2d_GPU(tkea(ibt,jbt,1))
+        call bcs2_2d(tkea(ibt,jbt,1))
 !!!! Problem with comm_1s2d_end_GPU
         call comm_1s2d_end_GPU(kmh(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                           khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
-        call bcs2_2d_GPU(kmh(ibc,jbc,1))
+        call bcs2_2d(kmh(ibc,jbc,1))
         !-----
         call comm_2d_corner_GPU(tkea(ibt,jbt,1))
         call comm_2d_corner_GPU(kmh(ibc,jbc,1))
@@ -2650,8 +2650,8 @@
         if(timestats.ge.1) time_turb=time_turb+mytime()
 
         !-----
-        call bc2d_GPU(tkea(ibt,jbt,nk+1))
-        call bc2d_GPU(kmh(ibc,jbc,nk+1))
+        call bc2d(tkea(ibt,jbt,nk+1))
+        call bc2d(kmh(ibc,jbc,nk+1))
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
@@ -2662,10 +2662,10 @@
         !-----
         call comm_1s2d_end_GPU(tkea(ibt,jbt,nk+1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
                                               kvcs1(1,1),kvcs2(1,1),kvcn1(1,1),kvcn2(1,1),reqs_kvc)
-        call bcs2_2d_GPU(tkea(ibt,jbt,nk+1))
+        call bcs2_2d(tkea(ibt,jbt,nk+1))
         call comm_1s2d_end_GPU(kmh(ibc,jbc,nk+1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                              khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
-        call bcs2_2d_GPU(kmh(ibc,jbc,nk+1))
+        call bcs2_2d(kmh(ibc,jbc,nk+1))
         !-----
         call comm_2d_corner_GPU(tkea(ibt,jbt,nk+1))
         call comm_2d_corner_GPU(kmh(ibc,jbc,nk+1))
@@ -2706,7 +2706,7 @@
           jb3d,je3d,kb3d,ke3d,nout3d,imp,jmp,kmt,ni,nj,nk,dx,dy,dz,tconfig, &
           myid,timestats,time_turb,mytime,bbc
       use constants
-      use bc_module, only: bc2d_GPU, bcw_GPU, bct2_GPU, bcs2_2d_GPU
+      use bc_module, only: bc2d, bcw, bct2, bcs2_2d
       use comm_module
       implicit none
 
@@ -2838,8 +2838,8 @@
 
       if(timestats.ge.1) time_turb=time_turb+mytime()
       !$acc data copy(kmh,kmv)
-      call bcw_GPU(kmh,1)
-      call bcw_GPU(kmv,1)
+      call bcw(kmh,1)
+      call bcw(kmv,1)
       !$acc end data
 #ifdef MPI
       call comm_1t_start_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
@@ -2852,8 +2852,8 @@
                            kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
       call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
       call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      call bct2_GPU(kmh)
-      call bct2_GPU(kmv)
+      call bct2(kmh)
+      call bct2(kmv)
 #endif
 
 !--------------------------------------------------------------
@@ -2907,7 +2907,7 @@
         enddo
 
         !$acc data copy(kmv)
-        call bc2d_GPU(kmv(ibc,jbc,1))
+        call bc2d(kmv(ibc,jbc,1))
         !$acc end data
 #ifdef MPI
         call comm_1s2d_start_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
@@ -2915,7 +2915,7 @@
         call comm_1s2d_end_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                           khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
         call comm_2d_corner_GPU(kmv(ibc,jbc,1))
-        call bcs2_2d_GPU(kmv(ibc,jbc,1))
+        call bcs2_2d(kmv(ibc,jbc,1))
 #endif
 
       IF( tconfig.eq.1 )THEN
@@ -2964,7 +2964,7 @@
           jb3d,je3d,kb3d,ke3d,nout3d,kmt,imp,jmp,ni,nj,nk,nx,ny,dx,dy,timestats, &
           time_turb,mytime,l_h,lhref1,lhref2,idiss,output_dissten
       use constants
-      use bc_module, only: bcw_GPU, bct2_GPU
+      use bc_module, only: bcw, bct2
       use comm_module
       implicit none
 
@@ -3059,7 +3059,7 @@
       if(timestats.ge.1) time_turb=time_turb+mytime()
 
       !$acc data copy(kmh)
-      call bcw_GPU(kmh,1)
+      call bcw(kmh,1)
       !$acc end data
 #ifdef MPI
       call comm_1t_start_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
@@ -3067,7 +3067,7 @@
       call comm_1t_end_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
                            khcs1,khcs2,khcn1,khcn2,reqs_khc)
       call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      call bct2_GPU(kmh)
+      call bct2(kmh)
 #endif
 
         ! Extrapolate:
@@ -3128,7 +3128,7 @@
           jb3d,je3d,kb3d,ke3d,nout3d,imp,jmp,kmt,ni,nj,nk,timestats,time_turb, &
           mytime,idiss,output_dissten,bbc,myid,l_inf
       use constants
-      use bc_module, only: bc2d_GPU, bcw_GPU, bct2_GPU, bcs2_2d_GPU
+      use bc_module, only: bc2d, bcw, bct2, bcs2_2d
       use comm_module
       implicit none
 
@@ -3195,7 +3195,7 @@
       if(timestats.ge.1) time_turb=time_turb+mytime()
 
       !$acc data copy(kmv)
-      call bcw_GPU(kmv,1)
+      call bcw(kmv,1)
       !$acc end data
 
 #ifdef MPI
@@ -3205,7 +3205,7 @@
       call comm_1t_end_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
                            kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
       call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      call bct2_GPU(kmv)
+      call bct2(kmv)
 #endif
 
 !--------------------------------------------------------------
@@ -3245,7 +3245,7 @@
         enddo
 
         !$acc data copy(kmv)
-        call bc2d_GPU(kmv(ibc,jbc,1))
+        call bc2d(kmv(ibc,jbc,1))
         !$acc end data
 #ifdef MPI
         call comm_1s2d_start_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
@@ -3253,7 +3253,7 @@
         call comm_1s2d_end_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                           khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
         call comm_2d_corner_GPU(kmv(ibc,jbc,1))
-        call bcs2_2d_GPU(kmv(ibc,jbc,1))
+        call bcs2_2d(kmv(ibc,jbc,1))
 #endif
 
         do j=0,nj+1

--- a/src/turbnba.F
+++ b/src/turbnba.F
@@ -34,7 +34,7 @@
           ibt,iet,jbt,jet,kbt,ket,imp,jmp,rmp,kmt,cmp,ni,nj,nk,dx,dy,dz,myid, &
           tconfig,rdx,rdy,rdz,bbc,axisymm
       use constants
-      use bc_module, only: bc2d_GPU, bcs2_GPU, bct2_GPU, bcs2_2d_GPU
+      use bc_module, only: bc2d, bcs2, bct2, bcs2_2d
       use comm_module, only : comm_1s_start_GPU,comm_1s_end_GPU,comm_2d_start_GPU, &
           comm_2dew_end_GPU,comm_2dns_end_GPU,comm_2d_corner_GPU,getcorner_GPU,getcornert_GPU
       implicit none
@@ -149,9 +149,7 @@
                                 ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s)
       call comm_1s_end_GPU(lenscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
                               ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s)
-      !$acc data copy(lenscl)
-      call bcs2_GPU(lenscl)
-      !$acc end data
+      call bcs2(lenscl,device=.false.)
       call getcorner_GPU(lenscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
 #endif
 
@@ -197,15 +195,13 @@
       enddo
 
       do k=1,2
-        !$acc data copy(grdscl)
-        call bc2d_GPU(grdscl(ib,jb,k))
-        !$acc end data
+        call bc2d(grdscl(ib,jb,k),device=.false.)
 #ifdef MPI
         call comm_2d_start_GPU(grdscl(ib,jb,k),west,newwest,east,neweast,   &
                                            south,newsouth,north,newnorth,reqs_s)
         call comm_2dew_end_GPU(grdscl(ib,jb,k),west,newwest,east,neweast,reqs_s)
         call comm_2dns_end_GPU(grdscl(ib,jb,k),south,newsouth,north,newnorth,reqs_s)
-        call bcs2_2d_GPU(grdscl(ib,jb,k))
+        call bcs2_2d(grdscl(ib,jb,k))
         call comm_2d_corner_GPU(grdscl(ib,jb,k))
 #endif
       enddo
@@ -231,7 +227,7 @@
 
 #ifdef MPI
       !$acc data copy(tkea)
-      call bct2_GPU(tkea)
+      call bct2(tkea)
       call getcornert_GPU(tkea,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
       !$acc end data
 #endif
@@ -474,7 +470,7 @@
           ibt,iet,jbt,jet,kbt,ket,imp,jmp,rmp,kmt,cmp,ni,nj,nk,dx,dy,dz,myid, &
           tconfig,rdx,rdy,rdz,bbc,axisymm
       use constants
-      use bc_module, only: bcs2_GPU
+      use bc_module, only: bcs2
       use comm_module, only : comm_1s_start_GPU,comm_1s_end_GPU,getcorner_GPU,getcornert_GPU
       implicit none
 
@@ -569,9 +565,7 @@
                                 ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s)
       call comm_1s_end_GPU(grdscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
                               ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s)
-      !$acc data copy(grdscl)
-      call bcs2_GPU(grdscl)
-      !$acc end data
+      call bcs2(grdscl,device=.false.)
       call getcorner_GPU(grdscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
 #endif
 


### PR DESCRIPTION
This PR eliminates duplicate routines in the comm.F and bc.F modules.  It does this by enabling the runtime activation/deactivation of OpenACC directives via the if conditionals provided by the OpenACC standard.

The verification statistics match those from PR #122. 

ifort CPU versus nvhpc GPU
===========================

Metrics
-------
36 stat variables are identical.
42 stat variables show a mean relative difference > 1e-06
8 stat variables show a mean relative difference <= 1e-06


0th-order
---------
1 stat variables are identical.
9 stat variables show a mean relative difference > 1e-06
2 stat variables show a mean relative difference <= 1e-06

1st-order
---------
254 stat variables are identical.
2 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06

