### PR TITLE
Overflow fixes from George

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -386,7 +386,7 @@ module_mp_jensen_ishmael.o: input.o module_ra_etc.o
 mp_driver.o: constants.o input.o misclibs.o kessler.o goddard.o thompson.o lfoice.o morrison.o module_mp_nssl_2mom.o module_mp_p3.o module_mp_jensen_ishmael.o
 param.o: constants.o input.o init_terrain.o bc.o comm.o bcast.o thompson.o morrison.o module_mp_nssl_2mom.o goddard.o lfoice.o module_mp_p3.o module_mp_jensen_ishmael.o ib_module.o eddy_recycle.o lsnudge.o
 parcel.o: constants.o input.o cm1libs.o misclibs.o bc.o comm.o writeout_nc.o
-droplet.o: constants.o input.o cm1libs.o bc.o comm.o comm_droplet.o parcel.o mersennetwister_mod.o
+droplet.o: constants.o input.o cm1libs.o bc.o comm.o comm_droplet.o parcel.o mersennetwister_mod.o writeout_nc.o
 pdef.o: input.o bc.o comm.o
 pdcomp.o: constants.o input.o adv.o poiss.o ib_module.o
 poiss.o: input.o singleton.o
@@ -396,7 +396,7 @@ restart.o: constants.o input.o writeout_nc.o lsnudge.o goddard.o lfoice.o
 sfcphys.o: constants.o input.o cm1libs.o
 solve1.o: constants.o input.o bc.o comm.o diff2.o turbtend.o misclibs.o testcase_simple_phys.o ib_module.o eddy_recycle.o lsnudge.o
 solve2.o: constants.o input.o bc.o comm.o adv.o adv_routines.o sound.o sounde.o soundns.o soundcb.o anelp.o misclibs.o module_mp_nssl_2mom.o ib_module.o eddy_recycle.o
-solve3.o: constants.o input.o bc.o comm.o adv_routines.o misclibs.o parcel.o pdcomp.o lsnudge.o ib_module.o droplet.o
+solve3.o: constants.o input.o bc.o comm.o adv_routines.o misclibs.o parcel.o pdcomp.o lsnudge.o ib_module.o droplet.o maxmin.o
 sorad3d.o: radlib3d.o
 sound.o: constants.o input.o misclibs.o bc.o comm.o ib_module.o
 sounde.o: constants.o input.o misclibs.o bc.o comm.o ib_module.o maxmin.o

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -191,7 +191,7 @@ end module cuda_rt
       integer, dimension(:), allocatable :: reqt
       integer :: reqc,reqk
       real, dimension(:,:), allocatable :: pdata,ploc
-      real, dimension(:,:,:,:), allocatable :: dpten
+      double precision, dimension(:,:,:,:), allocatable :: dpten
       logical, dimension(:,:,:), allocatable :: flag
 
 !--- arrays for MPI ---
@@ -2294,7 +2294,7 @@ end module cuda_rt
       allocate(  pdata_locind(nparcelsLocal,3) )
       pdata_locind = undefined_index
 
-      allocate( dpten(ib:ie,jb:je,kb:ke,2) )
+      allocate( dpten(ib:ie,jb:je,kb:ke,6) )
       dpten = 0.0
 
       allocate( flag(ib:ie,jb:je,kb:ke) )

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -3538,7 +3538,7 @@ end module cuda_rt
         !     array with size "nparcels*npvals" (saving memory space) 
         !     and thus implemented below 
         if ( iprcl.eq.1 .and. prcl_droplet.eq.1 ) then
-           call droplet_diag(rtime,nrec,zh,zf,pdata,pdata_locind,dpten,uten,vten,wten)
+           call droplet_diag(rtime,nrec,zh,zf,pdata,pdata_locind,dpten)
         end if
 
         nrec = nrec + 1

--- a/src/cm1libs.F
+++ b/src/cm1libs.F
@@ -83,6 +83,25 @@
 
 !
 ! ---------------------------------------------------------------------
+! THIS FUNCTION CALCULATES THE LIQUID SATURATION VAPOR PRESSURE AS
+! A FUNCTION OF TEMPERATURE AND PRESSURE
+!
+      double precision FUNCTION dESLF(P,T)
+      !$acc routine seq
+
+      IMPLICIT NONE
+      double precision, intent(in) :: T,P
+      double precision :: ESL
+
+      esl=611.2d0 * DEXP( 17.67d0 * ( T  - 273.15d0 ) / ( T  - 29.65d0 ) )
+      ! 171023 (fix for very cold temps):
+      deslf = min( esl , p*0.5d0 )
+
+
+      END FUNCTION dESLF
+
+!
+! ---------------------------------------------------------------------
 ! THIS FUNCTION CALCULATES THE ICE SATURATION VAPOR MIXING RATIO AS A
 ! FUNCTION OF TEMPERATURE AND PRESSURE
 !

--- a/src/comm.F
+++ b/src/comm.F
@@ -40,7 +40,7 @@
   public :: comm_1s2d_start_GPU,comm_1s2d_end_GPU
   public :: comm_2we_start_GPU,comm_2we_end_GPU
   public :: comm_2d_corner_GPU
-  public :: comm_1s_tend_halo_GPU
+  public :: comm_1s_tend_halo_GPU,comm_1u_tend_halo_GPU,comm_1v_tend_halo_GPU
   public :: getcorneru_GPU,getcornerv_GPU,getcornert_GPU,getcornerw_GPU,getcorner_GPU
   public :: getcorneru3_GPU,getcornerv3_GPU,getcornerw3_GPU
   public :: prepcorners3_GPU,prepcornert_GPU,prepcorners_GPU
@@ -11180,11 +11180,11 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       use mpi
       implicit none
  
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
+      double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
 
-      real, dimension(2,nj,nk) :: west,newwest,east,neweast
-      real, dimension(ni,2,nk) :: south,newsouth,north,newnorth
-      real, dimension(2,2,nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      double precision, dimension(2,nj,nk) :: west,newwest,east,neweast
+      double precision, dimension(ni,2,nk) :: south,newsouth,north,newnorth
+      double precision, dimension(2,2,nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
       integer reqs(8)
  
       integer :: i,j,k,nn,nr,index
@@ -11206,7 +11206,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       if(ibe.eq.0)then
         nr = nr + 1
         !$acc host_data use_device(neweast)
-        call mpi_irecv(neweast,2*cs1we,MPI_REAL,myeast,tag1,   &
+        call mpi_irecv(neweast,2*cs1we,MPI_DOUBLE_PRECISION,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
       endif
@@ -11220,7 +11220,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       if(ibw.eq.0)then
         nr = nr + 1
         !$acc host_data use_device(newwest)
-        call mpi_irecv(newwest,2*cs1we,MPI_REAL,mywest,tag2,   &
+        call mpi_irecv(newwest,2*cs1we,MPI_DOUBLE_PRECISION,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
       endif
@@ -11234,7 +11234,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       if(ibs.eq.0)then
         nr = nr + 1
         !$acc host_data use_device(newsouth)
-        call mpi_irecv(newsouth,2*cs1sn,MPI_REAL,mysouth,tag3,   &
+        call mpi_irecv(newsouth,2*cs1sn,MPI_DOUBLE_PRECISION,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
       endif
@@ -11248,7 +11248,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       if(ibn.eq.0)then
         nr = nr + 1
         !$acc host_data use_device(newnorth)
-        call mpi_irecv(newnorth,2*cs1sn,MPI_REAL,mynorth,tag4,   &
+        call mpi_irecv(newnorth,2*cs1sn,MPI_DOUBLE_PRECISION,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
       endif
@@ -11272,7 +11272,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         nr = nr + 1
         !$acc host_data use_device(west)
-        call mpi_isend(west,2*cs1we,MPI_REAL,mywest,tag1,   &
+        call mpi_isend(west,2*cs1we,MPI_DOUBLE_PRECISION,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
       endif
@@ -11292,7 +11292,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         nr = nr + 1
         !$acc host_data use_device(east)
-        call mpi_isend(east,2*cs1we,MPI_REAL,myeast,tag2,   &
+        call mpi_isend(east,2*cs1we,MPI_DOUBLE_PRECISION,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
       endif
@@ -11312,7 +11312,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         nr = nr + 1
         !$acc host_data use_device(north)
-        call mpi_isend(north,2*cs1sn,MPI_REAL,mynorth,tag3,   &
+        call mpi_isend(north,2*cs1sn,MPI_DOUBLE_PRECISION,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
       endif
@@ -11332,7 +11332,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         nr = nr + 1
         !$acc host_data use_device(south)
-        call mpi_isend(south,2*cs1sn,MPI_REAL,mysouth,tag4,   &
+        call mpi_isend(south,2*cs1sn,MPI_DOUBLE_PRECISION,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
       endif
@@ -11449,7 +11449,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
         !$acc host_data use_device(nw2)
-        call mpi_irecv(nw2,2*2*nk,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
+        call mpi_irecv(nw2,2*2*nk,MPI_DOUBLE_PRECISION,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
         index_nw = nr
@@ -11462,7 +11462,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
         !$acc host_data use_device(sw2)
-        call mpi_irecv(sw2,2*2*nk,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
+        call mpi_irecv(sw2,2*2*nk,MPI_DOUBLE_PRECISION,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
         index_sw = nr
@@ -11475,7 +11475,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
         !$acc host_data use_device(ne2)
-        call mpi_irecv(ne2,2*2*nk,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
+        call mpi_irecv(ne2,2*2*nk,MPI_DOUBLE_PRECISION,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
         index_ne = nr
@@ -11488,7 +11488,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
         !$acc host_data use_device(se2)
-        call mpi_irecv(se2,2*2*nk,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
+        call mpi_irecv(se2,2*2*nk,MPI_DOUBLE_PRECISION,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
         index_se = nr
@@ -11507,7 +11507,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
 
         !$acc host_data use_device(se1)
-        call mpi_isend(se1,2*2*nk,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
+        call mpi_isend(se1,2*2*nk,MPI_DOUBLE_PRECISION,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(5),ierr)
         !$acc end host_data
       endif
@@ -11524,7 +11524,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         !$acc host_data use_device(ne1)
-        call mpi_isend(ne1,2*2*nk,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
+        call mpi_isend(ne1,2*2*nk,MPI_DOUBLE_PRECISION,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(6),ierr)
         !$acc end host_data
       endif
@@ -11541,7 +11541,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         !$acc host_data use_device(sw1)
-        call mpi_isend(sw1,2*2*nk,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
+        call mpi_isend(sw1,2*2*nk,MPI_DOUBLE_PRECISION,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(7),ierr)
         !$acc end host_data
       endif
@@ -11558,7 +11558,7 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
         enddo
         enddo
         !$acc host_data use_device(nw1)
-        call mpi_isend(nw1,2*2*nk,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
+        call mpi_isend(nw1,2*2*nk,MPI_DOUBLE_PRECISION,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(8),ierr)
         !$acc end host_data
       endif
@@ -11631,6 +11631,945 @@ if(Debug) print *, "prepcorners3_GPU: Im called"
 !$acc end data 
 
       end subroutine comm_1s_tend_halo_GPU
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+
+      subroutine comm_1u_tend_halo_GPU(s)
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,nf,ierr,cs1we,cs1sn,timestats,time_mps2,mytime, &
+          mynw,mysw,myne,myse,myeast,mywest,mynorth,mysouth
+      use mpi
+      implicit none
+ 
+      double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
+
+      double precision, dimension(3,nj,nk) :: west,newwest,east,neweast
+      double precision, dimension(ni+1,2,nk) :: south,newsouth,north,newnorth
+      double precision, dimension(3,2,nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      integer reqs(8)
+ 
+      integer :: i,j,k,nn,nr,index
+      integer :: tag1,tag2,tag3,tag4
+      integer :: index_east,index_west,index_south,index_north
+      integer :: index_nw,index_sw,index_ne,index_se
+      integer, dimension(mpi_status_size,8) :: status1
+      logical, parameter :: Debug = .FALSE.
+ 
+!------------------------------------------------
+!$acc data create(west,newwest,east,neweast,south,newsouth,north,newnorth,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+
+      nr = 0
+
+      nf=nf+1
+      tag1=nf
+
+      ! receive east
+      if(ibe.eq.0)then
+        nr = nr + 1
+        !$acc host_data use_device(neweast)
+        call mpi_irecv(neweast,3*nj*nk,MPI_DOUBLE_PRECISION,myeast,tag1,   &
+                      MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+
+!----------
+
+      nf=nf+1
+      tag2=nf
+
+      ! receive west
+      if(ibw.eq.0)then
+        nr = nr + 1
+        !$acc host_data use_device(newwest)
+        call mpi_irecv(newwest,3*nj*nk,MPI_DOUBLE_PRECISION,mywest,tag2,   &
+                      MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+
+!----------
+
+      nf=nf+1
+      tag3=nf
+
+      ! receive south
+      if(ibs.eq.0)then
+        nr = nr + 1
+        !$acc host_data use_device(newsouth)
+        call mpi_irecv(newsouth,(ni+1)*2*nk,MPI_DOUBLE_PRECISION,mysouth,tag3,   &
+                      MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+
+!----------
+
+      nf=nf+1
+      tag4=nf
+
+      ! receive north
+      if(ibn.eq.0)then
+        nr = nr + 1
+        !$acc host_data use_device(newnorth)
+        call mpi_irecv(newnorth,(ni+1)*2*nk,MPI_DOUBLE_PRECISION,mynorth,tag4,   &
+                      MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+
+!------------------------------------------------
+!------------------------------------------------
+!------------------------------------------------
+
+      nr = 4
+ 
+      ! send west
+      if(ibw.eq.0)then
+!$omp parallel do default(shared)   &
+!$omp private(j,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(j,k)
+        do k=1,nk
+        do j=1,nj
+          west(1,j,k)=s(-1,j,k)
+          west(2,j,k)=s( 0,j,k)
+          west(3,j,k)=s( 1,j,k)
+        enddo
+        enddo
+        nr = nr + 1
+        !$acc host_data use_device(west)
+        call mpi_isend(west,3*nj*nk,MPI_DOUBLE_PRECISION,mywest,tag1,   &
+                       MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+ 
+!----------
+ 
+      ! send east
+      if(ibe.eq.0)then
+!$omp parallel do default(shared)   &
+!$omp private(j,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(j,k)
+        do k=1,nk
+        do j=1,nj
+          east(1,j,k)=s(ni+1,j,k)
+          east(2,j,k)=s(ni+2,j,k)
+          east(3,j,k)=s(ni+3,j,k)
+        enddo
+        enddo
+        nr = nr + 1
+        !$acc host_data use_device(east)
+        call mpi_isend(east,3*nj*nk,MPI_DOUBLE_PRECISION,myeast,tag2,   &
+                       MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+ 
+!----------
+ 
+      ! send north
+      if(ibn.eq.0)then
+!$omp parallel do default(shared)   &
+!$omp private(i,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
+        do k=1,nk
+        do i=1,ni+1
+          north(i,1,k)=s(i,nj+1,k)
+          north(i,2,k)=s(i,nj+2,k)
+        enddo
+        enddo
+        nr = nr + 1
+        !$acc host_data use_device(north)
+        call mpi_isend(north,(ni+1)*2*nk,MPI_DOUBLE_PRECISION,mynorth,tag3,   &
+                       MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+ 
+!----------
+ 
+      ! send south
+      if(ibs.eq.0)then
+!$omp parallel do default(shared)   &
+!$omp private(i,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
+        do k=1,nk
+        do i=1,ni+1
+          south(i,1,k)=s(i,-1,k)
+          south(i,2,k)=s(i, 0,k)
+        enddo
+        enddo
+        nr = nr + 1
+        !$acc host_data use_device(south)
+        call mpi_isend(south,(ni+1)*2*nk,MPI_DOUBLE_PRECISION,mysouth,tag4,   &
+                       MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+
+!---------------------------------------------------------------------
+
+      index_east = -1
+      index_west = -1
+      index_south = -1
+      index_north = -1
+
+      nr = 0
+      if(ibe.eq.0)then
+        nr = nr + 1
+        index_east = nr
+      endif
+      if(ibw.eq.0)then
+        nr = nr + 1
+        index_west = nr
+      endif
+      if(ibs.eq.0)then
+        nr = nr + 1
+        index_south = nr
+      endif
+      if(ibn.eq.0)then
+        nr = nr + 1
+        index_north = nr
+      endif
+
+      nn = 1
+      do while( nn .le. nr )
+        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
+        nn = nn + 1
+ 
+      if(index.eq.index_east)then
+!$omp parallel do default(shared)   &
+!$omp private(j,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(j,k)
+        do k=1,nk
+        do j=1,nj
+          s(ni-1,j,k)=s(ni-1,j,k)+neweast(1,j,k)
+          s(ni  ,j,k)=s(ni  ,j,k)+neweast(2,j,k)
+          s(ni+1,j,k)=s(ni+1,j,k)+neweast(3,j,k)
+        enddo
+        enddo
+      elseif(index.eq.index_west)then
+!$omp parallel do default(shared)   &
+!$omp private(j,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(j,k)
+        do k=1,nk
+        do j=1,nj
+          s(1,j,k)=s(1,j,k)+newwest(1,j,k)
+          s(2,j,k)=s(2,j,k)+newwest(2,j,k)
+          s(3,j,k)=s(3,j,k)+newwest(3,j,k)
+        enddo
+        enddo
+      elseif(index.eq.index_south)then
+!$omp parallel do default(shared)   &
+!$omp private(i,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
+        do k=1,nk
+        do i=1,ni+1
+          s(i,1,k)=s(i,1,k)+newsouth(i,1,k)
+          s(i,2,k)=s(i,2,k)+newsouth(i,2,k)
+        enddo
+        enddo
+      elseif(index.eq.index_north)then
+!$omp parallel do default(shared)   &
+!$omp private(i,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
+        do k=1,nk
+        do i=1,ni+1
+          s(i,nj-1,k)=s(i,nj-1,k)+newnorth(i,1,k)
+          s(i,nj  ,k)=s(i,nj  ,k)+newnorth(i,2,k)
+        enddo
+        enddo
+      endif
+
+      enddo
+
+!----------
+
+      nr = 0
+
+      if(ibw.eq.0)then
+        nr = nr+1
+      endif
+      if(ibe.eq.0)then
+        nr = nr+1
+      endif
+      if(ibn.eq.0)then
+        nr = nr+1
+      endif
+      if(ibs.eq.0)then
+        nr = nr+1
+      endif
+
+    if( nr.ge.1 )then
+      call MPI_WAITALL(nr,reqs(5:5+nr-1),status1(1:mpi_status_size,5:5+nr-1),ierr)
+    endif
+      if(timestats.ge.1) time_mps2=time_mps2+mytime()
+ 
+!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!  Now, get data from corners:
+
+      nr = 0
+      index_nw = -1
+      index_sw = -1
+      index_ne = -1
+      index_se = -1
+
+!------------------------------------------------------------------
+
+      tag1=5001
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+        nr = nr + 1
+        !$acc host_data use_device(nw2)
+        call mpi_irecv(nw2,3*2*nk,MPI_DOUBLE_PRECISION,mynw,tag1,MPI_COMM_WORLD,   &
+                       reqs(nr),ierr)
+        !$acc end host_data
+        index_nw = nr
+      endif
+
+!-----
+
+      tag2=5002
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+        nr = nr + 1
+        !$acc host_data use_device(sw2)
+        call mpi_irecv(sw2,3*2*nk,MPI_DOUBLE_PRECISION,mysw,tag2,MPI_COMM_WORLD,   &
+                       reqs(nr),ierr)
+        !$acc end host_data
+        index_sw = nr
+      endif
+
+!-----
+
+      tag3=5003
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+        nr = nr + 1
+        !$acc host_data use_device(ne2)
+        call mpi_irecv(ne2,3*2*nk,MPI_DOUBLE_PRECISION,myne,tag3,MPI_COMM_WORLD,   &
+                       reqs(nr),ierr)
+        !$acc end host_data
+        index_ne = nr
+      endif
+
+!-----
+
+      tag4=5004
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+        nr = nr + 1
+        !$acc host_data use_device(se2)
+        call mpi_irecv(se2,3*2*nk,MPI_DOUBLE_PRECISION,myse,tag4,MPI_COMM_WORLD,   &
+                       reqs(nr),ierr)
+        !$acc end host_data
+        index_se = nr
+      endif
+
+!------------------------------------------------------------------
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,2
+        do i=1,3
+          se1(i,j,k)=s(ni+i,-2+j,k)
+        enddo
+        enddo
+        enddo
+
+        !$acc host_data use_device(se1)
+        call mpi_isend(se1,3*2*nk,MPI_DOUBLE_PRECISION,myse,tag1,MPI_COMM_WORLD,   &
+                       reqs(5),ierr)
+        !$acc end host_data
+      endif
+ 
+!-----
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,2
+        do i=1,3
+          ne1(i,j,k)=s(ni+i,nj+j,k)
+        enddo
+        enddo
+        enddo
+        !$acc host_data use_device(ne1)
+        call mpi_isend(ne1,3*2*nk,MPI_DOUBLE_PRECISION,myne,tag2,MPI_COMM_WORLD,   &
+                       reqs(6),ierr)
+        !$acc end host_data
+      endif
+ 
+!-----
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,2
+        do i=1,3
+          sw1(i,j,k)=s(-2+i,-2+j,k)
+        enddo
+        enddo
+        enddo
+        !$acc host_data use_device(sw1)
+        call mpi_isend(sw1,3*2*nk,MPI_DOUBLE_PRECISION,mysw,tag3,MPI_COMM_WORLD,   &
+                       reqs(7),ierr)
+        !$acc end host_data
+      endif
+ 
+!-----
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,2
+        do i=1,3
+          nw1(i,j,k)=s(-2+i,nj+j,k)
+        enddo
+        enddo
+        enddo
+        !$acc host_data use_device(nw1)
+        call mpi_isend(nw1,3*2*nk,MPI_DOUBLE_PRECISION,mynw,tag4,MPI_COMM_WORLD,   &
+                       reqs(8),ierr)
+        !$acc end host_data
+      endif
+ 
+!-----
+
+      nn = 1
+      do while( nn .le. nr )
+        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
+        nn = nn + 1
+
+      if(index.eq.index_nw)then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,2
+        do i=1,3
+          s(i,nj-2+j,k)=s(i,nj-2+j,k)+nw2(i,j,k)
+        enddo
+        enddo
+        enddo
+      elseif(index.eq.index_sw)then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,2
+        do i=1,3
+          s(i,j,k)=s(i,j,k)+sw2(i,j,k)
+        enddo
+        enddo
+        enddo
+      elseif(index.eq.index_ne)then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,2
+        do i=1,3
+          s(ni-2+i,nj-2+j,k)=s(ni-2+i,nj-2+j,k)+ne2(i,j,k)
+        enddo
+        enddo
+        enddo
+      elseif(index.eq.index_se)then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,2
+        do i=1,3
+          s(ni-2+i,j,k)=s(ni-2+i,j,k)+se2(i,j,k)
+        enddo
+        enddo
+        enddo
+      endif
+
+      enddo
+
+!-----
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+        call MPI_WAIT (reqs(5),MPI_STATUS_IGNORE,ierr)
+      endif
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+        call MPI_WAIT (reqs(6),MPI_STATUS_IGNORE,ierr)
+      endif
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+        call MPI_WAIT (reqs(7),MPI_STATUS_IGNORE,ierr)
+      endif
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+        call MPI_WAIT (reqs(8),MPI_STATUS_IGNORE,ierr)
+      endif
+!-----
+!$acc end data 
+
+      end subroutine comm_1u_tend_halo_GPU
+
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+
+      subroutine comm_1v_tend_halo_GPU(s)
+      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
+          wbc,ebc,sbc,nbc,nf,ierr,cs1we,cs1sn,timestats,time_mps2,mytime, &
+          mynw,mysw,myne,myse,myeast,mywest,mynorth,mysouth
+      use mpi
+      implicit none
+ 
+      double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: s
+
+      double precision, dimension(2,nj+1,nk) :: west,newwest,east,neweast
+      double precision, dimension(ni,3,nk) :: south,newsouth,north,newnorth
+      double precision, dimension(2,3,nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      integer reqs(8)
+ 
+      integer :: i,j,k,nn,nr,index
+      integer :: tag1,tag2,tag3,tag4
+      integer :: index_east,index_west,index_south,index_north
+      integer :: index_nw,index_sw,index_ne,index_se
+      integer, dimension(mpi_status_size,8) :: status1
+      logical, parameter :: Debug = .FALSE.
+ 
+!------------------------------------------------
+!$acc data create(west,newwest,east,neweast,south,newsouth,north,newnorth,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+
+      nr = 0
+
+      nf=nf+1
+      tag1=nf
+
+      ! receive east
+      if(ibe.eq.0)then
+        nr = nr + 1
+        !$acc host_data use_device(neweast)
+        call mpi_irecv(neweast,2*(nj+1)*nk,MPI_DOUBLE_PRECISION,myeast,tag1,   &
+                      MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+
+!----------
+
+      nf=nf+1
+      tag2=nf
+
+      ! receive west
+      if(ibw.eq.0)then
+        nr = nr + 1
+        !$acc host_data use_device(newwest)
+        call mpi_irecv(newwest,2*(nj+1)*nk,MPI_DOUBLE_PRECISION,mywest,tag2,   &
+                      MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+
+!----------
+
+      nf=nf+1
+      tag3=nf
+
+      ! receive south
+      if(ibs.eq.0)then
+        nr = nr + 1
+        !$acc host_data use_device(newsouth)
+        call mpi_irecv(newsouth,ni*3*nk,MPI_DOUBLE_PRECISION,mysouth,tag3,   &
+                      MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+
+!----------
+
+      nf=nf+1
+      tag4=nf
+
+      ! receive north
+      if(ibn.eq.0)then
+        nr = nr + 1
+        !$acc host_data use_device(newnorth)
+        call mpi_irecv(newnorth,ni*3*nk,MPI_DOUBLE_PRECISION,mynorth,tag4,   &
+                      MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+
+!------------------------------------------------
+!------------------------------------------------
+!------------------------------------------------
+
+      nr = 4
+ 
+      ! send west
+      if(ibw.eq.0)then
+!$omp parallel do default(shared)   &
+!$omp private(j,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(j,k)
+        do k=1,nk
+        do j=1,nj+1
+          west(1,j,k)=s(-1,j,k)
+          west(2,j,k)=s( 0,j,k)
+        enddo
+        enddo
+        nr = nr + 1
+        !$acc host_data use_device(west)
+        call mpi_isend(west,2*(nj+1)*nk,MPI_DOUBLE_PRECISION,mywest,tag1,   &
+                       MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+ 
+!----------
+ 
+      ! send east
+      if(ibe.eq.0)then
+!$omp parallel do default(shared)   &
+!$omp private(j,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(j,k)
+        do k=1,nk
+        do j=1,nj+1
+          east(1,j,k)=s(ni+1,j,k)
+          east(2,j,k)=s(ni+2,j,k)
+        enddo
+        enddo
+        nr = nr + 1
+        !$acc host_data use_device(east)
+        call mpi_isend(east,2*(nj+1)*nk,MPI_DOUBLE_PRECISION,myeast,tag2,   &
+                       MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+ 
+!----------
+ 
+      ! send north
+      if(ibn.eq.0)then
+!$omp parallel do default(shared)   &
+!$omp private(i,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
+        do k=1,nk
+        do i=1,ni
+          north(i,1,k)=s(i,nj+1,k)
+          north(i,2,k)=s(i,nj+2,k)
+          north(i,3,k)=s(i,nj+3,k)
+        enddo
+        enddo
+        nr = nr + 1
+        !$acc host_data use_device(north)
+        call mpi_isend(north,ni*3*nk,MPI_DOUBLE_PRECISION,mynorth,tag3,   &
+                       MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+ 
+!----------
+ 
+      ! send south
+      if(ibs.eq.0)then
+!$omp parallel do default(shared)   &
+!$omp private(i,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
+        do k=1,nk
+        do i=1,ni
+          south(i,1,k)=s(i,-1,k)
+          south(i,2,k)=s(i, 0,k)
+          south(i,3,k)=s(i, 1,k)
+        enddo
+        enddo
+        nr = nr + 1
+        !$acc host_data use_device(south)
+        call mpi_isend(south,ni*3*nk,MPI_DOUBLE_PRECISION,mysouth,tag4,   &
+                       MPI_COMM_WORLD,reqs(nr),ierr)
+        !$acc end host_data
+      endif
+
+!---------------------------------------------------------------------
+
+      index_east = -1
+      index_west = -1
+      index_south = -1
+      index_north = -1
+
+      nr = 0
+      if(ibe.eq.0)then
+        nr = nr + 1
+        index_east = nr
+      endif
+      if(ibw.eq.0)then
+        nr = nr + 1
+        index_west = nr
+      endif
+      if(ibs.eq.0)then
+        nr = nr + 1
+        index_south = nr
+      endif
+      if(ibn.eq.0)then
+        nr = nr + 1
+        index_north = nr
+      endif
+
+      nn = 1
+      do while( nn .le. nr )
+        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
+        nn = nn + 1
+ 
+      if(index.eq.index_east)then
+!$omp parallel do default(shared)   &
+!$omp private(j,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(j,k)
+        do k=1,nk
+        do j=1,nj+1
+          s(ni-1,j,k)=s(ni-1,j,k)+neweast(1,j,k)
+          s(ni  ,j,k)=s(ni  ,j,k)+neweast(2,j,k)
+        enddo
+        enddo
+      elseif(index.eq.index_west)then
+!$omp parallel do default(shared)   &
+!$omp private(j,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(j,k)
+        do k=1,nk
+        do j=1,nj+1
+          s(1,j,k)=s(1,j,k)+newwest(1,j,k)
+          s(2,j,k)=s(2,j,k)+newwest(2,j,k)
+        enddo
+        enddo
+      elseif(index.eq.index_south)then
+!$omp parallel do default(shared)   &
+!$omp private(i,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
+        do k=1,nk
+        do i=1,ni
+          s(i,1,k)=s(i,1,k)+newsouth(i,1,k)
+          s(i,2,k)=s(i,2,k)+newsouth(i,2,k)
+          s(i,3,k)=s(i,3,k)+newsouth(i,3,k)
+        enddo
+        enddo
+      elseif(index.eq.index_north)then
+!$omp parallel do default(shared)   &
+!$omp private(i,k)
+!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
+        do k=1,nk
+        do i=1,ni
+          s(i,nj-1,k)=s(i,nj-1,k)+newnorth(i,1,k)
+          s(i,nj  ,k)=s(i,nj  ,k)+newnorth(i,2,k)
+          s(i,nj+1,k)=s(i,nj+1,k)+newnorth(i,3,k)
+        enddo
+        enddo
+      endif
+
+      enddo
+
+!----------
+
+      nr = 0
+
+      if(ibw.eq.0)then
+        nr = nr+1
+      endif
+      if(ibe.eq.0)then
+        nr = nr+1
+      endif
+      if(ibn.eq.0)then
+        nr = nr+1
+      endif
+      if(ibs.eq.0)then
+        nr = nr+1
+      endif
+
+    if( nr.ge.1 )then
+      call MPI_WAITALL(nr,reqs(5:5+nr-1),status1(1:mpi_status_size,5:5+nr-1),ierr)
+    endif
+      if(timestats.ge.1) time_mps2=time_mps2+mytime()
+ 
+!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!  Now, get data from corners:
+
+      nr = 0
+      index_nw = -1
+      index_sw = -1
+      index_ne = -1
+      index_se = -1
+
+!------------------------------------------------------------------
+
+      tag1=5001
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+        nr = nr + 1
+        !$acc host_data use_device(nw2)
+        call mpi_irecv(nw2,2*3*nk,MPI_DOUBLE_PRECISION,mynw,tag1,MPI_COMM_WORLD,   &
+                       reqs(nr),ierr)
+        !$acc end host_data
+        index_nw = nr
+      endif
+
+!-----
+
+      tag2=5002
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+        nr = nr + 1
+        !$acc host_data use_device(sw2)
+        call mpi_irecv(sw2,2*3*nk,MPI_DOUBLE_PRECISION,mysw,tag2,MPI_COMM_WORLD,   &
+                       reqs(nr),ierr)
+        !$acc end host_data
+        index_sw = nr
+      endif
+
+!-----
+
+      tag3=5003
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+        nr = nr + 1
+        !$acc host_data use_device(ne2)
+        call mpi_irecv(ne2,2*3*nk,MPI_DOUBLE_PRECISION,myne,tag3,MPI_COMM_WORLD,   &
+                       reqs(nr),ierr)
+        !$acc end host_data
+        index_ne = nr
+      endif
+
+!-----
+
+      tag4=5004
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+        nr = nr + 1
+        !$acc host_data use_device(se2)
+        call mpi_irecv(se2,2*3*nk,MPI_DOUBLE_PRECISION,myse,tag4,MPI_COMM_WORLD,   &
+                       reqs(nr),ierr)
+        !$acc end host_data
+        index_se = nr
+      endif
+
+!------------------------------------------------------------------
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,3
+        do i=1,2
+          se1(i,j,k)=s(ni+i,-2+j,k)
+        enddo
+        enddo
+        enddo
+
+        !$acc host_data use_device(se1)
+        call mpi_isend(se1,2*3*nk,MPI_DOUBLE_PRECISION,myse,tag1,MPI_COMM_WORLD,   &
+                       reqs(5),ierr)
+        !$acc end host_data
+      endif
+ 
+!-----
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,3
+        do i=1,2
+          ne1(i,j,k)=s(ni+i,nj+j,k)
+        enddo
+        enddo
+        enddo
+        !$acc host_data use_device(ne1)
+        call mpi_isend(ne1,2*3*nk,MPI_DOUBLE_PRECISION,myne,tag2,MPI_COMM_WORLD,   &
+                       reqs(6),ierr)
+        !$acc end host_data
+      endif
+ 
+!-----
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,3
+        do i=1,2
+          sw1(i,j,k)=s(-2+i,-2+j,k)
+        enddo
+        enddo
+        enddo
+        !$acc host_data use_device(sw1)
+        call mpi_isend(sw1,2*3*nk,MPI_DOUBLE_PRECISION,mysw,tag3,MPI_COMM_WORLD,   &
+                       reqs(7),ierr)
+        !$acc end host_data
+      endif
+ 
+!-----
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,3
+        do i=1,2
+          nw1(i,j,k)=s(-2+i,nj+j,k)
+        enddo
+        enddo
+        enddo
+        !$acc host_data use_device(nw1)
+        call mpi_isend(nw1,2*3*nk,MPI_DOUBLE_PRECISION,mynw,tag4,MPI_COMM_WORLD,   &
+                       reqs(8),ierr)
+        !$acc end host_data
+      endif
+ 
+!-----
+
+      nn = 1
+      do while( nn .le. nr )
+        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
+        nn = nn + 1
+
+      if(index.eq.index_nw)then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,3
+        do i=1,2
+          s(i,nj-2+j,k)=s(i,nj-2+j,k)+nw2(i,j,k)
+        enddo
+        enddo
+        enddo
+      elseif(index.eq.index_sw)then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,3
+        do i=1,2
+          s(i,j,k)=s(i,j,k)+sw2(i,j,k)
+        enddo
+        enddo
+        enddo
+      elseif(index.eq.index_ne)then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,3
+        do i=1,2
+          s(ni-2+i,nj-2+j,k)=s(ni-2+i,nj-2+j,k)+ne2(i,j,k)
+        enddo
+        enddo
+        enddo
+      elseif(index.eq.index_se)then
+!$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
+        do k=1,nk
+        do j=1,3
+        do i=1,2
+          s(ni-2+i,j,k)=s(ni-2+i,j,k)+se2(i,j,k)
+        enddo
+        enddo
+        enddo
+      endif
+
+      enddo
+
+!-----
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+        call MPI_WAIT (reqs(5),MPI_STATUS_IGNORE,ierr)
+      endif
+
+      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+        call MPI_WAIT (reqs(6),MPI_STATUS_IGNORE,ierr)
+      endif
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+        call MPI_WAIT (reqs(7),MPI_STATUS_IGNORE,ierr)
+      endif
+
+      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+        call MPI_WAIT (reqs(8),MPI_STATUS_IGNORE,ierr)
+      endif
+!-----
+!$acc end data 
+
+      end subroutine comm_1v_tend_halo_GPU
+
+
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -140,7 +140,8 @@ contains
         write(*,*) "Too many new droplets will enter the MPI rank: ", myid
         write(*,*) "nparcelsLocalActive,nparcelsLocal",nparcelsLocalActive,nparcelsLocal
         write(*,*) "Arriving, holes to fill: ", sum(Arrive), numHoles
-        stop "Stop the program ..."
+        write(*,*) "Stop the program ..."
+        call stopcm1
     end if
 
 #if 0 
@@ -171,7 +172,8 @@ contains
           write(*,*) "Unmatched total leaving droplets vs. total entering droplets..."
           write(*,*) "Total leaving droplets: ", n_send
           write(*,*) "Total entering droplets: ", n_recv
-          stop "Stop the program ..."
+          write(*,*) "Stop the program ..."
+          call stopcm1
        end if
     end if
 
@@ -483,7 +485,8 @@ contains
           call update_new_droplet ( ise, Arrive, ptrArrive, holes_ind, pdata, droplet_se2)
        else
           write(*,*) indx," is not a nearest neighbor for myid = ",myid
-          stop "Stop the program..."
+          write(*,*) "Stop the program..."
+          call stopcm1
        end if
        n = n + 1
      end do

--- a/src/constants.F
+++ b/src/constants.F
@@ -7,10 +7,10 @@
     real :: g,rd,rv,cp,cpinv,cv,cpv,cvv,rcp,                                 &
             cpdcv,rovcp,rddcp,rddcv,rddrv,cvdrd,cpdrd,eps,reps,repsm1,       &
             cpt,cvt,pnum,xlv,lathv,xls,lvdcp,condc,cpl,cpi,lv1,lv2,ls1,ls2,  &
-            rhow,c_e1,c_e2,c_s,rcs,earth_radius,govtwo,mw,ms,surften,ion,os, &
-            ru
+            rhow,c_e1,c_e2,c_s,rcs,earth_radius,govtwo
+    double precision :: rhow_dp,cp_dp,cpl_dp,mw,ms,surften,ion,os,ru,lv1_dp,lv2_dp
 
-    !$acc declare create (ru,mw,surften,rhow,ion,os,ms,lv1,lv2,cpl,cp,eps)
+    !$acc declare create (ru,mw,surften,rhow,rhow_dp,ion,os,ms,lv1,lv1_dp,lv2,lv2_dp,cpl,cpl_dp,cp,cp_dp,eps)
 
       !----------------
 
@@ -64,7 +64,7 @@
 
       integer, parameter :: undefined_index = -100
 
-      real, parameter :: pdata_buffer = 0.10      ! additional storage space for pdata from
+      real, parameter :: pdata_buffer = 0.20      ! additional storage space for pdata from
                                                   ! each MPI rank to account for the droplet
                                                   ! communication between MPI ranks;
                                                   ! this is a percent of
@@ -101,6 +101,7 @@
         g      = 9.81
         rd     = 287.0
         cp     = 1015.0
+        cp_dp  = 1015.0d0
         cpv    = 1870.0
         xlv    = 2.47e6
         xls    = 2834000.0
@@ -112,6 +113,7 @@
         g      = 9.81
         rd     = 287.0
         cp     = 1004.0
+        cp_dp  = 1004.0d0
         cpv    = 1870.0
         xlv    = 2.50e6
         xls    = 2834000.0
@@ -132,6 +134,7 @@
         g      = 9.81
         rd     = 287.04
         cp     = 1005.7
+        cp_dp  = 1005.7d0
         cpv    = 1870.0
         xlv    = 2501000.0
         xls    = 2834000.0
@@ -164,18 +167,24 @@
       lvdcp  = xlv/cp
       condc  = xlv*xlv/(rv*cp)
       cpl    = 4190.0
+      cpl_dp = 4190.0d0
       cpi    = 2106.0
       lv1    = xlv+(cpl-cpv)*to
       lv2    = cpl-cpv
+    ! kludge !
+      lv1_dp = 3134708.0d0
+      lv2_dp = 2320.0d0
+    ! kludge !
       ls1    = xls+(cpi-cpv)*to
       ls2    = cpi-cpv
       rhow   = 1.0e3
-      mw     = 0.018015  !kg/mol, molecular weight water
-      ms     = 0.05844   !kg/mol, molecular weight of salt (or droplet solute)
-      surften= 7.28e-2   !Droplet surface tension
-      ion    = 2.0       !# of ions available in solute
-      os     = 1.093     !Droplet osmotic coefficient
-      ru     = 8.3144    !J/mol-K Universal gas constant
+      rhow_dp = 1.0d3
+      mw     = 0.018015d0  !kg/mol, molecular weight water
+      ms     = 0.05844d0   !kg/mol, molecular weight of salt (or droplet solute)
+      surften= 7.28d-2   !Droplet surface tension
+      ion    = 2.0d0       !# of ions available in solute
+      os     = 1.093d0     !Droplet osmotic coefficient
+      ru     = 8.3144d0    !J/mol-K Universal gas constant
 
 
 
@@ -194,7 +203,7 @@
       c_s = ( c_m * c_m * c_m / ( c_e1 + c_e2 ) )**0.25   ! Smagorinsky constant
       rcs = 1.0/c_s
 
-      !$acc update device (ru,mw,surften,rhow,ion,os,ms,lv1,lv2,cpl,cp,eps)
+      !$acc update device (ru,mw,surften,rhow,rhow_dp,ion,os,ms,lv1,lv1_dp,lv2,lv2_dp,cpl,cpl_dp,cp,cp_dp,eps)
 
       end subroutine set_constants
 

--- a/src/domaindiag.F
+++ b/src/domaindiag.F
@@ -10584,7 +10584,7 @@
 
     !$acc parallel default(present)
     !$acc loop gang vector
-    do k=1,nk+1
+    do k=1,nk
       sbar(k) = 0.0
     enddo
     !$acc end parallel

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -55,7 +55,7 @@
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p,                    &
                                sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,                   &
                                n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,            &
-                               uten,vten,wten,thten,qten,dten,pdata_locind)
+                               dpten,pdata_locind)
       use input, only : ib,ie,jb,je,kb,ke,ibl,iel,jbl,jel,numq,ni,nj,nk,imp,jmp,kmp,rmp,cmp, &
           kmt,npvals,npvars,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,bbc,tbc,imove,zt,rzt, &
           umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
@@ -95,7 +95,7 @@
       real, intent(in), dimension(ibl:iel,jbl:jel) :: s10
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: rho,prs,ta
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: pi0,th0,th_in,ppa
-      double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: uten,vten,wten,thten,qten,dten
+      double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke,6) :: dpten
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke,numq) :: qa
       real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: ua
       real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: va
@@ -354,7 +354,7 @@
 #ifdef _B4B01F
     !$acc update &
     !$acc host(pdata,xf,yf,zf,zh,sigma,sigmaf, &
-    !$acc      ua,va,wa,qa,ta,rho,prs,znt,qten,thten,zs)
+    !$acc      ua,va,wa,qa,ta,rho,prs,znt,dpten,zs)
 #else
     !JMD WARNING: Loop does not yet match CPU version.
     !$acc parallel default(present)
@@ -488,7 +488,7 @@
 
       !Project the feedback onto the grid, using ORIGINAL location
       call project_feedback(iflag,jflag,kflag,x3d0,y3d0,z3d0,sig3d0, &
-                            rhop0,taup0,rp0,tval,uten,vten,wten,qten,thten,dten, &
+                            rhop0,taup0,rp0,tval,dpten, &
                             xh,xf,yh,yf,zh,zf,sigma,sigmaf, &
                             sigdot,dvpdt1,dvpdt2,dvpdt3,drpdt,dtpdt,dmpdt, &
                             rhoval,part_grav1,part_grav2,part_grav3,pdata,np)
@@ -499,14 +499,13 @@
       stop 'FATAL error occurred in the index search BE_integration'
     endif
 
-    !Now that the tendency terms are computed, need to adjust the thten by the exner function:
 
     !$acc parallel default(present)
     !$acc loop gang vector collapse(3)
     do k=kb,ke
        do j=jb,je
           do i=ib,ie
-             thten(i,j,k) = thten(i,j,k)*pi0(i,j,k)
+             dpten(i,j,k,5) = dpten(i,j,k,5)*pi0(i,j,k)
           end do
        end do
     end do
@@ -1522,8 +1521,8 @@
       end subroutine interpolate_to_parcel
 
       subroutine project_feedback(iflag,jflag,kflag,x3d,y3d,z3d,sig3d, &
-                                  rhop0,taup0,rp0,tval,uten,vten,wten, &
-                                  qten,thten,dten,xh,xf,yh,yf,zh,zf,sigma,  &
+                                  rhop0,taup0,rp0,tval, &
+                                  dpten,xh,xf,yh,yf,zh,zf,sigma,  &
                                   sigmaf,sigdot,dvpdt1,dvpdt2,dvpdt3,  &
                                   drpdt,dtpdt,dmpdt,rhoval,part_grav1, &
                                   part_grav2,part_grav3,pdata,np)
@@ -1549,7 +1548,7 @@
       real, intent(in), dimension(ib:ie,jb:je,kb:ke) :: zh
       real, intent(in), dimension(kb:ke) :: sigma
       real, intent(in), dimension(kb:ke+1) :: sigmaf
-      double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: uten,vten,wten,thten,qten,dten
+      double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke,6) :: dpten
 
       integer, intent(in) :: np
       integer, intent(in) :: iflag,jflag,kflag
@@ -1610,21 +1609,21 @@
       partmass = pdata(np,prms) + VolP*rhow
 
       !$acc atomic update
-      uten(i,j,k)       = uten(i,j,k)       - partmass/rhoval*(dvpdt1-part_grav1)*w1/dV*pdata(np,prmult)
+      dpten(i,j,k,3)       = dpten(i,j,k,3)       - partmass/rhoval*(dvpdt1-part_grav1)*w1/dV*pdata(np,prmult)
       !$acc atomic update
-      uten(i+1,j,k)     = uten(i+1,j,k)     - partmass/rhoval*(dvpdt1-part_grav1)*w2/dV*pdata(np,prmult)
+      dpten(i+1,j,k,3)     = dpten(i+1,j,k,3)     - partmass/rhoval*(dvpdt1-part_grav1)*w2/dV*pdata(np,prmult)
       !$acc atomic update
-      uten(i,j+1,k)     = uten(i,j+1,k)     - partmass/rhoval*(dvpdt1-part_grav1)*w3/dV*pdata(np,prmult)
+      dpten(i,j+1,k,3)     = dpten(i,j+1,k,3)     - partmass/rhoval*(dvpdt1-part_grav1)*w3/dV*pdata(np,prmult)
       !$acc atomic update
-      uten(i,j,k+1)     = uten(i,j,k+1)     - partmass/rhoval*(dvpdt1-part_grav1)*w4/dV*pdata(np,prmult)
+      dpten(i,j,k+1,3)     = dpten(i,j,k+1,3)     - partmass/rhoval*(dvpdt1-part_grav1)*w4/dV*pdata(np,prmult)
       !$acc atomic update
-      uten(i+1,j,k+1)   = uten(i+1,j,k+1)   - partmass/rhoval*(dvpdt1-part_grav1)*w5/dV*pdata(np,prmult)
+      dpten(i+1,j,k+1,3)   = dpten(i+1,j,k+1,3)   - partmass/rhoval*(dvpdt1-part_grav1)*w5/dV*pdata(np,prmult)
       !$acc atomic update
-      uten(i,j+1,k+1)   = uten(i,j+1,k+1)   - partmass/rhoval*(dvpdt1-part_grav1)*w6/dV*pdata(np,prmult)
+      dpten(i,j+1,k+1,3)   = dpten(i,j+1,k+1,3)   - partmass/rhoval*(dvpdt1-part_grav1)*w6/dV*pdata(np,prmult)
       !$acc atomic update
-      uten(i+1,j+1,k)   = uten(i+1,j+1,k)   - partmass/rhoval*(dvpdt1-part_grav1)*w7/dV*pdata(np,prmult)
+      dpten(i+1,j+1,k,3)   = dpten(i+1,j+1,k,3)   - partmass/rhoval*(dvpdt1-part_grav1)*w7/dV*pdata(np,prmult)
       !$acc atomic update
-      uten(i+1,j+1,k+1) = uten(i+1,j+1,k+1) - partmass/rhoval*(dvpdt1-part_grav1)*w8/dV*pdata(np,prmult)
+      dpten(i+1,j+1,k+1,3) = dpten(i+1,j+1,k+1,3) - partmass/rhoval*(dvpdt1-part_grav1)*w8/dV*pdata(np,prmult)
 
       !What interpolation is doing, for reference
       ! uval = ua(i  ,j  ,k  )*w1 &
@@ -1681,21 +1680,21 @@
       w8 = rx*ry*rz
 
       !$acc atomic update
-      vten(i,j,k)       = vten(i,j,k)       - partmass/rhoval*(dvpdt2-part_grav2)*w1/dV*pdata(np,prmult)
+      dpten(i,j,k,4)       = dpten(i,j,k,4)       - partmass/rhoval*(dvpdt2-part_grav2)*w1/dV*pdata(np,prmult)
       !$acc atomic update
-      vten(i+1,j,k)     = vten(i+1,j,k)     - partmass/rhoval*(dvpdt2-part_grav2)*w2/dV*pdata(np,prmult)
+      dpten(i+1,j,k,4)     = dpten(i+1,j,k,4)     - partmass/rhoval*(dvpdt2-part_grav2)*w2/dV*pdata(np,prmult)
       !$acc atomic update
-      vten(i,j+1,k)     = vten(i,j+1,k)     - partmass/rhoval*(dvpdt2-part_grav2)*w3/dV*pdata(np,prmult)
+      dpten(i,j+1,k,4)     = dpten(i,j+1,k,4)     - partmass/rhoval*(dvpdt2-part_grav2)*w3/dV*pdata(np,prmult)
       !$acc atomic update
-      vten(i,j,k+1)     = vten(i,j,k+1)     - partmass/rhoval*(dvpdt2-part_grav2)*w4/dV*pdata(np,prmult)
+      dpten(i,j,k+1,4)     = dpten(i,j,k+1,4)     - partmass/rhoval*(dvpdt2-part_grav2)*w4/dV*pdata(np,prmult)
       !$acc atomic update
-      vten(i+1,j,k+1)   = vten(i+1,j,k+1)   - partmass/rhoval*(dvpdt2-part_grav2)*w5/dV*pdata(np,prmult)
+      dpten(i+1,j,k+1,4)   = dpten(i+1,j,k+1,4)   - partmass/rhoval*(dvpdt2-part_grav2)*w5/dV*pdata(np,prmult)
       !$acc atomic update
-      vten(i,j+1,k+1)   = vten(i,j+1,k+1)   - partmass/rhoval*(dvpdt2-part_grav2)*w6/dV*pdata(np,prmult)
+      dpten(i,j+1,k+1,4)   = dpten(i,j+1,k+1,4)   - partmass/rhoval*(dvpdt2-part_grav2)*w6/dV*pdata(np,prmult)
       !$acc atomic update
-      vten(i+1,j+1,k)   = vten(i+1,j+1,k)   - partmass/rhoval*(dvpdt2-part_grav2)*w7/dV*pdata(np,prmult)
+      dpten(i+1,j+1,k,4)   = dpten(i+1,j+1,k,4)   - partmass/rhoval*(dvpdt2-part_grav2)*w7/dV*pdata(np,prmult)
       !$acc atomic update
-      vten(i+1,j+1,k+1) = vten(i+1,j+1,k+1) - partmass/rhoval*(dvpdt2-part_grav2)*w8/dV*pdata(np,prmult)
+      dpten(i+1,j+1,k+1,4) = dpten(i+1,j+1,k+1,4) - partmass/rhoval*(dvpdt2-part_grav2)*w8/dV*pdata(np,prmult)
 
       ! vval = va(i  ,j  ,k  )*w1 &
       !      + va(i+1,j  ,k  )*w2 &
@@ -1747,21 +1746,21 @@
       w8 = rx*ry*rz
 
       !$acc atomic update
-      wten(i,j,k)       = wten(i,j,k)       - partmass/rhoval*(dvpdt3-part_grav3)*w1/dV*pdata(np,prmult)
+      dpten(i,j,k,5)       = dpten(i,j,k,5)       - partmass/rhoval*(dvpdt3-part_grav3)*w1/dV*pdata(np,prmult)
       !$acc atomic update
-      wten(i+1,j,k)     = wten(i+1,j,k)     - partmass/rhoval*(dvpdt3-part_grav3)*w2/dV*pdata(np,prmult)
+      dpten(i+1,j,k,5)     = dpten(i+1,j,k,5)     - partmass/rhoval*(dvpdt3-part_grav3)*w2/dV*pdata(np,prmult)
       !$acc atomic update
-      wten(i,j+1,k)     = wten(i,j+1,k)     - partmass/rhoval*(dvpdt3-part_grav3)*w3/dV*pdata(np,prmult)
+      dpten(i,j+1,k,5)     = dpten(i,j+1,k,5)     - partmass/rhoval*(dvpdt3-part_grav3)*w3/dV*pdata(np,prmult)
       !$acc atomic update
-      wten(i,j,k+1)     = wten(i,j,k+1)     - partmass/rhoval*(dvpdt3-part_grav3)*w4/dV*pdata(np,prmult)
+      dpten(i,j,k+1,5)     = dpten(i,j,k+1,5)     - partmass/rhoval*(dvpdt3-part_grav3)*w4/dV*pdata(np,prmult)
       !$acc atomic update
-      wten(i+1,j,k+1)   = wten(i+1,j,k+1)   - partmass/rhoval*(dvpdt3-part_grav3)*w5/dV*pdata(np,prmult)
+      dpten(i+1,j,k+1,5)   = dpten(i+1,j,k+1,5)   - partmass/rhoval*(dvpdt3-part_grav3)*w5/dV*pdata(np,prmult)
       !$acc atomic update
-      wten(i,j+1,k+1)   = wten(i,j+1,k+1)   - partmass/rhoval*(dvpdt3-part_grav3)*w6/dV*pdata(np,prmult)
+      dpten(i,j+1,k+1,5)   = dpten(i,j+1,k+1,5)   - partmass/rhoval*(dvpdt3-part_grav3)*w6/dV*pdata(np,prmult)
       !$acc atomic update
-      wten(i+1,j+1,k)   = wten(i+1,j+1,k)   - partmass/rhoval*(dvpdt3-part_grav3)*w7/dV*pdata(np,prmult)
+      dpten(i+1,j+1,k,5)   = dpten(i+1,j+1,k,5)   - partmass/rhoval*(dvpdt3-part_grav3)*w7/dV*pdata(np,prmult)
       !$acc atomic update
-      wten(i+1,j+1,k+1) = wten(i+1,j+1,k+1) - partmass/rhoval*(dvpdt3-part_grav3)*w8/dV*pdata(np,prmult)
+      dpten(i+1,j+1,k+1,5) = dpten(i+1,j+1,k+1,5) - partmass/rhoval*(dvpdt3-part_grav3)*w8/dV*pdata(np,prmult)
 
       ! wval = wa(i  ,j  ,k  )*w1 &
       !      + wa(i+1,j  ,k  )*w2 &
@@ -1817,21 +1816,21 @@
 
       if(imoist.eq.1)then
         !$acc atomic update
-        qten(i,j,k)       = qten(i,j,k)       - dmpdt/rhoval/dV*w1*pdata(np,prmult)
+        dpten(i,j,k,2)       = dpten(i,j,k,2)       - dmpdt/rhoval/dV*w1*pdata(np,prmult)
         !$acc atomic update
-        qten(i+1,j,k)     = qten(i+1,j,k)     - dmpdt/rhoval/dV*w2*pdata(np,prmult)
+        dpten(i+1,j,k,2)     = dpten(i+1,j,k,2)     - dmpdt/rhoval/dV*w2*pdata(np,prmult)
         !$acc atomic update
-        qten(i,j+1,k)     = qten(i,j+1,k)     - dmpdt/rhoval/dV*w3*pdata(np,prmult)
+        dpten(i,j+1,k,2)     = dpten(i,j+1,k,2)     - dmpdt/rhoval/dV*w3*pdata(np,prmult)
         !$acc atomic update
-        qten(i,j,k+1)     = qten(i,j,k+1)     - dmpdt/rhoval/dV*w4*pdata(np,prmult)
+        dpten(i,j,k+1,2)     = dpten(i,j,k+1,2)     - dmpdt/rhoval/dV*w4*pdata(np,prmult)
         !$acc atomic update
-        qten(i+1,j,k+1)   = qten(i+1,j,k+1)   - dmpdt/rhoval/dV*w5*pdata(np,prmult)
+        dpten(i+1,j,k+1,2)   = dpten(i+1,j,k+1,2)   - dmpdt/rhoval/dV*w5*pdata(np,prmult)
         !$acc atomic update
-        qten(i,j+1,k+1)   = qten(i,j+1,k+1)   - dmpdt/rhoval/dV*w6*pdata(np,prmult)
+        dpten(i,j+1,k+1,2)   = dpten(i,j+1,k+1,2)   - dmpdt/rhoval/dV*w6*pdata(np,prmult)
         !$acc atomic update
-        qten(i+1,j+1,k)   = qten(i+1,j+1,k)   - dmpdt/rhoval/dV*w7*pdata(np,prmult)
+        dpten(i+1,j+1,k,2)   = dpten(i+1,j+1,k,2)   - dmpdt/rhoval/dV*w7*pdata(np,prmult)
         !$acc atomic update
-        qten(i+1,j+1,k+1) = qten(i+1,j+1,k+1) - dmpdt/rhoval/dV*w8*pdata(np,prmult)
+        dpten(i+1,j+1,k+1,2) = dpten(i+1,j+1,k+1,2) - dmpdt/rhoval/dV*w8*pdata(np,prmult)
 
         ! qval = qa(i  ,j  ,k  ,nqv)*w1 &
         !      + qa(i+1,j  ,k  ,nqv)*w2 &
@@ -1846,28 +1845,28 @@
       lhv=lv1-lv2*pdata(np,prt)
 
       !$acc atomic update
-      thten(i,j,k)       = thten(i,j,k) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w1/dV*pdata(np,prmult)
+      dpten(i,j,k,1)       = dpten(i,j,k,1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w1/dV*pdata(np,prmult)
 
       !$acc atomic update
-      thten(i+1,j,k)     = thten(i+1,j,k) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w2/dV*pdata(np,prmult)
+      dpten(i+1,j,k,1)     = dpten(i+1,j,k,1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w2/dV*pdata(np,prmult)
 
       !$acc atomic update
-      thten(i,j+1,k)     = thten(i,j+1,k) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w3/dV*pdata(np,prmult)
+      dpten(i,j+1,k,1)     = dpten(i,j+1,k,1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w3/dV*pdata(np,prmult)
 
       !$acc atomic update
-      thten(i,j,k+1)     = thten(i,j,k+1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w4/dV*pdata(np,prmult)
+      dpten(i,j,k+1,1)     = dpten(i,j,k+1,1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w4/dV*pdata(np,prmult)
 
       !$acc atomic update
-      thten(i+1,j,k+1)   = thten(i+1,j,k+1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w5/dV*pdata(np,prmult)
+      dpten(i+1,j,k+1,1)   = dpten(i+1,j,k+1,1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w5/dV*pdata(np,prmult)
 
       !$acc atomic update
-      thten(i,j+1,k+1)   = thten(i,j+1,k+1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w6/dV*pdata(np,prmult)
+      dpten(i,j+1,k+1,1)   = dpten(i,j+1,k+1,1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w6/dV*pdata(np,prmult)
 
       !$acc atomic update
-      thten(i+1,j+1,k)   = thten(i+1,j+1,k) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w7/dV*pdata(np,prmult)
+      dpten(i+1,j+1,k,1)   = dpten(i+1,j+1,k,1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w7/dV*pdata(np,prmult)
 
       !$acc atomic update
-      thten(i+1,j+1,k+1) = thten(i+1,j+1,k+1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w8/dV*pdata(np,prmult)
+      dpten(i+1,j+1,k+1,1) = dpten(i+1,j+1,k+1,1) - (dtpdt - 3*lhv/cpl/rp0*drpdt)*6.0*(rhow/rhop0)*(cpl/cp)*taup0*pi*rp0*viscosity*w8/dV*pdata(np,prmult)
 
       ! tval   = ta(i  ,j  ,k  )*w1 &
       !        + ta(i+1,j  ,k  )*w2 &
@@ -1880,11 +1879,11 @@
 
       ! GHB: diagnostic purposes only: number of drops in each grid cell
       !$acc atomic update
-      dten(iflag,jflag,kflag) = dten(iflag,jflag,kflag) + 1.0
+      dpten(iflag,jflag,kflag,6) = dpten(iflag,jflag,kflag,6) + 1.0
 
       end subroutine project_feedback
 
-      subroutine droplet_diag(rtime,nrec,zh,zf,pdata,pdata_locind,dpten,uten,vten,wten)
+      subroutine droplet_diag(rtime,nrec,zh,zf,pdata,pdata_locind,dpten)
 
       use input
       use constants
@@ -1897,9 +1896,6 @@
       integer, intent(inout) :: nrec
       real, intent(in) :: rtime
       double precision, intent(in), dimension(ib:ie,jb:je,kb:ke,6) :: dpten
-      real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: uten
-      real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: vten
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: wten
       real, intent(in), dimension(nparcelsLocal,npvals) :: pdata
       integer, intent(inout), dimension(nparcelsLocal,3) :: pdata_locind    ! x/y/z location index of each parcel
       real, intent(in), dimension(ib:ie,jb:je,kb:ke) :: zh

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -2964,6 +2964,7 @@
         ! quantities come in already non-dimensionalized, so must be converted back;
         rnext = tempr*radius
         Tnext = tempt*Tp
+        Tnext = max(Tnext,1.0d-12) !To avoid divide by zero if the solution starts to diverge; gets flagged later
         dnext = rnext*2.0d0
 
         esa = deslf(prsval,tval)

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -21,7 +21,7 @@
   real :: restime_min,restime_max,restime_min10,restime_max10,dhres !Bin parameters for droplet residence time
   real :: dhrad,rmin,rmax,rmin10,rmax10  !Bin parameters for droplet size
 
-  real :: u10_ssgf 
+  double precision :: u10_ssgf 
   real :: num_destroyed,num_injected,mass_destroyed,mass_injected !Cumulative particle counts between droplet_diag calls
 
   ! If we already know that a parcel stays on the same process 
@@ -48,14 +48,14 @@
 
   CONTAINS
 
-      subroutine droplet_driver(dt,mtime,xh,uh,ruh,xf,yh,vh,rvh,yf,zh,mh,rmh,zf,mf,zs,    &
+      subroutine droplet_driver(dt,dbldt,mtime,xh,uh,ruh,xf,yh,vh,rvh,yf,zh,mh,rmh,zf,mf,zs, &
                                sigma,sigmaf,znt,rho,ua,va,wa,s10,pdata,                   &
-                               th_in,qa,th0,pi0,ppa,prs,                                  &
+                               th_in,qa,th0,pi0,ppa,prs,ta,                               &
                                pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,                           &
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p,                    &
                                sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,                   &
                                n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,            &
-                               uten,vten,wten,thten,qten,pdata_locind)
+                               uten,vten,wten,thten,qten,dten,pdata_locind)
       use input, only : ib,ie,jb,je,kb,ke,ibl,iel,jbl,jel,numq,ni,nj,nk,imp,jmp,kmp,rmp,cmp, &
           kmt,npvals,npvars,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,bbc,tbc,imove,zt,rzt, &
           umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
@@ -66,9 +66,7 @@
       use constants
       use comm_module
       use comm_droplet_module
-      use misclibs
       use parcel_module
-      use cm1libs , only : eslf
 #ifdef MPI
       use mpi
 #endif
@@ -81,6 +79,7 @@
 !-----------------------------------------------------------------------
 
       real, intent(in) :: dt
+      double precision, intent(in) :: dbldt
       double precision, intent(in) :: mtime
       real, intent(in), dimension(ib:ie) :: xh,uh,ruh
       real, intent(in), dimension(ib:ie+1) :: xf
@@ -94,13 +93,13 @@
       real, intent(in), dimension(kb:ke+1) :: sigmaf
       real, intent(in), dimension(ib:ie,jb:je) :: znt
       real, intent(in), dimension(ibl:iel,jbl:jel) :: s10
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: rho,prs
+      real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: rho,prs,ta
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: pi0,th0,th_in,ppa
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: thten,qten
+      double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: uten,vten,wten,thten,qten,dten
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke,numq) :: qa
-      real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: ua,uten
-      real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: va,vten
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: wa,wten
+      real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: ua
+      real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: va
+      real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: wa
       real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
 
       real, intent(inout), dimension(jmp,kmp) :: pw1,pw2,pe1,pe2
@@ -115,7 +114,7 @@
       integer, intent(inout), dimension(nparcelsLocal,3) :: pdata_locind    ! x/y/z location index of each parcel
 
       !Need to compute the true temperature
-      real, dimension(ib:ie,jb:je,kb:ke) :: ta
+!!!      real, dimension(ib:ie,jb:je,kb:ke) :: ta   ! GHB: now passed from solve3
 
       integer :: n,np,i,j,k,iflag,jflag,kflag
       integer :: ix,iy,iz
@@ -212,7 +211,7 @@
 #else
       !$acc data copyin (randomNumbers,randomNumbers%state)
 #endif
-      !$acc enter data create (ta)
+!!!      !$acc enter data create (ta)    ! GHB: now passed from solve3
 
     IF(bbc.eq.1)THEN
       ! free slip ... extrapolate:
@@ -447,7 +446,7 @@
 !      write(*,'(a8,i,8e15.6)') 'DHR3',np,rhval,tval,rhoval,qval,x3d,y3d,z3d,pdata(np,prrp)
 !      end if
 
-      call BE_integration(dt,np,pdata,pdata_locind,xf,yf,x3d,y3d,z3d,sig3d, &
+      call BE_integration(dt,dbldt,np,pdata,pdata_locind,xf,yf,x3d,y3d,z3d,sig3d, &
                           uval,vval,wval,qval,rhoval,prsval,tval,Nup,rhop0, &
                           taup0,rp0,part_grav1,part_grav2,part_grav3,debug, &
                           neighbor,num_fallout,errcode)
@@ -489,7 +488,7 @@
 
       !Project the feedback onto the grid, using ORIGINAL location
       call project_feedback(iflag,jflag,kflag,x3d0,y3d0,z3d0,sig3d0, &
-                            rhop0,taup0,rp0,tval,uten,vten,wten,qten,thten, &
+                            rhop0,taup0,rp0,tval,uten,vten,wten,qten,thten,dten, &
                             xh,xf,yh,yf,zh,zf,sigma,sigmaf, &
                             sigdot,dvpdt1,dvpdt2,dvpdt3,drpdt,dtpdt,dmpdt, &
                             rhoval,part_grav1,part_grav2,part_grav3,pdata,np)
@@ -623,12 +622,19 @@
           np = nparcelsLocalActive
           i=0
           do while (i.lt. numBackfill) 
+            if(np.le.0)then
+              ! GHB 220616: nothing will be done in this case; just give backfill_ind a 
+              !             harmless value and move on
+              i=i+1
+              backfill_ind(i) = nparcelsLocalActive+1
+            else
             if ( .not. ((pdata_locind(np,1) .eq. undefined_index) .and. &
               (pdata_locind(np,2) .eq. undefined_index)) ) then
               i=i+1
               backfill_ind(i) = np
             end if
             np=np-1
+            endif
           enddo
        end if
     end if
@@ -665,10 +671,10 @@
     ! Step 5: Update the count of new active droplets with contiguous memory !
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    write(*,105) mtime,myid,nparcelsLocalActive, &
-        (nparcelsLocalActive + sum(Arrive) - sum(Depart) - num_fallout), &
-        sum(Arrive),sum(Depart),num_fallout
-    call flush(6) 
+!    write(*,105) mtime,myid,nparcelsLocalActive, &
+!        (nparcelsLocalActive + sum(Arrive) - sum(Depart) - num_fallout), &
+!        sum(Arrive),sum(Depart),num_fallout
+!    call flush(6) 
     nparcelsLocalActive = nparcelsLocalActive + sum(Arrive) - sum(Depart) - num_fallout
  105     format(f8.3,' myid: ',i4,' nlocalAct: ',i10,2x,i10,' num{Arrive,Depart,Fall}: ',i10,2x,i10,2x,i10)
 
@@ -746,9 +752,9 @@
       end do
 
 #ifdef MPI
-      call mpi_allreduce(mpi_in_place,u10_ssgf,1,mpi_real,mpi_sum,mpi_comm_world,ierr)
+      call mpi_allreduce(mpi_in_place,u10_ssgf,1,mpi_double_precision,mpi_sum,mpi_comm_world,ierr)
 #endif
-      u10_ssgf = u10_ssgf/real(nx*ny)
+      u10_ssgf = u10_ssgf/dble(nx*ny)
 
       !Only inject if a certain time has elapsed (specified in the namelist file)
       if (floor(mtime/drop_inject_elapse) .ne. floor((mtime+dt)/drop_inject_elapse)) then
@@ -818,7 +824,7 @@
 
    if(timestats.ge.1) time_droplet_inject=time_droplet_inject+mytime()
   
-   !$acc exit data delete (ta)
+!!!   !$acc exit data delete (ta)    ! GHB: now passed from solve3
 
    if(timestats.ge.1) time_phys_H2D=time_phys_H2D+mytime()
 
@@ -826,7 +832,7 @@
 
 !----------------------------------------------------------------------
 
-   subroutine BE_integration(dt,np,pdata,pdata_locind,xf,yf,x3d,y3d, &
+   subroutine BE_integration(dt,dbldt,np,pdata,pdata_locind,xf,yf,x3d,y3d, &
                                 z3d,sig3d,uval,vval,wval,qval,rhoval, &
                                 prsval,tval,Nup,rhop0,taup0,rp0, &
                                 part_grav1,part_grav2,part_grav3, &
@@ -835,16 +841,15 @@
       use input, only : ib,ie,jb,je,kb,ke,numq,npvals,nx,ny,viscosity, &
           pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
           prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pru,prv,prw,prt,prqv,prprs,prrho,pract,prtime,prmult, &
-          ni,nj,mywest,mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcelsLocal,myid,dx,dy
-      use constants
+          ni,nj,mywest,mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcelsLocal,myid,dx,dy,pi_sp,pi_dp
+      use constants , only : rhow,rhow_dp,undefined_index
       use comm_module
-      use misclibs
       use parcel_module
-      use cm1libs , only : eslf
       use mpi
 
       implicit none
 
+      double precision, intent(in) :: dbldt
       real, intent(in), dimension(ib:ie+1) :: xf
       real, intent(in), dimension(jb:je+1) :: yf
       integer, intent(in) :: np
@@ -868,12 +873,14 @@
       real :: tprhs,tptmp
       real :: k1tp,k2tp,k1rp,k2rp
       real :: rprhs,rptmp
-      real :: taup,Rep,Shp,diffnorm
-      real :: rhop,volp,tp0,volp0
+      real :: Rep,Shp,diffnorm
+      real :: tp0
       real :: sig1
       real :: top,bot,restime10_tmp,rad10_tmp
       integer :: i,j,k,ibin
-      real :: taup_scale,dt_nondim,guess
+      double precision :: taup,volp,rhop
+      double precision :: taup_scale,dt_nondim
+      double precision :: guess
       double precision :: rt_zeros(2),rt_start(2)
     
       integer :: mflag,flag
@@ -898,16 +905,16 @@
       xrhs1 = pdata(np,prvpx)
       xrhs2 = pdata(np,prvpy)
       xrhs3 = pdata(np,prvpz)
-      volp  = 4.0/3.0*pi*pdata(np,prrp)**3
-      rhop  = (pdata(np,prms)+volp*rhow)/volp  !Density including the solute mass
-      taup  = rhop*(2.0*pdata(np,prrp))**2/18.0/rhoval/viscosity
+      volp  = (4.0d0/3.0d0)*pi_dp*dble(pdata(np,prrp))**3
+      rhop  = (dble(pdata(np,prms))+volp*rhow_dp)/volp  !Density including the solute mass
+      taup  = rhop*(2.0d0*dble(pdata(np,prrp)))**2/(18.0d0*dble(rhoval)*dble(viscosity))
 
       !Original, for calculating changes in momentum, mass, and energy
       rhop0 = rhop
       taup0 = taup
       rp0   = pdata(np,prrp)
       tp0   = pdata(np,prtp)
-      volp0 = 4.0/3.0*pi*rp0**3
+!!!      volp0 = 4.0/3.0*pi_sp*rp0**3    ! not used
 
 
       diffnorm = sqrt( (uval-pdata(np,prvpx))**2+ &
@@ -918,9 +925,9 @@
       Nup = 2.0 + 0.6*sqrt(Rep)*pr_num**(1.0/3.0)
       Shp = 2.0 + 0.6*sqrt(Rep)*sc_num**(1.0/3.0)
 
-      vrhs1 = 1.0/taup*(uval - pdata(np,prvpx)) + part_grav1
-      vrhs2 = 1.0/taup*(vval - pdata(np,prvpy)) + part_grav2
-      vrhs3 = 1.0/taup*(wval - pdata(np,prvpz)) + part_grav3
+      vrhs1 = (1.0d0/taup)*(uval - pdata(np,prvpx)) + part_grav1
+      vrhs2 = (1.0d0/taup)*(vval - pdata(np,prvpy)) + part_grav2
+      vrhs3 = (1.0d0/taup)*(wval - pdata(np,prvpz)) + part_grav3
 
       !Position and velocity are straightforward:
 
@@ -928,18 +935,18 @@
       y3d = pdata(np,pry) + dt*pdata(np,prvpy)
       z3d = pdata(np,prz) + dt*pdata(np,prvpz)
 
-      pdata(np,prvpx) = (pdata(np,prvpx) + dt*uval/taup + dt*part_grav1)/(1 + dt/taup)
-      pdata(np,prvpy) = (pdata(np,prvpy) + dt*vval/taup + dt*part_grav2)/(1 + dt/taup)
-      pdata(np,prvpz) = (pdata(np,prvpz) + dt*wval/taup + dt*part_grav3)/(1 + dt/taup)
+      pdata(np,prvpx) = (pdata(np,prvpx) + uval*(dbldt/taup) + dbldt*part_grav1)/(1.0d0 + dbldt/taup)
+      pdata(np,prvpy) = (pdata(np,prvpy) + vval*(dbldt/taup) + dbldt*part_grav2)/(1.0d0 + dbldt/taup)
+      pdata(np,prvpz) = (pdata(np,prvpz) + wval*(dbldt/taup) + dbldt*part_grav3)/(1.0d0 + dbldt/taup)
 
       !Nonlinear solver for the radius and temperature:
 
       !Nondimensionalize parameters before the solver using 1-micron water droplet as ref
-      taup_scale = rhow*(1.0e-6)**2/(18*rhoval*viscosity)
+      taup_scale = rhow_dp*(1.0d-6)**2/(18.0d0*dble(rhoval)*dble(viscosity))
 
-      dt_nondim = dt/taup_scale
+      dt_nondim = dbldt/taup_scale
       
-      guess = 0.0
+      guess = 0.0d0
 
       !Gives initial guess into nonlinear solver
       !mflag = 0, has equilibrium radius; mflag = 1, no equilibrium (uses itself as initial guess)
@@ -947,7 +954,7 @@
 
       !Nondimensionalize the guesses
       if (mflag.eq.0) then
-         rt_start(1) = dble(guess)/dble(pdata(np,prrp))
+         rt_start(1) = guess/dble(pdata(np,prrp))
          rt_start(2) = dble(tval)/dble(pdata(np,prtp))
       else
          rt_start(1) = 1.0
@@ -955,12 +962,12 @@
       end if
 
       !Start using the standard Gauss-Newton algorithm
-      call gauss_newton_2d(dble(diffnorm),dble(dt_nondim),dble(taup_scale),rt_start,rt_zeros,flag,dble(prsval),dble(rhoval),dble(tval),dble(qval),dble(pdata(np,prtp)),dble(pdata(np,prms)),dble(pdata(np,prrp)),np)
+      call gauss_newton_2d(dble(diffnorm),dt_nondim,taup_scale,rt_start,rt_zeros,flag,dble(prsval),dble(rhoval),dble(tval),dble(qval),dble(pdata(np,prtp)),dble(pdata(np,prms)),dble(pdata(np,prrp)),np)
 
       !If Gauss-Newton failed to converge, flag is set to 1 and try Levenberg-Marquardt algorithm
       if (flag==1) then
          num100 = num100+1
-         call LV_solver(dble(diffnorm),dble(dt_nondim),dble(taup_scale),rt_start,rt_zeros,flag,dble(prsval),dble(rhoval),dble(tval),dble(qval),dble(pdata(np,prtp)),dble(pdata(np,prms)),dble(pdata(np,prrp)),np)
+         call LV_solver(dble(diffnorm),dt_nondim,taup_scale,rt_start,rt_zeros,flag,dble(prsval),dble(rhoval),dble(tval),dble(qval),dble(pdata(np,prtp)),dble(pdata(np,prms)),dble(pdata(np,prrp)),np)
       end if
 
       !In rare cases both nonlinear solvers fail to converge
@@ -1004,7 +1011,7 @@
             !$acc atomic update
             num_destroyed = num_destroyed + pdata(np,prmult)
             !$acc atomic update
-            mass_destroyed = mass_destroyed + (pdata(np,prms)+rhow*4.0/3.0*pi*pdata(np,prrp)**3)*pdata(np,prmult)
+            mass_destroyed = mass_destroyed + (pdata(np,prms)+rhow*4.0/3.0*pi_sp*pdata(np,prrp)**3)*pdata(np,prmult)
  
             !Log this dead particle into the relevant histograms
             !First residence time
@@ -1164,7 +1171,6 @@
                         zt,rzt,imoist,nqv,bbc,imove,umove,vmove
       use constants
       use parcel_module
-      use cm1libs , only : eslf
       implicit none
 
       real, intent(in), dimension(ib:ie+1) :: xf
@@ -1517,7 +1523,7 @@
 
       subroutine project_feedback(iflag,jflag,kflag,x3d,y3d,z3d,sig3d, &
                                   rhop0,taup0,rp0,tval,uten,vten,wten, &
-                                  qten,thten,xh,xf,yh,yf,zh,zf,sigma,  &
+                                  qten,thten,dten,xh,xf,yh,yf,zh,zf,sigma,  &
                                   sigmaf,sigdot,dvpdt1,dvpdt2,dvpdt3,  &
                                   drpdt,dtpdt,dmpdt,rhoval,part_grav1, &
                                   part_grav2,part_grav3,pdata,np)
@@ -1529,7 +1535,6 @@
                         pract,prt,viscosity,nparcelsLocalActive
       use constants
       use parcel_module
-      use cm1libs , only : eslf
       implicit none
 
       real, intent(in) :: dvpdt1,dvpdt2,dvpdt3,drpdt,dtpdt,dmpdt
@@ -1544,10 +1549,7 @@
       real, intent(in), dimension(ib:ie,jb:je,kb:ke) :: zh
       real, intent(in), dimension(kb:ke) :: sigma
       real, intent(in), dimension(kb:ke+1) :: sigmaf
-      real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: uten
-      real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: vten
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: wten
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: thten,qten
+      double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke) :: uten,vten,wten,thten,qten,dten
 
       integer, intent(in) :: np
       integer, intent(in) :: iflag,jflag,kflag
@@ -1609,7 +1611,6 @@
 
       !$acc atomic update
       uten(i,j,k)       = uten(i,j,k)       - partmass/rhoval*(dvpdt1-part_grav1)*w1/dV*pdata(np,prmult)
-      !$acc end atomic
       !$acc atomic update
       uten(i+1,j,k)     = uten(i+1,j,k)     - partmass/rhoval*(dvpdt1-part_grav1)*w2/dV*pdata(np,prmult)
       !$acc atomic update
@@ -1877,6 +1878,10 @@
       !        + ta(i+1,j+1,k  )*w7 &
       !        + ta(i+1,j+1,k+1)*w8
 
+      ! GHB: diagnostic purposes only: number of drops in each grid cell
+      !$acc atomic update
+      dten(iflag,jflag,kflag) = dten(iflag,jflag,kflag) + 1.0
+
       end subroutine project_feedback
 
       subroutine droplet_diag(rtime,nrec,zh,zf,pdata,pdata_locind,dpten,uten,vten,wten)
@@ -1891,7 +1896,7 @@
 
       integer, intent(inout) :: nrec
       real, intent(in) :: rtime
-      real, intent(in), dimension(ib:ie,jb:je,kb:ke,2) :: dpten
+      double precision, intent(in), dimension(ib:ie,jb:je,kb:ke,6) :: dpten
       real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: uten
       real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: vten
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: wten
@@ -1908,14 +1913,16 @@
       integer :: tnumpart
       real :: radavg,radsqr,radmin,radmax,Tpavg,Tpmin,Tpmax,Tpsqr,Tfavg,qfavg,prsavg,rhoavg,tnummult,tnumdrop,tnumaerosol
       real :: partnum(nk),numconc(nk),vp1mean(nk),vp2mean(nk),vp3mean(nk),vp1msqr(nk),vp2msqr(nk),vp3msqr(nk),Tpsrc(nk),qvsrc(nk),qf(nk),Tf(nk),radmean(nk),radmsqr(nk),Tpmean(nk),Tpmsqr(nk),qfsat(nk),m1src(nk),m2src(nk),m3src(nk),qstarmean(nk)
+      double precision, dimension(nk) :: qstardp,radmsqrdp
 
       integer, parameter :: num0 = 18, num1 = 20   !Number of 0th and 1st order statistics in droplet_diag
-      real :: rad10_tmp,qstar_tmp
+      real :: rad10_tmp
+      double precision :: qstar_tmp
       integer :: ibin
 
 #ifdef MPI
-      real, dimension(num0) :: droplet_diag0     ! temporary array for MPI reduce operation for the 0th-order diagnostic except rtime
-      real, dimension(nz,num1) :: droplet_diag1     ! temporary array for MPI reduce operation for the 0th-order diagnostic except rtime
+      double precision, dimension(num0) :: droplet_diag0     ! temporary array for MPI reduce operation for the 0th-order diagnostic except rtime
+      double precision, dimension(nz,num1) :: droplet_diag1     ! temporary array for MPI reduce operation for the 0th-order diagnostic except rtime
 #endif
 
       !Compute the various types of droplet statistics
@@ -1926,8 +1933,8 @@
 
       !$acc data create (dumzh,dumzf,partnum,numconc,Tpsrc,qvsrc,qf, &
       !$acc              Tf,radmean,Tpmean,qfsat,vp1mean,vp2mean, &
-      !$acc              vp3mean,vp1msqr,vp2msqr,vp3msqr,radmsqr, &
-      !$acc              Tpmsqr,m1src,m2src,m3src,qstarmean)
+      !$acc              vp3mean,vp1msqr,vp2msqr,vp3msqr,radmsqrdp, &
+      !$acc              Tpmsqr,m1src,m2src,m3src,qstardp)
 
       !!!!!!! 0th order  !!!!!!!!
 
@@ -1977,7 +1984,7 @@
       !$acc end parallel
 
 #ifdef MPI
-      droplet_diag0(1) = real(tnumpart)
+      droplet_diag0(1) = dble(tnumpart)
       droplet_diag0(2) = tnummult
       droplet_diag0(3) = tnumaerosol
       droplet_diag0(4) = tnumdrop
@@ -1998,24 +2005,24 @@
 
       ! The root rank will collect the diagnostic from different MPI ranks
       if ( myid == 0 ) then
-         call mpi_reduce(MPI_IN_PLACE,droplet_diag0(1),14,MPI_REAL, &
+         call mpi_reduce(MPI_IN_PLACE,droplet_diag0(1),14,MPI_DOUBLE_PRECISION, &
                          MPI_SUM,0,MPI_COMM_WORLD,ierr)
       else
-         call mpi_reduce(droplet_diag0(1),droplet_diag0(1),14,MPI_REAL, &
+         call mpi_reduce(droplet_diag0(1),droplet_diag0(1),14,MPI_DOUBLE_PRECISION, &
                          MPI_SUM,0,MPI_COMM_WORLD,ierr)
       end if
       if ( myid == 0 ) then
-         call mpi_reduce(MPI_IN_PLACE,droplet_diag0(15),2,MPI_REAL, &
+         call mpi_reduce(MPI_IN_PLACE,droplet_diag0(15),2,MPI_DOUBLE_PRECISION, &
                          MPI_MIN,0,MPI_COMM_WORLD,ierr)
       else
-         call mpi_reduce(droplet_diag0(15),droplet_diag0(15),2,MPI_REAL, &
+         call mpi_reduce(droplet_diag0(15),droplet_diag0(15),2,MPI_DOUBLE_PRECISION, &
                          MPI_MIN,0,MPI_COMM_WORLD,ierr)
       end if
       if ( myid == 0 ) then
-         call mpi_reduce(MPI_IN_PLACE,droplet_diag0(17),2,MPI_REAL, &
+         call mpi_reduce(MPI_IN_PLACE,droplet_diag0(17),2,MPI_DOUBLE_PRECISION, &
                          MPI_MAX,0,MPI_COMM_WORLD,ierr)
       else
-         call mpi_reduce(droplet_diag0(17),droplet_diag0(17),2,MPI_REAL, &
+         call mpi_reduce(droplet_diag0(17),droplet_diag0(17),2,MPI_DOUBLE_PRECISION, &
                          MPI_MAX,0,MPI_COMM_WORLD,ierr)
       end if
       if ( myid == 0 ) then 
@@ -2039,14 +2046,14 @@
          Tpmax = droplet_diag0(18)
 #endif
          if (tnumpart .gt. 0) then
-            radavg = radavg/tnumpart
-            radsqr = radsqr/tnumpart
-            Tpavg = Tpavg/tnumpart
-            Tpsqr = Tpsqr/tnumpart
-            Tfavg = Tfavg/tnumpart
-            qfavg = qfavg/tnumpart
-            prsavg = prsavg/tnumpart
-            rhoavg = rhoavg/tnumpart
+            radavg = radavg/dble(tnumpart)
+            radsqr = radsqr/dble(tnumpart)
+            Tpavg = Tpavg/dble(tnumpart)
+            Tpsqr = Tpsqr/dble(tnumpart)
+            Tfavg = Tfavg/dble(tnumpart)
+            qfavg = qfavg/dble(tnumpart)
+            prsavg = prsavg/dble(tnumpart)
+            rhoavg = rhoavg/dble(tnumpart)
          else 
             radavg = 0
             radsqr = 0
@@ -2095,9 +2102,9 @@
          Tpmean(k) = 0.0
          Tpmsqr(k) = 0.0
          radmean(k) = 0.0
-         radmsqr(k) = 0.0
+         radmsqrdp(k) = 0.0
          qfsat(k) = 0.0
-         qstarmean(k) = 0.0
+         qstardp(k) = 0.0d0
       end do
       !$acc end parallel
 
@@ -2133,13 +2140,13 @@
          !$acc atomic update
          radmean(k) = radmean(k) + pdata(np,prrp)
          !$acc atomic update
-         radmsqr(k) = radmsqr(k) + pdata(np,prrp)**2
+         radmsqrdp(k) = radmsqrdp(k) + dble(pdata(np,prrp))**2
 
          if (pdata(np,prt) .gt. 200.0) then    ! Avoid this breaking if the temperature is unrealistic 
                                                ! (like at initialization; other times this is a problem, but let it break elsewhere)
             call calc_qstar(qstar_tmp,pdata(np,prprs),pdata(np,prrho),pdata(np,prt),pdata(np,prqv),pdata(np,prtp),pdata(np,prms),pdata(np,prrp))
             !$acc atomic update
-            qstarmean(k) = qstarmean(k) + qstar_tmp
+            qstardp(k) = qstardp(k) + qstar_tmp
             !$acc atomic update
             qfsat(k) = qfsat(k) + eslf(pdata(np,prprs),pdata(np,prt))*(mw/(ru*pdata(np,prt)*pdata(np,prrho)))
          else
@@ -2162,9 +2169,9 @@
          !$acc loop vector collapse(2) reduction(+:Tpsrc_tmp,qvsrc_tmp,m1src_tmp,m2src_tmp,m3src_tmp)
          do j=1,nj
             do i=1,ni
-               m1src_tmp = m1src_tmp + uten(i,j,k)
-               m2src_tmp = m2src_tmp + vten(i,j,k)
-               m3src_tmp = m3src_tmp + wten(i,j,k)
+               m1src_tmp = m1src_tmp + dpten(i,j,k,3)
+               m2src_tmp = m2src_tmp + dpten(i,j,k,4)
+               m3src_tmp = m3src_tmp + dpten(i,j,k,5)
                Tpsrc_tmp = Tpsrc_tmp + dpten(i,j,k,1)
                qvsrc_tmp = qvsrc_tmp + dpten(i,j,k,2)
             end do
@@ -2191,8 +2198,8 @@
 
       !$acc update host (dumzf,dumzh,numconc,partnum,Tpsrc,qvsrc,qf, &
       !$acc              Tf,radmean,Tpmean,qfsat,vp1mean,vp2mean, &
-      !$acc              vp3mean,vp1msqr,vp2msqr,vp3msqr,radmsqr, &
-      !$acc              Tpmsqr,m1src,m2src,m3src,qstarmean)
+      !$acc              vp3mean,vp1msqr,vp2msqr,vp3msqr,radmsqrdp, &
+      !$acc              Tpmsqr,m1src,m2src,m3src,qstardp)
 
 #ifdef MPI
 
@@ -2215,17 +2222,17 @@
          droplet_diag1(iz,15) = Tpmean(iz)
          droplet_diag1(iz,16) = Tpmsqr(iz)
          droplet_diag1(iz,17) = radmean(iz)
-         droplet_diag1(iz,18) = radmsqr(iz)
+         droplet_diag1(iz,18) = radmsqrdp(iz)
          droplet_diag1(iz,19) = qfsat(iz)
-         droplet_diag1(iz,20) = qstarmean(iz)
+         droplet_diag1(iz,20) = qstardp(iz)
       end do
 
       ! The root rank will collect the diagnostic from different MPI ranks
       if ( myid == 0 ) then
-         call mpi_reduce(MPI_IN_PLACE,droplet_diag1,nk*num1,MPI_REAL, &
+         call mpi_reduce(MPI_IN_PLACE,droplet_diag1,nk*num1,MPI_DOUBLE_PRECISION, &
                          MPI_SUM,0,MPI_COMM_WORLD,ierr)
       else
-         call mpi_reduce(droplet_diag1,droplet_diag1,nk*num1,MPI_REAL, &
+         call mpi_reduce(droplet_diag1,droplet_diag1,nk*num1,MPI_DOUBLE_PRECISION, &
                          MPI_SUM,0,MPI_COMM_WORLD,ierr)
       end if
 
@@ -2251,9 +2258,9 @@
             Tpmean(iz) = droplet_diag1(iz,15)
             Tpmsqr(iz) = droplet_diag1(iz,16)
             radmean(iz) = droplet_diag1(iz,17)
-            radmsqr(iz) = droplet_diag1(iz,18)
+            radmsqrdp(iz) = droplet_diag1(iz,18)
             qfsat(iz) = droplet_diag1(iz,19)
-            qstarmean(iz) = droplet_diag1(iz,20)
+            qstardp(iz) = droplet_diag1(iz,20)
          end do
  
 #endif
@@ -2274,9 +2281,10 @@
                Tpmean(iz) = Tpmean(iz)/partnum(iz)
                Tpmsqr(iz) = Tpmsqr(iz)/partnum(iz)
                radmean(iz) = radmean(iz)/partnum(iz)
-               radmsqr(iz) = radmsqr(iz)/partnum(iz)
+               radmsqr(iz) = sngl( min( 1.0d30 , radmsqrdp(iz)/dble(partnum(iz)) ) )
                qfsat(iz) = qfsat(iz)/partnum(iz)
-               qstarmean(iz) = qstarmean(iz)/partnum(iz)
+               ! GHB: i keep getting overflow errors here; so, just limit to a big number
+               qstarmean(iz) = sngl( min( 1.0d30 , qstardp(iz)/dble(partnum(iz)) ) )
             else
                vp1mean(iz) = 0.0
                vp2mean(iz) = 0.0
@@ -2306,7 +2314,7 @@
       if ( myid == 0 ) then
 #endif
          write(6,200) 'rtime', rtime
-         write(6,200) 'tnumpart',real(tnumpart)
+         write(6,200) 'tnumpart',sngl(tnumpart)
          write(6,200) 'radavg',radavg
          write(6,200) 'radmin',radmin
          write(6,200) 'radmax',radmax
@@ -2581,46 +2589,47 @@
 
       subroutine rad_solver2(guess,mflag,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
       !$acc routine seq
-      use constants
-      use cm1libs , only : eslf
+      use input , only : pi_dp
+      use constants , only : rhow_dp,mw,ms,surften,ion,os,ru
+      use cm1libs , only : deslf
       implicit none
 
-      real, intent(out) :: guess
+      double precision, intent(out) :: guess
       integer, intent(out) :: mflag
       real, intent(in) :: prsval,rhoval,tval,qval,Tp,m_s,radius
       integer, intent(in) :: np
-      real :: a, c, esa, Q, R, M, theta, S, T, rhval
+      double precision :: a, c, esa, Q, R, M, theta, S, T, rhval
 
       mflag = 0
-      esa = eslf(real(prsval),real(tval))  !Saturation vapor pressure at droplet temperature
+      esa = deslf(dble(prsval),dble(tval))  !Saturation vapor pressure at droplet temperature
 
       rhval = (ru*tval*rhoval*qval)/(mw*esa)
 
       !Calculate the equilibrium radius based on "rhval"
       !Solve the cubic for the equilibrium radius
 
-      if (rhval .lt. 0.999) then
-         a = -(2*mw*surften)/(ru*rhow*tval)/LOG(rhval)
-         c = (ion*os*m_s*(mw/ms))/((4.0/3.0)*pi*rhow)/LOG(rhval) 
+      if (rhval .lt. 0.999d0) then
+         a = -(2.0d0*mw*surften)/(ru*rhow_dp*tval)/LOG(rhval)
+         c = (ion*os*m_s*(mw/ms))/((4.0d0/3.0d0)*pi_dp*rhow_dp)/LOG(rhval) 
      
          !Use Cardano's method for cubic solution
-         Q = (a**2.0)/9.0
-         R = (2.0*a**3.0+27.0*c)/54.0
-         M = R**2.0-Q**3.0
+         Q = (a*a)/9.0d0
+         R = (2.0d0*a*a*a+27.0d0*c)/54.0d0
+         M = R*R-Q*Q*Q
 
 
-         if (M<0) then
-           theta = acos(R/sqrt(Q**3.0))
-           guess = -(2*sqrt(Q)*cos((theta-pi*2.0)/3.0))-a/3.0
+         if (M<0.0d0) then
+           theta = acos(R/sqrt(Q*Q*Q))
+           guess = -(2.0d0*sqrt(Q)*cos((theta-pi_dp*2.0d0)/3.0d0))-a/3.0d0
 
-           if (guess < 0) then
-           guess = -(2*sqrt(Q)*cos((theta+pi*2.0)/3.0))-a/3.0
+           if (guess < 0.0d0) then
+           guess = -(2.0d0*sqrt(Q)*cos((theta+pi_dp*2.0d0)/3.0d0))-a/3.0d0
            end if
 
          else
-           S = -(R/abs(R))*(abs(R)+sqrt(M))**(1.0/3.0)
+           S = -(R/abs(R))*(abs(R)+sqrt(M))**(1.0d0/3.0d0)
            T = Q/S
-           guess = S + T - a/3.0
+           guess = S + T - a/3.0d0
 
          end if
 
@@ -2652,15 +2661,15 @@
 
         iterations = 0
         flag = 0
-        error = 1.e-8
+        error = 1.0d-8
 
         !Initialize the solution vector
         v1(1) = rt_start(1)
         v1(2) = rt_start(2)
          
         !Initialize the correction to zero
-        correct(1) = 0.0
-        correct(2) = 0.0
+        correct(1) = 0.0d0
+        correct(2) = 0.0d0
 
         !Default max iterations before Gauss-Newton deemed failure (and moves onto a new scheme)
         !Rare that it gets above ~5
@@ -2671,10 +2680,16 @@
                 iterations = iterations + 1
 
                 !Compute the RHS of the droplet temp and radius equations
-                call ie_vrt_nd(diffnorm,v1(1),v1(2),fv1,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+                call ie_vrt_nd(diffnorm,v1(1),v1(2),fv1,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np,flag)
                 !Approximate the Jacobian
-                call jacob_approx_2d(diffnorm,v1(1),v1(2),dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+                call jacob_approx_2d(diffnorm,v1(1),v1(2),dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np,flag)
 
+              if( abs(J(1,1)).gt.1.0d76 ) flag = 1
+              if( abs(J(1,2)).gt.1.0d76 ) flag = 1
+              if( abs(J(2,1)).gt.1.0d76 ) flag = 1
+              if( abs(J(2,2)).gt.1.0d76 ) flag = 1
+
+              if( flag.eq.0 )then
                 !Matrix to be inverted via G-N method
                 fancy(1,1) = J(1,1)*J(1,1)+J(2,1)*J(2,1)
                 fancy(1,2) = J(1,1)*J(1,2)+J(2,1)*J(2,2)
@@ -2683,10 +2698,14 @@
 
                 !Determinant -- exit if it is too near zero, indicates failed convergence
                 det = fancy(1,1)*fancy(2,2) - fancy(1,2)*fancy(2,1)
-                if (abs(det) .lt. 1.0e-10) then
+                ! GHB: try this
+                if (  (abs(det) .lt. 1.0d-10) .or. (abs(det).gt.1.0d100) ) then
                    flag = 1
                    EXIT
                 end if
+              else
+                exit
+              endif
                 
                 call inverse_finder_2d(fancy,det,inv)
 
@@ -2703,13 +2722,13 @@
                 rt_zeros(1) = v1(1) - correct(1)
                 rt_zeros(2) = v1(2) - correct(2)
 
-                relax = 1.0
+                relax = 1.0d0
                 counts = 0
                 !If either the temperature or radius goes negative, take a series of smaller adjustment steps
-                do while ((rt_zeros(1)<0) .OR. (rt_zeros(2)<0) .OR. (rt_zeros(1) .ne. rt_zeros(1)))
+                do while ((rt_zeros(1)<0.0d0) .OR. (rt_zeros(2)<0.0d0) .OR. (rt_zeros(1) .ne. rt_zeros(1)))
 
                    counts = counts + 1
-                   coeff = 0.5
+                   coeff = 0.5d0
                    relax = relax * coeff
                    rt_zeros(1) = v1(1)-(finalJ(1,1)*fv1(1)+finalJ(1,2)*fv1(2))*relax
                    rt_zeros(2) = v1(2)-(finalJ(2,1)*fv1(1)+finalJ(2,2)*fv1(2))*relax
@@ -2718,7 +2737,7 @@
                 end do
 
                 !Failure to converge if these drop too low -- send to LV solver
-                if (rt_zeros(1)<0.01 .OR. rt_zeros(2)<0.01) then
+                if (rt_zeros(1)<0.01d0 .OR. rt_zeros(2)<0.01d0) then
                    flag = 1
                    EXIT
                 end if
@@ -2734,7 +2753,7 @@
         end do
       !These indicate that this failed -- set flag = 1 to send to LV solver
       if (iterations == iteration_max) flag = 1
-      if ((rt_zeros(1) .ne. rt_zeros(1)) .OR. rt_zeros(1)<0 .OR. (rt_zeros(2) .ne. rt_zeros(2)) .OR. rt_zeros(2)<0) flag = 1
+      if ((rt_zeros(1) .ne. rt_zeros(1)) .OR. rt_zeros(1)<0.0d0 .OR. (rt_zeros(2) .ne. rt_zeros(2)) .OR. rt_zeros(2)<0.0d0) flag = 1
 
       end subroutine gauss_newton_2d
 
@@ -2757,36 +2776,42 @@
 
         !Performs the Levenberg-Marquardt algorithm -- a modification on Newton's method
 
-        error = 1.0e-8
+        error = 1.0d-8
 
         
         !Preliminary
-        I(1,1)=1.0
-        I(2,1)=0.0
-        I(1,2)=0.0
-        I(2,2)=1.0
+        I(1,1)=1.0d0
+        I(2,1)=0.0d0
+        I(1,2)=0.0d0
+        I(2,2)=1.0d0
         iterations = 0
         iterations_max = 1000
         flag = 0
         v1(1) = rt_start(1)
         v1(2) = rt_start(2)
-        fv2(1) = 1.0
-        fv2(2) = 1.0
+        fv2(1) = 1.0d0
+        fv2(2) = 1.0d0
 
         !These are parameters to the solver, could be adjusted but these work
-        lambda = 0.001
-        lup = 2.0
-        ldown = 2.0
+        lambda = 0.001d0
+        lup = 2.0d0
+        ldown = 2.0d0
 
         do while ((sqrt(fv2(1)*fv2(1)+fv2(2)*fv2(2)) > error) .AND. (iterations<iterations_max))
 
         iterations = iterations + 1
 
         !Approximate the Jacobian of the system
-        call jacob_approx_2d(diffnorm,v1(1),v1(2),dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+        call jacob_approx_2d(diffnorm,v1(1),v1(2),dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np,flag)
         !Compute the RHS of the temperature and radius equations
-        call ie_vrt_nd(diffnorm,v1(1),v1(2),fv1,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+        call ie_vrt_nd(diffnorm,v1(1),v1(2),fv1,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np,flag)
 
+      if( abs(J(1,1)).gt.1.0d76 ) flag = 1
+      if( abs(J(1,2)).gt.1.0d76 ) flag = 1
+      if( abs(J(2,1)).gt.1.0d76 ) flag = 1
+      if( abs(J(2,2)).gt.1.0d76 ) flag = 1
+
+      if( flag.eq.0 )then
         !Calculate the update matrix which must be inverted
         g(1,1) = J(1,1)*J(1,1)+J(2,1)*J(2,1)+lambda*I(1,1)
         g(1,2) = J(1,1)*J(1,2)+J(2,1)*J(2,2)+lambda*I(1,2)
@@ -2796,16 +2821,20 @@
         gradC(1) = J(1,1)*fv1(1)+J(2,1)*fv1(2)
         gradC(2) = J(1,2)*fv1(1)+J(2,2)*fv1(2)
 
-        C(1) = 0.5*fv1(1)*fv1(1)
-        C(2) = 0.5*fv1(2)*fv1(2)
+        C(1) = 0.5d0*fv1(1)*fv1(1)
+        C(2) = 0.5d0*fv1(2)*fv1(2)
 
         !Exit if the determinant is too close to zero -- failed convergence
         det = g(1,1)*g(2,2) - g(1,2)*g(2,1)
-        if (abs(det) .lt. 1.0e-10) then
+        ! GHB: try this
+        if ( (abs(det) .lt. 1.0d-10) .or. (abs(det).gt.1.0d100) ) then
              flag = 1
              EXIT
         end if
         call inverse_finder_2d(g,det,invg)
+      else
+        EXIT
+      endif
 
         !Solve for correction vector
         correct(1) = invg(1,1)*gradC(1)+invg(1,2)*gradC(2)
@@ -2820,16 +2849,22 @@
         end if
 
         !Failed if temperature or radius goes negative
-        if (rt_zeros(1)<0.0 .OR. rt_zeros(2)<0.0) then
+        if (rt_zeros(1)<0.0d0 .OR. rt_zeros(2)<0.0d0) then
             flag = 1
             EXIT
         end if
 
         !Use the RHS to update the lambda parameter
-        call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),fv2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+        call ie_vrt_nd(diffnorm,rt_zeros(1),rt_zeros(2),fv2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np,flag)
 
-        newC(1) = 0.5*fv2(1)*fv2(1)
-        newC(2) = 0.5*fv2(2)*fv2(2)
+      if( abs(fv1(1)).gt.1.0d76 ) flag = 1
+      if( abs(fv1(2)).gt.1.0d76 ) flag = 1
+      if( abs(fv2(1)).gt.1.0d76 ) flag = 1
+      if( abs(fv2(2)).gt.1.0d76 ) flag = 1
+
+      if( flag.eq.0 )then
+        newC(1) = 0.5d0*fv2(1)*fv2(1)
+        newC(2) = 0.5d0*fv2(2)*fv2(2)
 
         if (sqrt(newC(1)*newC(1)+newC(2)*newC(2))<sqrt(C(1)*C(1)+C(2)*C(2))) then
            v1(1) = rt_zeros(1)
@@ -2838,6 +2873,9 @@
         else
            lambda = lambda*lup
         end if
+      else
+        EXIT
+      endif
 
         end do
 
@@ -2847,7 +2885,7 @@
         end if
 
         !Failed if it returns negative radius or temperature
-        if (rt_zeros(1) < 0 .OR. rt_zeros(2) < 0) then
+        if (rt_zeros(1) < 0.0d0 .OR. rt_zeros(2) < 0.0d0) then
            flag = 1
         end if
 
@@ -2861,11 +2899,11 @@
         double precision, dimension(1:2, 1:2), intent(out) :: invC
 
         invC = reshape((/C(2, 2), -C(2,1), -C(1, 2), C(1, 1)/),(/2,2/))
-        invC = (1./det)*invC
+        invC = (1.0d0/det)*invC
 
       end subroutine inverse_finder_2d
 
-      subroutine jacob_approx_2d(diffnorm,rnext,tnext,dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+      subroutine jacob_approx_2d(diffnorm,rnext,tnext,dt_nondim,J,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np,flag)
         !$acc routine seq
         implicit none
         integer :: n
@@ -2874,15 +2912,16 @@
         double precision, intent(out), dimension(1:2, 1:2) :: J
         double precision :: diff,v_output(3),rt_output(2),xper(2),fxper(2),ynext(2),xper2(2),fxper2(2)
         integer, intent(in) :: np
+        integer, intent(inout) :: flag
 
         !Take a very small difference to approximate the derivatives
-        diff = 1E-12
+        diff = 1d-12
 
         ynext(1) = rnext
         ynext(2) = tnext
 
         !Evaluate RHS 
-        call ie_vrt_nd(diffnorm,rnext,tnext,rt_output,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+        call ie_vrt_nd(diffnorm,rnext,tnext,rt_output,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np,flag)
 
         xper(1) = ynext(1)
         xper(2) = ynext(2)
@@ -2894,8 +2933,8 @@
            xper(n) = xper(n) + diff
            xper2(n) = xper2(n) - diff
 
-           call ie_vrt_nd(diffnorm,xper(1),xper(2),fxper,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
-           call ie_vrt_nd(diffnorm,xper2(1),xper2(2),fxper2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+           call ie_vrt_nd(diffnorm,xper(1),xper(2),fxper,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np,flag)
+           call ie_vrt_nd(diffnorm,xper2(1),xper2(2),fxper2,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np,flag)
 
            !Use these differences to compute the Jacobian
            J(1,n) = (fxper(1)-rt_output(1))/diff
@@ -2906,79 +2945,89 @@
 
       end subroutine jacob_approx_2d
 
-      subroutine ie_vrt_nd(diffnorm,tempr,tempt,rt_output,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np)
+      subroutine ie_vrt_nd(diffnorm,tempr,tempt,rt_output,dt_nondim,taup_scale,prsval,rhoval,tval,qval,Tp,m_s,radius,np,flag)
       !$acc routine seq
-      use constants
-      use input, only : viscosity,pr_num,sc_num
-      use cm1libs , only : eslf
+      use constants, only : rhow_dp,mw,ru,surften,ion,os,ms,cp_dp,cpl_dp,lv1_dp,lv2_dp
+      use input, only : viscosity,pr_num,sc_num,pi_dp
+      use cm1libs , only : deslf
       implicit none
 
       double precision, intent(in) :: diffnorm,tempr,tempt,taup_scale,dt_nondim,prsval,rhoval,tval,qval,Tp,m_s,radius
       double precision, intent(out) :: rT_output(2)
       integer, intent(in) :: np
+      integer, intent(inout) :: flag
 
       double precision :: esa,dnext,rhop,Rep,taup,rprime,Tprime,qstr,Shp,Nup,VolP,lhv
       double precision :: Tnext,rnext
+      double precision :: tmp
 
         ! quantities come in already non-dimensionalized, so must be converted back;
         rnext = tempr*radius
         Tnext = tempt*Tp
-        dnext = rnext*2.0
+        dnext = rnext*2.0d0
 
-        esa = eslf(real(prsval),real(tval))
-        VolP = (4.0/3.0)*pi*rnext**3
-        rhop = (m_s + VolP*rhow)/VolP
+        esa = deslf(prsval,tval)
+        VolP = (4.0d0/3.0d0)*pi_dp*rnext**3
+        rhop = (m_s + VolP*rhow_dp)/VolP
 
-        Rep = dnext*diffnorm/viscosity
-        taup = (rhop*dnext**2)/(18.0*rhoval*viscosity)
-        Nup = 2.0 + 0.6*sqrt(Rep)*pr_num**(1.0/3.0)
-        Shp = 2.0 + 0.6*sqrt(Rep)*sc_num**(1.0/3.0)
+        Rep = max( 0.0d0 , dnext*diffnorm/dble(viscosity) )
+        taup = (rhop*dnext**2)/(18.0d0*rhoval*dble(viscosity))
+        Nup = 2.0d0 + 0.6d0*dsqrt(Rep)*dble(pr_num)**(1.0d0/3.0d0)
+        Shp = 2.0d0 + 0.6d0*dsqrt(Rep)*dble(sc_num)**(1.0d0/3.0d0)
 
-        lhv=lv1-lv2*tval
+        lhv=lv1_dp-lv2_dp*tval
 
         !!! Humidity !!!
-        qstr = (mw/(ru*Tnext*rhoval))*esa*exp(((lhv*mw/ru)*((1.0/tval)-(1.0/Tnext))) + ((2.0*mw*surften)/(ru*rhow*rnext*Tnext)) - ((ion*os*m_s*(mw/ms))/(VolP*rhop-m_s)))
+        ! GHB prevent overflow by limiting term inside exponent:
+        tmp = ((lhv*mw/ru)*((1.0d0/max(1.0d-10,tval))-(1.0d0/max(1.0d-10,Tnext)))) + ((2.0d0*mw*surften)/(ru*rhow_dp*rnext*Tnext)) - ((ion*os*m_s*(mw/ms))/(VolP*rhop-m_s))
+        if( tmp.gt.600.0 )then
+          qstr = qval
+          flag = 1
+        else
+          qstr = (mw/(ru*Tnext*rhoval))*esa*dexp( tmp )
+        endif
         !!!!!!!!!!!!!!!!!!
 
         !!! Radius !!!
-        rprime = (1.0/9.0)*(Shp/sc_num)*(rhop/rhow)*(rnext/taup)*(qval - qstr)
+        rprime = (1.0d0/9.0d0)*(Shp/dble(sc_num))*(rhop/rhow_dp)*(rnext/taup)*(qval - qstr)
         rprime = rprime*(taup_scale/radius)
 
         !!! Temperature !!!
-        Tprime = -(1.0/3.0)*(Nup/pr_num)*(cp/cpl)*(rhop/rhow)/taup*(Tnext-tval) + 3.0*lhv/(rnext*cpl)*rprime*(radius/taup_scale)
+        Tprime = -(1.0d0/3.0d0)*(Nup/dble(pr_num))*(cp_dp/cpl_dp)*(rhop/rhow_dp)/taup*(Tnext-tval) + 3.0d0*lhv/(rnext*cpl_dp)*rprime*(radius/taup_scale)
         Tprime = Tprime*(taup_scale/Tp)
 
-        rT_output(1) = rnext/radius - 1.0  - dt_nondim*rprime
-        rT_output(2) = Tnext/Tp - 1.0  - dt_nondim*Tprime
+        rT_output(1) = rnext/radius - 1.0d0  - dt_nondim*rprime
+        rT_output(2) = Tnext/Tp - 1.0d0  - dt_nondim*Tprime
 
       end subroutine ie_vrt_nd
 
       subroutine calc_qstar(qstar,prsval,rhoval,tval,qval,Tp,m_s,radius)
       !$acc routine seq
-      use constants
-      use input, only : viscosity,pr_num,sc_num
-      use cm1libs , only : eslf
+      use constants , only : rhow_dp,mw,ms,surften,ion,os,ru,lv1_dp,lv2_dp
+      use input, only : viscosity,pr_num,sc_num,pi_dp
+      use cm1libs , only : deslf
       implicit none
 
       real, intent(in) :: prsval,rhoval,tval,qval,Tp,m_s,radius
-      real, intent(out) :: qstar
+      double precision, intent(out) :: qstar
 
-      real :: esa,Rep,taup,rprime,Tprime,qstr,Shp,Nup,lhv
-      real :: diameter
-      real :: Volp,rhop
+      double precision :: esa,Rep,taup,rprime,Tprime,qstr,Shp,Nup,lhv
+      double precision :: diameter
+      double precision :: Volp,rhop
 
       !Calculate qstar, the specific humidity at the droplet surface 
    
-      diameter = radius*2.0
+      diameter = dble(radius)*2.0d0
 
-      esa = eslf(prsval,tval)
-      VolP = (4.0/3.0)*pi*radius**3
-      rhop = (m_s + VolP*rhow)/VolP
+      esa = deslf(dble(prsval),dble(tval))
+      VolP = (4.0d0/3.0d0)*pi_dp*dble(radius)**3
+      rhop = (dble(m_s) + VolP*rhow_dp)/VolP
 
-      lhv=lv1-lv2*tval
+      lhv=lv1_dp-lv2_dp*dble(tval)
 
-      qstar = (mw/(ru*Tp*rhoval))*esa*exp(((lhv*mw/ru)*((1.0/tval)-(1.0/Tp))) + &
-              ((2.0*mw*surften)/(ru*rhow*radius*Tp)) - ((ion*os*m_s*(mw/ms))/(VolP*rhop-m_s)))
+      ! GHB prevent overflow by limiting term inside exponent:
+      qstar = (mw/(ru*dble(Tp)*dble(rhoval)))*esa*dexp( min( 600.0d0 , ((lhv*mw/ru)*((1.0d0/dble(tval))-(1.0d0/dble(Tp)))) + &
+              ((2.0d0*mw*surften)/(ru*rhow_dp*dble(radius)*dble(Tp))) - ((ion*os*dble(m_s)*(mw/ms))/(VolP*rhop-dble(m_s))) ) )
 
       end subroutine calc_qstar
 
@@ -3435,7 +3484,7 @@
     call disp_err( nf90_put_att(ncid,varid,"long_name","Number of droplets which failed the 2st round Levenberg-Marquardt iteration this time step") , .true. )
     call disp_err( nf90_put_att(ncid,varid,"units","No units") , .true. )
 
-    call disp_err( nf90_def_var(ncid,"u10_ssgf",nf90_float,timeid,varid) , .true. )
+    call disp_err( nf90_def_var(ncid,"u10_ssgf",nf90_double,timeid,varid) , .true. )
     call disp_err( nf90_put_att(ncid,varid,"long_name","10-meter wind speed used in the spray SSGF") , .true. )
     call disp_err( nf90_put_att(ncid,varid,"units","m/s3") , .true. )
 

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -427,10 +427,21 @@
           rand = getRandomReal(randomNumbers)
           tmpz = rand*injectHMax
 
-          ! check if this parcel falls into this MPI region
-          ! if parcel is on a tile boundary, let the eastmost/northmost tile own it
-          if ( tmpx .ge. xf(1) .and. tmpx .lt. xf(ni+1) .and. &
-               tmpy .ge. yf(1) .and. tmpy .lt. yf(nj+1) ) then
+          if(myid.eq.0) print *,n,tmpx,tmpy,tmpz
+
+          ! Check if this parcel falls into this MPI region
+          ! Exception case:
+          !   - if parcel is on a tile boundary, let the eastmost/northmost tile own it
+          !   - if parcel is on the northmost or eastmost boundary of the whole domain,
+          !     let the MPI rank which inclues that boundary owns it
+          if ( (tmpx .ge. xf(1) .and. tmpx .lt. xf(ni+1) .and. &
+                tmpy .ge. yf(1) .and. tmpy .lt. yf(nj+1)) .or. &
+               (tmpx .eq. xfref(nx+1) .and. xf(ni+1) .eq. xfref(nx+1) .and. & 
+                tmpy .ge. yf(1) .and. tmpy .lt. yf(nj+1)) .or. & 
+               (tmpy .eq. yfref(ny+1) .and. yf(nj+1) .eq. yfref(ny+1) .and. &
+                tmpx .ge. xf(1) .and. tmpx .lt. xf(ni+1)) .or. & 
+               (tmpx .eq. xfref(nx+1) .and. tmpy .eq. yfref(ny+1) .and. &
+                xf(ni+1) .eq. xfref(nx+1) .and. yf(nj+1) .eq. yfref(ny+1)) ) then
 
              pdata(i,prx) = tmpx
              pdata(i,pry) = tmpy
@@ -441,7 +452,7 @@
 !             endif
 
              if (prcl_droplet.eq.1) then
-    
+
                 pdata(i,prvpx) = 0.0
                 pdata(i,prvpy) = 0.0
                 pdata(i,prvpz) = 0.0

--- a/src/input.F
+++ b/src/input.F
@@ -224,6 +224,8 @@
       real(kind=dp) :: pi_dp
       real(kind=qp) :: pi_qp
 
+      !$acc declare create (pi_sp,pi_dp)
+
 !-----------------------------------------------------------------------
 !  timestats:
 

--- a/src/param.F
+++ b/src/param.F
@@ -2828,6 +2828,8 @@
       if(dowr) write(outfile,*) '  pi_qp = ',pi_qp
       if(dowr) write(outfile,*)
 
+      !$acc update device(pi_sp,pi_dp)
+
 !--------------------------------------------------------------
 !  Configuration for simulations with moisture
 !

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -188,7 +188,7 @@
       integer, intent(in) :: rbufsz,num_soil_layers
       real, intent(inout) :: dt,dtlast
       double precision, intent(in   ) :: mtime
-      double precision, intent(inout) :: dbldt
+      double precision, intent(in   ) :: dbldt
       double precision, intent(in   ) :: mass1
       double precision, intent(inout) :: mass2
       logical, intent(in) :: dosfcflx
@@ -262,7 +262,7 @@
       real, intent(inout), dimension(ibl:iel,jbl:jel) :: tmn,tml,t0ml,hml,h0ml,huml,hvml,tmoml
       real, intent(inout), dimension(ibp:iep,jbp:jep,kbp:kep,npt) :: pta,pt3d,ptten
       real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke,2) :: dpten
+      double precision, intent(inout), dimension(ib:ie,jb:je,kb:ke,6) :: dpten
       real, intent(in), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: cfb
       real, intent(in), dimension(kpb:kpe) :: cfa,cfc,ad1,ad2
       complex, intent(inout), dimension(ipb:ipe,jpb:jpe,kpb:kpe) :: pdt,lgbth,lgbph
@@ -952,51 +952,28 @@
 
           !$acc parallel default(present) private(i,j,k)
           !$acc loop gang vector collapse(3)
-          do k=kb,ke+1
-          do j=jb,je
-          do i=ib,ie
-            wten(i,j,k) = 0.0
-          enddo
-          enddo
-          enddo
-          
-          !$acc loop gang vector collapse(3)
-          do k=kb,ke
-          do j=jb,je
-          do i=ib,ie+1
-            uten(i,j,k) = 0.0
-          enddo
-          enddo
-          enddo
-
-          !$acc loop gang vector collapse(3)
-          do k=kb,ke
-          do j=jb,je+1
-          do i=ib,ie
-            vten(i,j,k) = 0.0
-          enddo
-          enddo
-          enddo
-
-          !$acc loop gang vector collapse(3)
           do k=kb,ke
           do j=jb,je
           do i=ib,ie
             dpten(i,j,k,1) = 0.0
             dpten(i,j,k,2) = 0.0
+            dpten(i,j,k,3) = 0.0
+            dpten(i,j,k,4) = 0.0
+            dpten(i,j,k,5) = 0.0
+            dpten(i,j,k,6) = 0.0
           enddo
           enddo
           enddo
           !$acc end parallel
 
-          call   droplet_driver(dt,mtime,xh,uh,ruh,xf,yh,vh,rvh,yf,zh,mh,rmh,zf,mf,zs,    &
+          call   droplet_driver(dt,dbldt,mtime,xh,uh,ruh,xf,yh,vh,rvh,yf,zh,mh,rmh,zf,mf,zs, &
                                sigma,sigmaf,zntmp,rho,rru,rrv,rrw,s10,pdata,              &
-                               tha,qa,th0,pi0,ppi,prs,                                    &
+                               tha,qa,th0,pi0,ppi,prs,dum1,                               &
                                pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,                           &
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p,                    &
                                sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,                   &
                                n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,            &
-                               uten,vten,wten,dpten(ib,jb,kb,1),dpten(ib,jb,kb,2),        &
+                               dpten(ib,jb,kb,3),dpten(ib,jb,kb,4),dpten(ib,jb,kb,5),dpten(ib,jb,kb,1),dpten(ib,jb,kb,2),dpten(ib,jb,kb,6),        &
                                pdata_locind)
           if(timestats.ge.1) time_parcels=time_parcels+mytime()
 #ifdef MPI
@@ -1004,6 +981,9 @@
           if(timestats.ge.1) time_lb=time_lb+mytime()
           call comm_1s_tend_halo_GPU(dpten(ib,jb,kb,1))
           call comm_1s_tend_halo_GPU(dpten(ib,jb,kb,2))
+          call comm_1u_tend_halo_GPU(dpten(ib,jb,kb,3))
+          call comm_1v_tend_halo_GPU(dpten(ib,jb,kb,4))
+          call comm_1s_tend_halo_GPU(dpten(ib,jb,kb,5))
 #else
           call bcs_tend_halo(dpten(ib,jb,kb,1))
           call bcs_tend_halo(dpten(ib,jb,kb,2))
@@ -1011,7 +991,7 @@
 #ifdef MPI
           if(timestats.ge.1) time_dpc=time_dpc+mytime()
 #endif
-          if( nout3d.ge.2 )then
+          if( nout3d.ge.6 )then
             !$omp parallel do default(shared) private(i,j,k)
             !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
             do k=1,nk
@@ -1021,6 +1001,10 @@
               ! (see out1 and out2 in cm1out* files)
               out3d(i,j,k,1) = dpten(i,j,k,1)
               out3d(i,j,k,2) = dpten(i,j,k,2)
+              out3d(i,j,k,3) = dpten(i,j,k,3)
+              out3d(i,j,k,4) = dpten(i,j,k,4)
+              out3d(i,j,k,5) = dpten(i,j,k,5)
+              out3d(i,j,k,6) = dpten(i,j,k,6)
             enddo
             enddo
             enddo
@@ -1030,38 +1014,62 @@
             !$omp parallel do default(shared) private(i,j,k)
             !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
             do k=1,nk
-            do j=1,nj
-            do i=1,ni
+            do j=1,nj+1
+            do i=1,ni+1
               th3d(i,j,k)=th3d(i,j,k)+dt*dpten(i,j,k,1)
               q3d(i,j,k,nqv)=q3d(i,j,k,nqv)+dt*dpten(i,j,k,2)
+              u3d(i,j,k)=u3d(i,j,k)+dt*dpten(i,j,k,3)
+              v3d(i,j,k)=v3d(i,j,k)+dt*dpten(i,j,k,4)
+              w3d(i,j,k)=w3d(i,j,k)+dt*dpten(i,j,k,5)
             enddo
             enddo
             enddo
             if(timestats.ge.1) time_parcels=time_parcels+mytime()
             call bcs_GPU(th3d)
             call bcs_GPU(q3d(ib,jb,kb,nqv))
+            call bcu_GPU(u3d)
+            call bcv_GPU(v3d)
+            call bcw_GPU(w3d,1)
 #ifdef MPI
             call sync()
             if(timestats.ge.1) time_lb=time_lb+mytime()
+            !----
             call comm_3s_start_GPU(th3d,rw31,rw32,re31,re32,   &
                                     rs31,rs32,rn31,rn32,reqs_y)
             call comm_3s_start_GPU(q3d(ib,jb,kb,nqv)  &
                        ,qw31(1,1,1,nqv),qw32(1,1,1,nqv),qe31(1,1,1,nqv),qe32(1,1,1,nqv)     &
                        ,qs31(1,1,1,nqv),qs32(1,1,1,nqv),qn31(1,1,1,nqv),qn32(1,1,1,nqv)     &
                        ,reqs_q(1,nqv) )
+            call comm_3u_start_GPU(u3d,uw31,uw32,ue31,ue32,   &
+                                       us31,us32,un31,un32,reqs_u)
+            call comm_3v_start_GPU(v3d,vw31,vw32,ve31,ve32,   &
+                                       vs31,vs32,vn31,vn32,reqs_v)
+            call comm_3w_start_GPU(w3d,ww31,ww32,we31,we32,   &
+                                       ws31,ws32,wn31,wn32,reqs_w)
+            !----
             call comm_3s_end_GPU(th3d,rw31,rw32,re31,re32,rs31,rs32,rn31,rn32,reqs_y)
             call comm_3s_end_GPU(q3d(ib,jb,kb,nqv)  &
                        ,qw31(1,1,1,nqv),qw32(1,1,1,nqv),qe31(1,1,1,nqv),qe32(1,1,1,nqv)     &
                        ,qs31(1,1,1,nqv),qs32(1,1,1,nqv),qn31(1,1,1,nqv),qn32(1,1,1,nqv)     &
                        ,reqs_q(1,nqv) )
+            call comm_3u_end_GPU(u3d,uw31,uw32,ue31,ue32,   &
+                                     us31,us32,un31,un32,reqs_u)
+            call comm_3v_end_GPU(v3d,vw31,vw32,ve31,ve32,   &
+                                     vs31,vs32,vn31,vn32,reqs_v)
+            call comm_3w_end_GPU(w3d,ww31,ww32,we31,we32,   &
+                                     ws31,ws32,wn31,wn32,reqs_w)
+            !----
 #endif
             !$omp parallel do default(shared) private(i,j,k)
             !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
             do k=1,nk
-            do j=0,nj+1
-            do i=0,ni+1
+            do j=0,nj+2
+            do i=0,ni+2
               tha(i,j,k)=th3d(i,j,k)
               qa(i,j,k,nqv)=q3d(i,j,k,nqv)
+              ua(i,j,k)=u3d(i,j,k)
+              va(i,j,k)=v3d(i,j,k)
+              wa(i,j,k)=w3d(i,j,k)
             enddo
             enddo
             enddo

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -973,8 +973,7 @@
                                nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p,                    &
                                sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,                   &
                                n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,            &
-                               dpten(ib,jb,kb,3),dpten(ib,jb,kb,4),dpten(ib,jb,kb,5),dpten(ib,jb,kb,1),dpten(ib,jb,kb,2),dpten(ib,jb,kb,6),        &
-                               pdata_locind)
+                               dpten,pdata_locind)
           if(timestats.ge.1) time_parcels=time_parcels+mytime()
 #ifdef MPI
           call sync()


### PR DESCRIPTION
This has multiple additions from George:
- A conversion of a number of variables to double precision and additional checks to prevent overflow issues in droplet iteration
- Computing velocity tendencies at the node center (different than humidity and temperature tendencies) and adding them to the velocity solvers
- Rearranging a few things for making droplet stats more convenient

The correctness statistics for this PR is as follows:

ifort on CPU versus nvhpc on CPU
==========================

Metrics
--------
39 stat variables are identical.
41 stat variables show a mean relative difference > 1e-06
6 stat variables show a mean relative difference <= 1e-06

0th-order
----------
3 stat variables are identical.
5 stat variables show a mean relative difference > 1e-06
4 stat variables show a mean relative difference <= 1e-06

1st-order
---------
254 stat variables are identical.
2 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06


nvhpc on CPU versus nvhpc on GPU
============================

Metrics
--------
39 stat variables are identical.
42 stat variables show a mean relative difference > 1e-06
5 stat variables show a mean relative difference <= 1e-06


0th-order
----------
3 stat variables are identical.
8 stat variables show a mean relative difference > 1e-06
1 stat variables show a mean relative difference <= 1e-06

1st-order
---------
254 stat variables are identical.
2 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06
