### PR TITLE
Eliminated duplicate comm subroutines

### DIFF
--- a/run/gust.verify.cpu.sh
+++ b/run/gust.verify.cpu.sh
@@ -6,10 +6,10 @@
 #PBS -q main
 #PBS -A UNDM0006
 
-# module --force purge
-# module load ncarenv intel cray-mpich ncarcompilers
-# mpiexec -n 2 -ppn 2 ./cpu.ifort.exe --namelist namelist_ASD.verify >& gust.mpi.ifort.namelist.ASD.log
-
 module --force purge
-module load ncarenv nvhpc cray-mpich ncarcompilers
-mpiexec -n 2 -ppn 2 ./cpu.nvhpc.exe --namelist namelist_ASD.verify >& gust.mpi.nvhpc.namelist.ASD.log
+module load ncarenv intel cray-mpich ncarcompilers
+mpiexec -n 2 -ppn 2 ./cpu.ifort.exe --namelist namelist_ASD.verify >& gust.mpi.ifort.namelist.ASD.log
+
+# module --force purge
+# module load ncarenv nvhpc cray-mpich ncarcompilers
+# mpiexec -n 2 -ppn 2 ./cpu.nvhpc.exe --namelist namelist_ASD.verify >& gust.mpi.nvhpc.namelist.ASD.log

--- a/run/gust.verify.cpu.sh
+++ b/run/gust.verify.cpu.sh
@@ -6,8 +6,10 @@
 #PBS -q main
 #PBS -A UNDM0006
 
+# module --force purge
+# module load ncarenv intel cray-mpich ncarcompilers
+# mpiexec -n 2 -ppn 2 ./cpu.ifort.exe --namelist namelist_ASD.verify >& gust.mpi.ifort.namelist.ASD.log
 
 module --force purge
-module load ncarenv intel cray-mpich ncarcompilers
-
-mpiexec -n 2 -ppn 2 ./cpu.exe --namelist namelist_ASD.input >& gust.mpi.ifort.namelist.ASD.log
+module load ncarenv nvhpc cray-mpich ncarcompilers
+mpiexec -n 2 -ppn 2 ./cpu.nvhpc.exe --namelist namelist_ASD.verify >& gust.mpi.nvhpc.namelist.ASD.log

--- a/run/gust.verify.gpu.sh
+++ b/run/gust.verify.gpu.sh
@@ -10,4 +10,4 @@ module purge
 module load ncarenv nvhpc cuda cray-mpich ncarcompilers
 
 export MPICH_GPU_SUPPORT_ENABLED=1
-mpiexec -n 2 -ppn 2 get_local_rank ./gpu.exe --namelist namelist_ASD.input >& gust.mpi.openacc.namelist.ASD.log
+mpiexec -n 2 -ppn 2 get_local_rank ./gpu.exe --namelist namelist_ASD.input.400M >& gust.mpi.openacc.namelist.ASD.log

--- a/run/gust.verify.gpu.sh
+++ b/run/gust.verify.gpu.sh
@@ -10,4 +10,4 @@ module purge
 module load ncarenv nvhpc cuda cray-mpich ncarcompilers
 
 export MPICH_GPU_SUPPORT_ENABLED=1
-mpiexec -n 2 -ppn 2 get_local_rank ./gpu.exe --namelist namelist_ASD.input.400M >& gust.mpi.openacc.namelist.ASD.log
+mpiexec -n 2 -ppn 2 get_local_rank ./gpu.exe --namelist namelist_ASD.verify >& gust.mpi.openacc.namelist.ASD.log

--- a/src/adv_routines.F
+++ b/src/adv_routines.F
@@ -9540,7 +9540,7 @@
 
 #ifdef MPI
       if(timestats.ge.1) time_swath=time_swath+mytime()
-      call comm_2d_start_GPU(s,west,newwest,east,neweast,   &
+      call comm_2d_start(s,west,newwest,east,neweast,   &
                            south,newsouth,north,newnorth,reqs)
 #else
       if(wbc.eq.1)then
@@ -9633,7 +9633,7 @@
 
 #ifdef MPI
       if(timestats.ge.1) time_swath=time_swath+mytime()
-      call comm_2dew_end_GPU(s,west,newwest,east,neweast,reqs)
+      call comm_2dew_end(s,west,newwest,east,neweast,reqs)
 #endif
 
 !-------------------------
@@ -9704,7 +9704,7 @@
 
 #ifdef MPI
       if(timestats.ge.1) time_swath=time_swath+mytime()
-      call comm_2dns_end_GPU(s,south,newsouth,north,newnorth,reqs)
+      call comm_2dns_end(s,south,newsouth,north,newnorth,reqs)
 #endif
 
 !-------------------------

--- a/src/azimavg.F
+++ b/src/azimavg.F
@@ -2646,10 +2646,10 @@
 
         call bc2d(dum1(ib,jb,1),device=.false.)
 #ifdef MPI
-        call comm_2d_start(dum1(ib,jb,1),west,newwest,east,neweast,   &
-                                         south,newsouth,north,newnorth,reqs)
-        call comm_2dew_end(dum1(ib,jb,1),west,newwest,east,neweast,reqs)
-        call comm_2dns_end(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs)
+        call comm_2d_start_GPU(dum1(ib,jb,1),west,newwest,east,neweast,   &
+                           south,newsouth,north,newnorth,reqs,device=.false.)
+        call comm_2dew_end_GPU(dum1(ib,jb,1),west,newwest,east,neweast,reqs,device=.false.)
+        call comm_2dns_end_GPU(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs,device=.false.)
         call bcs2_2d(dum1(ib,jb,1),device=.false.)
         call comm_2d_corner_GPU(dum1(ib,jb,1),device=.false.)
 #endif
@@ -2675,10 +2675,10 @@
 
         call bc2d(dum1(ib,jb,1),device=.false.)
 #ifdef MPI
-        call comm_2d_start(dum1(ib,jb,1),west,newwest,east,neweast,   &
-                                         south,newsouth,north,newnorth,reqs)
-        call comm_2dew_end(dum1(ib,jb,1),west,newwest,east,neweast,reqs)
-        call comm_2dns_end(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs)
+        call comm_2d_start_GPU(dum1(ib,jb,1),west,newwest,east,neweast,   &
+                               south,newsouth,north,newnorth,reqs,device=.false.)
+        call comm_2dew_end_GPU(dum1(ib,jb,1),west,newwest,east,neweast,reqs,device=.false.)
+        call comm_2dns_end_GPU(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs,device=.false.)
         call bcs2_2d(dum1(ib,jb,1),device=.false.)
         call comm_2d_corner_GPU(dum1(ib,jb,1),device=.false.)
 #endif

--- a/src/azimavg.F
+++ b/src/azimavg.F
@@ -2214,7 +2214,7 @@
     ! Pass 1:  find min surface pressure
 
 #ifdef MPI
-      call comm_2d_corner_GPU(pp3d(ib,jb,1),device=.false.)
+      call comm_2d_corner(pp3d(ib,jb,1),device=.false.)
 #endif
 
       ppmin = 1.0e30
@@ -2646,12 +2646,12 @@
 
         call bc2d(dum1(ib,jb,1),device=.false.)
 #ifdef MPI
-        call comm_2d_start_GPU(dum1(ib,jb,1),west,newwest,east,neweast,   &
+        call comm_2d_start(dum1(ib,jb,1),west,newwest,east,neweast,   &
                            south,newsouth,north,newnorth,reqs,device=.false.)
-        call comm_2dew_end_GPU(dum1(ib,jb,1),west,newwest,east,neweast,reqs,device=.false.)
-        call comm_2dns_end_GPU(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs,device=.false.)
+        call comm_2dew_end(dum1(ib,jb,1),west,newwest,east,neweast,reqs,device=.false.)
+        call comm_2dns_end(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs,device=.false.)
         call bcs2_2d(dum1(ib,jb,1),device=.false.)
-        call comm_2d_corner_GPU(dum1(ib,jb,1),device=.false.)
+        call comm_2d_corner(dum1(ib,jb,1),device=.false.)
 #endif
 
         do j=1,nj
@@ -2675,12 +2675,12 @@
 
         call bc2d(dum1(ib,jb,1),device=.false.)
 #ifdef MPI
-        call comm_2d_start_GPU(dum1(ib,jb,1),west,newwest,east,neweast,   &
+        call comm_2d_start(dum1(ib,jb,1),west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs,device=.false.)
-        call comm_2dew_end_GPU(dum1(ib,jb,1),west,newwest,east,neweast,reqs,device=.false.)
-        call comm_2dns_end_GPU(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs,device=.false.)
+        call comm_2dew_end(dum1(ib,jb,1),west,newwest,east,neweast,reqs,device=.false.)
+        call comm_2dns_end(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs,device=.false.)
         call bcs2_2d(dum1(ib,jb,1),device=.false.)
-        call comm_2d_corner_GPU(dum1(ib,jb,1),device=.false.)
+        call comm_2d_corner(dum1(ib,jb,1),device=.false.)
 #endif
 
     !---------------------------------------

--- a/src/azimavg.F
+++ b/src/azimavg.F
@@ -2214,7 +2214,7 @@
     ! Pass 1:  find min surface pressure
 
 #ifdef MPI
-      call comm_2d_corner(pp3d(ib,jb,1))
+      call comm_2d_corner_GPU(pp3d(ib,jb,1),device=.false.)
 #endif
 
       ppmin = 1.0e30
@@ -2651,7 +2651,7 @@
         call comm_2dew_end(dum1(ib,jb,1),west,newwest,east,neweast,reqs)
         call comm_2dns_end(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs)
         call bcs2_2d(dum1(ib,jb,1),device=.false.)
-        call comm_2d_corner(dum1(ib,jb,1))
+        call comm_2d_corner_GPU(dum1(ib,jb,1),device=.false.)
 #endif
 
         do j=1,nj
@@ -2680,7 +2680,7 @@
         call comm_2dew_end(dum1(ib,jb,1),west,newwest,east,neweast,reqs)
         call comm_2dns_end(dum1(ib,jb,1),south,newsouth,north,newnorth,reqs)
         call bcs2_2d(dum1(ib,jb,1),device=.false.)
-        call comm_2d_corner(dum1(ib,jb,1))
+        call comm_2d_corner_GPU(dum1(ib,jb,1),device=.false.)
 #endif
 
     !---------------------------------------

--- a/src/base.F
+++ b/src/base.F
@@ -37,7 +37,7 @@
       use bc_module, only: bcu, bcv, bcs, extrapbcs, &
           bcu2, bcv2
       use comm_module, only: comm_all_s_GPU,getcorneru3_GPU,getcornerv3_GPU, &
-          comm_3u_start,comm_3u_end,comm_3v_start,comm_3v_end
+          comm_3u_start_GPU,comm_3u_end_GPU,comm_3v_start_GPU,comm_3v_end_GPU
       use goddard_module, only : T0K,T00K,RT0
       use cm1libs , only : rslf,rsif
       use turb_module , only : ramp_up_turb
@@ -2657,10 +2657,10 @@
 
       !--------
 #ifdef MPI
-      call comm_3u_start(u0,uw31,uw32,ue31,ue32,   &
-                            us31,us32,un31,un32,reqs_u)
-      call comm_3u_end(u0,uw31,uw32,ue31,ue32,   &
-                          us31,us32,un31,un32,reqs_u)
+      call comm_3u_start_GPU(u0,uw31,uw32,ue31,ue32,   &
+                            us31,us32,un31,un32,reqs_u,device=.false.)
+      call comm_3u_end_GPU(u0,uw31,uw32,ue31,ue32,   &
+                          us31,us32,un31,un32,reqs_u,device=.false.)
       call getcorneru3_GPU(u0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
                           s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1),device=.false.)
       call bcu2(u0,device=.false.)
@@ -2675,10 +2675,10 @@
       enddo
       !--------
 #ifdef MPI
-      call comm_3v_start(v0,vw31,vw32,ve31,ve32,   &
-                            vs31,vs32,vn31,vn32,reqs_v)
-      call comm_3v_end(v0,vw31,vw32,ve31,ve32,   &
-                          vs31,vs32,vn31,vn32,reqs_v)
+      call comm_3v_start_GPU(v0,vw31,vw32,ve31,ve32,   &
+                          vs31,vs32,vn31,vn32,reqs_v,device=.false.)
+      call comm_3v_end_GPU(v0,vw31,vw32,ve31,ve32,   &
+                          vs31,vs32,vn31,vn32,reqs_v,device=.false.)
       call getcornerv3_GPU(v0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
                           s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1),device=.false.)
       call bcv2(v0,device=.false.)

--- a/src/base.F
+++ b/src/base.F
@@ -36,8 +36,8 @@
       use constants
       use bc_module, only: bcu, bcv, bcs, extrapbcs, &
           bcu2, bcv2
-      use comm_module, only: comm_all_s_GPU,getcorneru3_GPU,getcornerv3_GPU, &
-          comm_3u_start_GPU,comm_3u_end_GPU,comm_3v_start_GPU,comm_3v_end_GPU
+      use comm_module, only: comm_all_s,getcorneru3,getcornerv3, &
+          comm_3u_start,comm_3u_end,comm_3v_start,comm_3v_end
       use goddard_module, only : T0K,T00K,RT0
       use cm1libs , only : rslf,rsif
       use turb_module , only : ramp_up_turb
@@ -2042,19 +2042,19 @@
       nu=0
       nv=0
       nw=0
-     call comm_all_s_GPU( pi0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+     call comm_all_s( pi0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
            n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
-      call comm_all_s_GPU(prs0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+      call comm_all_s(prs0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
            n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
-      call comm_all_s_GPU( th0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+      call comm_all_s( th0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
            n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
-      call comm_all_s_GPU( qv0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+      call comm_all_s( qv0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
            n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
-      call comm_all_s_GPU( qc0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+      call comm_all_s( qc0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
            n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
-      call comm_all_s_GPU( qi0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+      call comm_all_s( qi0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
            n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
-      call comm_all_s_GPU( rh0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+      call comm_all_s( rh0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
            n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
 #endif
 
@@ -2127,7 +2127,7 @@
 
       call bcs(rho0,device=.false.)
 #ifdef MPI
-      call comm_all_s_GPU(rho0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+      call comm_all_s(rho0,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                          n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
 #endif
       call extrapbcs(rho0,device=.false.)
@@ -2657,11 +2657,11 @@
 
       !--------
 #ifdef MPI
-      call comm_3u_start_GPU(u0,uw31,uw32,ue31,ue32,   &
+      call comm_3u_start(u0,uw31,uw32,ue31,ue32,   &
                             us31,us32,un31,un32,reqs_u,device=.false.)
-      call comm_3u_end_GPU(u0,uw31,uw32,ue31,ue32,   &
+      call comm_3u_end(u0,uw31,uw32,ue31,ue32,   &
                           us31,us32,un31,un32,reqs_u,device=.false.)
-      call getcorneru3_GPU(u0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
+      call getcorneru3(u0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
                           s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1),device=.false.)
       call bcu2(u0,device=.false.)
 #endif
@@ -2675,11 +2675,11 @@
       enddo
       !--------
 #ifdef MPI
-      call comm_3v_start_GPU(v0,vw31,vw32,ve31,ve32,   &
+      call comm_3v_start(v0,vw31,vw32,ve31,ve32,   &
                           vs31,vs32,vn31,vn32,reqs_v,device=.false.)
-      call comm_3v_end_GPU(v0,vw31,vw32,ve31,ve32,   &
+      call comm_3v_end(v0,vw31,vw32,ve31,ve32,   &
                           vs31,vs32,vn31,vn32,reqs_v,device=.false.)
-      call getcornerv3_GPU(v0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
+      call getcornerv3(v0,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
                           s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1),device=.false.)
       call bcv2(v0,device=.false.)
 #endif

--- a/src/bc.F
+++ b/src/bc.F
@@ -2956,6 +2956,8 @@
          logical, intent(inout) :: openacc
          logical, optional :: device
 
+      ! Set logical flag if subroutine is called on GPU or CPU resident
+      ! data. The default to for GPU resident data.
       if(present(device)) then
          if(device) then
             openacc = .true.

--- a/src/bc.F
+++ b/src/bc.F
@@ -2957,7 +2957,8 @@
          logical, optional :: device
 
       ! Set logical flag if subroutine is called on GPU or CPU resident
-      ! data. The default to for GPU resident data.
+      ! data.  If the device flag is not set, it is assumed that it is
+      ! GPU resident.
       if(present(device)) then
          if(device) then
             openacc = .true.

--- a/src/comm.F
+++ b/src/comm.F
@@ -3316,6 +3316,7 @@
       call SetMsgParams(openacc,gdirect,device,gpudirect)
 !------------------------------------------------
 
+
       nr = 0
       nw=nw+1
       tag1=3000+nw
@@ -8603,6 +8604,9 @@
          logical, intent(inout) :: openacc, gdirect
          logical, optional :: device,gpudirect
 
+      ! Set logical flags if subroutine is called on GPU or CPU resident
+      ! data. The default to for GPU resident data. If the data is GPU
+      ! use gpudirect by default
       if(present(device)) then
          if(device) then
             openacc = .true.

--- a/src/comm.F
+++ b/src/comm.F
@@ -267,7 +267,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine getcornert_GPU(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      subroutine getcornert_GPU(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -275,6 +275,7 @@
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: t
       real, intent(inout), dimension(nk+1) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      logical, optional, intent(in) :: device,gpudirect
 
       integer k,nn,nr,nrb,index
       integer :: index_nw,index_sw,index_ne,index_se
@@ -282,6 +283,10 @@
       integer tag1,tag2,tag3,tag4
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug =.FALSE.
+      logical :: openacc, gdirect
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !-----
       nr = 0
@@ -295,7 +300,7 @@
 
       if(ibw.eq.0 .and. ibn.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(nw2)
+        !$acc host_data use_device(nw2) if(gdirect)
         call mpi_irecv(nw2,nkp1,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -308,7 +313,7 @@
 
       if(ibw.eq.0 .and. ibs.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(sw2)
+        !$acc host_data use_device(sw2) if(gdirect)
         call mpi_irecv(sw2,nkp1,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -321,7 +326,7 @@
 
       if(ibe.eq.0 .and. ibn.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(ne2)
+        !$acc host_data use_device(ne2) if(gdirect)
         call mpi_irecv(ne2,nkp1,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -334,7 +339,7 @@
 
       if(ibe.eq.0 .and. ibs.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(se2)
+        !$acc host_data use_device(se2) if(gdirect)
         call mpi_irecv(se2,nkp1,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -347,12 +352,12 @@
 
       if(ibe.eq.0 .and. ibs.eq.0)then
         !$omp parallel do default(shared) private(k)
-        !$acc parallel loop default(present) private(k)
+        !$acc parallel loop default(present) if(openacc)
         do k=1,nkp1
           se1(k)=t(ni,1,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(se1)
+        !$acc host_data use_device(se1) if(gdirect)
         call mpi_isend(se1,nkp1,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -362,12 +367,12 @@
 
       if(ibe.eq.0 .and. ibn.eq.0)then
         !$omp parallel do default(shared) private(k)
-        !$acc parallel loop default(present) private(k)
+        !$acc parallel loop default(present) if(openacc)
         do k=1,nkp1
           ne1(k)=t(ni,nj,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(ne1)
+        !$acc host_data use_device(ne1) if(gdirect)
         call mpi_isend(ne1,nkp1,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -377,12 +382,12 @@
 
       if(ibw.eq.0 .and. ibs.eq.0)then
         !$omp parallel do default(shared) private(k)
-        !$acc parallel loop default(present) private(k)
+        !$acc parallel loop default(present) if(openacc)
         do k=1,nkp1
           sw1(k)=t(1,1,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(sw1)
+        !$acc host_data use_device(sw1) if(gdirect)
         call mpi_isend(sw1,nkp1,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -392,12 +397,12 @@
 
       if(ibw.eq.0 .and. ibn.eq.0)then
         !$omp parallel do default(shared) private(k)
-        !$acc parallel loop default(present) private(k)
+        !$acc parallel loop default(present) if(openacc)
         do k=1,nkp1
           nw1(k)=t(1,nj,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(nw1)
+        !$acc host_data use_device(nw1) if(gdirect)
         call mpi_isend(nw1,nkp1,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -412,25 +417,25 @@
 
       if(index.eq.index_nw)then
         !$omp parallel do default(shared) private(k)
-        !$acc parallel loop default(present) private(k)
+        !$acc parallel loop default(present) if(openacc)
         do k=1,nkp1
           t(0,nj+1,k)=nw2(k)
         enddo
       elseif(index.eq.index_sw)then
         !$omp parallel do default(shared) private(k)
-        !$acc parallel loop default(present) private(k)
+        !$acc parallel loop default(present) if(openacc)
         do k=1,nkp1
           t(0,0,k)=sw2(k)
         enddo
       elseif(index.eq.index_ne)then
         !$omp parallel do default(shared) private(k)
-        !$acc parallel loop default(present) private(k)
+        !$acc parallel loop default(present) if(openacc)
         do k=1,nkp1
           t(ni+1,nj+1,k)=ne2(k)
         enddo
       elseif(index.eq.index_se)then
         !$omp parallel do default(shared) private(k)
-        !$acc parallel loop default(present) private(k)
+        !$acc parallel loop default(present) if(openacc)
         do k=1,nkp1
           t(ni+1,0,k)=se2(k)
         enddo
@@ -4691,7 +4696,7 @@
 
 
       subroutine comm_1t_start_GPU(t,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
+                      south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,ct1we,ct1sn,nf,ierr,timestats,time_mps1,mytime, &
           myeast,mywest,mysouth,mynorth
@@ -4704,11 +4709,15 @@
       real south(ni,nk+1),newsouth(ni,nk+1)
       real north(ni,nk+1),newnorth(ni,nk+1)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
 
       integer i,j,k,nr
       integer tag1,tag2,tag3,tag4
       logical, parameter :: Debug=.FALSE.
+      logical :: openacc, gdirect
 
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !------------------------------------------------
      
@@ -4720,7 +4729,7 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(neweast)
+        !$acc host_data use_device(neweast) if(gdirect)
         call mpi_irecv(neweast,ct1we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4734,7 +4743,7 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newwest)
+        !$acc host_data use_device(newwest) if(gdirect)
         call mpi_irecv(newwest,ct1we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4748,7 +4757,7 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newsouth)
+        !$acc host_data use_device(newsouth) if(gdirect)
         call mpi_irecv(newsouth,ct1sn,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4762,7 +4771,7 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newnorth)
+        !$acc host_data use_device(newnorth) if(gdirect)
         call mpi_irecv(newnorth,ct1sn,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4776,16 +4785,15 @@
 
       ! send west
       if(ibw.eq.0)then
-!$acc parallel loop gang vector collapse(2) default(present) private(j,k)
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
+        !$omp parallel do default(shared) private(j,k)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nkp1
         do j=1,nj
           west(j,k)=t(1,j,k)
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(west)
+        !$acc host_data use_device(west) if(gdirect)
         call mpi_isend(west,ct1we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4795,16 +4803,15 @@
 
       ! send east
       if(ibe.eq.0)then
-!$acc parallel loop gang vector collapse(2) default(present) private(j,k)
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
+        !$omp parallel do default(shared) private(j,k)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nkp1
         do j=1,nj
           east(j,k)=t(ni,j,k)
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(east)
+        !$acc host_data use_device(east) if(gdirect)
         call mpi_isend(east,ct1we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4814,16 +4821,15 @@
 
       ! send north
       if(ibn.eq.0)then
-!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
+        !$omp parallel do default(shared) private(i,k)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nkp1
         do i=1,ni
           north(i,k)=t(i,nj,k)
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(north)
+        !$acc host_data use_device(north) if(gdirect)
         call mpi_isend(north,ct1sn,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4833,16 +4839,15 @@
 
       ! send south
       if(ibs.eq.0)then
-!$acc parallel loop gang vector collapse(2) default(present) private(i,k)
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
+        !$omp parallel do default(shared) private(i,k)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do k=1,nkp1
         do i=1,ni
           south(i,k)=t(i,1,k)
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(south)
+        !$acc host_data use_device(south) if(gdirect)
         call mpi_isend(south,ct1sn,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4860,7 +4865,7 @@
 
 
       subroutine comm_1t_end_GPU(t,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
+                            south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,mytime,ierr,timestats,time_mps2,time_bc, &
           p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
@@ -4873,10 +4878,15 @@
       real south(ni,nk+1),newsouth(ni,nk+1)
       real north(ni,nk+1),newnorth(ni,nk+1)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
 
       integer i,j,k,nn,nr,index
       integer :: index_east,index_west,index_south,index_north
       integer, dimension(mpi_status_size,8) :: status1
+      logical :: openacc,gdirect
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !---------------------------------------------------------------------
 
@@ -4910,36 +4920,32 @@
         nn = nn + 1
 
       if(index.eq.index_east)then
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-!$acc parallel loop gang vector default(present) collapse(2) private(j,k)
+        !$omp parallel do default(shared) private(j,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nkp1
         do j=1,nj
           t(ni+1,j,k)=neweast(j,k)
         enddo
         enddo
       elseif(index.eq.index_west)then
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-!$acc parallel loop gang vector default(present) collapse(2) private(j,k)
+        !$omp parallel do default(shared) private(j,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nkp1
         do j=1,nj
           t(0,j,k)=newwest(j,k)
         enddo
         enddo
       elseif(index.eq.index_south)then
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-!$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+        !$omp parallel do default(shared) private(i,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nkp1
         do i=1,ni
           t(i,0,k)=newsouth(i,k)
         enddo
         enddo
       elseif(index.eq.index_north)then
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-!$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+        !$omp parallel do default(shared) private(i,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nkp1
         do i=1,ni
           t(i,nj+1,k)=newnorth(i,k)
@@ -4959,18 +4965,16 @@
         if(ibw.eq.1)then
 
           if(p2tchsww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-!$acc parallel loop gang vector default(present)
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(0,0,k)=t(1,0,k)
             enddo
           endif
 
           if(p2tchnww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-!$acc parallel loop gang vector default(present) 
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(0,nj+1,k)=t(1,nj+1,k)
             enddo
@@ -4981,18 +4985,16 @@
         if(ibe.eq.1)then
 
           if(p2tchsee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-!$acc parallel loop gang vector default(present)
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(ni+1,0,k)=t(ni,0,k)
             enddo
           endif
 
           if(p2tchnee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-!$acc parallel loop gang vector default(present) 
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(ni+1,nj+1,k)=t(ni,nj+1,k)
             enddo
@@ -5007,18 +5009,16 @@
         if(ibs.eq.1)then
 
           if(p2tchsws)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-!$acc parallel loop gang vector default(present) 
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(0,0,k)=t(0,1,k)
             enddo
           endif
 
           if(p2tchses)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-!$acc parallel loop gang vector default(present)
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(ni+1,0,k)=t(ni+1,1,k)
             enddo
@@ -5029,18 +5029,16 @@
         if(ibn.eq.1)then
 
           if(p2tchnwn)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-!$acc parallel loop gang vector default(present)
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(0,nj+1,k)=t(0,nj,k)
             enddo
           endif
 
           if(p2tchnen)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-!$acc parallel loop gang vector default(present)
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(ni+1,nj+1,k)=t(ni+1,nj,k)
             enddo
@@ -5076,7 +5074,6 @@
       if(timestats.ge.1) time_mps2=time_mps2+mytime()
 
 !----------
-!      !$acc update device(t)
       end subroutine comm_1t_end_GPU
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/comm.F
+++ b/src/comm.F
@@ -26,13 +26,6 @@
   public :: comm_all_s_GPU
   public :: getcorner3_2d_GPU
 
-  !CPU only routines
-  public :: comm_1s_start,comm_1s_end
-  public :: comm_3t_start,comm_3t_end
-  public :: comm_3u_start,comm_3u_end
-  public :: comm_3v_start,comm_3v_end
-  public :: comm_3w_start,comm_3w_end
-
   public :: sync
 
   CONTAINS
@@ -2107,166 +2100,9 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-
-      ! tk1
-      subroutine comm_3t_start(t,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
-          nf,ct3we,ct3sn,nkp1,timestats,time_mps1,mytime,ierr, &
-          myeast,mywest,mynorth,mysouth
-      use mpi
-      implicit none
-
-      real t(ib:ie,jb:je,kb:ke+1)
-      real west(cmp,nj,nk+1),newwest(cmp,nj,nk+1)
-      real east(cmp,nj,nk+1),neweast(cmp,nj,nk+1)
-      real south(ni,cmp,nk+1),newsouth(ni,cmp,nk+1)
-      real north(ni,cmp,nk+1),newnorth(ni,cmp,nk+1)
-      integer reqs(8)
-
-      integer i,j,k,nr
-      integer tag1,tag2,tag3,tag4
-
-!------------------------------------------------
-
-      nr = 0
-
-      nf=nf+1
-      tag1=nf
-
-      ! receive east
-      if(ibe.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(neweast,ct3we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag2=nf
-
-      ! receive west
-      if(ibw.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newwest,ct3we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag3=nf
-
-      ! receive south
-      if(ibs.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newsouth,ct3sn,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag4=nf
-
-      ! receive north
-      if(ibn.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newnorth,ct3sn,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr = 4
-
-      ! send west
-      if(ibw.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nkp1
-        do j=1,nj
-        do i=1,cmp
-          west(i,j,k)=t(i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(west,ct3we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      ! send east
-      if(ibe.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nkp1
-        do j=1,nj
-        do i=1,cmp
-          east(i,j,k)=t(ni-cmp+i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(east,ct3we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      ! send north
-      if(ibn.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,ni
-          north(i,j,k)=t(i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(north,ct3sn,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      ! send south
-      if(ibs.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,ni
-          south(i,j,k)=t(i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(south,ct3sn,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      if(timestats.ge.1) time_mps1=time_mps1+mytime()
-
-      end subroutine comm_3t_start
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
       ! tk1
       subroutine comm_3t_start_GPU(t,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
+                        south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
           nf,ct3we,ct3sn,nkp1,timestats,time_mps1,mytime,ierr, &
           myeast,mywest,mynorth,mysouth
@@ -2279,13 +2115,15 @@
       real south(ni,cmp,nk+1),newsouth(ni,cmp,nk+1)
       real north(ni,cmp,nk+1),newnorth(ni,cmp,nk+1)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
 
       integer i,j,k,nr
       integer tag1,tag2,tag3,tag4
       logical, parameter :: Debug =.FALSE.
-      !$acc declare present(t) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc, gdirect
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 !------------------------------------------------
 
       nr = 0
@@ -2296,7 +2134,7 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(neweast)
+        !$acc host_data use_device(neweast) if(gdirect)
         call mpi_irecv(neweast,ct3we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -2310,7 +2148,7 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newwest)
+        !$acc host_data use_device(newwest) if(gdirect)
         call mpi_irecv(newwest,ct3we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -2324,7 +2162,7 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newsouth)
+        !$acc host_data use_device(newsouth) if(gdirect)
         call mpi_irecv(newsouth,ct3sn,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -2338,7 +2176,7 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newnorth)
+        !$acc host_data use_device(newnorth) if(gdirect)
         call mpi_irecv(newnorth,ct3sn,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -2353,7 +2191,7 @@
       ! send west
       if(ibw.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nkp1
         do j=1,nj
         do i=1,cmp
@@ -2362,7 +2200,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(west)
+        !$acc host_data use_device(west) if(gdirect)
         call mpi_isend(west,ct3we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -2373,7 +2211,7 @@
       ! send east
       if(ibe.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nkp1
         do j=1,nj
         do i=1,cmp
@@ -2382,7 +2220,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(east)
+        !$acc host_data use_device(east) if(gdirect)
         call mpi_isend(east,ct3we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -2393,7 +2231,7 @@
       ! send north
       if(ibn.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nkp1
         do j=1,cmp
         do i=1,ni
@@ -2402,7 +2240,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(north)
+        !$acc host_data use_device(north) if(gdirect)
         call mpi_isend(north,ct3sn,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -2413,7 +2251,7 @@
       ! send south
       if(ibs.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nkp1
         do j=1,cmp
         do i=1,ni
@@ -2422,7 +2260,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(south)
+        !$acc host_data use_device(south) if(gdirect)
         call mpi_isend(south,ct3sn,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -2433,231 +2271,12 @@
       if(timestats.ge.1) time_mps1=time_mps1+mytime()
       end subroutine comm_3t_start_GPU
 
-
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine comm_3t_end(t,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
-          ierr,nkp1,ebc,wbc,sbc,nbc,timestats,time_mps2,time_bc,mytime, &
-          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
-      use mpi
-      implicit none
-
-      real t(ib:ie,jb:je,kb:ke+1)
-      real west(cmp,nj,nk+1),newwest(cmp,nj,nk+1)
-      real east(cmp,nj,nk+1),neweast(cmp,nj,nk+1)
-      real south(ni,cmp,nk+1),newsouth(ni,cmp,nk+1)
-      real north(ni,cmp,nk+1),newnorth(ni,cmp,nk+1)
-      integer reqs(8)
-
-      integer i,j,k,nn,nr,index
-      integer :: index_east,index_west,index_south,index_north
-      integer, dimension(mpi_status_size,8) :: status1
-
-!-------------------------------------------------------------------
-
-      index_east = -1
-      index_west = -1
-      index_south = -1
-      index_north = -1
-
-      nr = 0
-      if(ibe.eq.0)then
-        nr = nr + 1
-        index_east = nr
-      endif
-      if(ibw.eq.0)then
-        nr = nr + 1
-        index_west = nr
-      endif
-      if(ibs.eq.0)then
-        nr = nr + 1
-        index_south = nr
-      endif
-      if(ibn.eq.0)then
-        nr = nr + 1
-        index_north = nr
-      endif
-
-      nn = 1
-      do while( nn .le. nr )
-        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
-
-      if(index.eq.index_east)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nkp1
-        do j=1,nj
-        do i=1,cmp
-          t(ni+i,j,k)=neweast(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_west)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nkp1
-        do j=1,nj
-        do i=1,cmp
-          t(i-cmp,j,k)=newwest(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_south)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,ni
-          t(i,j-cmp,k)=newsouth(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_north)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,ni
-          t(i,nj+j,k)=newnorth(i,j,k)
-        enddo
-        enddo
-        enddo
-      endif
-
-      enddo
-
-      if(timestats.ge.1) time_mps2=time_mps2+mytime()
-
-!----------
-!  patch for corner
-
-     if( (ebc.eq.2.or.wbc.eq.2).and.(sbc.eq.1.or.nbc.eq.1) )then
-
-        if(ibw.eq.1)then
-
-          if(p2tchsww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nkp1
-              t(0,0,k)=t(1,0,k)
-            enddo
-          endif
-
-          if(p2tchnww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nkp1
-              t(0,nj+1,k)=t(1,nj+1,k)
-            enddo
-          endif
-
-        endif
-
-        if(ibe.eq.1)then
-
-          if(p2tchsee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nkp1
-              t(ni+1,0,k)=t(ni,0,k)
-            enddo
-          endif
-
-          if(p2tchnee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nkp1
-              t(ni+1,nj+1,k)=t(ni,nj+1,k)
-            enddo
-          endif
-
-        endif
-
-      endif
-
-      if( (ebc.eq.1.or.wbc.eq.1).and.(sbc.eq.2.or.nbc.eq.2) )then
-
-        if(ibs.eq.1)then
-
-          if(p2tchsws)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nkp1
-              t(0,0,k)=t(0,1,k)
-            enddo
-          endif
-
-          if(p2tchses)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nkp1
-              t(ni+1,0,k)=t(ni+1,1,k)
-            enddo
-          endif
-
-        endif
-
-        if(ibn.eq.1)then
-
-          if(p2tchnwn)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nkp1
-              t(0,nj+1,k)=t(0,nj,k)
-            enddo
-          endif
-
-          if(p2tchnen)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nkp1
-              t(ni+1,nj+1,k)=t(ni+1,nj,k)
-            enddo
-          endif
-
-        endif
-
-      endif
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-!----------
-
-      nr = 0
-
-      if(ibw.eq.0)then
-        nr = nr+1
-      endif
-      if(ibe.eq.0)then
-        nr = nr+1
-      endif
-      if(ibn.eq.0)then
-        nr = nr+1
-      endif
-      if(ibs.eq.0)then
-        nr = nr+1
-      endif
-
-    if( nr.ge.1 )then
-      call MPI_WAITALL(nr,reqs(5:5+nr-1),status1(1:mpi_status_size,5:5+nr-1),ierr)
-    endif
-
-      if(timestats.ge.1) time_mps2=time_mps2+mytime()
-
-      end subroutine comm_3t_end
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
 
       subroutine comm_3t_end_GPU(t,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
+                      south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
           ierr,nkp1,ebc,wbc,sbc,nbc,timestats,time_mps2,time_bc,mytime, &
           p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
@@ -2670,14 +2289,15 @@
       real south(ni,cmp,nk+1),newsouth(ni,cmp,nk+1)
       real north(ni,cmp,nk+1),newnorth(ni,cmp,nk+1)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
 
       integer i,j,k,nn,nr,index
       integer :: index_east,index_west,index_south,index_north
       integer, dimension(mpi_status_size,8) :: status1
-      !$acc declare present(t) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc, gdirect
 
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 !-------------------------------------------------------------------
 
 
@@ -2711,7 +2331,7 @@
 
       if(index.eq.index_east)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc) 
         do k=1,nkp1
         do j=1,nj
         do i=1,cmp
@@ -2721,7 +2341,7 @@
         enddo
       elseif(index.eq.index_west)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc) 
         do k=1,nkp1
         do j=1,nj
         do i=1,cmp
@@ -2731,7 +2351,7 @@
         enddo
       elseif(index.eq.index_south)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc) 
         do k=1,nkp1
         do j=1,cmp
         do i=1,ni
@@ -2741,7 +2361,7 @@
         enddo
       elseif(index.eq.index_north)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc) 
         do k=1,nkp1
         do j=1,cmp
         do i=1,ni
@@ -2764,7 +2384,7 @@
 
           if(p2tchsww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(0,0,k)=t(1,0,k)
             enddo
@@ -2772,7 +2392,7 @@
 
           if(p2tchnww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(0,nj+1,k)=t(1,nj+1,k)
             enddo
@@ -2784,7 +2404,7 @@
 
           if(p2tchsee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(ni+1,0,k)=t(ni,0,k)
             enddo
@@ -2792,7 +2412,7 @@
 
           if(p2tchnee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(ni+1,nj+1,k)=t(ni,nj+1,k)
             enddo
@@ -2808,7 +2428,7 @@
 
           if(p2tchsws)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(0,0,k)=t(0,1,k)
             enddo
@@ -2816,7 +2436,7 @@
 
           if(p2tchses)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(ni+1,0,k)=t(ni+1,1,k)
             enddo
@@ -2828,7 +2448,7 @@
 
           if(p2tchnwn)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(0,nj+1,k)=t(0,nj,k)
             enddo
@@ -2836,7 +2456,7 @@
 
           if(p2tchnen)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nkp1
               t(ni+1,nj+1,k)=t(ni+1,nj,k)
             enddo
@@ -2874,168 +2494,12 @@
 
       ! tk2
 
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
- 
-      subroutine comm_3u_start(u,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
-          timestats,mytime,nu,time_mpu1,cs3we,cu3sn,ierr,mynorth,mysouth,myeast,mywest
-      use mpi
-      implicit none
- 
-      real u(ib:ie+1,jb:je,kb:ke)
-      real west(cmp,nj,nk),newwest(cmp,nj,nk)
-      real east(cmp,nj,nk),neweast(cmp,nj,nk)
-      real south(ni+1,cmp,nk),newsouth(ni+1,cmp,nk)
-      real north(ni+1,cmp,nk),newnorth(ni+1,cmp,nk)
-      integer reqs(8)
- 
-      integer i,j,k,nr
-      integer tag1,tag2,tag3,tag4
- 
-!------------------------------------------------
-
-      nr = 0
-
-      nu=nu+1
-      tag1=1000+nu
-
-      ! receive east
-      if(ibe.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(neweast,cs3we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nu=nu+1
-      tag2=1000+nu
- 
-      ! receive west
-      if(ibw.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newwest,cs3we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nu=nu+1
-      tag3=1000+nu
-
-      ! receive north
-      if(ibn.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newnorth,cu3sn,MPI_REAL,mynorth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nu=nu+1
-      tag4=1000+nu
-
-      ! receive south
-      if(ibs.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newsouth,cu3sn,MPI_REAL,mysouth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr = 4
- 
-      ! send west
-      if(ibw.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj
-        do i=1,cmp
-          west(i,j,k)=u(i+1,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(west,cs3we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
-
-      ! send east
-      if(ibe.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj
-        do i=1,cmp
-          east(i,j,k)=u(ni-cmp+i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(east,cs3we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
- 
-      ! send south
-      if(ibs.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni+1
-          south(i,j,k)=u(i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(south,cu3sn,MPI_REAL,mysouth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      ! send north
-      if(ibn.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni+1
-         north(i,j,k)=u(i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(north,cu3sn,MPI_REAL,mynorth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
-
-      if(timestats.ge.1) time_mpu1=time_mpu1+mytime()
- 
-      end subroutine comm_3u_start
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
  
       subroutine comm_3u_start_GPU(u,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
+                      south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
           timestats,mytime,nu,time_mpu1,cs3we,cu3sn,ierr,mynorth,mysouth,myeast,mywest
       use mpi
@@ -3047,14 +2511,15 @@
       real south(ni+1,cmp,nk),newsouth(ni+1,cmp,nk)
       real north(ni+1,cmp,nk),newnorth(ni+1,cmp,nk)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
  
       integer i,j,k,nr
       integer tag1,tag2,tag3,tag4
       logical, parameter :: Debug =.FALSE.
-      !$acc declare present(u) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc,gdirect
  
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 !------------------------------------------------
 
       nr = 0
@@ -3063,7 +2528,7 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(neweast)
+        !$acc host_data use_device(neweast) if(gdirect)
         call mpi_irecv(neweast,cs3we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3077,7 +2542,7 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newwest)
+        !$acc host_data use_device(newwest) if(gdirect)
         call mpi_irecv(newwest,cs3we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3091,7 +2556,7 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newnorth)
+        !$acc host_data use_device(newnorth) if(gdirect)
         call mpi_irecv(newnorth,cu3sn,MPI_REAL,mynorth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3105,7 +2570,7 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newsouth)
+        !$acc host_data use_device(newsouth) if(gdirect)
         call mpi_irecv(newsouth,cu3sn,MPI_REAL,mysouth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3120,7 +2585,7 @@
       ! send west
       if(ibw.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -3129,7 +2594,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(west)
+        !$acc host_data use_device(west) if(gdirect)
         call mpi_isend(west,cs3we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3140,7 +2605,7 @@
       ! send east
       if(ibe.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -3149,7 +2614,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(east)
+        !$acc host_data use_device(east) if(gdirect)
         call mpi_isend(east,cs3we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3160,7 +2625,7 @@
       ! send south
       if(ibs.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni+1
@@ -3169,7 +2634,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(south)
+        !$acc host_data use_device(south) if(gdirect)
         call mpi_isend(south,cu3sn,MPI_REAL,mysouth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3180,7 +2645,7 @@
       ! send north
       if(ibn.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni+1
@@ -3189,7 +2654,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(north)
+        !$acc host_data use_device(north) if(gdirect)
         call mpi_isend(north,cu3sn,MPI_REAL,mynorth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3201,234 +2666,12 @@
  
       end subroutine comm_3u_start_GPU
 
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
- 
-      subroutine comm_3u_end(u,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
-          ebc,wbc,sbc,nbc,ierr,timestats,time_mpu2,mytime,time_bc, &
-          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
-      use mpi
-      implicit none
- 
-      real u(ib:ie+1,jb:je,kb:ke)
-      real west(cmp,nj,nk),newwest(cmp,nj,nk)
-      real east(cmp,nj,nk),neweast(cmp,nj,nk)
-      real south(ni+1,cmp,nk),newsouth(ni+1,cmp,nk)
-      real north(ni+1,cmp,nk),newnorth(ni+1,cmp,nk)
-      integer reqs(8)
- 
-      integer i,j,k,nn,nr,index
-      integer :: index_east,index_west,index_south,index_north
-      integer, dimension(mpi_status_size,8) :: status1
-
-!----------
-
-      index_east = -1
-      index_west = -1
-      index_south = -1
-      index_north = -1
-
-      nr = 0
-      if(ibe.eq.0)then
-        nr = nr + 1
-        index_east = nr
-      endif
-      if(ibw.eq.0)then
-        nr = nr + 1
-        index_west = nr
-      endif
-      if(ibn.eq.0)then
-        nr = nr + 1
-        index_north = nr
-      endif
-      if(ibs.eq.0)then
-        nr = nr + 1
-        index_south = nr
-      endif
-
-      nn = 1
-      do while( nn .le. nr )
-        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
- 
-      if(index.eq.index_east)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj
-        do i=1,cmp
-          u(ni+1+i,j,k)=neweast(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_west)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj
-        do i=1,cmp
-          u(i-cmp,j,k)=newwest(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_north)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni+1
-          u(i,nj+j,k)=newnorth(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_south)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni+1
-          u(i,j-cmp,k)=newsouth(i,j,k)
-        enddo
-        enddo
-        enddo
-      endif
-
-      enddo
-
-      if(timestats.ge.1) time_mpu2=time_mpu2+mytime()
-
-!----------
-!  patch for corner
- 
-      if( (ebc.eq.2.or.wbc.eq.2).and.(sbc.eq.1.or.nbc.eq.1) )then
- 
-        if(ibw.eq.1)then
- 
-          if(p2tchsww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              u(0,0,k)=u(1,0,k)
-            enddo
-          endif
- 
-          if(p2tchnww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              u(0,nj+1,k)=u(1,nj+1,k)
-            enddo
-          endif
- 
-        endif
- 
-        if(ibe.eq.1)then
- 
-          if(p2tchsee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              u(ni+2,0,k)=u(ni+1,0,k)
-            enddo
-          endif
- 
-          if(p2tchnee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              u(ni+2,nj+1,k)=u(ni+1,nj+1,k)
-            enddo
-          endif
- 
-        endif
- 
-      endif
-
-      if( (ebc.eq.1.or.wbc.eq.1).and.(sbc.eq.2.or.nbc.eq.2) )then
- 
-        if(ibs.eq.1)then
- 
-          if(p2tchsws)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              u(0,0,k)=u(0,1,k)
-            enddo
-          endif
- 
-          if(p2tchses)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              u(ni+2,0,k)=u(ni+2,1,k)
-            enddo
-          endif
- 
-        endif
- 
-        if(ibn.eq.1)then
- 
-          if(p2tchnwn)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              u(0,nj+1,k)=u(0,nj,k)
-            enddo
-          endif
- 
-          if(p2tchnen)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              u(ni+2,nj+1,k)=u(ni+2,nj,k)
-            enddo
-          endif
- 
-        endif
- 
-      endif
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-!----------
-
-      nr = 0
-
-      if(ibw.eq.0)then
-        nr = nr+1
-      endif
-      if(ibe.eq.0)then
-        nr = nr+1
-      endif
-      if(ibn.eq.0)then
-        nr = nr+1
-      endif
-      if(ibs.eq.0)then
-        nr = nr+1
-      endif
-
-    if( nr.ge.1 )then
-      call MPI_WAITALL(nr,reqs(5:5+nr-1),status1(1:mpi_status_size,5:5+nr-1),ierr)
-    endif
-
-      if(timestats.ge.1) time_mpu2=time_mpu2+mytime()
- 
-!----------
- 
-      end subroutine comm_3u_end
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
  
       subroutine comm_3u_end_GPU(u,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
+                      south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
           ebc,wbc,sbc,nbc,ierr,timestats,time_mpu2,mytime,time_bc, &
           p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
@@ -3441,13 +2684,15 @@
       real south(ni+1,cmp,nk),newsouth(ni+1,cmp,nk)
       real north(ni+1,cmp,nk),newnorth(ni+1,cmp,nk)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
  
       integer i,j,k,nn,nr,index
       integer :: index_east,index_west,index_south,index_north
       integer, dimension(mpi_status_size,8) :: status1
-      !$acc declare present(u) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc, gdirect
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !----------
 
@@ -3480,7 +2725,7 @@
  
       if(index.eq.index_east)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -3490,7 +2735,7 @@
         enddo
       elseif(index.eq.index_west)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -3500,7 +2745,7 @@
         enddo
       elseif(index.eq.index_north)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni+1
@@ -3510,7 +2755,7 @@
         enddo
       elseif(index.eq.index_south)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni+1
@@ -3533,7 +2778,7 @@
  
           if(p2tchsww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               u(0,0,k)=u(1,0,k)
             enddo
@@ -3541,7 +2786,7 @@
  
           if(p2tchnww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               u(0,nj+1,k)=u(1,nj+1,k)
             enddo
@@ -3553,7 +2798,7 @@
  
           if(p2tchsee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               u(ni+2,0,k)=u(ni+1,0,k)
             enddo
@@ -3561,7 +2806,7 @@
  
           if(p2tchnee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               u(ni+2,nj+1,k)=u(ni+1,nj+1,k)
             enddo
@@ -3577,7 +2822,7 @@
  
           if(p2tchsws)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               u(0,0,k)=u(0,1,k)
             enddo
@@ -3585,7 +2830,7 @@
  
           if(p2tchses)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               u(ni+2,0,k)=u(ni+2,1,k)
             enddo
@@ -3597,7 +2842,7 @@
  
           if(p2tchnwn)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               u(0,nj+1,k)=u(0,nj,k)
             enddo
@@ -3605,7 +2850,7 @@
  
           if(p2tchnen)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               u(ni+2,nj+1,k)=u(ni+2,nj,k)
             enddo
@@ -3643,168 +2888,12 @@
  
       end subroutine comm_3u_end_GPU
 
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
- 
-      subroutine comm_3v_start(v,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
-          wbc,ebc,sbc,nbc,timestats,mytime,nv,time_mpv1,cv3we,cs3sn,ierr, &
-          myeast,mywest,mysouth,mynorth
-      use mpi
-      implicit none
- 
-      real v(ib:ie,jb:je+1,kb:ke)
-      real west(cmp,nj+1,nk),newwest(cmp,nj+1,nk)
-      real east(cmp,nj+1,nk),neweast(cmp,nj+1,nk)
-      real south(ni,cmp,nk),newsouth(ni,cmp,nk)
-      real north(ni,cmp,nk),newnorth(ni,cmp,nk)
-      integer reqs(8)
- 
-      integer i,j,k,nr
-      integer tag1,tag2,tag3,tag4
- 
-!------------------------------------------------
-
-      nr = 0
-
-      nv=nv+1
-      tag1=2000+nv
-
-      ! receive east
-      if(ibe.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(neweast,cv3we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nv=nv+1
-      tag2=2000+nv
- 
-      ! receive west
-      if(ibw.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newwest,cv3we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nv=nv+1
-      tag3=2000+nv
- 
-      ! receive north
-      if(ibn.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newnorth,cs3sn,MPI_REAL,mynorth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nv=nv+1
-      tag4=2000+nv
- 
-      ! receive south
-      if(ibs.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newsouth,cs3sn,MPI_REAL,mysouth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr = 4
- 
-      ! send west
-      if(ibw.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj+1
-        do i=1,cmp
-          west(i,j,k)=v(i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(west,cv3we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
-
-      if(ibe.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj+1
-        do i=1,cmp
-          east(i,j,k)=v(ni-cmp+i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(east,cv3we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      ! send south
-      if(ibs.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni
-          south(i,j,k)=v(i,j+1,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(south,cs3sn,MPI_REAL,mysouth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
-
-      ! send north
-      if(ibn.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni
-          north(i,j,k)=v(i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(north,cs3sn,MPI_REAL,mynorth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
-
-      if(timestats.ge.1) time_mpv1=time_mpv1+mytime()
- 
-      end subroutine comm_3v_start
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
  
       subroutine comm_3v_start_GPU(v,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
+                      south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,timestats,mytime,nv,time_mpv1,cv3we,cs3sn,ierr, &
           myeast,mywest,mysouth,mynorth
@@ -3817,14 +2906,15 @@
       real south(ni,cmp,nk),newsouth(ni,cmp,nk)
       real north(ni,cmp,nk),newnorth(ni,cmp,nk)
       integer reqs(8)
+      logical, optional, intent(in) :: device, gpudirect
  
       integer i,j,k,nr
       integer tag1,tag2,tag3,tag4
       logical, parameter :: Debug =.FALSE.
-      !$acc declare present(v) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc,gdirect
  
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 !------------------------------------------------
 
       nr = 0
@@ -3834,7 +2924,7 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(neweast)
+        !$acc host_data use_device(neweast) if(gdirect)
         call mpi_irecv(neweast,cv3we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3848,7 +2938,7 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newwest)
+        !$acc host_data use_device(newwest) if(gdirect)
         call mpi_irecv(newwest,cv3we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3862,7 +2952,7 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newnorth)
+        !$acc host_data use_device(newnorth) if(gdirect)
         call mpi_irecv(newnorth,cs3sn,MPI_REAL,mynorth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3876,7 +2966,7 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newsouth)
+        !$acc host_data use_device(newsouth) if(gdirect)
         call mpi_irecv(newsouth,cs3sn,MPI_REAL,mysouth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3891,7 +2981,7 @@
       ! send west
       if(ibw.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj+1
         do i=1,cmp
@@ -3900,7 +2990,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(west)
+        !$acc host_data use_device(west) if(gdirect)
         call mpi_isend(west,cv3we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3910,7 +3000,7 @@
 
       if(ibe.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj+1
         do i=1,cmp
@@ -3919,7 +3009,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(east)
+        !$acc host_data use_device(east) if(gdirect)
         call mpi_isend(east,cv3we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3930,7 +3020,7 @@
       ! send south
       if(ibs.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -3939,7 +3029,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(south)
+        !$acc host_data use_device(south) if(gdirect)
         call mpi_isend(south,cs3sn,MPI_REAL,mysouth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3950,7 +3040,7 @@
       ! send north
       if(ibn.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -3959,7 +3049,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(north)
+        !$acc host_data use_device(north) if(gdirect)
         call mpi_isend(north,cs3sn,MPI_REAL,mynorth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -3975,232 +3065,12 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
-      subroutine comm_3v_end(v,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
-          ebc,wbc,sbc,nbc,ierr,timestats,time_mpv2,mytime,time_bc, &
-          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
-      use mpi
-      implicit none
- 
-      real v(ib:ie,jb:je+1,kb:ke)
-      real west(cmp,nj+1,nk),newwest(cmp,nj+1,nk)
-      real east(cmp,nj+1,nk),neweast(cmp,nj+1,nk)
-      real south(ni,cmp,nk),newsouth(ni,cmp,nk)
-      real north(ni,cmp,nk),newnorth(ni,cmp,nk)
-      integer reqs(8)
- 
-      integer i,j,k,nn,nr,index
-      integer :: index_east,index_west,index_south,index_north
-      integer, dimension(mpi_status_size,8) :: status1
- 
-!--------
-
-      index_east = -1
-      index_west = -1
-      index_south = -1
-      index_north = -1
-
-      nr = 0
-      if(ibe.eq.0)then
-        nr = nr + 1
-        index_east = nr
-      endif
-      if(ibw.eq.0)then
-        nr = nr + 1
-        index_west = nr
-      endif
-      if(ibn.eq.0)then
-        nr = nr + 1
-        index_north = nr
-      endif
-      if(ibs.eq.0)then
-        nr = nr + 1
-        index_south = nr
-      endif
-
-      nn = 1
-      do while( nn .le. nr )
-        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
- 
-      if(index.eq.index_east)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj+1
-        do i=1,cmp
-          v(ni+i,j,k)=neweast(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_west)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,nj+1
-        do i=1,cmp
-          v(i-cmp,j,k)=newwest(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_north)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni
-          v(i,nj+1+j,k)=newnorth(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_south)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=1,nk
-        do j=1,cmp
-        do i=1,ni
-          v(i,j-cmp,k)=newsouth(i,j,k)
-        enddo
-        enddo
-        enddo
-      endif
-
-      enddo
-
-      if(timestats.ge.1) time_mpv2=time_mpv2+mytime()
-
-!----------
-!  patch for corner
- 
-      if( (ebc.eq.2.or.wbc.eq.2).and.(sbc.eq.1.or.nbc.eq.1) )then
- 
-        if(ibw.eq.1)then
- 
-          if(p2tchsww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              v(0,0,k)=v(1,0,k)
-            enddo
-          endif
- 
-          if(p2tchnww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              v(0,nj+2,k)=v(1,nj+2,k)
-            enddo
-          endif
- 
-        endif
- 
-        if(ibe.eq.1)then
- 
-          if(p2tchsee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              v(ni+1,0,k)=v(ni,0,k)
-            enddo
-          endif
- 
-          if(p2tchnee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              v(ni+1,nj+2,k)=v(ni,nj+2,k)
-            enddo
-          endif
- 
-        endif
- 
-      endif
-
-      if( (ebc.eq.1.or.wbc.eq.1).and.(sbc.eq.2.or.nbc.eq.2) )then
- 
-        if(ibs.eq.1)then
- 
-          if(p2tchsws)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              v(0,0,k)=v(0,1,k)
-            enddo
-          endif
- 
-          if(p2tchses)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              v(ni+1,0,k)=v(ni+1,1,k)
-            enddo
-          endif
- 
-        endif
- 
-        if(ibn.eq.1)then
- 
-          if(p2tchnwn)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              v(0,nj+2,k)=v(0,nj+1,k)
-            enddo
-          endif
- 
-          if(p2tchnen)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              v(ni+1,nj+2,k)=v(ni+1,nj+1,k)
-            enddo
-          endif
- 
-        endif
- 
-      endif
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-!--------
-
-      nr = 0
-
-      if(ibw.eq.0)then
-        nr = nr+1
-      endif
-      if(ibe.eq.0)then
-        nr = nr+1
-      endif
-      if(ibn.eq.0)then
-        nr = nr+1
-      endif
-      if(ibs.eq.0)then
-        nr = nr+1
-      endif
-
-    if( nr.ge.1 )then
-      call MPI_WAITALL(nr,reqs(5:5+nr-1),status1(1:mpi_status_size,5:5+nr-1),ierr)
-    endif
-
-      if(timestats.ge.1) time_mpv2=time_mpv2+mytime()
- 
-!----------
- 
-      end subroutine comm_3v_end
-
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
       subroutine comm_3v_end_GPU(v,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
+                      south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
           ebc,wbc,sbc,nbc,ierr,timestats,time_mpv2,mytime,time_bc, &
           p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
@@ -4213,14 +3083,15 @@
       real south(ni,cmp,nk),newsouth(ni,cmp,nk)
       real north(ni,cmp,nk),newnorth(ni,cmp,nk)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
  
       integer i,j,k,nn,nr,index
       integer :: index_east,index_west,index_south,index_north
       integer, dimension(mpi_status_size,8) :: status1
-      !$acc declare present(v) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc, gdirect
  
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 !--------
 
       index_east = -1
@@ -4252,7 +3123,7 @@
  
       if(index.eq.index_east)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj+1
         do i=1,cmp
@@ -4262,7 +3133,7 @@
         enddo
       elseif(index.eq.index_west)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj+1
         do i=1,cmp
@@ -4272,7 +3143,7 @@
         enddo
       elseif(index.eq.index_north)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -4282,7 +3153,7 @@
         enddo
       elseif(index.eq.index_south)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -4305,7 +3176,7 @@
  
           if(p2tchsww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               v(0,0,k)=v(1,0,k)
             enddo
@@ -4313,7 +3184,7 @@
  
           if(p2tchnww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               v(0,nj+2,k)=v(1,nj+2,k)
             enddo
@@ -4325,7 +3196,7 @@
  
           if(p2tchsee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               v(ni+1,0,k)=v(ni,0,k)
             enddo
@@ -4333,7 +3204,7 @@
  
           if(p2tchnee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               v(ni+1,nj+2,k)=v(ni,nj+2,k)
             enddo
@@ -4349,7 +3220,7 @@
  
           if(p2tchsws)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               v(0,0,k)=v(0,1,k)
             enddo
@@ -4357,7 +3228,7 @@
  
           if(p2tchses)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               v(ni+1,0,k)=v(ni+1,1,k)
             enddo
@@ -4369,7 +3240,7 @@
  
           if(p2tchnwn)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               v(0,nj+2,k)=v(0,nj+1,k)
             enddo
@@ -4377,7 +3248,7 @@
  
           if(p2tchnen)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               v(ni+1,nj+2,k)=v(ni+1,nj+1,k)
             enddo
@@ -4416,169 +3287,12 @@
  
       end subroutine comm_3v_end_GPU
 
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
- 
-      subroutine comm_3w_start(w,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
-          ierr,timestats,mytime,nw,time_mpw1,cw3we,cw3sn,mywest,myeast, & 
-          mysouth,mynorth
-      use mpi
-      implicit none
- 
-      real w(ib:ie,jb:je,kb:ke+1)
-      real west(cmp,nj,nk-1),newwest(cmp,nj,nk-1)
-      real east(cmp,nj,nk-1),neweast(cmp,nj,nk-1)
-      real south(ni,cmp,nk-1),newsouth(ni,cmp,nk-1)
-      real north(ni,cmp,nk-1),newnorth(ni,cmp,nk-1)
-      integer reqs(8)
- 
-      integer i,j,k,nr
-      integer tag1,tag2,tag3,tag4
- 
-!------------------------------------------------
-
-      nr = 0
-
-      nw=nw+1
-      tag1=3000+nw
-
-      ! receive east
-      if(ibe.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(neweast,cw3we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nw=nw+1
-      tag2=3000+nw
- 
-      ! receive west
-      if(ibw.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newwest,cw3we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
-
-      nw=nw+1
-      tag3=3000+nw
- 
-      ! receive north
-      if(ibn.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newnorth,cw3sn,MPI_REAL,mynorth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      nw=nw+1
-      tag4=3000+nw
- 
-      ! receive south
-      if(ibs.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newsouth,cw3sn,MPI_REAL,mysouth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr = 4
- 
-      ! send west
-      if(ibw.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=2,nk
-        do j=1,nj
-        do i=1,cmp
-          west(i,j,k-1)=w(i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(west,cw3we,MPI_REAL,mywest,tag1,    &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
-
-      ! send east
-      if(ibe.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=2,nk
-        do j=1,nj
-        do i=1,cmp
-          east(i,j,k-1)=w(ni-cmp+i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(east,cw3we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      ! send south
-      if(ibs.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=2,nk
-        do j=1,cmp
-        do i=1,ni
-          south(i,j,k-1)=w(i,j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(south,cw3sn,MPI_REAL,mysouth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
-
-      ! send north
-      if(ibn.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=2,nk
-        do j=1,cmp
-        do i=1,ni
-          north(i,j,k-1)=w(i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(north,cw3sn,MPI_REAL,mynorth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
-
-      if(timestats.ge.1) time_mpw1=time_mpw1+mytime()
- 
-      end subroutine comm_3w_start
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
  
       subroutine comm_3w_start_GPU(w,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
+                      south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
           ierr,timestats,mytime,nw,time_mpw1,cw3we,cw3sn,mywest,myeast, &
           mysouth,mynorth
@@ -4591,14 +3305,15 @@
       real south(ni,cmp,nk-1),newsouth(ni,cmp,nk-1)
       real north(ni,cmp,nk-1),newnorth(ni,cmp,nk-1)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
  
       integer i,j,k,nr
       integer tag1,tag2,tag3,tag4
       logical, parameter :: Debug =.FALSE.
-      !$acc declare present(w) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc,gdirect
  
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 !------------------------------------------------
 
       nr = 0
@@ -4607,7 +3322,7 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(neweast)
+        !$acc host_data use_device(neweast) if(gdirect)
         call mpi_irecv(neweast,cw3we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4621,7 +3336,7 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newwest)
+        !$acc host_data use_device(newwest) if(gdirect)
         call mpi_irecv(newwest,cw3we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4635,7 +3350,7 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newnorth)
+        !$acc host_data use_device(newnorth) if(gdirect)
         call mpi_irecv(newnorth,cw3sn,MPI_REAL,mynorth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4649,7 +3364,7 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newsouth)
+        !$acc host_data use_device(newsouth) if(gdirect)
         call mpi_irecv(newsouth,cw3sn,MPI_REAL,mysouth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4664,7 +3379,7 @@
       ! send west
       if(ibw.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=2,nk
         do j=1,nj
         do i=1,cmp
@@ -4673,7 +3388,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(west)
+        !$acc host_data use_device(west) if(gdirect)
         call mpi_isend(west,cw3we,MPI_REAL,mywest,tag1,    &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4684,7 +3399,7 @@
       ! send east
       if(ibe.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=2,nk
         do j=1,nj
         do i=1,cmp
@@ -4693,7 +3408,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(east)
+        !$acc host_data use_device(east) if(gdirect)
         call mpi_isend(east,cw3we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4704,7 +3419,7 @@
       ! send south
       if(ibs.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=2,nk
         do j=1,cmp
         do i=1,ni
@@ -4713,7 +3428,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(south)
+        !$acc host_data use_device(south) if(gdirect)
         call mpi_isend(south,cw3sn,MPI_REAL,mysouth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4724,7 +3439,7 @@
       ! send north
       if(ibn.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=2,nk
         do j=1,cmp
         do i=1,ni
@@ -4733,7 +3448,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(north)
+        !$acc host_data use_device(north) if(gdirect)
         call mpi_isend(north,cw3sn,MPI_REAL,mynorth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -4749,229 +3464,8 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
- 
-      subroutine comm_3w_end(w,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
-          wbc,ebc,nbc,sbc,ierr,mytime,timestats,time_mpw2,time_bc, &
-          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
-      use mpi
-      implicit none
- 
-      real w(ib:ie,jb:je,kb:ke+1)
-      real west(cmp,nj,nk-1),newwest(cmp,nj,nk-1)
-      real east(cmp,nj,nk-1),neweast(cmp,nj,nk-1)
-      real south(ni,cmp,nk-1),newsouth(ni,cmp,nk-1)
-      real north(ni,cmp,nk-1),newnorth(ni,cmp,nk-1)
-      integer reqs(8)
- 
-      integer i,j,k,nn,nr,index
-      integer :: index_east,index_west,index_south,index_north
-      integer, dimension(mpi_status_size,8) :: status1
-
-!--------
-
-      index_east = -1
-      index_west = -1
-      index_south = -1
-      index_north = -1
-
-      nr = 0
-      if(ibe.eq.0)then
-        nr = nr + 1
-        index_east = nr
-      endif
-      if(ibw.eq.0)then
-        nr = nr + 1
-        index_west = nr
-      endif
-      if(ibn.eq.0)then
-        nr = nr + 1
-        index_north = nr
-      endif
-      if(ibs.eq.0)then
-        nr = nr + 1
-        index_south = nr
-      endif
-
-      nn = 1
-      do while( nn .le. nr )
-        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
- 
-      if(index.eq.index_east)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=2,nk
-        do j=1,nj
-        do i=1,cmp
-          w(ni+i,j,k)=neweast(i,j,k-1)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_west)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=2,nk
-        do j=1,nj
-        do i=1,cmp
-          w(i-cmp,j,k)=newwest(i,j,k-1)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_north)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=2,nk
-        do j=1,cmp
-        do i=1,ni
-          w(i,nj+j,k)=newnorth(i,j,k-1)
-        enddo
-        enddo
-        enddo
-      elseif(index.eq.index_south)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j,k)
-        do k=2,nk
-        do j=1,cmp
-        do i=1,ni
-          w(i,j-cmp,k)=newsouth(i,j,k-1)
-        enddo
-        enddo
-        enddo
-      endif
-
-      enddo
- 
-      if(timestats.ge.1) time_mpw2=time_mpw2+mytime()
-
-!----------
-!  patch for corner
- 
-      if( (ebc.eq.2.or.wbc.eq.2).and.(sbc.eq.1.or.nbc.eq.1) )then
- 
-        if(ibw.eq.1)then
- 
-          if(p2tchsww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=2,nk
-              w(0,0,k)=w(1,0,k)
-            enddo
-          endif
- 
-          if(p2tchnww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=2,nk
-              w(0,nj+1,k)=w(1,nj+1,k)
-            enddo
-          endif
- 
-        endif
- 
-        if(ibe.eq.1)then
- 
-          if(p2tchsee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=2,nk
-              w(ni+1,0,k)=w(ni,0,k)
-            enddo
-          endif
- 
-          if(p2tchnee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=2,nk
-              w(ni+1,nj+1,k)=w(ni,nj+1,k)
-            enddo
-          endif
- 
-        endif
- 
-      endif
-
-      if( (ebc.eq.1.or.wbc.eq.1).and.(sbc.eq.2.or.nbc.eq.2) )then
- 
-        if(ibs.eq.1)then
- 
-          if(p2tchsws)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=2,nk
-              w(0,0,k)=w(0,1,k)
-            enddo
-          endif
- 
-          if(p2tchses)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=2,nk
-              w(ni+1,0,k)=w(ni+1,1,k)
-            enddo
-          endif
- 
-        endif
- 
-        if(ibn.eq.1)then
- 
-          if(p2tchnwn)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=2,nk
-              w(0,nj+1,k)=w(0,nj,k)
-            enddo
-          endif
- 
-          if(p2tchnen)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=2,nk
-              w(ni+1,nj+1,k)=w(ni+1,nj,k)
-            enddo
-          endif
- 
-        endif
- 
-      endif
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-!--------
-
-      nr = 0
-
-      if(ibw.eq.0)then
-        nr = nr+1
-      endif
-      if(ibe.eq.0)then
-        nr = nr+1
-      endif
-      if(ibn.eq.0)then
-        nr = nr+1
-      endif
-      if(ibs.eq.0)then
-        nr = nr+1
-      endif
-
-    if( nr.ge.1 )then
-      call MPI_WAITALL(nr,reqs(5:5+nr-1),status1(1:mpi_status_size,5:5+nr-1),ierr)
-    endif
-
-      if(timestats.ge.1) time_mpw2=time_mpw2+mytime()
- 
-!----------
- 
-      end subroutine comm_3w_end
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
- 
       subroutine comm_3w_end_GPU(w,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
+                         south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
           wbc,ebc,nbc,sbc,ierr,mytime,timestats,time_mpw2,time_bc, &
           p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
@@ -4984,14 +3478,15 @@
       real south(ni,cmp,nk-1),newsouth(ni,cmp,nk-1)
       real north(ni,cmp,nk-1),newnorth(ni,cmp,nk-1)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
  
       integer i,j,k,nn,nr,index
       integer :: index_east,index_west,index_south,index_north
       integer, dimension(mpi_status_size,8) :: status1
-      !$acc declare present(w) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc,gdirect
 
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 !--------
 
       index_east = -1
@@ -5023,7 +3518,7 @@
  
       if(index.eq.index_east)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=2,nk
         do j=1,nj
         do i=1,cmp
@@ -5033,7 +3528,7 @@
         enddo
       elseif(index.eq.index_west)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=2,nk
         do j=1,nj
         do i=1,cmp
@@ -5043,7 +3538,7 @@
         enddo
       elseif(index.eq.index_north)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=2,nk
         do j=1,cmp
         do i=1,ni
@@ -5053,7 +3548,7 @@
         enddo
       elseif(index.eq.index_south)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=2,nk
         do j=1,cmp
         do i=1,ni
@@ -5076,16 +3571,15 @@
  
           if(p2tchsww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=2,nk
               w(0,0,k)=w(1,0,k)
             enddo
           endif
  
           if(p2tchnww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=2,nk
               w(0,nj+1,k)=w(1,nj+1,k)
             enddo
@@ -5096,18 +3590,16 @@
         if(ibe.eq.1)then
  
           if(p2tchsee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=2,nk
               w(ni+1,0,k)=w(ni,0,k)
             enddo
           endif
  
           if(p2tchnee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$omp parallel do default(shared) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=2,nk
               w(ni+1,nj+1,k)=w(ni,nj+1,k)
             enddo
@@ -5123,7 +3615,7 @@
  
           if(p2tchsws)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=2,nk
               w(0,0,k)=w(0,1,k)
             enddo
@@ -5131,7 +3623,7 @@
  
           if(p2tchses)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=2,nk
               w(ni+1,0,k)=w(ni+1,1,k)
             enddo
@@ -5143,7 +3635,7 @@
  
           if(p2tchnwn)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=2,nk
               w(0,nj+1,k)=w(0,nj,k)
             enddo
@@ -5151,7 +3643,7 @@
  
           if(p2tchnen)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=2,nk
               w(ni+1,nj+1,k)=w(ni+1,nj,k)
             enddo
@@ -5526,156 +4018,12 @@
 
       end subroutine comm_1s2d_end_GPU
 
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-      subroutine comm_1s_start(s,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
-          wbc,ebc,sbc,nbc,nf,cs1we,cs1sn,ierr,timestats,time_mps1,mytime, & 
-          myeast,mywest,mysouth,mynorth
-      use mpi
-      implicit none
- 
-      real s(ib:ie,jb:je,kb:ke)
-      real west(nj,nk),newwest(nj,nk)
-      real east(nj,nk),neweast(nj,nk)
-      real south(ni,nk),newsouth(ni,nk)
-      real north(ni,nk),newnorth(ni,nk)
-      integer reqs(8)
- 
-      integer i,j,k,nr
-      integer tag1,tag2,tag3,tag4
- 
-!------------------------------------------------
-
-      nr = 0
-
-      nf=nf+1
-      tag1=nf
-
-      ! receive east
-      if(ibe.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(neweast,cs1we,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag2=nf
-
-      ! receive west
-      if(ibw.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newwest,cs1we,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag3=nf
-
-      ! receive south
-      if(ibs.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newsouth,cs1sn,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag4=nf
-
-      ! receive north
-      if(ibn.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newnorth,cs1sn,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr = 4
- 
-      ! send west
-      if(ibw.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-        do k=1,nk
-        do j=1,nj
-          west(j,k)=s(1,j,k)
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(west,cs1we,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      ! send east
-      if(ibe.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-        do k=1,nk
-        do j=1,nj
-          east(j,k)=s(ni,j,k)
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(east,cs1we,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      ! send north
-      if(ibn.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-        do k=1,nk
-        do i=1,ni
-          north(i,k)=s(i,nj,k)
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(north,cs1sn,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      ! send south
-      if(ibs.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-        do k=1,nk
-        do i=1,ni
-          south(i,k)=s(i,1,k)
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(south,cs1sn,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
- 
-      if(timestats.ge.1) time_mps1=time_mps1+mytime()
- 
-      end subroutine comm_1s_start
-
 
       subroutine comm_1s_start_GPU(s,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
+                         south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,nf,cs1we,cs1sn,ierr,timestats,time_mps1,mytime, & 
           myeast,mywest,mysouth,mynorth
@@ -5688,14 +4036,16 @@
       real south(ni,nk),newsouth(ni,nk)
       real north(ni,nk),newnorth(ni,nk)
       integer reqs(8)
-      !$acc declare present(s) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
- 
+      logical, optional, intent(in) :: device,gpudirect
+
       integer i,j,k,nr
       integer tag1,tag2,tag3,tag4
       logical, parameter :: Debug =.FALSE.
+      logical :: openacc, gdirect
  
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
+
 !------------------------------------------------
 
       nr = 0
@@ -5704,7 +4054,7 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(neweast)
+        !$acc host_data use_device(neweast) if(gdirect)
         call mpi_irecv(neweast,cs1we,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5718,7 +4068,7 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newwest)
+        !$acc host_data use_device(newwest) if(gdirect)
         call mpi_irecv(newwest,cs1we,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5732,7 +4082,7 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newsouth)
+        !$acc host_data use_device(newsouth) if(gdirect)
         call mpi_irecv(newsouth,cs1sn,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5746,7 +4096,7 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newnorth)
+        !$acc host_data use_device(newnorth) if(gdirect)
         call mpi_irecv(newnorth,cs1sn,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5761,14 +4111,14 @@
       ! send west
       if(ibw.eq.0)then
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nk
         do j=1,nj
           west(j,k)=s(1,j,k)
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(west)
+        !$acc host_data use_device(west) if(gdirect)
         call mpi_isend(west,cs1we,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5779,14 +4129,14 @@
       ! send east
       if(ibe.eq.0)then
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nk
         do j=1,nj
           east(j,k)=s(ni,j,k)
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(east)
+        !$acc host_data use_device(east) if(gdirect)
         call mpi_isend(east,cs1we,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5797,14 +4147,14 @@
       ! send north
       if(ibn.eq.0)then
         !$omp parallel do default(shared) private(i,k)
-        !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nk
         do i=1,ni
           north(i,k)=s(i,nj,k)
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(north)
+        !$acc host_data use_device(north) if(gdirect)
         call mpi_isend(north,cs1sn,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5815,14 +4165,14 @@
       ! send south
       if(ibs.eq.0)then
         !$omp parallel do default(shared) private(i,k)
-        !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nk
         do i=1,ni
           south(i,k)=s(i,1,k)
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(south)
+        !$acc host_data use_device(south) if(gdirect)
         call mpi_isend(south,cs1sn,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5835,226 +4185,12 @@
  
       end subroutine comm_1s_start_GPU
 
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
- 
-      subroutine comm_1s_end(s,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
-          ebc,wbc,sbc,nbc,timestats,mytime,ierr,time_bc,time_mps2, &
-          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
-      use mpi
-      implicit none
- 
-      real s(ib:ie,jb:je,kb:ke)
-      real west(nj,nk),newwest(nj,nk)
-      real east(nj,nk),neweast(nj,nk)
-      real south(ni,nk),newsouth(ni,nk)
-      real north(ni,nk),newnorth(ni,nk)
-      integer reqs(8)
- 
-      integer i,j,k,nn,nr,index
-      integer :: index_east,index_west,index_south,index_north
-      integer, dimension(mpi_status_size,8) :: status1
-
-!---------------------------------------------------------------------
-
-      index_east = -1
-      index_west = -1
-      index_south = -1
-      index_north = -1
-
-      nr = 0
-      if(ibe.eq.0)then
-        nr = nr + 1
-        index_east = nr
-      endif
-      if(ibw.eq.0)then
-        nr = nr + 1
-        index_west = nr
-      endif
-      if(ibs.eq.0)then
-        nr = nr + 1
-        index_south = nr
-      endif
-      if(ibn.eq.0)then
-        nr = nr + 1
-        index_north = nr
-      endif
-
-      nn = 1
-      do while( nn .le. nr )
-        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
- 
-      if(index.eq.index_east)then
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-        do k=1,nk
-        do j=1,nj
-          s(ni+1,j,k)=neweast(j,k)
-        enddo
-        enddo
-      elseif(index.eq.index_west)then
-!$omp parallel do default(shared)   &
-!$omp private(j,k)
-        do k=1,nk
-        do j=1,nj
-          s(0,j,k)=newwest(j,k)
-        enddo
-        enddo
-      elseif(index.eq.index_south)then
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-        do k=1,nk
-        do i=1,ni
-          s(i,0,k)=newsouth(i,k)
-        enddo
-        enddo
-      elseif(index.eq.index_north)then
-!$omp parallel do default(shared)   &
-!$omp private(i,k)
-        do k=1,nk
-        do i=1,ni
-          s(i,nj+1,k)=newnorth(i,k)
-        enddo
-        enddo
-      endif
-
-      enddo
-
-      if(timestats.ge.1) time_mps2=time_mps2+mytime()
-
-!----------
-!  patch for corner
- 
-      if( (ebc.eq.2.or.wbc.eq.2).and.(sbc.eq.1.or.nbc.eq.1) )then
- 
-        if(ibw.eq.1)then
- 
-          if(p2tchsww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(0,0,k)=s(1,0,k)
-            enddo
-          endif
- 
-          if(p2tchnww)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(0,nj+1,k)=s(1,nj+1,k)
-            enddo
-          endif
- 
-        endif
- 
-        if(ibe.eq.1)then
- 
-          if(p2tchsee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(ni+1,0,k)=s(ni,0,k)
-            enddo
-          endif
- 
-          if(p2tchnee)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(ni+1,nj+1,k)=s(ni,nj+1,k)
-            enddo
-          endif
- 
-        endif
- 
-      endif
-
-      if( (ebc.eq.1.or.wbc.eq.1).and.(sbc.eq.2.or.nbc.eq.2) )then
- 
-        if(ibs.eq.1)then
- 
-          if(p2tchsws)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(0,0,k)=s(0,1,k)
-            enddo
-          endif
- 
-          if(p2tchses)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(ni+1,0,k)=s(ni+1,1,k)
-            enddo
-          endif
- 
-        endif
- 
-        if(ibn.eq.1)then
- 
-          if(p2tchnwn)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(0,nj+1,k)=s(0,nj,k)
-            enddo
-          endif
- 
-          if(p2tchnen)then
-!$omp parallel do default(shared)   &
-!$omp private(k)
-            do k=1,nk
-              s(ni+1,nj+1,k)=s(ni+1,nj,k)
-            enddo
-          endif
- 
-        endif
- 
-      endif
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-!----------
-
-      nr = 0
-
-      if(ibw.eq.0)then
-        nr = nr+1
-      endif
-      if(ibe.eq.0)then
-        nr = nr+1
-      endif
-      if(ibn.eq.0)then
-        nr = nr+1
-      endif
-      if(ibs.eq.0)then
-        nr = nr+1
-      endif
-
-    if( nr.ge.1 )then
-      call MPI_WAITALL(nr,reqs(5:5+nr-1),status1(1:mpi_status_size,5:5+nr-1),ierr)
-    endif
-
-      if(timestats.ge.1) time_mps2=time_mps2+mytime()
- 
-!----------
- 
-      end subroutine comm_1s_end
-
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       subroutine comm_1s_end_GPU(s,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
+                      south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
           ebc,wbc,sbc,nbc,timestats,mytime,ierr,time_bc,time_mps2, &
           p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
@@ -6067,14 +4203,16 @@
       real south(ni,nk),newsouth(ni,nk)
       real north(ni,nk),newnorth(ni,nk)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
  
       integer i,j,k,nn,nr,index
       integer :: index_east,index_west,index_south,index_north
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug=.False.
-      !$acc declare present(s) &
-      !$acc present(west,newwest,east,neweast) &
-      !$acc present(south,newsouth,north,newnorth)
+      logical :: openacc, gdirect
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !---------------------------------------------------------------------
 ! SM: GPU Direct back in
@@ -6108,7 +4246,7 @@
  
       if(index.eq.index_east)then
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nk
         do j=1,nj
           s(ni+1,j,k)=neweast(j,k)
@@ -6116,7 +4254,7 @@
         enddo
       elseif(index.eq.index_west)then
         !$omp parallel do default(shared) private(j,k)
-        !$acc parallel loop gang vector default(present) collapse(2) private(j,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nk
         do j=1,nj
           s(0,j,k)=newwest(j,k)
@@ -6124,7 +4262,7 @@
         enddo
       elseif(index.eq.index_south)then
         !$omp parallel do default(shared) private(i,k)
-        !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nk
         do i=1,ni
           s(i,0,k)=newsouth(i,k)
@@ -6132,7 +4270,7 @@
         enddo
       elseif(index.eq.index_north)then
         !$omp parallel do default(shared) private(i,k)
-        !$acc parallel loop gang vector default(present) collapse(2) private(i,k)
+        !$acc parallel loop gang vector default(present) collapse(2) if(openacc)
         do k=1,nk
         do i=1,ni
           s(i,nj+1,k)=newnorth(i,k)
@@ -6153,7 +4291,7 @@
  
           if(p2tchsww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(0,0,k)=s(1,0,k)
             enddo
@@ -6161,7 +4299,7 @@
  
           if(p2tchnww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(0,nj+1,k)=s(1,nj+1,k)
             enddo
@@ -6173,7 +4311,7 @@
  
           if(p2tchsee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(ni+1,0,k)=s(ni,0,k)
             enddo
@@ -6181,7 +4319,7 @@
  
           if(p2tchnee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(ni+1,nj+1,k)=s(ni,nj+1,k)
             enddo
@@ -6197,7 +4335,7 @@
  
           if(p2tchsws)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(0,0,k)=s(0,1,k)
             enddo
@@ -6205,7 +4343,7 @@
  
           if(p2tchses)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(ni+1,0,k)=s(ni+1,1,k)
             enddo
@@ -6217,7 +4355,7 @@
  
           if(p2tchnwn)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(0,nj+1,k)=s(0,nj,k)
             enddo
@@ -6225,7 +4363,7 @@
  
           if(p2tchnen)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(ni+1,nj+1,k)=s(ni+1,nj,k)
             enddo

--- a/src/comm.F
+++ b/src/comm.F
@@ -27,7 +27,6 @@
   public :: getcorner3_2d_GPU
 
   !CPU only routines
-  public :: comm_2d_start, comm_2dns_end,comm_2dew_end
   public :: comm_1s_start,comm_1s_end
   public :: comm_3t_start,comm_3t_end
   public :: comm_3u_start,comm_3u_end
@@ -1788,7 +1787,7 @@
       ! send west
       if(ibw.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -1810,7 +1809,7 @@
       ! send east
       if(ibe.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -1832,7 +1831,7 @@
       ! send north
       if(ibn.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -1854,7 +1853,7 @@
       ! send south
       if(ibs.eq.0)then
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -1939,7 +1938,7 @@
       if(index.eq.index_east)then
         !$acc update device(neweast) if(openacc .and. (.not. gdirect))
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -1950,7 +1949,7 @@
       elseif(index.eq.index_west)then
         !$acc update device(newwest) if(openacc .and. (.not. gdirect))
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,nj
         do i=1,cmp
@@ -1961,7 +1960,7 @@
       elseif(index.eq.index_south)then
         !$acc update device(newsouth) if(openacc .and. (.not. gdirect))
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -1972,7 +1971,7 @@
       elseif(index.eq.index_north)then
         !$acc update device(newnorth) if(openacc .and. (.not. gdirect))
         !$omp parallel do default(shared) private(i,j,k)
-        !$acc parallel loop gang vector default(present) collapse(3) private(i,j,k) if(openacc)
+        !$acc parallel loop gang vector default(present) collapse(3) if(openacc)
         do k=1,nk
         do j=1,cmp
         do i=1,ni
@@ -1995,7 +1994,7 @@
 
           if(p2tchsww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k) if(openacc)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(0,0,k)=s(1,0,k)
             enddo
@@ -2003,7 +2002,7 @@
 
           if(p2tchnww)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k) if(openacc)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(0,nj+1,k)=s(1,nj+1,k)
             enddo
@@ -2015,7 +2014,7 @@
  
           if(p2tchsee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k) if(openacc)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(ni+1,0,k)=s(ni,0,k)
             enddo
@@ -2023,7 +2022,7 @@
  
           if(p2tchnee)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k) if(openacc)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(ni+1,nj+1,k)=s(ni,nj+1,k)
             enddo
@@ -2039,7 +2038,7 @@
  
           if(p2tchsws)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k) if(openacc)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(0,0,k)=s(0,1,k)
             enddo
@@ -2047,7 +2046,7 @@
  
           if(p2tchses)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k) if(openacc)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(ni+1,0,k)=s(ni+1,1,k)
             enddo
@@ -2059,7 +2058,7 @@
  
           if(p2tchnwn)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k) if(openacc)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(0,nj+1,k)=s(0,nj,k)
             enddo
@@ -2067,7 +2066,7 @@
  
           if(p2tchnen)then
             !$omp parallel do default(shared) private(k)
-            !$acc parallel loop gang vector default(present) private(k) if(openacc)
+            !$acc parallel loop gang vector default(present) if(openacc)
             do k=1,nk
               s(ni+1,nj+1,k)=s(ni+1,nj,k)
             enddo
@@ -7648,158 +7647,12 @@
 
       end subroutine comm_1w_end_GPU
 
-
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine comm_2d_start(s,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
-          nf,ierr,timestats,time_mpq1,mytime,myeast,mywest,mysouth,mynorth
-      use mpi
-      implicit none
-
-      real, dimension(ib:ie,jb:je) :: s
-      real, dimension(cmp,nj) :: west,newwest,east,neweast
-      real, dimension(ni,cmp) :: south,newsouth,north,newnorth
-      integer reqs(8)
-
-      integer i,j,nr
-      integer tag1,tag2,tag3,tag4
-
-!------------------------------------------------
-
-      nr = 0
-
-      nf=nf+1
-      tag1=nf
-
-      ! receive east
-      if(ibe.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(neweast,cmp*nj,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag2=nf
-
-      ! receive west
-      if(ibw.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newwest,cmp*nj,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag3=nf
-
-      ! receive south
-      if(ibs.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newsouth,ni*cmp,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag4=nf
-
-      ! receive north
-      if(ibn.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newnorth,ni*cmp,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr = 4
-
-      ! send west
-      if(ibw.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j)
-        do j=1,nj
-        do i=1,cmp
-          west(i,j)=s(i,j)
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(west,cmp*nj,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      ! send east
-      if(ibe.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j)
-        do j=1,nj
-        do i=1,cmp
-          east(i,j)=s(ni-cmp+i,j)
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(east,cmp*nj,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      ! send north
-      if(ibn.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j)
-        do j=1,cmp
-        do i=1,ni
-          north(i,j)=s(i,nj-cmp+j)
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(north,ni*cmp,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      ! send south
-      if(ibs.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j)
-        do j=1,cmp
-        do i=1,ni
-          south(i,j)=s(i,j)
-        enddo
-        enddo
-        nr = nr + 1
-        call mpi_isend(south,ni*cmp,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      if(timestats.ge.1) time_mpq1=time_mpq1+mytime()
-
-      end subroutine comm_2d_start
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
 
       subroutine comm_2d_start_GPU(s,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
+                 south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
           nf,ierr,timestats,time_mpq1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
@@ -7809,10 +7662,15 @@
       real, dimension(cmp,nj) :: west,newwest,east,neweast
       real, dimension(ni,cmp) :: south,newsouth,north,newnorth
       integer reqs(8)
+      logical, optional, intent(in)  :: device,gpudirect
 
       integer i,j,nr
       integer tag1,tag2,tag3,tag4
       logical, parameter :: Debug = .FALSE.
+      logical :: openacc, gdirect
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !------------------------------------------------
       nr = 0
@@ -7824,7 +7682,7 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(neweast)
+        !$acc host_data use_device(neweast) if(gdirect)
         call mpi_irecv(neweast,cmp*nj,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -7838,7 +7696,7 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newwest)
+        !$acc host_data use_device(newwest) if(gdirect)
         call mpi_irecv(newwest,cmp*nj,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -7852,7 +7710,7 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newsouth)
+        !$acc host_data use_device(newsouth) if(gdirect)
         call mpi_irecv(newsouth,ni*cmp,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -7866,7 +7724,7 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newnorth)
+        !$acc host_data use_device(newnorth) if(gdirect)
         call mpi_irecv(newnorth,ni*cmp,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -7880,7 +7738,7 @@
 
       ! send west
       if(ibw.eq.0)then
-        !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         !$omp parallel do default(shared) private(i,j)
         do j=1,nj
         do i=1,cmp
@@ -7888,7 +7746,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(west)
+        !$acc host_data use_device(west) if(gdirect)
         call mpi_isend(west,cmp*nj,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -7898,7 +7756,7 @@
 
       ! send east
       if(ibe.eq.0)then
-        !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         !$omp parallel do default(shared) private(i,j)
         do j=1,nj
         do i=1,cmp
@@ -7906,7 +7764,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(east)
+        !$acc host_data use_device(east) if(gdirect)
         call mpi_isend(east,cmp*nj,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -7916,7 +7774,7 @@
 
       ! send north
       if(ibn.eq.0)then
-        !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         !$omp parallel do default(shared) private(i,j)
         do j=1,cmp
         do i=1,ni
@@ -7924,7 +7782,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(north)
+        !$acc host_data use_device(north) if(gdirect)
         call mpi_isend(north,ni*cmp,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -7934,7 +7792,7 @@
 
       ! send south
       if(ibs.eq.0)then
-        !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         !$omp parallel do default(shared) private(i,j)
         do j=1,cmp
         do i=1,ni
@@ -7942,7 +7800,7 @@
         enddo
         enddo
         nr = nr + 1
-        !$acc host_data use_device(south)
+        !$acc host_data use_device(south) if(gdirect)
         call mpi_isend(south,ni*cmp,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -7953,14 +7811,11 @@
       if(timestats.ge.1) time_mpq1=time_mpq1+mytime()
       end subroutine comm_2d_start_GPU
 
-
-
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-
-      subroutine comm_2dew_end(s,west,newwest,east,neweast,reqs)
+      subroutine comm_2dew_end_GPU(s,west,newwest,east,neweast,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ierr, &
           timestats,time_mpq2,mytime
       use mpi
@@ -7968,69 +7823,14 @@
 
       real, dimension(ib:ie,jb:je) :: s
       real, dimension(cmp,nj) :: west,newwest,east,neweast
-      integer reqs(8)
-
-      integer i,j,nn,nr,index
-
-!-------------------------------------------------------------------
-
-      nr = 0
-      if(ibe.eq.0)then
-        nr = nr + 1
-      endif
-      if(ibw.eq.0)then
-        nr = nr + 1
-      endif
-
-      nn = 1
-      do while( nn .le. nr )
-        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
-      enddo
-
-      if(ibe.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j)
-        do j=1,nj
-        do i=1,cmp
-          s(ni+i,j)=neweast(i,j)
-        enddo
-        enddo
-      endif
-
-      if(ibw.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j)
-        do j=1,nj
-        do i=1,cmp
-          s(i-cmp,j)=newwest(i,j)
-        enddo
-        enddo
-      endif
-
-!----------
-
-      if(timestats.ge.1) time_mpq2=time_mpq2+mytime()
-
-      end subroutine comm_2dew_end
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine comm_2dew_end_GPU(s,west,newwest,east,neweast,reqs)
-      use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ierr, &
-          timestats,time_mpq2,mytime
-      use mpi
-      implicit none
-
-      real, dimension(ib:ie,jb:je) :: s
-      real, dimension(cmp,nj) :: west,newwest,east,neweast
+      logical, optional, intent(in) :: device,gpudirect
       integer reqs(8)
       logical, parameter :: Debug = .FALSE.
       integer i,j,nn,nr,index
+      logical :: openacc, gdirect
 
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 !-------------------------------------------------------------------
 
       nr = 0
@@ -8043,14 +7843,13 @@
 
       nn = 1
 
-      !!$acc update host(s)
       do while( nn .le. nr )
         call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
         nn = nn + 1
       enddo
 
       if(ibe.eq.0)then
-        !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         !$omp parallel do default(shared) private(i,j)
         do j=1,nj
         do i=1,cmp
@@ -8060,7 +7859,7 @@
       endif
 
       if(ibw.eq.0)then
-        !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         !$omp parallel do default(shared) private(i,j)
         do j=1,nj
         do i=1,cmp
@@ -8072,17 +7871,13 @@
 !----------
 
       if(timestats.ge.1) time_mpq2=time_mpq2+mytime()
-      !!$acc update device(s)
       end subroutine comm_2dew_end_GPU
 
-
-
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-
-      subroutine comm_2dns_end(s,south,newsouth,north,newnorth,reqs)
+      subroutine comm_2dns_end_GPU(s,south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,ierr,timestats,time_mpq2,mytime
       use mpi
@@ -8091,104 +7886,16 @@
       real, dimension(ib:ie,jb:je) :: s
       real, dimension(ni,cmp) :: south,newsouth,north,newnorth
       integer reqs(8)
-
-      integer i,j,nn,nr1,nr,index
-      integer, dimension(mpi_status_size,8) :: status1
-
-!-------------------------------------------------------------------
-
-      nr1 = 0
-      if(ibe.eq.0)then
-        nr1 = nr1 + 1
-      endif
-      if(ibw.eq.0)then
-        nr1 = nr1 + 1
-      endif
-
-      nr = 0
-      if(ibs.eq.0)then
-        nr = nr + 1
-      endif
-      if(ibn.eq.0)then
-        nr = nr + 1
-      endif
-
-      nn = 1
-      do while( nn .le. nr )
-        call MPI_WAITANY(nr,reqs(nr1+1:nr1+nr),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
-      enddo
-
-      if(ibs.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j)
-        do j=1,cmp
-        do i=1,ni
-          s(i,j-cmp)=newsouth(i,j)
-        enddo
-        enddo
-      endif
-
-      if(ibn.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i,j)
-        do j=1,cmp
-        do i=1,ni
-          s(i,nj+j)=newnorth(i,j)
-        enddo
-        enddo
-      endif
-
-!----------
-
-      nr = 0
-
-      if(ibw.eq.0)then
-        nr = nr+1
-      endif
-
-      if(ibe.eq.0)then
-        nr = nr+1
-      endif
-
-      if(ibn.eq.0)then
-        nr = nr+1
-      endif
-
-      if(ibs.eq.0)then
-        nr = nr+1
-      endif
-
-    if( nr.ge.1 )then
-      call MPI_WAITALL(nr,reqs(5:5+nr-1),status1(1:mpi_status_size,5:5+nr-1),ierr)
-    endif
-
-!----------
-
-      if(timestats.ge.1) time_mpq2=time_mpq2+mytime()
-
-      end subroutine comm_2dns_end
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine comm_2dns_end_GPU(s,south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn, &
-          wbc,ebc,sbc,nbc,ierr,timestats,time_mpq2,mytime
-      use mpi
-      implicit none
-
-      real, dimension(ib:ie,jb:je) :: s
-      real, dimension(ni,cmp) :: south,newsouth,north,newnorth
-      integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
 
       integer i,j,nn,nr1,nr,index
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug = .FALSE.
+      logical :: openacc,gdirect
 
 !-------------------------------------------------------------------
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
       nr1 = 0
       if(ibe.eq.0)then
@@ -8206,7 +7913,6 @@
         nr = nr + 1
       endif
 
-      !!$acc update host(s)
       nn = 1
       do while( nn .le. nr )
         call MPI_WAITANY(nr,reqs(nr1+1:nr1+nr),index,MPI_STATUS_IGNORE,ierr)
@@ -8214,7 +7920,7 @@
       enddo
 
       if(ibs.eq.0)then
-        !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         !$omp parallel do default(shared) private(i,j)
         do j=1,cmp
         do i=1,ni
@@ -8224,7 +7930,7 @@
       endif
 
       if(ibn.eq.0)then
-        !$acc parallel loop gang vector collapse(2) default(present) private(i,j)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         !$omp parallel do default(shared) private(i,j)
         do j=1,cmp
         do i=1,ni
@@ -8260,7 +7966,6 @@
 !----------
 
       if(timestats.ge.1) time_mpq2=time_mpq2+mytime()
-!      !$acc update device(s)
       end subroutine comm_2dns_end_GPU
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -8673,16 +8378,12 @@
         call bcs(s)
       ENDIF
 #ifdef MPI
-      if(Debug) print *,'prepcorners_GPU point #1'
       IF( comm.eq.1 )THEN
         call comm_1s_start_GPU(s,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
         call comm_1s_end_GPU(  s,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
       ENDIF
-      if(Debug) print *,'prepcorners_GPU point #2'
       call getcorner_GPU(s,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-      if(Debug) print *,'prepcorners_GPU point #3'
       call bcs2(s)
-      if(Debug) print *,'prepcorners_GPU point #4'
 #endif
 
       IF( bbc.eq.1 .or. bbc.eq.2 .or. bbc.eq.3 )THEN

--- a/src/comm.F
+++ b/src/comm.F
@@ -32,7 +32,6 @@
   public :: comm_3u_start,comm_3u_end
   public :: comm_3v_start,comm_3v_end
   public :: comm_3w_start,comm_3w_end
-  public :: comm_1s2d_start,comm_1s2d_end
 
   public :: sync
 
@@ -5190,153 +5189,12 @@
  
       end subroutine comm_3w_end_GPU
 
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine comm_1s2d_start(s,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
-          nf,ierr,timestats,time_mps1,mytime,myeast,mywest,mysouth,mynorth
-      use mpi
-      implicit none
- 
-      real s(ib:ie,jb:je)
-      real west(nj),newwest(nj)
-      real east(nj),neweast(nj)
-      real south(ni),newsouth(ni)
-      real north(ni),newnorth(ni)
-      integer reqs(8)
- 
-      integer i,j,nr
-      integer tag1,tag2,tag3,tag4
- 
-!------------------------------------------------
-
-      nr = 0
-
-      nf=nf+1
-      tag1=nf
-
-      ! receive east
-      if(ibe.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(neweast,nj,MPI_REAL,myeast,tag1,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag2=nf
-
-      ! receive west
-      if(ibw.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newwest,nj,MPI_REAL,mywest,tag2,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag3=nf
-
-      ! receive south
-      if(ibs.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newsouth,ni,MPI_REAL,mysouth,tag3,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
-
-      nf=nf+1
-      tag4=nf
-
-      ! receive north
-      if(ibn.eq.0)then
-        nr = nr + 1
-        call mpi_irecv(newnorth,ni,MPI_REAL,mynorth,tag4,   &
-                      MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr = 4
- 
-      ! send west
-      if(ibw.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(j)
-        do j=1,nj
-          west(j)=s(1,j)
-        enddo
-        nr = nr + 1
-        call mpi_isend(west,nj,MPI_REAL,mywest,tag1,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      ! send east
-      if(ibe.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(j)
-        do j=1,nj
-          east(j)=s(ni,j)
-        enddo
-        nr = nr + 1
-        call mpi_isend(east,nj,MPI_REAL,myeast,tag2,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      ! send north
-      if(ibn.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i)
-        do i=1,ni
-          north(i)=s(i,nj)
-        enddo
-        nr = nr + 1
-        call mpi_isend(north,ni,MPI_REAL,mynorth,tag3,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
- 
-!----------
- 
-      ! send south
-      if(ibs.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i)
-        do i=1,ni
-          south(i)=s(i,1)
-        enddo
-        nr = nr + 1
-        call mpi_isend(south,ni,MPI_REAL,mysouth,tag4,   &
-                       MPI_COMM_WORLD,reqs(nr),ierr)
-      endif
-
-!----------
- 
-      if(timestats.ge.1) time_mps1=time_mps1+mytime()
- 
-      end subroutine comm_1s2d_start
-
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
 
       subroutine comm_1s2d_start_GPU(s,west,newwest,east,neweast,   &
-                                 south,newsouth,north,newnorth,reqs)
+                          south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
           nf,ierr,timestats,time_mps1,mytime,myeast,mywest,mysouth,mynorth
       use mpi
@@ -5348,11 +5206,16 @@
       real south(ni),newsouth(ni)
       real north(ni),newnorth(ni)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
 
       integer i,j,nr
       integer tag1,tag2,tag3,tag4
       logical, parameter :: Debug =.FALSE.
+      logical :: openacc, gdirect
 
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 !------------------------------------------------
 
       nr = 0
@@ -5361,7 +5224,7 @@
       ! receive east
       if(ibe.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(neweast)
+        !$acc host_data use_device(neweast) if(gdirect)
         call mpi_irecv(neweast,nj,MPI_REAL,myeast,tag1,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5375,7 +5238,7 @@
       ! receive west
       if(ibw.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newwest)
+        !$acc host_data use_device(newwest) if(gdirect)
         call mpi_irecv(newwest,nj,MPI_REAL,mywest,tag2,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5389,7 +5252,7 @@
       ! receive south
       if(ibs.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newsouth)
+        !$acc host_data use_device(newsouth) if(gdirect)
         call mpi_irecv(newsouth,ni,MPI_REAL,mysouth,tag3,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5403,7 +5266,7 @@
       ! receive north
       if(ibn.eq.0)then
         nr = nr + 1
-        !$acc host_data use_device(newnorth)
+        !$acc host_data use_device(newnorth) if(gdirect)
         call mpi_irecv(newnorth,ni,MPI_REAL,mynorth,tag4,   &
                       MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5418,12 +5281,12 @@
       ! send west
       if(ibw.eq.0)then
         !$omp parallel do default(shared) private(j)
-        !$acc parallel loop gang vector default(present) 
+        !$acc parallel loop gang vector default(present) if(openacc) 
         do j=1,nj
           west(j)=s(1,j)
         enddo
         nr = nr + 1
-        !$acc host_data use_device(west)
+        !$acc host_data use_device(west) if(gdirect)
         call mpi_isend(west,nj,MPI_REAL,mywest,tag1,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5433,14 +5296,13 @@
 
       ! send east
       if(ibe.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(j)
-        !$acc parallel loop gang vector default(present)
+        !$omp parallel do default(shared) private(j)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do j=1,nj
           east(j)=s(ni,j)
         enddo
         nr = nr + 1
-        !$acc host_data use_device(east)
+        !$acc host_data use_device(east) if(gdirect)
         call mpi_isend(east,nj,MPI_REAL,myeast,tag2,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5450,14 +5312,13 @@
 
       ! send north
       if(ibn.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i)
-        !$acc parallel loop gang vector default(present)
+        !$omp parallel do default(shared) private(i)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do i=1,ni
           north(i)=s(i,nj)
         enddo
         nr = nr + 1
-        !$acc host_data use_device(north)
+        !$acc host_data use_device(north) if(gdirect)
         call mpi_isend(north,ni,MPI_REAL,mynorth,tag3,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5467,15 +5328,14 @@
 
       ! send south
       if(ibs.eq.0)then
-!$omp parallel do default(shared)   &
-!$omp private(i)
-        !$acc parallel loop gang vector default(present)
+        !$omp parallel do default(shared) private(i)
+        !$acc parallel loop gang vector default(present) if(openacc)
         do i=1,ni
           south(i)=s(i,1)
         enddo
         nr = nr + 1
 
-        !$acc host_data use_device(south)
+        !$acc host_data use_device(south) if(gdirect)
         call mpi_isend(south,ni,MPI_REAL,mysouth,tag4,   &
                        MPI_COMM_WORLD,reqs(nr),ierr)
         !$acc end host_data
@@ -5487,183 +5347,12 @@
 
       end subroutine comm_1s2d_start_GPU
 
-
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- 
- 
-      subroutine comm_1s2d_end(s,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
-      use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn, &
-          wbc,ebc,nbc,sbc,timestats,mytime,time_mps2,time_bc,ierr, &
-          p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
-      use mpi
-      implicit none
- 
-      real s(ib:ie,jb:je)
-      real west(nj),newwest(nj)
-      real east(nj),neweast(nj)
-      real south(ni),newsouth(ni)
-      real north(ni),newnorth(ni)
-      integer reqs(8)
- 
-      integer i,j,nn,nr,index
-      integer :: index_east,index_west,index_south,index_north
-      integer, dimension(mpi_status_size,8) :: status1
-
-!---------------------------------------------------------------------
-
-      index_east = -1
-      index_west = -1
-      index_south = -1
-      index_north = -1
-
-      nr = 0
-      if(ibe.eq.0)then
-        nr = nr + 1
-        index_east = nr
-      endif
-      if(ibw.eq.0)then
-        nr = nr + 1
-        index_west = nr
-      endif
-      if(ibs.eq.0)then
-        nr = nr + 1
-        index_south = nr
-      endif
-      if(ibn.eq.0)then
-        nr = nr + 1
-        index_north = nr
-      endif
-
-      nn = 1
-      do while( nn .le. nr )
-        call MPI_WAITANY(nr,reqs(1:nr),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
- 
-      if(index.eq.index_east)then
-        !$omp parallel do default(shared) private(j)
-        do j=1,nj
-          s(ni+1,j)=neweast(j)
-        enddo
-      elseif(index.eq.index_west)then
-        !$omp parallel do default(shared) private(j)
-        do j=1,nj
-          s(0,j)=newwest(j)
-        enddo
-      elseif(index.eq.index_south)then
-        !$omp parallel do default(shared) private(i)
-        do i=1,ni
-          s(i,0)=newsouth(i)
-        enddo
-      elseif(index.eq.index_north)then
-        !$omp parallel do default(shared) private(i)
-        do i=1,ni
-          s(i,nj+1)=newnorth(i)
-        enddo
-      endif
-
-      enddo
-
-      if(timestats.ge.1) time_mps2=time_mps2+mytime()
-
-!----------
-!  patch for corner
- 
-      if( (ebc.eq.2.or.wbc.eq.2).and.(sbc.eq.1.or.nbc.eq.1) )then
- 
-        if(ibw.eq.1)then
- 
-          if(p2tchsww)then
-              s(0,0)=s(1,0)
-          endif
- 
-          if(p2tchnww)then
-              s(0,nj+1)=s(1,nj+1)
-          endif
- 
-        endif
- 
-        if(ibe.eq.1)then
- 
-          if(p2tchsee)then
-              s(ni+1,0)=s(ni,0)
-          endif
- 
-          if(p2tchnee)then
-              s(ni+1,nj+1)=s(ni,nj+1)
-          endif
- 
-        endif
- 
-      endif
-
-      if( (ebc.eq.1.or.wbc.eq.1).and.(sbc.eq.2.or.nbc.eq.2) )then
- 
-        if(ibs.eq.1)then
- 
-          if(p2tchsws)then
-              s(0,0)=s(0,1)
-          endif
- 
-          if(p2tchses)then
-              s(ni+1,0)=s(ni+1,1)
-          endif
- 
-        endif
- 
-        if(ibn.eq.1)then
- 
-          if(p2tchnwn)then
-              s(0,nj+1)=s(0,nj)
-          endif
- 
-          if(p2tchnen)then
-              s(ni+1,nj+1)=s(ni+1,nj)
-          endif
- 
-        endif
- 
-      endif
-
-      if(timestats.ge.1) time_bc=time_bc+mytime()
-
-!----------
-
-      nr = 0
-
-      if(ibw.eq.0)then
-        nr = nr+1
-      endif
-      if(ibe.eq.0)then
-        nr = nr+1
-      endif
-      if(ibn.eq.0)then
-        nr = nr+1
-      endif
-      if(ibs.eq.0)then
-        nr = nr+1
-      endif
-
-    if( nr.ge.1 )then
-      call MPI_WAITALL(nr,reqs(5:5+nr-1),status1(1:mpi_status_size,5:5+nr-1),ierr)
-    endif
-
-      if(timestats.ge.1) time_mps2=time_mps2+mytime()
- 
-!----------
- 
-      end subroutine comm_1s2d_end
-
-
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
 
       subroutine comm_1s2d_end_GPU(s,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs)
+                     south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn, &
           wbc,ebc,nbc,sbc,timestats,mytime,time_mps2,time_bc,ierr, &
           p2tchsww,p2tchnww,p2tchsee,p2tchnee,p2tchsws,p2tchses,p2tchnwn,p2tchnen
@@ -5676,10 +5365,15 @@
       real south(ni),newsouth(ni)
       real north(ni),newnorth(ni)
       integer reqs(8)
+      logical, optional, intent(in) :: device,gpudirect
 
       integer i,j,nn,nr,index
       integer :: index_east,index_west,index_south,index_north
       integer, dimension(mpi_status_size,8) :: status1
+      logical :: openacc,gdirect
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !---------------------------------------------------------------------
 
@@ -5713,25 +5407,25 @@
 
       if(index.eq.index_east)then
         !$omp parallel do default(shared) private(j)
-        !$acc parallel loop default(present) private(j)
+        !$acc parallel loop default(present) if(openacc)
         do j=1,nj
           s(ni+1,j)=neweast(j)
         enddo
       elseif(index.eq.index_west)then
         !$omp parallel do default(shared) private(j)
-        !$acc parallel loop default(present) private(j)
+        !$acc parallel loop default(present) if(openacc)
         do j=1,nj
           s(0,j)=newwest(j)
         enddo
       elseif(index.eq.index_south)then
         !$omp parallel do default(shared) private(i)
-        !$acc parallel loop default(present) private(i)
+        !$acc parallel loop default(present) if(openacc)
         do i=1,ni
           s(i,0)=newsouth(i)
         enddo
       elseif(index.eq.index_north)then
         !$omp parallel do default(shared) private(i)
-        !$acc parallel loop default(present) private(i)
+        !$acc parallel loop default(present) if(openacc)
         do i=1,ni
           s(i,nj+1)=newnorth(i)
         enddo
@@ -5741,7 +5435,7 @@
 
       if(timestats.ge.1) time_mps2=time_mps2+mytime()
 
-      !$acc parallel default(present)
+      !$acc parallel default(present) if(openacc)
 !----------
 !  patch for corner
       !print *,'ibw: ',ibw
@@ -5828,7 +5522,6 @@
     endif
 
       if(timestats.ge.1) time_mps2=time_mps2+mytime()
-      !stop 'comm_1s2d_end_GPU:'
 !----------
 
       end subroutine comm_1s2d_end_GPU

--- a/src/comm.F
+++ b/src/comm.F
@@ -6012,7 +6012,7 @@
 !------------------------------------------------------------------
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        !$acc parallel loop gang vector default(present) if(openacc)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           se1(i,j)=s(ni-cmp+i,j)
@@ -6027,7 +6027,7 @@
 !-----
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        !$acc parallel loop gang vector default(present) if(openacc)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           ne1(i,j)=s(ni-cmp+i,nj-cmp+j)
@@ -6042,7 +6042,7 @@
 !-----
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        !$acc parallel loop gang vector default(present) if(openacc)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           sw1(i,j)=s(i,j)
@@ -6057,7 +6057,7 @@
 !-----
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        !$acc parallel loop gang vector default(present) if(openacc)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           nw1(i,j)=s(i,nj-cmp+j)
@@ -6077,28 +6077,28 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-        !$acc parallel loop gang vector default(present) if(openacc)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           s(-cmp+i,nj+j)=nw2(i,j)
         enddo
         enddo
       elseif(index.eq.index_sw)then
-        !$acc parallel loop gang vector default(present) if(openacc)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           s(-cmp+i,-cmp+j)=sw2(i,j)
         enddo
         enddo
       elseif(index.eq.index_ne)then
-        !$acc parallel loop gang vector default(present) if(openacc)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           s(ni+i,nj+j)=ne2(i,j)
         enddo
         enddo
       elseif(index.eq.index_se)then
-        !$acc parallel loop gang vector default(present) if(openacc)
+        !$acc parallel loop gang vector collapse(2) default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           s(ni+i,-cmp+j)=se2(i,j)
@@ -8398,8 +8398,8 @@
          logical, optional :: device,gpudirect
 
       ! Set logical flags if subroutine is called on GPU or CPU resident
-      ! data. The default to for GPU resident data. If the data is GPU
-      ! use gpudirect by default
+      ! data. The default to for GPU resident data.  If the device flag 
+      ! is not set, it is assumed that it is GPU resident.
       if(present(device)) then
          if(device) then
             openacc = .true.

--- a/src/comm.F
+++ b/src/comm.F
@@ -460,7 +460,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine getcorneru_GPU(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      subroutine getcorneru_GPU(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -468,6 +468,7 @@
 
       real, intent(inout), dimension(ib:ie+1,jb:je,kb:ke) :: u
       real, intent(inout), dimension(nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      logical, optional, intent(in) :: device,gpudirect
 
       integer k,nn,nr,nrb,index
       integer :: index_nw,index_sw,index_ne,index_se
@@ -475,17 +476,17 @@
       integer tag,count
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug =.FALSE.
+      logical :: openacc, gdirect
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !-----
-#ifndef _GPUDIRECT
-      if(Debug) print *,'getcorneru_GPU:'
-#endif
       nr = 0
       index_nw = -1
       index_sw = -1
       index_ne = -1
       index_se = -1
-!      !$acc update host(u)
 !-----------------------------------------------------------------------
 
       tag=5001
@@ -493,10 +494,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-!!$acc host_data use_device(nw2)
+        !$acc host_data use_device(nw2) if(gdirect)
         call mpi_irecv(nw2,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
-!!$acc end host_data
+        !$acc end host_data
         index_nw = nr
       endif
 
@@ -507,10 +508,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-!!$acc host_data use_device(sw2)
+        !$acc host_data use_device(sw2) if(gdirect)
         call mpi_irecv(sw2,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
-!!$acc end host_data
+        !$acc end host_data
         index_sw = nr
       endif
 
@@ -521,10 +522,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-!!$acc host_data use_device(ne2)
+        !$acc host_data use_device(ne2) if(gdirect)
         call mpi_irecv(ne2,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
-!!$acc end host_data
+        !$acc end host_data
         index_ne = nr
       endif
 
@@ -535,10 +536,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-!!$acc host_data use_device(se2)
+        !$acc host_data use_device(se2) if(gdirect)
         call mpi_irecv(se2,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
-!!$acc end host_data
+        !$acc end host_data
         index_se = nr
       endif
 
@@ -550,18 +551,16 @@
       count=nk
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
+        !$omp parallel do default(shared) private(k)
         do k=1,nk
           se1(k)=u(ni,1,k)
         enddo
         nrb = nrb + 1
-        !$acc update host(se1)
-!!$acc host_data use_device(se1)
+        !$acc host_data use_device(se1) if(gdirect)
         call mpi_isend(se1,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
-!!$acc end host_data
+        !$acc end host_data
       endif
 
 !-----
@@ -570,18 +569,16 @@
       count=nk
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
+        !$omp parallel do default(shared) private(k)
         do k=1,nk
           ne1(k)=u(ni,nj,k)
         enddo
         nrb = nrb + 1
-        !$acc update host(ne1)
-!!$acc host_data use_device(ne1)
+        !$acc host_data use_device(ne1) if(gdirect)
         call mpi_isend(ne1,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
-!!$acc end host_data
+        !$acc end host_data
       endif
 
 !-----
@@ -590,18 +587,16 @@
       count=nk
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
+        !$omp parallel do default(shared) private(k)
         do k=1,nk
           sw1(k)=u(2,1,k)
         enddo
         nrb = nrb + 1
-        !$acc update host(sw1)
-!!$acc host_data use_device(sw1)
+        !$acc host_data use_device(sw1) if(gdirect)
         call mpi_isend(sw1,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
-!!$acc end host_data
+        !$acc end host_data
       endif
 
 !-----
@@ -610,18 +605,16 @@
       count=nk
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
+        !$omp parallel do default(shared) private(k)
         do k=1,nk
           nw1(k)=u(2,nj,k)
         enddo
         nrb = nrb + 1
-        !$acc update host(nw1)
-!!$acc host_data use_device(nw1)
+        !$acc host_data use_device(nw1) if(gdirect)
         call mpi_isend(nw1,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
-!!$acc end host_data
+        !$acc end host_data
       endif
 
 !-----------------------------------------------------------------------
@@ -632,34 +625,26 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-        !$acc update device(nw2)
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
+        !$omp parallel do default(shared) private(k)
         do k=1,nk
           u(0,nj+1,k)=nw2(k)
         enddo
       elseif(index.eq.index_sw)then
-        !$acc update device(sw2)  
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
+        !$omp parallel do default(shared) private(k)
         do k=1,nk
           u(0,0,k)=sw2(k)
         enddo
       elseif(index.eq.index_ne)then
-        !$acc update device(ne2)
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
+        !$omp parallel do default(shared) private(k)
         do k=1,nk
           u(ni+2,nj+1,k)=ne2(k)
         enddo
       elseif(index.eq.index_se)then
-        !$acc update device(se2)
-!$acc parallel loop gang vector default(present) private(k)
-!$omp parallel do default(shared)   &
-!$omp private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
+        !$omp parallel do default(shared) private(k)
         do k=1,nk
           u(ni+2,0,k)=se2(k)
         enddo
@@ -685,7 +670,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine getcornerv_GPU(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      subroutine getcornerv_GPU(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -693,6 +678,7 @@
 
       real, intent(inout), dimension(ib:ie,jb:je+1,kb:ke) :: v
       real, intent(inout), dimension(nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      logical, optional, intent(in) :: device,gpudirect
 
       integer k,nn,nr,nrb,index
       integer :: index_nw,index_sw,index_ne,index_se
@@ -700,6 +686,10 @@
       integer tag,count
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug =.FALSE.
+      logical :: openacc,gdirect
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !-----
 
@@ -708,7 +698,6 @@
       index_sw = -1
       index_ne = -1
       index_se = -1
-!      !$acc update host(v)
 !-----------------------------------------------------------------------
 
       tag=5011
@@ -716,7 +705,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(nw2)
+        !$acc host_data use_device(nw2) if(gdirect)
         call mpi_irecv(nw2,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -730,7 +719,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(sw2)
+        !$acc host_data use_device(sw2) if(gdirect)
         call mpi_irecv(sw2,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -744,7 +733,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(ne2)
+        !$acc host_data use_device(ne2) if(gdirect)
         call mpi_irecv(ne2,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -758,7 +747,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(se2)
+        !$acc host_data use_device(se2) if(gdirect)
         call mpi_irecv(se2,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -773,13 +762,13 @@
       count=nk
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           se1(k)=v(ni,2,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(se1)
+        !$acc host_data use_device(se1) if(gdirect)
         call mpi_isend(se1,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -791,13 +780,13 @@
       count=nk
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           ne1(k)=v(ni,nj,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(ne1)
+        !$acc host_data use_device(ne1) if(gdirect)
         call mpi_isend(ne1,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -809,13 +798,13 @@
       count=nk
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           sw1(k)=v(1,2,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(sw1)
+        !$acc host_data use_device(sw1) if(gdirect)
         call mpi_isend(sw1,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -827,13 +816,13 @@
       count=nk
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           nw1(k)=v(1,nj,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(nw1)
+        !$acc host_data use_device(nw1) if(gdirect)
         call mpi_isend(nw1,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -847,25 +836,25 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           v(0,nj+2,k)=nw2(k)
         enddo
       elseif(index.eq.index_sw)then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           v(0,0,k)=sw2(k)
         enddo
       elseif(index.eq.index_ne)then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           v(ni+1,nj+2,k)=ne2(k)
         enddo
       elseif(index.eq.index_se)then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           v(ni+1,0,k)=se2(k)
@@ -893,7 +882,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine getcornerw_GPU(w,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      subroutine getcornerw_GPU(w,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -901,6 +890,7 @@
 
       real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: w
       real, intent(inout), dimension(nk) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
+      logical, optional, intent(in) :: device,gpudirect
 
       integer k,nn,nr,nrb,index
       integer :: index_nw,index_sw,index_ne,index_se
@@ -908,7 +898,10 @@
       integer tag,count
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug =.FALSE.
+      logical :: openacc,gdirect
 
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 !-----
       nr = 0
       index_nw = -1
@@ -922,7 +915,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(nw2)
+        !$acc host_data use_device(nw2) if(gdirect)
         call mpi_irecv(nw2,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -936,7 +929,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(sw2)
+        !$acc host_data use_device(sw2) if(gdirect)
         call mpi_irecv(sw2,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -950,7 +943,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(ne2)
+        !$acc host_data use_device(ne2) if(gdirect)
         call mpi_irecv(ne2,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -964,7 +957,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(se2)
+        !$acc host_data use_device(se2) if(gdirect)
         call mpi_irecv(se2,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -979,13 +972,13 @@
       count=nk
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           se1(k)=w(ni,1,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(se1)
+        !$acc host_data use_device(se1) if(gdirect)
         call mpi_isend(se1,count,MPI_REAL,myse,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -997,13 +990,13 @@
       count=nk
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           ne1(k)=w(ni,nj,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(ne1)
+        !$acc host_data use_device(ne1) if(gdirect)
         call mpi_isend(ne1,count,MPI_REAL,myne,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -1015,13 +1008,13 @@
       count=nk
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           sw1(k)=w(1,1,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(sw1)
+        !$acc host_data use_device(sw1) if(gdirect)
         call mpi_isend(sw1,count,MPI_REAL,mysw,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -1033,13 +1026,13 @@
       count=nk
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           nw1(k)=w(1,nj,k)
         enddo
         nrb = nrb + 1
-        !$acc host_data use_device(nw1)
+        !$acc host_data use_device(nw1) if(gdirect)
         call mpi_isend(nw1,count,MPI_REAL,mynw,tag,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -1053,25 +1046,25 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           w(0,nj+1,k)=nw2(k)
         enddo
       elseif(index.eq.index_sw)then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           w(0,0,k)=sw2(k)
         enddo
       elseif(index.eq.index_ne)then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           w(ni+1,nj+1,k)=ne2(k)
         enddo
       elseif(index.eq.index_se)then
-        !$acc parallel loop gang vector default(present) private(k)
+        !$acc parallel loop gang vector default(present) if(openacc)
         !$omp parallel do default(shared) private(k)
         do k=1,nk
           w(ni+1,0,k)=se2(k)

--- a/src/comm.F
+++ b/src/comm.F
@@ -24,17 +24,16 @@
   public :: getcorneru3_GPU,getcornerv3_GPU,getcornerw3_GPU
   public :: prepcorners3_GPU,prepcornert_GPU,prepcorners_GPU
   public :: comm_all_s_GPU
+  public :: getcorner3_2d_GPU
 
   !CPU only routines
   public :: comm_2d_start, comm_2dns_end,comm_2dew_end
-  public :: comm_2d_corner
   public :: comm_1s_start,comm_1s_end
   public :: comm_3t_start,comm_3t_end
   public :: comm_3u_start,comm_3u_end
   public :: comm_3v_start,comm_3v_end
   public :: comm_3w_start,comm_3w_end
   public :: comm_1s2d_start,comm_1s2d_end
-  public :: getcorner3_2d  
 
   public :: sync
 
@@ -8264,156 +8263,38 @@
 !      !$acc update device(s)
       end subroutine comm_2dns_end_GPU
 
-
-
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-
-      subroutine comm_2d_corner(s)
+      subroutine comm_2d_corner_GPU(s,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn, &
           mynw,mysw,myne,myse,timestats,time_mptk1,mytime,ierr
       use mpi
       implicit none
 
       real, dimension(ib:ie,jb:je) :: s
-
-      integer reqs(8)
-      integer :: tag1,tag2,tag3,tag4,nr,nrb
-      integer, dimension(mpi_status_size,8) :: status1
-
-!------------------------------------------------
-
-      nr = 0
-
-!-----
-
-      tag1=5061
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(s(0,nj+1),1,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-      endif
-
-!-----
-
-      tag2=5062
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(s(0,0),1,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-      endif
-
-!-----
-
-      tag3=5063
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(s(ni+1,nj+1),1,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-      endif
-
-!-----
-
-      tag4=5064
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr = nr + 1
-        call mpi_irecv(s(ni+1,0),1,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nrb = 4
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nrb = nrb + 1
-        call mpi_isend(s(ni,1),1,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-      endif
-
-!-----
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nrb = nrb + 1
-        call mpi_isend(s(ni,nj),1,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-      endif
-
-!-----
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nrb = nrb + 1
-        call mpi_isend(s(1,1),1,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-      endif
-
-!-----
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nrb = nrb + 1
-        call mpi_isend(s(1,nj),1,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(nrb),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      if( nr.ge.1 )then
-        call MPI_WAITALL(nr,reqs(1:nr),status1(1:mpi_status_size,1:nr),ierr)
-      endif
-
-!-----
-
-    nrb = nrb-4
-
-    if( nrb.ge.1 )then
-      call MPI_WAITALL(nrb,reqs(5:5+nrb-1),status1(1:mpi_status_size,5:5+nrb-1),ierr)
-    endif
-
-!-----
-
-      if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-
-      end subroutine comm_2d_corner
-
-
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine comm_2d_corner_GPU(s)
-      use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn, &
-          mynw,mysw,myne,myse,timestats,time_mptk1,mytime,ierr
-      use mpi
-      implicit none
-
-      real, dimension(ib:ie,jb:je) :: s
+      logical, optional, intent(in) :: device,gpudirect
 
       integer reqs(8)
       integer :: tag1,tag2,tag3,tag4,nr,nrb
       integer, dimension(mpi_status_size,8) :: status1
       logical, parameter :: Debug = .FALSE.
+      logical :: openacc,gdirect
+
 !------------------------------------------------
 
       nr = 0
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !-----
      if(Debug) print *,'comm_2d_corner_GPU:'
       tag1=5061
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(s(0,nj+1))
+        !$acc host_data use_device(s(0,nj+1)) if(gdirect)
         call mpi_irecv(s(0,nj+1),1,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -8425,7 +8306,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(s(0,0))
+        !$acc host_data use_device(s(0,0)) if(gdirect)
         call mpi_irecv(s(0,0),1,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -8437,7 +8318,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(s(ni+1,nj+1))
+        !$acc host_data use_device(s(ni+1,nj+1)) if(gdirect)
         call mpi_irecv(s(ni+1,nj+1),1,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -8449,7 +8330,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
-        !$acc host_data use_device(s(ni+1,0))
+        !$acc host_data use_device(s(ni+1,0)) if(gdirect)
         call mpi_irecv(s(ni+1,0),1,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
         !$acc end host_data
@@ -8463,7 +8344,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nrb = nrb + 1
-        !$acc host_data use_device(s(ni,1))
+        !$acc host_data use_device(s(ni,1)) if(gdirect)
         call mpi_isend(s(ni,1),1,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -8473,7 +8354,7 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nrb = nrb + 1
-        !$acc host_data use_device(s(ni,nj))
+        !$acc host_data use_device(s(ni,nj)) if(gdirect)
         call mpi_isend(s(ni,nj),1,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -8483,7 +8364,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nrb = nrb + 1
-        !$acc host_data use_device(s(1,1))
+        !$acc host_data use_device(s(1,1)) if(gdirect)
         call mpi_isend(s(1,1),1,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -8493,7 +8374,7 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nrb = nrb + 1
-        !$acc host_data use_device(s(1,nj))
+        !$acc host_data use_device(s(1,nj)) if(gdirect)
         call mpi_isend(s(1,nj),1,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(nrb),ierr)
         !$acc end host_data
@@ -8524,19 +8405,24 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine getcorner3_2d(s)
+      subroutine getcorner3_2d_GPU(s,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn, &
           mynw,mysw,myne,myse,timestats,time_mptk1,mytime,ierr
       use mpi
       implicit none
  
       real, intent(inout), dimension(ib:ie,jb:je) :: s
+      logical, optional, intent(in) :: device,gpudirect
  
       real, dimension(cmp,cmp) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
       integer :: i,j,nn,nr,index
       integer :: index_nw,index_sw,index_ne,index_se
       integer reqs(8)
       integer tag1,tag2,tag3,tag4
+      logical :: gdirect, openacc
+
+      ! Set the GPU specific parameters to control communication
+      call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !-----
 
@@ -8546,14 +8432,18 @@
       index_ne = -1
       index_se = -1
 
+!$acc data create(nw1,nw2,ne1,ne2,sw1,sw2,se1,se2) if(openacc)
+
 !------------------------------------------------------------------
 
       tag1=5001
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
+        !$acc host_data use_device(nw2) if(gdirect)
         call mpi_irecv(nw2,cmp*cmp,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
+        !$acc end host_data
         index_nw = nr
       endif
 
@@ -8563,8 +8453,10 @@
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
+        !$acc host_data use_device(sw2) if(gdirect)
         call mpi_irecv(sw2,cmp*cmp,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
+        !$acc end host_data
         index_sw = nr
       endif
 
@@ -8574,8 +8466,10 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
+        !$acc host_data use_device(ne2) if(gdirect)
         call mpi_irecv(ne2,cmp*cmp,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
+        !$acc end host_data
         index_ne = nr
       endif
 
@@ -8585,57 +8479,71 @@
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
         nr = nr + 1
+        !$acc host_data use_device(se2) if(gdirect)
         call mpi_irecv(se2,cmp*cmp,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
                        reqs(nr),ierr)
+        !$acc end host_data
         index_se = nr
       endif
 
 !------------------------------------------------------------------
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+        !$acc parallel loop gang vector default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           se1(i,j)=s(ni-cmp+i,j)
         enddo
         enddo
+        !$acc host_data use_device(se1) if(gdirect)
         call mpi_isend(se1,cmp*cmp,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
                        reqs(5),ierr)
+        !$acc end host_data
       endif
  
 !-----
 
       if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+        !$acc parallel loop gang vector default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           ne1(i,j)=s(ni-cmp+i,nj-cmp+j)
         enddo
         enddo
+        !$acc host_data use_device(ne1) if(gdirect)
         call mpi_isend(ne1,cmp*cmp,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
                        reqs(6),ierr)
+        !$acc end host_data
       endif
  
 !-----
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
+        !$acc parallel loop gang vector default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           sw1(i,j)=s(i,j)
         enddo
         enddo
+        !$acc host_data use_device(sw1) if(gdirect)
         call mpi_isend(sw1,cmp*cmp,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
                        reqs(7),ierr)
+        !$acc end host_data
       endif
  
 !-----
 
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
+        !$acc parallel loop gang vector default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           nw1(i,j)=s(i,nj-cmp+j)
         enddo
         enddo
+        !$acc host_data use_device(nw1) if(gdirect)
         call mpi_isend(nw1,cmp*cmp,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
                        reqs(8),ierr)
+        !$acc end host_data
       endif
  
 !-----
@@ -8646,24 +8554,28 @@
         nn = nn + 1
 
       if(index.eq.index_nw)then
+        !$acc parallel loop gang vector default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           s(-cmp+i,nj+j)=nw2(i,j)
         enddo
         enddo
       elseif(index.eq.index_sw)then
+        !$acc parallel loop gang vector default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           s(-cmp+i,-cmp+j)=sw2(i,j)
         enddo
         enddo
       elseif(index.eq.index_ne)then
+        !$acc parallel loop gang vector default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           s(ni+i,nj+j)=ne2(i,j)
         enddo
         enddo
       elseif(index.eq.index_se)then
+        !$acc parallel loop gang vector default(present) if(openacc)
         do j=1,cmp
         do i=1,cmp
           s(ni+i,-cmp+j)=se2(i,j)
@@ -8692,10 +8604,11 @@
       endif
 
 !-----
+!$acc end data
 
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
 
-      end subroutine getcorner3_2d
+      end subroutine getcorner3_2d_GPU
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/comm.F
+++ b/src/comm.F
@@ -5,26 +5,26 @@
   public :: nabor
 
   !GPU enabled routines 
-  public :: comm_2d_start_GPU,comm_2dns_end_GPU,comm_2dew_end_GPU
-  public :: comm_1s_start_GPU,comm_1s_end_GPU
-  public :: comm_1w_start_GPU,comm_1w_end_GPU
-  public :: comm_1p_start_GPU,comm_1p_end_GPU
-  public :: comm_1t_start_GPU,comm_1t_end_GPU
-  public :: comm_2sn_start_GPU,comm_2sn_end_GPU
-  public :: comm_3s_start_GPU,comm_3s_end_GPU
-  public :: comm_3t_start_GPU,comm_3t_end_GPU
-  public :: comm_3w_start_GPU,comm_3w_end_GPU
-  public :: comm_3u_start_GPU,comm_3u_end_GPU
-  public :: comm_3v_start_GPU,comm_3v_end_GPU
-  public :: comm_1s2d_start_GPU,comm_1s2d_end_GPU
-  public :: comm_2we_start_GPU,comm_2we_end_GPU
-  public :: comm_2d_corner_GPU
-  public :: comm_1s_tend_halo_GPU,comm_1u_tend_halo_GPU,comm_1v_tend_halo_GPU
-  public :: getcorneru_GPU,getcornerv_GPU,getcornert_GPU,getcornerw_GPU,getcorner_GPU
-  public :: getcorneru3_GPU,getcornerv3_GPU,getcornerw3_GPU
-  public :: prepcorners3_GPU,prepcornert_GPU,prepcorners_GPU
-  public :: comm_all_s_GPU
-  public :: getcorner3_2d_GPU
+  public :: comm_2d_start,comm_2dns_end,comm_2dew_end
+  public :: comm_1s_start,comm_1s_end
+  public :: comm_1w_start,comm_1w_end
+  public :: comm_1p_start,comm_1p_end
+  public :: comm_1t_start,comm_1t_end
+  public :: comm_2sn_start,comm_2sn_end
+  public :: comm_3s_start,comm_3s_end
+  public :: comm_3t_start,comm_3t_end
+  public :: comm_3w_start,comm_3w_end
+  public :: comm_3u_start,comm_3u_end
+  public :: comm_3v_start,comm_3v_end
+  public :: comm_1s2d_start,comm_1s2d_end
+  public :: comm_2we_start,comm_2we_end
+  public :: comm_2d_corner
+  public :: comm_1s_tend_halo,comm_1u_tend_halo,comm_1v_tend_halo
+  public :: getcorneru,getcornerv,getcornert,getcornerw,getcorner
+  public :: getcorneru3,getcornerv3,getcornerw3
+  public :: prepcorners3,prepcornert,prepcorners
+  public :: comm_all_s
+  public :: getcorner3_2d
 
   public :: sync
 
@@ -70,7 +70,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine getcorner_GPU(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
+      subroutine getcorner(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -259,7 +259,7 @@
 !-----
 
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-      end subroutine getcorner_GPU
+      end subroutine getcorner
 
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -267,7 +267,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine getcornert_GPU(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
+      subroutine getcornert(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -453,14 +453,14 @@
 !-----
 
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-      end subroutine getcornert_GPU
+      end subroutine getcornert
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine getcorneru_GPU(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
+      subroutine getcorneru(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -663,14 +663,14 @@
 !-----
 
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-      end subroutine getcorneru_GPU
+      end subroutine getcorneru
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine getcornerv_GPU(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
+      subroutine getcornerv(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -874,7 +874,7 @@
 !-----
 
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-      end subroutine getcornerv_GPU
+      end subroutine getcornerv
 
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -882,7 +882,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine getcornerw_GPU(w,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
+      subroutine getcornerw(w,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -1084,13 +1084,13 @@
 !-----
 
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-      end subroutine getcornerw_GPU
+      end subroutine getcornerw
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine getcorner3_GPU(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
+      subroutine getcorner3(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           cmp,nkp1,mynw,mysw,myne,myse,ierr,timestats,time_mptk1,mytime
       use mpi
@@ -1312,7 +1312,7 @@
 !-----
  
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-      end subroutine getcorner3_GPU
+      end subroutine getcorner3
 
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -1320,7 +1320,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine comm_2we_start_GPU(s,west,newwest,east,neweast,reqs)
+      subroutine comm_2we_start(s,west,newwest,east,neweast,reqs)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           cs2we,nf,nkp1,myeast,mywest,ierr,timestats,time_mps3,mytime
       use mpi
@@ -1410,8 +1410,7 @@
 !----------
 
       if(timestats.ge.1) time_mps3=time_mps3+mytime()
-!      !$acc update device(s)
-      end subroutine comm_2we_start_GPU
+      end subroutine comm_2we_start
 
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -1419,7 +1418,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine comm_2we_end_GPU(s,west,newwest,east,neweast,reqs)
+      subroutine comm_2we_end(s,west,newwest,east,neweast,reqs)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           cs2we,nf,nkp1,myeast,mywest,ierr,timestats,time_mps4,mytime
       use mpi
@@ -1497,7 +1496,7 @@
       if(timestats.ge.1) time_mps4=time_mps4+mytime()
 !      !$acc update device(s)
 
-      end subroutine comm_2we_end_GPU
+      end subroutine comm_2we_end
 
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -1505,7 +1504,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine comm_2sn_start_GPU(s,south,newsouth,north,newnorth,reqs)
+      subroutine comm_2sn_start(s,south,newsouth,north,newnorth,reqs)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           nf,cs2sn,nkp1,mysouth,mynorth,ierr,timestats,time_mps3,mytime
       use mpi
@@ -1597,7 +1596,7 @@
 
       if(timestats.ge.1) time_mps3=time_mps3+mytime()
 
-      end subroutine comm_2sn_start_GPU
+      end subroutine comm_2sn_start
 
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -1605,7 +1604,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine comm_2sn_end_GPU(s,south,newsouth,north,newnorth,reqs)
+      subroutine comm_2sn_end(s,south,newsouth,north,newnorth,reqs)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibw,ibe,ibs,ibn, &
           nf,cs2sn,nkp1,mysouth,mynorth,ierr,timestats,time_mps4,mytime
       use mpi
@@ -1681,13 +1680,13 @@
     endif
 
       if(timestats.ge.1) time_mps4=time_mps4+mytime() 
-      end subroutine comm_2sn_end_GPU
+      end subroutine comm_2sn_end
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine comm_3s_start_GPU(s,west,newwest,east,neweast,   &
+      subroutine comm_3s_start(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs,gpudirect,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
           myeast,mywest,mysouth,mynorth,nf,cs3we,cs3sn,timestats,time_mps1, &
@@ -1863,13 +1862,13 @@
  
       if(timestats.ge.1) time_mps1=time_mps1+mytime()
 
-      end subroutine comm_3s_start_GPU
+      end subroutine comm_3s_start
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
-      subroutine comm_3s_end_GPU(s,west,newwest,east,neweast,   &
+      subroutine comm_3s_end(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs,gpudirect,device)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
           wbc,ebc,nbc,sbc,myeast,mywest,mysouth,mynorth,nf,cs3we,cs3sn,timestats, &
@@ -2092,14 +2091,14 @@
 
 !-----------------------------------------------------------
  
-      end subroutine comm_3s_end_GPU
+      end subroutine comm_3s_end
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
       ! tk1
-      subroutine comm_3t_start_GPU(t,west,newwest,east,neweast,   &
+      subroutine comm_3t_start(t,west,newwest,east,neweast,   &
                         south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
           nf,ct3we,ct3sn,nkp1,timestats,time_mps1,mytime,ierr, &
@@ -2267,13 +2266,13 @@
 !----------
 
       if(timestats.ge.1) time_mps1=time_mps1+mytime()
-      end subroutine comm_3t_start_GPU
+      end subroutine comm_3t_start
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine comm_3t_end_GPU(t,west,newwest,east,neweast,   &
+      subroutine comm_3t_end(t,west,newwest,east,neweast,   &
                       south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibs,ibn, &
           ierr,nkp1,ebc,wbc,sbc,nbc,timestats,time_mps2,time_bc,mytime, &
@@ -2488,7 +2487,7 @@
     endif
 
       if(timestats.ge.1) time_mps2=time_mps2+mytime()
-      end subroutine comm_3t_end_GPU
+      end subroutine comm_3t_end
 
       ! tk2
 
@@ -2496,7 +2495,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
-      subroutine comm_3u_start_GPU(u,west,newwest,east,neweast,   &
+      subroutine comm_3u_start(u,west,newwest,east,neweast,   &
                       south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
           timestats,mytime,nu,time_mpu1,cs3we,cu3sn,ierr,mynorth,mysouth,myeast,mywest
@@ -2662,13 +2661,13 @@
 
       if(timestats.ge.1) time_mpu1=time_mpu1+mytime()
  
-      end subroutine comm_3u_start_GPU
+      end subroutine comm_3u_start
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
-      subroutine comm_3u_end_GPU(u,west,newwest,east,neweast,   &
+      subroutine comm_3u_end(u,west,newwest,east,neweast,   &
                       south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
           ebc,wbc,sbc,nbc,ierr,timestats,time_mpu2,mytime,time_bc, &
@@ -2884,13 +2883,13 @@
       if(timestats.ge.1) time_mpu2=time_mpu2+mytime()
 !----------
  
-      end subroutine comm_3u_end_GPU
+      end subroutine comm_3u_end
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
-      subroutine comm_3v_start_GPU(v,west,newwest,east,neweast,   &
+      subroutine comm_3v_start(v,west,newwest,east,neweast,   &
                       south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,timestats,mytime,nv,time_mpv1,cv3we,cs3sn,ierr, &
@@ -3057,7 +3056,7 @@
 
       if(timestats.ge.1) time_mpv1=time_mpv1+mytime()
  
-      end subroutine comm_3v_start_GPU
+      end subroutine comm_3v_start
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -3067,7 +3066,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
-      subroutine comm_3v_end_GPU(v,west,newwest,east,neweast,   &
+      subroutine comm_3v_end(v,west,newwest,east,neweast,   &
                       south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
           ebc,wbc,sbc,nbc,ierr,timestats,time_mpv2,mytime,time_bc, &
@@ -3283,13 +3282,13 @@
 !      !$acc update device(v) 
 !----------
  
-      end subroutine comm_3v_end_GPU
+      end subroutine comm_3v_end
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
-      subroutine comm_3w_start_GPU(w,west,newwest,east,neweast,   &
+      subroutine comm_3w_start(w,west,newwest,east,neweast,   &
                       south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibs,ibn, &
           ierr,timestats,mytime,nw,time_mpw1,cw3we,cw3sn,mywest,myeast, &
@@ -3457,13 +3456,13 @@
 
       if(timestats.ge.1) time_mpw1=time_mpw1+mytime()
  
-      end subroutine comm_3w_start_GPU
+      end subroutine comm_3w_start
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
-      subroutine comm_3w_end_GPU(w,west,newwest,east,neweast,   &
+      subroutine comm_3w_end(w,west,newwest,east,neweast,   &
                          south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibe,ibw,ibn,ibs, &
           wbc,ebc,nbc,sbc,ierr,mytime,timestats,time_mpw2,time_bc, &
@@ -3678,13 +3677,13 @@
       if(timestats.ge.1) time_mpw2=time_mpw2+mytime()
 !----------
  
-      end subroutine comm_3w_end_GPU
+      end subroutine comm_3w_end
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine comm_1s2d_start_GPU(s,west,newwest,east,neweast,   &
+      subroutine comm_1s2d_start(s,west,newwest,east,neweast,   &
                           south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
           nf,ierr,timestats,time_mps1,mytime,myeast,mywest,mysouth,mynorth
@@ -3836,13 +3835,13 @@
 
       if(timestats.ge.1) time_mps1=time_mps1+mytime()
 
-      end subroutine comm_1s2d_start_GPU
+      end subroutine comm_1s2d_start
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine comm_1s2d_end_GPU(s,west,newwest,east,neweast,   &
+      subroutine comm_1s2d_end(s,west,newwest,east,neweast,   &
                      south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn, &
           wbc,ebc,nbc,sbc,timestats,mytime,time_mps2,time_bc,ierr, &
@@ -4015,13 +4014,13 @@
       if(timestats.ge.1) time_mps2=time_mps2+mytime()
 !----------
 
-      end subroutine comm_1s2d_end_GPU
+      end subroutine comm_1s2d_end
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine comm_1s_start_GPU(s,west,newwest,east,neweast,   &
+      subroutine comm_1s_start(s,west,newwest,east,neweast,   &
                          south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,nf,cs1we,cs1sn,ierr,timestats,time_mps1,mytime, & 
@@ -4180,15 +4179,14 @@
 !----------
  
       if(timestats.ge.1) time_mps1=time_mps1+mytime()
-      if(Debug) print *,'comm_1s_start_GPU: point #9'
  
-      end subroutine comm_1s_start_GPU
+      end subroutine comm_1s_start
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine comm_1s_end_GPU(s,west,newwest,east,neweast,   &
+      subroutine comm_1s_end(s,west,newwest,east,neweast,   &
                       south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
           ebc,wbc,sbc,nbc,timestats,mytime,ierr,time_bc,time_mps2, &
@@ -4397,7 +4395,7 @@
       if(timestats.ge.1) time_mps2=time_mps2+mytime()
 !----------
  
-      end subroutine comm_1s_end_GPU
+      end subroutine comm_1s_end
 
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -4405,7 +4403,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine comm_1p_start_GPU(s,west,newwest,east,neweast,   &
+      subroutine comm_1p_start(s,west,newwest,east,neweast,   &
                                  south,newsouth,north,newnorth,reqs)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,nf,ierr,timestats,time_mpp1,mytime, &
@@ -4563,12 +4561,11 @@
 !----------
 
       if(timestats.ge.1) time_mpp1=time_mpp1+mytime()
-      if(Debug) print *,'comm_1p_start_GPU point #9'
 
-      end subroutine comm_1p_start_GPU
+      end subroutine comm_1p_start
 
  
-      subroutine comm_1p_end_GPU(s,west,newwest,east,neweast,   &
+      subroutine comm_1p_end(s,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
           ebc,wbc,sbc,nbc,timestats,mytime,time_bc,time_mpp2,ierr
@@ -4680,7 +4677,7 @@
       if(timestats.ge.1) time_mpp2=time_mpp2+mytime()
 !----------
  
-      end subroutine comm_1p_end_GPU
+      end subroutine comm_1p_end
 
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -4688,7 +4685,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine comm_1t_start_GPU(t,west,newwest,east,neweast,   &
+      subroutine comm_1t_start(t,west,newwest,east,neweast,   &
                       south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,ct1we,ct1sn,nf,ierr,timestats,time_mps1,mytime, &
@@ -4849,7 +4846,7 @@
 !----------
 
       if(timestats.ge.1) time_mps1=time_mps1+mytime()
-      end subroutine comm_1t_start_GPU
+      end subroutine comm_1t_start
 
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -4857,7 +4854,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine comm_1t_end_GPU(t,west,newwest,east,neweast,   &
+      subroutine comm_1t_end(t,west,newwest,east,neweast,   &
                             south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,mytime,ierr,timestats,time_mps2,time_bc, &
@@ -5067,14 +5064,14 @@
       if(timestats.ge.1) time_mps2=time_mps2+mytime()
 
 !----------
-      end subroutine comm_1t_end_GPU
+      end subroutine comm_1t_end
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
  
-      subroutine comm_1w_start_GPU(w,ww1,ww2,we1,we2,   &
+      subroutine comm_1w_start(w,ww1,ww2,we1,we2,   &
                                  ws1,ws2,wn1,wn2,reqs)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,cw1we,cw1sn, &
@@ -5226,14 +5223,14 @@
 
       if(timestats.ge.1) time_mpw1=time_mpw1+mytime()
  
-      end subroutine comm_1w_start_GPU
+      end subroutine comm_1w_start
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
  
-      subroutine comm_1w_end_GPU(w,ww1,ww2,we1,we2,   &
+      subroutine comm_1w_end(w,ww1,ww2,we1,we2,   &
                                ws1,ws2,wn1,wn2,reqs)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibn,ibs, &
           wbc,ebc,sbc,nbc,timestats,mytime,ierr,time_bc,time_mpw2, &
@@ -5467,13 +5464,13 @@
 !     !$acc update device(w)
 !----------
 
-      end subroutine comm_1w_end_GPU
+      end subroutine comm_1w_end
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine comm_2d_start_GPU(s,west,newwest,east,neweast,   &
+      subroutine comm_2d_start(s,west,newwest,east,neweast,   &
                  south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn,wbc,ebc,sbc,nbc, &
           nf,ierr,timestats,time_mpq1,mytime,myeast,mywest,mysouth,mynorth
@@ -5631,13 +5628,13 @@
 !----------
 
       if(timestats.ge.1) time_mpq1=time_mpq1+mytime()
-      end subroutine comm_2d_start_GPU
+      end subroutine comm_2d_start
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine comm_2dew_end_GPU(s,west,newwest,east,neweast,reqs,device,gpudirect)
+      subroutine comm_2dew_end(s,west,newwest,east,neweast,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ierr, &
           timestats,time_mpq2,mytime
       use mpi
@@ -5693,13 +5690,13 @@
 !----------
 
       if(timestats.ge.1) time_mpq2=time_mpq2+mytime()
-      end subroutine comm_2dew_end_GPU
+      end subroutine comm_2dew_end
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine comm_2dns_end_GPU(s,south,newsouth,north,newnorth,reqs,device,gpudirect)
+      subroutine comm_2dns_end(s,south,newsouth,north,newnorth,reqs,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,ierr,timestats,time_mpq2,mytime
       use mpi
@@ -5788,13 +5785,13 @@
 !----------
 
       if(timestats.ge.1) time_mpq2=time_mpq2+mytime()
-      end subroutine comm_2dns_end_GPU
+      end subroutine comm_2dns_end
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine comm_2d_corner_GPU(s,device,gpudirect)
+      subroutine comm_2d_corner(s,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,ibe,ibw,ibs,ibn, &
           mynw,mysw,myne,myse,timestats,time_mptk1,mytime,ierr
       use mpi
@@ -5817,7 +5814,6 @@
       call SetMsgParams(openacc,gdirect,device,gpudirect)
 
 !-----
-     if(Debug) print *,'comm_2d_corner_GPU:'
       tag1=5061
       if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
         nr = nr + 1
@@ -5926,13 +5922,13 @@
 !-----
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
 
-      end subroutine comm_2d_corner_GPU
+      end subroutine comm_2d_corner
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine getcorner3_2d_GPU(s,device,gpudirect)
+      subroutine getcorner3_2d(s,device,gpudirect)
       use input, only : ib,ie,jb,je,ni,nj,cmp,ibe,ibw,ibs,ibn, &
           mynw,mysw,myne,myse,timestats,time_mptk1,mytime,ierr
       use mpi
@@ -6135,13 +6131,13 @@
 
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
 
-      end subroutine getcorner3_2d_GPU
+      end subroutine getcorner3_2d
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
  
-      subroutine comm_all_s_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+      subroutine comm_all_s(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device)
 
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt
@@ -6156,22 +6152,22 @@
       logical, optional, intent(in) :: device
       logical, parameter :: Debug = .FALSE.
 
-      call comm_3s_start_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s, &
+      call comm_3s_start(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s, &
                 device=device, gpudirect=.false.)
-      call comm_3s_end_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s, &
+      call comm_3s_end(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s, &
                 device=device,gpudirect=.false.)
-      call getcorner3_GPU(s,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),   &
+      call getcorner3(s,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),   &
                 s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1),device=device)
       call bcs2(s,device=device)
 
-      end subroutine comm_all_s_GPU
+      end subroutine comm_all_s
 
 #endif
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine prepcorners_GPU(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
+      subroutine prepcorners(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
                                pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,comm)
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt,ni,nj,nk, &
           tbc,bbc,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
@@ -6191,7 +6187,6 @@
       !$acc data present(s,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2, &
       !$acc              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2)
 
-      if(Debug) print *,'prepcorners_GPU'
 !--------------------------------------------!
 !  This subroutine is ONLY for parcel_interp !
 !--------------------------------------------!
@@ -6201,10 +6196,10 @@
       ENDIF
 #ifdef MPI
       IF( comm.eq.1 )THEN
-        call comm_1s_start_GPU(s,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-        call comm_1s_end_GPU(  s,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
+        call comm_1s_start(s,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
+        call comm_1s_end(  s,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
       ENDIF
-      call getcorner_GPU(s,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+      call getcorner(s,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
       call bcs2(s)
 #endif
 
@@ -6232,13 +6227,13 @@
 
       !$acc end data
 
-      end subroutine prepcorners_GPU
+      end subroutine prepcorners
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine prepcorners3_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+      subroutine prepcorners3(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                                 n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,comm)
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt,ni,nj,nk, &
           tbc,bbc,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
@@ -6260,7 +6255,7 @@
       IF( comm.eq.1 )THEN
         call bcs(s)
 #ifdef MPI
-        call comm_all_s_GPU(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+        call comm_all_s(s,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
 #endif
       ENDIF
@@ -6291,14 +6286,14 @@
 
       !$acc end data
 
-      end subroutine prepcorners3_GPU
+      end subroutine prepcorners3
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine prepcornert_GPU(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
+      subroutine prepcornert(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,comm)
       use input, only : ib,ie,jb,je,kb,ke,imp,jmp,kmp,cmp,rmp,kmt,ni,nj,nk, &
           tbc,bbc,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3
@@ -6321,22 +6316,22 @@
       !$acc data present (t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2, &
       !$acc               tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2)
 
-      if(Debug) print *,'prepcornert_GPU'
+      if(Debug) print *,'prepcornert'
       IF( comm.eq.1 )THEN
         call bcw(t,0)
       ENDIF
 #ifdef MPI
       IF( comm.eq.1 )THEN
-        call comm_1t_start_GPU(t,tkw1(1,1,1),tkw2(1,1,1),tke1(1,1,1),tke2(1,1,1),tks1(1,1,1),tks2(1,1,1),tkn1(1,1,1),tkn2(1,1,1),reqs_p)
-        call comm_1t_end_GPU(  t,tkw1(1,1,1),tkw2(1,1,1),tke1(1,1,1),tke2(1,1,1),tks1(1,1,1),tks2(1,1,1),tkn1(1,1,1),tkn2(1,1,1),reqs_p)
+        call comm_1t_start(t,tkw1(1,1,1),tkw2(1,1,1),tke1(1,1,1),tke2(1,1,1),tks1(1,1,1),tks2(1,1,1),tkn1(1,1,1),tkn2(1,1,1),reqs_p)
+        call comm_1t_end(  t,tkw1(1,1,1),tkw2(1,1,1),tke1(1,1,1),tke2(1,1,1),tks1(1,1,1),tks2(1,1,1),tkn1(1,1,1),tkn2(1,1,1),reqs_p)
       ENDIF
-      call getcornert_GPU(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      call getcornert(t,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
       call bct2(t)
 #endif
 
       !$acc end data
 
-      end subroutine prepcornert_GPU
+      end subroutine prepcornert
 
 #ifdef MPI
 
@@ -6344,7 +6339,7 @@
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine getcorneru3_GPU(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
+      subroutine getcorneru3(u,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibn,ibs, &
           wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
@@ -6555,13 +6550,13 @@
 !-----
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
 
-      end subroutine getcorneru3_GPU
+      end subroutine getcorneru3
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine getcornerv3_GPU(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
+      subroutine getcornerv3(v,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device,gpudirect)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,cmp,ibw,ibe,ibn,ibs, &
           wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
@@ -6774,205 +6769,13 @@
 
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
 
-      end subroutine getcornerv3_GPU
-
-
+      end subroutine getcornerv3
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
 
       subroutine getcornerw3(w,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,cmp,ibw,ibe,ibn,ibs, &
-          wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
-      use mpi
-      implicit none
-
-      real, intent(inout), dimension(ib:ie,jb:je,kb:ke+1) :: w
-      real, intent(inout), dimension(cmp,cmp,nk+1) :: nw1,nw2,ne1,ne2,sw1,sw2,se1,se2
-
-      integer :: i,j,k,nn,index
-      integer :: index_nw,index_sw,index_ne,index_se
-      integer reqs(8)
-      integer tag1,tag2,tag3,tag4,count,nr1,nr2
-      integer, dimension(mpi_status_size,8) :: status1
-
-      count=cmp*cmp*nkp1
-      nr1 = 0
-      index_nw = -1
-      index_sw = -1
-      index_ne = -1
-      index_se = -1
-
-!-----
-
-      tag1=5051
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(nw2,count,MPI_REAL,mynw,tag1,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_nw = nr1
-      endif
-
-!-----
-
-      tag2=5052
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(sw2,count,MPI_REAL,mysw,tag2,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_sw = nr1
-      endif
-
-!-----
-
-      tag3=5053
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(ne2,count,MPI_REAL,myne,tag3,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_ne = nr1
-      endif
-
-!-----
-
-      tag4=5054
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        nr1 = nr1+1
-        call mpi_irecv(se2,count,MPI_REAL,myse,tag4,MPI_COMM_WORLD,   &
-                       reqs(nr1),ierr)
-        index_se = nr1
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nr2 = 0
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,cmp
-          se1(i,j,k)=w(ni-cmp+i,j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(se1,count,MPI_REAL,myse,tag1,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-      if((ibe.eq.0.or.ibe.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,cmp
-          ne1(i,j,k)=w(ni-cmp+i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(ne1,count,MPI_REAL,myne,tag2,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibs.eq.0.or.ibs.eq.2))then
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,cmp
-          sw1(i,j,k)=w(i,j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(sw1,count,MPI_REAL,mysw,tag3,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-      if((ibw.eq.0.or.ibw.eq.2) .and. (ibn.eq.0.or.ibn.eq.2))then
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,cmp
-          nw1(i,j,k)=w(i,nj-cmp+j,k)
-        enddo
-        enddo
-        enddo
-        nr2 = nr2+1
-        call mpi_isend(nw1,count,MPI_REAL,mynw,tag4,MPI_COMM_WORLD,   &
-                       reqs(4+nr2),ierr)
-      endif
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-      nn = 1
-      do while( nn .le. nr1 )
-
-        call MPI_WAITANY(nr1,reqs(1:nr1),index,MPI_STATUS_IGNORE,ierr)
-        nn = nn + 1
-
-      if( index.eq.index_nw )then
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,cmp
-          w(-cmp+i,nj+j,k)=nw2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif( index.eq.index_sw )then
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,cmp
-          w(-cmp+i,-cmp+j,k)=sw2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif( index.eq.index_ne )then
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,cmp
-          w(ni+i,nj+j,k)=ne2(i,j,k)
-        enddo
-        enddo
-        enddo
-      elseif( index.eq.index_se )then
-        do k=1,nkp1
-        do j=1,cmp
-        do i=1,cmp
-          w(ni+i,-cmp+j,k)=se2(i,j,k)
-        enddo
-        enddo
-        enddo
-      endif
-
-      enddo
-
-!------------------------------------------------
-!------------------------------------------------
-!------------------------------------------------
-
-    if( nr2.ge.1 )then
-      call MPI_WAITALL(nr2,reqs(5:5+nr2-1),status1(1:mpi_status_size,5:5+nr2-1),ierr)
-    endif
-
-!-----
-
-      if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-
-      end subroutine getcornerw3
-
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-
-
-      subroutine getcornerw3_GPU(w,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,nkp1,cmp,ibw,ibe,ibn,ibs, &
           wbc,ebc,nbc,sbc,ierr,timestats,time_mptk1,mytime,mynw,mysw,myne,myse
       use mpi
@@ -7177,7 +6980,7 @@
 !-----
 
       if(timestats.ge.1) time_mptk1=time_mptk1+mytime()
-      end subroutine getcornerw3_GPU
+      end subroutine getcornerw3
 
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -7185,7 +6988,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine comm_1s_tend_halo_GPU(s)
+      subroutine comm_1s_tend_halo(s)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,nf,ierr,cs1we,cs1sn,timestats,time_mps2,mytime, &
           mynw,mysw,myne,myse,myeast,mywest,mynorth,mysouth
@@ -7642,14 +7445,14 @@
 !-----
 !$acc end data 
 
-      end subroutine comm_1s_tend_halo_GPU
+      end subroutine comm_1s_tend_halo
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine comm_1u_tend_halo_GPU(s)
+      subroutine comm_1u_tend_halo(s)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,nf,ierr,cs1we,cs1sn,timestats,time_mps2,mytime, &
           mynw,mysw,myne,myse,myeast,mywest,mynorth,mysouth
@@ -8110,7 +7913,7 @@
 !-----
 !$acc end data 
 
-      end subroutine comm_1u_tend_halo_GPU
+      end subroutine comm_1u_tend_halo
 
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -8118,7 +7921,7 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
 
-      subroutine comm_1v_tend_halo_GPU(s)
+      subroutine comm_1v_tend_halo(s)
       use input, only : ib,ie,jb,je,kb,ke,ni,nj,nk,ibe,ibw,ibs,ibn, &
           wbc,ebc,sbc,nbc,nf,ierr,cs1we,cs1sn,timestats,time_mps2,mytime, &
           mynw,mysw,myne,myse,myeast,mywest,mynorth,mysouth
@@ -8579,7 +8382,7 @@
 !-----
 !$acc end data 
 
-      end subroutine comm_1v_tend_halo_GPU
+      end subroutine comm_1v_tend_halo
 
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -330,13 +330,13 @@
   !$acc end parallel
 
   ! GHB 210714:
-    call prepcorners3_GPU( ta,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+    call prepcorners3( ta,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,1)
-    call prepcorners3_GPU(rho,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+    call prepcorners3(rho,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,1)
-    call prepcorners3_GPU(prs,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+    call prepcorners3(prs,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,1)
-    call prepcorners3_GPU(qa(ib,jb,kb,nqv),sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+    call prepcorners3(qa(ib,jb,kb,nqv),sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                           n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,1)
 
 !----------------------------------------------------------------------

--- a/src/hifrq.F
+++ b/src/hifrq.F
@@ -936,8 +936,8 @@
 
       call bcs(sadv,device=.false.)
 #ifdef MPI
-      call comm_3s_start_GPU(sadv,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
-      call comm_3s_end_GPU(sadv,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
+      call comm_3s_start(sadv,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
+      call comm_3s_end(sadv,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_s,device=.false.)
 #endif
 
     if( td_hadv.ge.1 .and. td_vadv.ge.1 )then

--- a/src/ib_module.F
+++ b/src/ib_module.F
@@ -191,10 +191,10 @@
       nu=0
       nv=0
       nw=0
-      call comm_2d_start(zsfoo,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs_p)
-      call comm_2dew_end(zsfoo,west,newwest,east,neweast,reqs_p)
-      call comm_2dns_end(zsfoo,south,newsouth,north,newnorth,reqs_p)
+      call comm_2d_start_GPU(zsfoo,west,newwest,east,neweast,   &
+                        south,newsouth,north,newnorth,reqs_p,device=.false.)
+      call comm_2dew_end_GPU(zsfoo,west,newwest,east,neweast,reqs_p,device=.false.)
+      call comm_2dns_end_GPU(zsfoo,south,newsouth,north,newnorth,reqs_p,device=.false.)
       call bcs2_2d(zsfoo,device=.false.)
       call bc2d(zsfoo,device=.false.)
       call getcorner3_2d_GPU(zsfoo,device=.false.)

--- a/src/ib_module.F
+++ b/src/ib_module.F
@@ -197,7 +197,7 @@
       call comm_2dns_end(zsfoo,south,newsouth,north,newnorth,reqs_p)
       call bcs2_2d(zsfoo,device=.false.)
       call bc2d(zsfoo,device=.false.)
-      call getcorner3_2d(zsfoo)
+      call getcorner3_2d_GPU(zsfoo,device=.false.)
 #endif
 
       do k=1,nk

--- a/src/ib_module.F
+++ b/src/ib_module.F
@@ -191,13 +191,13 @@
       nu=0
       nv=0
       nw=0
-      call comm_2d_start_GPU(zsfoo,west,newwest,east,neweast,   &
+      call comm_2d_start(zsfoo,west,newwest,east,neweast,   &
                         south,newsouth,north,newnorth,reqs_p,device=.false.)
-      call comm_2dew_end_GPU(zsfoo,west,newwest,east,neweast,reqs_p,device=.false.)
-      call comm_2dns_end_GPU(zsfoo,south,newsouth,north,newnorth,reqs_p,device=.false.)
+      call comm_2dew_end(zsfoo,west,newwest,east,neweast,reqs_p,device=.false.)
+      call comm_2dns_end(zsfoo,south,newsouth,north,newnorth,reqs_p,device=.false.)
       call bcs2_2d(zsfoo,device=.false.)
       call bc2d(zsfoo,device=.false.)
-      call getcorner3_2d_GPU(zsfoo,device=.false.)
+      call getcorner3_2d(zsfoo,device=.false.)
 #endif
 
       do k=1,nk

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -2251,69 +2251,69 @@
       nv=0
       nw=0
 
-      call comm_3u_start_GPU(ua,uw31,uw32,ue31,ue32,   &
+      call comm_3u_start(ua,uw31,uw32,ue31,ue32,   &
                           us31,us32,un31,un32,reqs_u,device=.false.)
-      call comm_3u_end_GPU(ua,uw31,uw32,ue31,ue32,   &
+      call comm_3u_end(ua,uw31,uw32,ue31,ue32,   &
                           us31,us32,un31,un32,reqs_u,device=.false.)
 
-      call comm_3v_start_GPU(va,vw31,vw32,ve31,ve32,   &
+      call comm_3v_start(va,vw31,vw32,ve31,ve32,   &
                             vs31,vs32,vn31,vn32,reqs_v,device=.false.)
-      call comm_3v_end_GPU(va,vw31,vw32,ve31,ve32,   &
+      call comm_3v_end(va,vw31,vw32,ve31,ve32,   &
                           vs31,vs32,vn31,vn32,reqs_v,device=.false.)
 
-      call comm_3w_start_GPU(wa,ww31,ww32,we31,we32,   &
+      call comm_3w_start(wa,ww31,ww32,we31,we32,   &
                             ws31,ws32,wn31,wn32,reqs_w,device=.false.)
-      call comm_3w_end_GPU(wa,ww31,ww32,we31,we32,   &
+      call comm_3w_end(wa,ww31,ww32,we31,we32,   &
                           ws31,ws32,wn31,wn32,reqs_w,device=.false.)
 
-      call comm_3s_start_GPU(ppi,sw31,sw32,se31,se32,   &
+      call comm_3s_start(ppi,sw31,sw32,se31,se32,   &
                              ss31,ss32,sn31,sn32,reqs_s,device=.false.)
-      call comm_3s_end_GPU(ppi,sw31,sw32,se31,se32,   &
+      call comm_3s_end(ppi,sw31,sw32,se31,se32,   &
                            ss31,ss32,sn31,sn32,reqs_s,device=.false.)
 
-      call comm_3s_start_GPU(tha,sw31,sw32,se31,se32,   &
+      call comm_3s_start(tha,sw31,sw32,se31,se32,   &
                              ss31,ss32,sn31,sn32,reqs_s,device=.false.)
-      call comm_3s_end_GPU(tha,sw31,sw32,se31,se32,   &
+      call comm_3s_end(tha,sw31,sw32,se31,se32,   &
                            ss31,ss32,sn31,sn32,reqs_s,device=.false.)
 
       IF(imoist.eq.1)THEN
         do n=1,numq
-          call comm_3s_start_GPU(qa(ibm,jbm,kbm,n),sw31,sw32,se31,se32,   &
+          call comm_3s_start(qa(ibm,jbm,kbm,n),sw31,sw32,se31,se32,   &
                                              ss31,ss32,sn31,sn32,reqs_s,device=.false.)
-          call comm_3s_end_GPU(qa(ibm,jbm,kbm,n),sw31,sw32,se31,se32,   &
+          call comm_3s_end(qa(ibm,jbm,kbm,n),sw31,sw32,se31,se32,   &
                                              ss31,ss32,sn31,sn32,reqs_s,device=.false.)
         enddo
       ENDIF
 
       IF( cm1setup.eq.1 .and. iusetke )THEN
-        call comm_3t_start_GPU(tkea,tkw1,tkw2,tke1,tke2,   &
+        call comm_3t_start(tkea,tkw1,tkw2,tke1,tke2,   &
                                 tks1,tks2,tkn1,tkn2,reqs_tk,device=.false.)
-        call comm_3t_end_GPU(tkea,tkw1,tkw2,tke1,tke2,   &
+        call comm_3t_end(tkea,tkw1,tkw2,tke1,tke2,   &
                               tks1,tks2,tkn1,tkn2,reqs_tk,device=.false.)
       ENDIF
 
       IF(iptra.eq.1)THEN
         do n=1,npt
-          call comm_3s_start_GPU(pta(ib,jb,kb,n),sw31,sw32,se31,se32,   &
+          call comm_3s_start(pta(ib,jb,kb,n),sw31,sw32,se31,se32,   &
                                              ss31,ss32,sn31,sn32,reqs_s,device=.false.)
-          call comm_3s_end_GPU(pta(ib,jb,kb,n),sw31,sw32,se31,se32,   &
+          call comm_3s_end(pta(ib,jb,kb,n),sw31,sw32,se31,se32,   &
                                            ss31,ss32,sn31,sn32,reqs_s,device=.false.)
         enddo
       ENDIF
 
-      call comm_3u_start_GPU(u0,uw31,uw32,ue31,ue32,   &
+      call comm_3u_start(u0,uw31,uw32,ue31,ue32,   &
                             us31,us32,un31,un32,reqs_u,device=.false.)
-      call comm_3u_end_GPU(u0,uw31,uw32,ue31,ue32,   &
+      call comm_3u_end(u0,uw31,uw32,ue31,ue32,   &
                           us31,us32,un31,un32,reqs_u,device=.false.)
 
-      call comm_3v_start_GPU(v0,vw31,vw32,ve31,ve32,   &
+      call comm_3v_start(v0,vw31,vw32,ve31,ve32,   &
                             vs31,vs32,vn31,vn32,reqs_v,device=.false.)
-      call comm_3v_end_GPU(v0,vw31,vw32,ve31,ve32,   &
+      call comm_3v_end(v0,vw31,vw32,ve31,ve32,   &
                           vs31,vs32,vn31,vn32,reqs_v,device=.false.)
 
-      call comm_3s_start_GPU(th0,sw31,sw32,se31,se32,   &
+      call comm_3s_start(th0,sw31,sw32,se31,se32,   &
                              ss31,ss32,sn31,sn32,reqs_s,device=.false.)
-      call comm_3s_end_GPU(th0,sw31,sw32,se31,se32,   &
+      call comm_3s_end(th0,sw31,sw32,se31,se32,   &
                            ss31,ss32,sn31,sn32,reqs_s,device=.false.)
 
       call MPI_BARRIER (MPI_COMM_WORLD,ierr)
@@ -2332,12 +2332,12 @@
         enddo
         call bc2d(tkea(ibt,jbt,1),device=.false.)
 #ifdef MPI
-        call comm_1s2d_start_GPU(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
+        call comm_1s2d_start(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
                                       ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s,device=.false.)
-        call comm_1s2d_end_GPU(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
+        call comm_1s2d_end(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
                                     ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s,device=.false.)
         call bcs2_2d(tkea(ibt,jbt,1),device=.false.)
-        call comm_2d_corner_GPU(tkea(ibt,jbt,1),device=.false.)
+        call comm_2d_corner(tkea(ibt,jbt,1),device=.false.)
 #endif
       endif
 
@@ -2421,8 +2421,8 @@
       if( psolver.eq.6 )then
         call bcs(phi1,device=.false.)
 #ifdef MPI
-        call comm_1s_start_GPU(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
-        call comm_1s_end_GPU(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_start(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_end(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
 #endif
         do k=kb,ke
         do j=jb,je
@@ -2491,10 +2491,10 @@
 
         call bcs(rho,device=.false.)
 #ifdef MPI
-        call comm_1s_start_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
-        call comm_1s_end_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_start(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_end(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
         call bcs2(rho,device=.false.)
-        call getcorner_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
+        call getcorner(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
 
       !$omp parallel do default(shared)  &
@@ -2510,17 +2510,17 @@
 
         call bcs(rr,device=.false.)
 #ifdef MPI
-        call comm_1s_start_GPU(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
-        call comm_1s_end_GPU(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_start(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_end(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
         call bcs2(rr,device=.false.)
-        call getcorner_GPU(rr,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
+        call getcorner(rr,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
         call bcs(rf,device=.false.)
 #ifdef MPI
-        call comm_1s_start_GPU(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
-        call comm_1s_end_GPU(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_start(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_end(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
         call bcs2(rf,device=.false.)
-        call getcorner_GPU(rf,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
+        call getcorner(rf,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
 
         ! meh 1 !
@@ -2621,8 +2621,8 @@
 
       call bcs(ppx,device=.false.)
 #ifdef MPI
-      call comm_1s_start_GPU(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
-      call comm_1s_end_GPU(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+      call comm_1s_start(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+      call comm_1s_end(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
 #endif
 
     ENDIF

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -2337,7 +2337,7 @@
         call comm_1s2d_end(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
                                            ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s)
         call bcs2_2d(tkea(ibt,jbt,1),device=.false.)
-        call comm_2d_corner(tkea(ibt,jbt,1))
+        call comm_2d_corner_GPU(tkea(ibt,jbt,1),device=.false.)
 #endif
       endif
 

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -2251,20 +2251,20 @@
       nv=0
       nw=0
 
-      call comm_3u_start(ua,uw31,uw32,ue31,ue32,   &
-                            us31,us32,un31,un32,reqs_u)
-      call comm_3u_end(ua,uw31,uw32,ue31,ue32,   &
-                          us31,us32,un31,un32,reqs_u)
+      call comm_3u_start_GPU(ua,uw31,uw32,ue31,ue32,   &
+                          us31,us32,un31,un32,reqs_u,device=.false.)
+      call comm_3u_end_GPU(ua,uw31,uw32,ue31,ue32,   &
+                          us31,us32,un31,un32,reqs_u,device=.false.)
 
-      call comm_3v_start(va,vw31,vw32,ve31,ve32,   &
-                            vs31,vs32,vn31,vn32,reqs_v)
-      call comm_3v_end(va,vw31,vw32,ve31,ve32,   &
-                          vs31,vs32,vn31,vn32,reqs_v)
+      call comm_3v_start_GPU(va,vw31,vw32,ve31,ve32,   &
+                            vs31,vs32,vn31,vn32,reqs_v,device=.false.)
+      call comm_3v_end_GPU(va,vw31,vw32,ve31,ve32,   &
+                          vs31,vs32,vn31,vn32,reqs_v,device=.false.)
 
-      call comm_3w_start(wa,ww31,ww32,we31,we32,   &
-                            ws31,ws32,wn31,wn32,reqs_w)
-      call comm_3w_end(wa,ww31,ww32,we31,we32,   &
-                          ws31,ws32,wn31,wn32,reqs_w)
+      call comm_3w_start_GPU(wa,ww31,ww32,we31,we32,   &
+                            ws31,ws32,wn31,wn32,reqs_w,device=.false.)
+      call comm_3w_end_GPU(wa,ww31,ww32,we31,we32,   &
+                          ws31,ws32,wn31,wn32,reqs_w,device=.false.)
 
       call comm_3s_start_GPU(ppi,sw31,sw32,se31,se32,   &
                              ss31,ss32,sn31,sn32,reqs_s,device=.false.)
@@ -2286,10 +2286,10 @@
       ENDIF
 
       IF( cm1setup.eq.1 .and. iusetke )THEN
-        call comm_3t_start(tkea,tkw1,tkw2,tke1,tke2,   &
-                                tks1,tks2,tkn1,tkn2,reqs_tk)
-        call comm_3t_end(tkea,tkw1,tkw2,tke1,tke2,   &
-                              tks1,tks2,tkn1,tkn2,reqs_tk)
+        call comm_3t_start_GPU(tkea,tkw1,tkw2,tke1,tke2,   &
+                                tks1,tks2,tkn1,tkn2,reqs_tk,device=.false.)
+        call comm_3t_end_GPU(tkea,tkw1,tkw2,tke1,tke2,   &
+                              tks1,tks2,tkn1,tkn2,reqs_tk,device=.false.)
       ENDIF
 
       IF(iptra.eq.1)THEN
@@ -2301,15 +2301,15 @@
         enddo
       ENDIF
 
-      call comm_3u_start(u0,uw31,uw32,ue31,ue32,   &
-                            us31,us32,un31,un32,reqs_u)
-      call comm_3u_end(u0,uw31,uw32,ue31,ue32,   &
-                          us31,us32,un31,un32,reqs_u)
+      call comm_3u_start_GPU(u0,uw31,uw32,ue31,ue32,   &
+                            us31,us32,un31,un32,reqs_u,device=.false.)
+      call comm_3u_end_GPU(u0,uw31,uw32,ue31,ue32,   &
+                          us31,us32,un31,un32,reqs_u,device=.false.)
 
-      call comm_3v_start(v0,vw31,vw32,ve31,ve32,   &
-                            vs31,vs32,vn31,vn32,reqs_v)
-      call comm_3v_end(v0,vw31,vw32,ve31,ve32,   &
-                          vs31,vs32,vn31,vn32,reqs_v)
+      call comm_3v_start_GPU(v0,vw31,vw32,ve31,ve32,   &
+                            vs31,vs32,vn31,vn32,reqs_v,device=.false.)
+      call comm_3v_end_GPU(v0,vw31,vw32,ve31,ve32,   &
+                          vs31,vs32,vn31,vn32,reqs_v,device=.false.)
 
       call comm_3s_start_GPU(th0,sw31,sw32,se31,se32,   &
                              ss31,ss32,sn31,sn32,reqs_s,device=.false.)
@@ -2421,8 +2421,8 @@
       if( psolver.eq.6 )then
         call bcs(phi1,device=.false.)
 #ifdef MPI
-        call comm_1s_start(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-        call comm_1s_end(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
+        call comm_1s_start_GPU(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_end_GPU(phi1,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
 #endif
         do k=kb,ke
         do j=jb,je
@@ -2491,8 +2491,8 @@
 
         call bcs(rho,device=.false.)
 #ifdef MPI
-        call comm_1s_start(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-        call comm_1s_end(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
+        call comm_1s_start_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_end_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
         call bcs2(rho,device=.false.)
         call getcorner_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
@@ -2510,15 +2510,15 @@
 
         call bcs(rr,device=.false.)
 #ifdef MPI
-        call comm_1s_start(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-        call comm_1s_end(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
+        call comm_1s_start_GPU(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_end_GPU(rr,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
         call bcs2(rr,device=.false.)
         call getcorner_GPU(rr,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
         call bcs(rf,device=.false.)
 #ifdef MPI
-        call comm_1s_start(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-        call comm_1s_end(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
+        call comm_1s_start_GPU(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+        call comm_1s_end_GPU(rf,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
         call bcs2(rf,device=.false.)
         call getcorner_GPU(rf,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
@@ -2621,8 +2621,8 @@
 
       call bcs(ppx,device=.false.)
 #ifdef MPI
-      call comm_1s_start(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-      call comm_1s_end(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
+      call comm_1s_start_GPU(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
+      call comm_1s_end_GPU(ppx,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,device=.false.)
 #endif
 
     ENDIF

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -2332,10 +2332,10 @@
         enddo
         call bc2d(tkea(ibt,jbt,1),device=.false.)
 #ifdef MPI
-        call comm_1s2d_start(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
-                                             ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s)
-        call comm_1s2d_end(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
-                                           ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s)
+        call comm_1s2d_start_GPU(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
+                                      ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s,device=.false.)
+        call comm_1s2d_end_GPU(tkea(ibt,jbt,1),sw31(1,1,1),sw32(1,1,1),se31(1,1,1),se32(1,1,1),   &
+                                    ss31(1,1,1),ss32(1,1,1),sn31(1,1,1),sn32(1,1,1),reqs_s,device=.false.)
         call bcs2_2d(tkea(ibt,jbt,1),device=.false.)
         call comm_2d_corner_GPU(tkea(ibt,jbt,1),device=.false.)
 #endif

--- a/src/init_terrain.F
+++ b/src/init_terrain.F
@@ -163,10 +163,10 @@
         nu=0
         nv=0
         nw=0
-        call comm_2d_start(zs,west,newwest,east,neweast,   &
-                              south,newsouth,north,newnorth,reqs_p)
-        call comm_2dew_end(zs,west,newwest,east,neweast,reqs_p)
-        call comm_2dns_end(zs,south,newsouth,north,newnorth,reqs_p)
+        call comm_2d_start_GPU(zs,west,newwest,east,neweast,   &
+                             south,newsouth,north,newnorth,reqs_p,device=.false.)
+        call comm_2dew_end_GPU(zs,west,newwest,east,neweast,reqs_p,device=.false.)
+        call comm_2dns_end_GPU(zs,south,newsouth,north,newnorth,reqs_p,device=.false.)
         call bcs2_2d(zs,device=.false.)
         call bc2d(zs,device=.false.)
         call getcorner3_2d_GPU(zs,device=.false.)
@@ -207,18 +207,18 @@
         call bc2d(dzdy,device=.false.)
 
 #ifdef MPI
-        call comm_2d_start(dzdx,west,newwest,east,neweast,   &
-                                south,newsouth,north,newnorth,reqs_p)
-        call comm_2dew_end(dzdx,west,newwest,east,neweast,reqs_p)
-        call comm_2dns_end(dzdx,south,newsouth,north,newnorth,reqs_p)
+        call comm_2d_start_GPU(dzdx,west,newwest,east,neweast,   &
+                               south,newsouth,north,newnorth,reqs_p,device=.false.)
+        call comm_2dew_end_GPU(dzdx,west,newwest,east,neweast,reqs_p,device=.false.)
+        call comm_2dns_end_GPU(dzdx,south,newsouth,north,newnorth,reqs_p,device=.false.)
         call bcs2_2d(dzdx,device=.false.)
         call bc2d(dzdx,device=.false.)
         call getcorner3_2d_GPU(dzdx,device=.false.)
 
-        call comm_2d_start(dzdy,west,newwest,east,neweast,   &
-                                south,newsouth,north,newnorth,reqs_p)
-        call comm_2dew_end(dzdy,west,newwest,east,neweast,reqs_p)
-        call comm_2dns_end(dzdy,south,newsouth,north,newnorth,reqs_p)
+        call comm_2d_start_GPU(dzdy,west,newwest,east,neweast,   &
+                               south,newsouth,north,newnorth,reqs_p,device=.false.)
+        call comm_2dew_end_GPU(dzdy,west,newwest,east,neweast,reqs_p,device=.false.)
+        call comm_2dns_end_GPU(dzdy,south,newsouth,north,newnorth,reqs_p,device=.false.)
         call bcs2_2d(dzdy,device=.false.)
         call bc2d(dzdy,device=.false.)
         call getcorner3_2d_GPU(dzdy,device=.false.)
@@ -236,10 +236,10 @@
 
         call bc2d(rgz,device=.false.)
 #ifdef MPI
-        call comm_2d_start(rgz,west,newwest,east,neweast,   &
-                               south,newsouth,north,newnorth,reqs_p)
-        call comm_2dew_end(rgz,west,newwest,east,neweast,reqs_p)
-        call comm_2dns_end(rgz,south,newsouth,north,newnorth,reqs_p)
+        call comm_2d_start_GPU(rgz,west,newwest,east,neweast,   &
+                               south,newsouth,north,newnorth,reqs_p,device=.false.)
+        call comm_2dew_end_GPU(rgz,west,newwest,east,neweast,reqs_p,device=.false.)
+        call comm_2dns_end_GPU(rgz,south,newsouth,north,newnorth,reqs_p,device=.false.)
         call bcs2_2d(rgz,device=.false.)
         call bc2d(rgz,device=.false.)
         call getcorner3_2d_GPU(rgz,device=.false.)

--- a/src/init_terrain.F
+++ b/src/init_terrain.F
@@ -163,13 +163,13 @@
         nu=0
         nv=0
         nw=0
-        call comm_2d_start_GPU(zs,west,newwest,east,neweast,   &
+        call comm_2d_start(zs,west,newwest,east,neweast,   &
                              south,newsouth,north,newnorth,reqs_p,device=.false.)
-        call comm_2dew_end_GPU(zs,west,newwest,east,neweast,reqs_p,device=.false.)
-        call comm_2dns_end_GPU(zs,south,newsouth,north,newnorth,reqs_p,device=.false.)
+        call comm_2dew_end(zs,west,newwest,east,neweast,reqs_p,device=.false.)
+        call comm_2dns_end(zs,south,newsouth,north,newnorth,reqs_p,device=.false.)
         call bcs2_2d(zs,device=.false.)
         call bc2d(zs,device=.false.)
-        call getcorner3_2d_GPU(zs,device=.false.)
+        call getcorner3_2d(zs,device=.false.)
 #endif
 
         zt = maxz
@@ -207,21 +207,21 @@
         call bc2d(dzdy,device=.false.)
 
 #ifdef MPI
-        call comm_2d_start_GPU(dzdx,west,newwest,east,neweast,   &
+        call comm_2d_start(dzdx,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs_p,device=.false.)
-        call comm_2dew_end_GPU(dzdx,west,newwest,east,neweast,reqs_p,device=.false.)
-        call comm_2dns_end_GPU(dzdx,south,newsouth,north,newnorth,reqs_p,device=.false.)
+        call comm_2dew_end(dzdx,west,newwest,east,neweast,reqs_p,device=.false.)
+        call comm_2dns_end(dzdx,south,newsouth,north,newnorth,reqs_p,device=.false.)
         call bcs2_2d(dzdx,device=.false.)
         call bc2d(dzdx,device=.false.)
-        call getcorner3_2d_GPU(dzdx,device=.false.)
+        call getcorner3_2d(dzdx,device=.false.)
 
-        call comm_2d_start_GPU(dzdy,west,newwest,east,neweast,   &
+        call comm_2d_start(dzdy,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs_p,device=.false.)
-        call comm_2dew_end_GPU(dzdy,west,newwest,east,neweast,reqs_p,device=.false.)
-        call comm_2dns_end_GPU(dzdy,south,newsouth,north,newnorth,reqs_p,device=.false.)
+        call comm_2dew_end(dzdy,west,newwest,east,neweast,reqs_p,device=.false.)
+        call comm_2dns_end(dzdy,south,newsouth,north,newnorth,reqs_p,device=.false.)
         call bcs2_2d(dzdy,device=.false.)
         call bc2d(dzdy,device=.false.)
-        call getcorner3_2d_GPU(dzdy,device=.false.)
+        call getcorner3_2d(dzdy,device=.false.)
 #endif
 
 !--------------------------------
@@ -236,13 +236,13 @@
 
         call bc2d(rgz,device=.false.)
 #ifdef MPI
-        call comm_2d_start_GPU(rgz,west,newwest,east,neweast,   &
+        call comm_2d_start(rgz,west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs_p,device=.false.)
-        call comm_2dew_end_GPU(rgz,west,newwest,east,neweast,reqs_p,device=.false.)
-        call comm_2dns_end_GPU(rgz,south,newsouth,north,newnorth,reqs_p,device=.false.)
+        call comm_2dew_end(rgz,west,newwest,east,neweast,reqs_p,device=.false.)
+        call comm_2dns_end(rgz,south,newsouth,north,newnorth,reqs_p,device=.false.)
         call bcs2_2d(rgz,device=.false.)
         call bc2d(rgz,device=.false.)
-        call getcorner3_2d_GPU(rgz,device=.false.)
+        call getcorner3_2d(rgz,device=.false.)
 #endif
 
         do j=jb+1,je

--- a/src/init_terrain.F
+++ b/src/init_terrain.F
@@ -169,7 +169,7 @@
         call comm_2dns_end(zs,south,newsouth,north,newnorth,reqs_p)
         call bcs2_2d(zs,device=.false.)
         call bc2d(zs,device=.false.)
-        call getcorner3_2d(zs)
+        call getcorner3_2d_GPU(zs,device=.false.)
 #endif
 
         zt = maxz
@@ -213,7 +213,7 @@
         call comm_2dns_end(dzdx,south,newsouth,north,newnorth,reqs_p)
         call bcs2_2d(dzdx,device=.false.)
         call bc2d(dzdx,device=.false.)
-        call getcorner3_2d(dzdx)
+        call getcorner3_2d_GPU(dzdx,device=.false.)
 
         call comm_2d_start(dzdy,west,newwest,east,neweast,   &
                                 south,newsouth,north,newnorth,reqs_p)
@@ -221,7 +221,7 @@
         call comm_2dns_end(dzdy,south,newsouth,north,newnorth,reqs_p)
         call bcs2_2d(dzdy,device=.false.)
         call bc2d(dzdy,device=.false.)
-        call getcorner3_2d(dzdy)
+        call getcorner3_2d_GPU(dzdy,device=.false.)
 #endif
 
 !--------------------------------
@@ -242,7 +242,7 @@
         call comm_2dns_end(rgz,south,newsouth,north,newnorth,reqs_p)
         call bcs2_2d(rgz,device=.false.)
         call bc2d(rgz,device=.false.)
-        call getcorner3_2d(rgz)
+        call getcorner3_2d_GPU(rgz,device=.false.)
 #endif
 
         do j=jb+1,je

--- a/src/param.F
+++ b/src/param.F
@@ -27,7 +27,7 @@
       use constants
       use init_terrain_module
       use bc_module, only: bcs
-      use comm_module, only: comm_all_s_GPU,nabor
+      use comm_module, only: comm_all_s,nabor
       use bcast_module
       use ib_module
       use eddy_recycle
@@ -8281,7 +8281,7 @@
       enddo
       call bcs(cc2,device=.false.)
 #ifdef MPI
-      call comm_all_s_GPU(cc2,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
+      call comm_all_s(cc2,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                      n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)
 #endif
 

--- a/src/param.F
+++ b/src/param.F
@@ -8279,9 +8279,7 @@
       enddo
       enddo
       enddo
-      !!$acc data copy(cc2,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s)
       call bcs(cc2,device=.false.)
-      !!$acc end data
 #ifdef MPI
       call comm_all_s_GPU(cc2,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,  &
                      n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,device=.false.)

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -898,7 +898,7 @@
       enddo
       if(timestats.ge.1) time_parceli=time_parceli+mytime()
       !!$acc update device(buoy)
-      call    prepcornert_GPU(buoy,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
+      call    prepcornert(buoy,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,1)
       !!$acc update host(buoy)
 
@@ -943,7 +943,7 @@
     endif
       if(timestats.ge.1) time_parceli=time_parceli+mytime()
       !!$acc update device(vpg)
-      call    prepcornert_GPU(vpg ,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
+      call    prepcornert(vpg ,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,  &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,1)
       !!$acc update host(vpg)
       ! cmr18:  at top/bottom boundaries, vpg + buoy = 0
@@ -965,9 +965,9 @@
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
-      call getcorneru_GPU(u3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-      call getcornerv_GPU(v3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-      call getcornerw_GPU(w3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+      call getcorneru(u3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+      call getcornerv(v3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+      call getcornerw(w3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
       call bcu2(u3d)
       call bcv2(v3d)
       call bcw2(w3d)
@@ -1070,53 +1070,35 @@
 
       if(timestats.ge.1) time_parceli=time_parceli+mytime()
 
-      !print *,'parcel_interp: point #1'
       if( prth.ge.1 )then
-        !!$acc update device(th)
-        call prepcorners_GPU(th ,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+        call prepcorners(th ,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
-        !!$acc update host(th)
       endif
-      !print *,'parcel_interp: point #2'
       if( prt.ge.1 )then
-        !!$acc update device(t)
-        call prepcorners_GPU(t  ,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+        call prepcorners(t  ,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
-        !!$acc update host(t)
       endif
-      !print *,'parcel_interp: point #3'
       if( prprs.ge.1 )then
-        !!$acc update device(prs)
-        call prepcorners_GPU(prs,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+        call prepcorners(prs,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
-        !!$acc update host(prs)
       endif
-      !print *,'parcel_interp: point #4'
       if( prrho.ge.1 )then
-        !!$acc update device(rho)
-        call prepcorners_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+        call prepcorners(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
-        !!$acc update host(rho)
       endif
-      !print *,'parcel_interp: point #5'
       if(prpt1.ge.1)then
-        !!$acc update device(pt3d)
         do n=1,npt
-          call prepcorners_GPU(pt3d(ib,jb,kb,n),nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+          call prepcorners(pt3d(ib,jb,kb,n),nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                                             pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,0)
         enddo
-        !!$acc update host(pt3d)
       endif
-      !print *,'parcel_interp: point #6'
-      !!$acc update device(q3d)
       if( prqv.ge.1 )then
-        call prepcorners_GPU(q3d(ib,jb,kb,nqv),nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+        call prepcorners(q3d(ib,jb,kb,nqv),nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                                            pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,0)
       endif
-      !print *,'parcel_interp: point #7'
       if( prq1.ge.1 .or. prnc1.ge.1 )then
         do n = 1,numq
-          call prepcorners_GPU(q3d(ib,jb,kb,n),nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+          call prepcorners(q3d(ib,jb,kb,n),nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                                            pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,0)
         enddo
       endif
@@ -1124,32 +1106,32 @@
       !print *,'parcel_interp: point #8'
       !!$acc update device(kmh,kmv)
       if( prkm.ge.1 )then
-        call prepcornert_GPU(kmh,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+        call prepcornert(kmh,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,0)
-        call prepcornert_GPU(kmv,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+        call prepcornert(kmv,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,0)
       endif
       !!$acc update host(kmh,kmv)
       !print *,'parcel_interp: point #9'
       !!$acc update device(khh,khv)
       if( prkh.ge.1 )then
-        call prepcornert_GPU(khh,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+        call prepcornert(khh,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,0)
-        call prepcornert_GPU(khv,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+        call prepcornert(khv,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,0)
       endif
       !!$acc update host(khh,khv)
       !print *,'parcel_interp: point #10'
       !!$acc update device(tke3d)
       if( prtke.ge.1 )then
-        call prepcornert_GPU(tke3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+        call prepcornert(tke3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                                tkw1,tkw2,tke1,tke2,tks1,tks2,tkn1,tkn2,reqs_p,0)
       endif
       !!$acc update host(tke3d)
       !print *,'parcel_interp: point #11'
       !!$acc update device(qdiag)
       if( prdbz.ge.1 )then
-        call prepcorners_GPU(qdiag(ibdq,jbdq,kbdq,qd_dbz),  &
+        call prepcorners(qdiag(ibdq,jbdq,kbdq,qd_dbz),  &
                              nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                              pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
       endif
@@ -1171,7 +1153,7 @@
 
       if(timestats.ge.1) time_parceli=time_parceli+mytime()
 
-      call prepcorners_GPU(dum1,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+      call prepcorners(dum1,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                             pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
     ENDIF
     IF( prqsi.ge.1 )THEN
@@ -1187,7 +1169,7 @@
 
       if(timestats.ge.1) time_parceli=time_parceli+mytime()
 
-      call prepcorners_GPU(dum2,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
+      call prepcorners(dum2,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1), &
                             pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p,1)
     ENDIF
     !  print *,'parcel_interp: point #13'

--- a/src/pdef.F
+++ b/src/pdef.F
@@ -113,7 +113,7 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_2we_start_GPU(dum,west(1,1,1),newwest(1,1,1),east(1,1,1),neweast(1,1,1),reqs_s)
+        call comm_2we_start(dum,west(1,1,1),newwest(1,1,1),east(1,1,1),neweast(1,1,1),reqs_s)
 #endif
 
 !----------------------------------------------------------------
@@ -152,7 +152,7 @@
 ! cm1r17:  include divx component
 
 #ifdef MPI
-        call comm_2we_end_GPU(dum,west(1,1,1),newwest(1,1,1),east(1,1,1),neweast(1,1,1),reqs_s)
+        call comm_2we_end(dum,west(1,1,1),newwest(1,1,1),east(1,1,1),neweast(1,1,1),reqs_s)
 #endif
 
         rdt=1.0/dt
@@ -374,7 +374,7 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_2sn_start_GPU(dum,south(1,1,1),newsouth(1,1,1),north(1,1,1),newnorth(1,1,1),reqs_s)
+        call comm_2sn_start(dum,south(1,1,1),newsouth(1,1,1),north(1,1,1),newnorth(1,1,1),reqs_s)
 #endif
 
 !----------------------------------------------------------------
@@ -413,7 +413,7 @@
 ! cm1r17:  include divx component
 
 #ifdef MPI
-      call comm_2sn_end_GPU(dum,south(1,1,1),newsouth(1,1,1),north(1,1,1),newnorth(1,1,1),reqs_s)
+      call comm_2sn_end(dum,south(1,1,1),newsouth(1,1,1),north(1,1,1),newnorth(1,1,1),reqs_s)
 #endif
 
       !$omp parallel do default(shared) private(i,j,k,foo1,foo2,foo3)

--- a/src/solve2.F
+++ b/src/solve2.F
@@ -598,7 +598,7 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_1s_start_GPU(t11,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
+        call comm_1s_start(t11,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
 #endif
 
 !--------------------------------------------------------------------
@@ -619,11 +619,11 @@
 !--------------------------------------------------------------------
         IF(nrk.ge.2)THEN
 #ifdef MPI
-          call comm_3u_end_GPU(u3d,uw31,uw32,ue31,ue32,   &
+          call comm_3u_end(u3d,uw31,uw32,ue31,ue32,   &
                                us31,us32,un31,un32,reqs_u)
-          call comm_3v_end_GPU(v3d,vw31,vw32,ve31,ve32,   &
+          call comm_3v_end(v3d,vw31,vw32,ve31,ve32,   &
                                vs31,vs32,vn31,vn32,reqs_v)
-          call comm_3w_end_GPU(w3d,ww31,ww32,we31,we32,   &
+          call comm_3w_end(w3d,ww31,ww32,we31,we32,   &
                                ws31,ws32,wn31,wn32,reqs_w)
 #endif
           if(terrain_flag)then
@@ -732,9 +732,9 @@
         IF(terrain_flag)THEN
           call bcw(rrw,0)
 #ifdef MPI
-          call comm_1w_start_GPU(rrw,ww1,ww2,we1,we2,   &
+          call comm_1w_start(rrw,ww1,ww2,we1,we2,   &
                                  ws1,ws2,wn1,wn2,reqs_w)
-          call comm_1w_end_GPU(rrw,ww1,ww2,we1,we2,   &
+          call comm_1w_end(rrw,ww1,ww2,we1,we2,   &
                                ws1,ws2,wn1,wn2,reqs_w)
 #endif
         ENDIF
@@ -1036,8 +1036,8 @@
         IF(nrk.ge.2)THEN
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
-          call comm_1s_end_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
-          call getcorner_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+          call comm_1s_end(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
+          call getcorner(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
           call bcs2(rho)
         ENDIF
 #endif
@@ -1134,8 +1134,8 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_1s_start_GPU(dum6,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
-        call comm_1s_end_GPU(  dum6,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
+        call comm_1s_start(dum6,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
+        call comm_1s_end(  dum6,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
 #endif
   
         !$omp parallel do default(shared) private(i,j,k)
@@ -1193,7 +1193,7 @@
       IF(nrk.ge.2)THEN
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_1s_end_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
+        call comm_1s_end(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
       ENDIF
 #endif
 
@@ -1248,7 +1248,7 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_1s_end_GPU(t11,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
+        call comm_1s_end(t11,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
 #endif
 !--------------------------------------------------------------------
 !  call sound
@@ -1490,7 +1490,7 @@
         IF(nrk.ge.2)THEN
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
-          call comm_3s_end_GPU(th3d,rw31,rw32,re31,re32,   &
+          call comm_3s_end(th3d,rw31,rw32,re31,re32,   &
                                 rs31,rs32,rn31,rn32,reqs_y)
         ENDIF
 #endif
@@ -1610,7 +1610,7 @@
       if( nrk.ge.2 )then
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_3s_end_GPU(q3d(ib,jb,kb,n)  &
+        call comm_3s_end(q3d(ib,jb,kb,n)  &
                        ,qw31(1,1,1,n),qw32(1,1,1,n),qe31(1,1,1,n),qe32(1,1,1,n)     &
                        ,qs31(1,1,1,n),qs32(1,1,1,n),qn31(1,1,1,n),qn32(1,1,1,n)     &
                        ,reqs_q(1,n) )
@@ -1809,9 +1809,9 @@
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
-      call comm_3u_start_GPU(u3d,uw31,uw32,ue31,ue32,   &
+      call comm_3u_start(u3d,uw31,uw32,ue31,ue32,   &
                              us31,us32,un31,un32,reqs_u)
-      call comm_3v_start_GPU(v3d,vw31,vw32,ve31,ve32,   &
+      call comm_3v_start(v3d,vw31,vw32,ve31,ve32,   &
                              vs31,vs32,vn31,vn32,reqs_v)
 #endif
       if(terrain_flag) then 
@@ -1820,7 +1820,7 @@
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
-      call comm_3w_start_GPU(w3d,ww31,ww32,we31,we32,   &
+      call comm_3w_start(w3d,ww31,ww32,we31,we32,   &
                              ws31,ws32,wn31,wn32,reqs_w)
 #endif
       IF(nrk.lt.nrkmax)THEN
@@ -1830,16 +1830,16 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_1s_start_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
-        call comm_1s_start_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
-        call comm_3s_start_GPU(th3d,rw31,rw32,re31,re32,   &
+        call comm_1s_start(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
+        call comm_1s_start(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
+        call comm_3s_start(th3d,rw31,rw32,re31,re32,   &
                                 rs31,rs32,rn31,rn32,reqs_y)
 #endif
         IF(imoist.eq.1)THEN
           do n=1,numq
             call bcs(q3d(ib,jb,kb,n))
 #ifdef MPI
-            call comm_3s_start_GPU(q3d(ib,jb,kb,n)  &
+            call comm_3s_start(q3d(ib,jb,kb,n)  &
                        ,qw31(1,1,1,n),qw32(1,1,1,n),qe31(1,1,1,n),qe32(1,1,1,n)     &
                        ,qs31(1,1,1,n),qs32(1,1,1,n),qn31(1,1,1,n),qn32(1,1,1,n)     &
                        ,reqs_q(1,n) )
@@ -1869,7 +1869,7 @@
         IF(nrk.ge.2)THEN
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
-          call comm_3t_end_GPU(tke3d,tkw1,tkw2,tke1,tke2,   &
+          call comm_3t_end(tke3d,tkw1,tkw2,tke1,tke2,   &
                                  tks1,tks2,tkn1,tkn2,reqs_tk)
         ENDIF
 #endif
@@ -1926,7 +1926,7 @@
 #ifdef MPI
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
-          call comm_3t_start_GPU(tke3d,tkw1,tkw2,tke1,tke2,   &
+          call comm_3t_start(tke3d,tkw1,tkw2,tke1,tke2,   &
                                    tks1,tks2,tkn1,tkn2,reqs_tk)
 #endif
 
@@ -1969,8 +1969,8 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_3s_start_GPU(qke3d,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_tk)
-        call comm_3s_end_GPU(  qke3d,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_tk)
+        call comm_3s_start(qke3d,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_tk)
+        call comm_3s_end(  qke3d,sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,reqs_tk)
 #endif
         weps = 10.0*epsilon
         diffit = 0
@@ -2046,7 +2046,7 @@
           IF(nrk.ge.2)THEN
             call sync()
             if(timestats.ge.1) time_lb=time_lb+mytime()
-            call comm_3s_end_GPU(pt3d(ib,jb,kb,n),                           &
+            call comm_3s_end(pt3d(ib,jb,kb,n),                           &
                   tw1(1,1,1,n),tw2(1,1,1,n),te1(1,1,1,n),te2(1,1,1,n),   &
                   ts1(1,1,1,n),ts2(1,1,1,n),tn1(1,1,1,n),tn2(1,1,1,n),   &
                   reqs_t(1,n))
@@ -2079,7 +2079,7 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_3s_start_GPU(pt3d(ib,jb,kb,n)   &
+        call comm_3s_start(pt3d(ib,jb,kb,n)   &
                      ,tw1(1,1,1,n),tw2(1,1,1,n),te1(1,1,1,n),te2(1,1,1,n)     &
                      ,ts1(1,1,1,n),ts2(1,1,1,n),tn1(1,1,1,n),tn2(1,1,1,n)     &
                      ,reqs_t(1,n) )
@@ -2184,7 +2184,7 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_3s_start_GPU(pt3d(ib,jb,kb,n)   &
+        call comm_3s_start(pt3d(ib,jb,kb,n)   &
                      ,tw1(1,1,1,n),tw2(1,1,1,n),te1(1,1,1,n),te2(1,1,1,n)     &
                      ,ts1(1,1,1,n),ts2(1,1,1,n),tn1(1,1,1,n),tn2(1,1,1,n)     &
                      ,reqs_t(1,n) )

--- a/src/solve3.F
+++ b/src/solve3.F
@@ -362,8 +362,8 @@
 #ifdef MPI
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
-          call comm_1s_start_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
-          call comm_3s_start_GPU(th3d,rw31,rw32,re31,re32,   &
+          call comm_1s_start(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
+          call comm_3s_start(th3d,rw31,rw32,re31,re32,   &
                                   rs31,rs32,rn31,rn32,reqs_y)
 #endif
 
@@ -371,7 +371,7 @@
           DO n=1,numq
             call bcs(q3d(ib,jb,kb,n))
 #ifdef MPI
-            call comm_3s_start_GPU(q3d(ib,jb,kb,n)  &
+            call comm_3s_start(q3d(ib,jb,kb,n)  &
                        ,qw31(1,1,1,n),qw32(1,1,1,n),qe31(1,1,1,n),qe32(1,1,1,n)     &
                        ,qs31(1,1,1,n),qs32(1,1,1,n),qn31(1,1,1,n),qn32(1,1,1,n)     &
                        ,reqs_q(1,n) )
@@ -384,7 +384,7 @@
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
-      call comm_1s_start_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
+      call comm_1s_start(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
 #endif
 
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
@@ -406,8 +406,8 @@
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
-      call comm_1s_start_GPU(rr,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
-      call comm_1s_start_GPU(rf,p3w1,p3w2,p3e1,p3e2,p3s1,p3s2,p3n1,p3n2,reqs_p3)
+      call comm_1s_start(rr,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
+      call comm_1s_start(rf,p3w1,p3w2,p3e1,p3e2,p3s1,p3s2,p3n1,p3n2,reqs_p3)
 #endif
 
       IF( psolver.eq.2 .or. psolver.eq.3 .or. psolver.eq.6 .or. psolver.eq.7 )THEN
@@ -443,7 +443,7 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_1s_start_GPU(ppx,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
+        call comm_1s_start(ppx,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
 #endif
 
       ENDIF
@@ -554,19 +554,19 @@
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
-      call comm_3u_end_GPU(u3d,uw31,uw32,ue31,ue32,   &
+      call comm_3u_end(u3d,uw31,uw32,ue31,ue32,   &
                            us31,us32,un31,un32,reqs_u)
-      call comm_3v_end_GPU(v3d,vw31,vw32,ve31,ve32,   &
+      call comm_3v_end(v3d,vw31,vw32,ve31,ve32,   &
                            vs31,vs32,vn31,vn32,reqs_v)
-      call comm_3w_end_GPU(w3d,ww31,ww32,we31,we32,   &
+      call comm_3w_end(w3d,ww31,ww32,we31,we32,   &
                            ws31,ws32,wn31,wn32,reqs_w)
 #endif
 
 #ifdef MPI
       if(   sgsmodel.eq.5 .or. sgsmodel.eq.6 )then
-        call getcorneru_GPU(u3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call getcornerv_GPU(v3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call getcornerw_GPU(w3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call getcorneru(u3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call getcornerv(v3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call getcornerw(w3d,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
         call bcu2(u3d)
         call bcv2(v3d)
         call bcw2(w3d)
@@ -662,9 +662,9 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_3u_start_GPU(rru,uw31,uw32,ue31,ue32,us31,us32,un31,un32,reqs_u)
-        call comm_3v_start_GPU(rrv,vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,reqs_v)
-        call comm_3w_start_GPU(rrw,ww31,ww32,we31,we32,ws31,ws32,wn31,wn32,reqs_w)
+        call comm_3u_start(rru,uw31,uw32,ue31,ue32,us31,us32,un31,un32,reqs_u)
+        call comm_3v_start(rrv,vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,reqs_v)
+        call comm_3w_start(rrw,ww31,ww32,we31,we32,ws31,ws32,wn31,wn32,reqs_w)
 #endif
       ENDIF
 
@@ -729,7 +729,7 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_3t_end_GPU(tke3d,tkw1,tkw2,tke1,tke2,   &
+        call comm_3t_end(tke3d,tkw1,tkw2,tke1,tke2,   &
                                tks1,tks2,tkn1,tkn2,reqs_tk)
 #endif
         !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k) 
@@ -749,7 +749,7 @@
       if(iptra.eq.1)then
 #ifdef MPI
           do n=1,npt
-          call comm_3s_end_GPU(pt3d(ib,jb,kb,n),                           &
+          call comm_3s_end(pt3d(ib,jb,kb,n),                           &
                 tw1(1,1,1,n),tw2(1,1,1,n),te1(1,1,1,n),te2(1,1,1,n),   &
                 ts1(1,1,1,n),ts2(1,1,1,n),tn1(1,1,1,n),tn2(1,1,1,n),   &
                 reqs_t(1,n))
@@ -776,8 +776,8 @@
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
-      call comm_1s_end_GPU(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
-      call comm_3s_end_GPU(th3d,rw31,rw32,re31,re32,rs31,rs32,rn31,rn32,reqs_y)
+      call comm_1s_end(pp3d,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_x)
+      call comm_3s_end(th3d,rw31,rw32,re31,re32,rs31,rs32,rn31,rn32,reqs_y)
 #endif
 
       !$acc parallel loop gang vector collapse(3) default(present) private(i,j,k)
@@ -797,7 +797,7 @@
       if(imoist.eq.1)then
 #ifdef MPI
         DO n=1,numq
-          call comm_3s_end_GPU(q3d(ib,jb,kb,n)  &
+          call comm_3s_end(q3d(ib,jb,kb,n)  &
                      ,qw31(1,1,1,n),qw32(1,1,1,n),qe31(1,1,1,n),qe32(1,1,1,n)     &
                      ,qs31(1,1,1,n),qs32(1,1,1,n),qn31(1,1,1,n),qn32(1,1,1,n)     &
                      ,reqs_q(1,n) )
@@ -823,16 +823,16 @@
         !-----
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_1s_end_GPU(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
-        call getcorner_GPU(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call comm_1s_end(rho,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
+        call getcorner(rho,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
         call bcs2(rho)
         !-----
-        call comm_1s_end_GPU(rr,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
-        call getcorner_GPU(rr,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call comm_1s_end(rr,p2w1,p2w2,p2e1,p2e2,p2s1,p2s2,p2n1,p2n2,reqs_p2)
+        call getcorner(rr,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
         call bcs2(rr)
         !-----
-        call comm_1s_end_GPU(rf,p3w1,p3w2,p3e1,p3e2,p3s1,p3s2,p3n1,p3n2,reqs_p3)
-        call getcorner_GPU(rf,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call comm_1s_end(rf,p3w1,p3w2,p3e1,p3e2,p3s1,p3s2,p3n1,p3n2,reqs_p3)
+        call getcorner(rf,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
         call bcs2(rf)
         !-----
 #endif
@@ -850,7 +850,7 @@
         enddo
 #ifdef MPI
         IF( psolver.eq.2 .or. psolver.eq.3 .or. psolver.eq.6 .or. psolver.eq.7 )THEN
-          call comm_1p_end_GPU(ppx,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
+          call comm_1p_end(ppx,zw1,zw2,ze1,ze2,zs1,zs2,zn1,zn2,reqs_z)
         ENDIF
 #endif
 
@@ -864,14 +864,14 @@
         !  get corner info, ghost zone data, etc:
         !  (may not parallelize correctly if this is not done)
 #ifdef MPI
-        call comm_3u_end_GPU( rru,uw31,uw32,ue31,ue32,us31,us32,un31,un32,reqs_u)
-        call comm_3v_end_GPU( rrv,vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,reqs_v)
-        call comm_3w_end_GPU( rrw,ww31,ww32,we31,we32,ws31,ws32,wn31,wn32,reqs_w)
-        call getcorneru3_GPU(rru,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
+        call comm_3u_end( rru,uw31,uw32,ue31,ue32,us31,us32,un31,un32,reqs_u)
+        call comm_3v_end( rrv,vw31,vw32,ve31,ve32,vs31,vs32,vn31,vn32,reqs_v)
+        call comm_3w_end( rrw,ww31,ww32,we31,we32,ws31,ws32,wn31,wn32,reqs_w)
+        call getcorneru3(rru,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
                              s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
-        call getcornerv3_GPU(rrv,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
+        call getcornerv3(rrv,n3w1(1,1,1),n3w2(1,1,1),n3e1(1,1,1),n3e2(1,1,1),  &
                              s3w1(1,1,1),s3w2(1,1,1),s3e1(1,1,1),s3e2(1,1,1))
-        call getcornerw3_GPU(rrw,n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2)
+        call getcornerw3(rrw,n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2)
         call bcu2(rru)
         call bcv2(rrv)
         call bcw2(rrw)
@@ -978,11 +978,11 @@
 #ifdef MPI
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
-          call comm_1s_tend_halo_GPU(dpten(ib,jb,kb,1))
-          call comm_1s_tend_halo_GPU(dpten(ib,jb,kb,2))
-          call comm_1u_tend_halo_GPU(dpten(ib,jb,kb,3))
-          call comm_1v_tend_halo_GPU(dpten(ib,jb,kb,4))
-          call comm_1s_tend_halo_GPU(dpten(ib,jb,kb,5))
+          call comm_1s_tend_halo(dpten(ib,jb,kb,1))
+          call comm_1s_tend_halo(dpten(ib,jb,kb,2))
+          call comm_1u_tend_halo(dpten(ib,jb,kb,3))
+          call comm_1v_tend_halo(dpten(ib,jb,kb,4))
+          call comm_1s_tend_halo(dpten(ib,jb,kb,5))
 #else
           call bcs_tend_halo(dpten(ib,jb,kb,1))
           call bcs_tend_halo(dpten(ib,jb,kb,2))
@@ -1033,29 +1033,29 @@
             call sync()
             if(timestats.ge.1) time_lb=time_lb+mytime()
             !----
-            call comm_3s_start_GPU(th3d,rw31,rw32,re31,re32,   &
+            call comm_3s_start(th3d,rw31,rw32,re31,re32,   &
                                     rs31,rs32,rn31,rn32,reqs_y)
-            call comm_3s_start_GPU(q3d(ib,jb,kb,nqv)  &
+            call comm_3s_start(q3d(ib,jb,kb,nqv)  &
                        ,qw31(1,1,1,nqv),qw32(1,1,1,nqv),qe31(1,1,1,nqv),qe32(1,1,1,nqv)     &
                        ,qs31(1,1,1,nqv),qs32(1,1,1,nqv),qn31(1,1,1,nqv),qn32(1,1,1,nqv)     &
                        ,reqs_q(1,nqv) )
-            call comm_3u_start_GPU(u3d,uw31,uw32,ue31,ue32,   &
+            call comm_3u_start(u3d,uw31,uw32,ue31,ue32,   &
                                        us31,us32,un31,un32,reqs_u)
-            call comm_3v_start_GPU(v3d,vw31,vw32,ve31,ve32,   &
+            call comm_3v_start(v3d,vw31,vw32,ve31,ve32,   &
                                        vs31,vs32,vn31,vn32,reqs_v)
-            call comm_3w_start_GPU(w3d,ww31,ww32,we31,we32,   &
+            call comm_3w_start(w3d,ww31,ww32,we31,we32,   &
                                        ws31,ws32,wn31,wn32,reqs_w)
             !----
-            call comm_3s_end_GPU(th3d,rw31,rw32,re31,re32,rs31,rs32,rn31,rn32,reqs_y)
-            call comm_3s_end_GPU(q3d(ib,jb,kb,nqv)  &
+            call comm_3s_end(th3d,rw31,rw32,re31,re32,rs31,rs32,rn31,rn32,reqs_y)
+            call comm_3s_end(q3d(ib,jb,kb,nqv)  &
                        ,qw31(1,1,1,nqv),qw32(1,1,1,nqv),qe31(1,1,1,nqv),qe32(1,1,1,nqv)     &
                        ,qs31(1,1,1,nqv),qs32(1,1,1,nqv),qn31(1,1,1,nqv),qn32(1,1,1,nqv)     &
                        ,reqs_q(1,nqv) )
-            call comm_3u_end_GPU(u3d,uw31,uw32,ue31,ue32,   &
+            call comm_3u_end(u3d,uw31,uw32,ue31,ue32,   &
                                      us31,us32,un31,un32,reqs_u)
-            call comm_3v_end_GPU(v3d,vw31,vw32,ve31,ve32,   &
+            call comm_3v_end(v3d,vw31,vw32,ve31,ve32,   &
                                      vs31,vs32,vn31,vn32,reqs_v)
-            call comm_3w_end_GPU(w3d,ww31,ww32,we31,we32,   &
+            call comm_3w_end(w3d,ww31,ww32,we31,we32,   &
                                      ws31,ws32,wn31,wn32,reqs_w)
             !----
 #endif

--- a/src/sound.F
+++ b/src/sound.F
@@ -30,7 +30,7 @@
       use misclibs , only : convinitu,convinitv,get_wnudge
       use bc_module, only: bcs, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
           ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn
-      use comm_module, only : comm_1s_start_GPU,comm_1p_end_GPU,sync
+      use comm_module, only : comm_1s_start,comm_1p_end,sync
       use ib_module
       implicit none
 
@@ -331,10 +331,8 @@
 #ifdef MPI
         if( n.ne.1 )then
           if(timestats.ge.1) time_sound=time_sound+mytime()
-          !!$acc update host(ppd)
-          call comm_1p_end_GPU(ppd,pw1,pw2,pe1,pe2,   &
+          call comm_1p_end(ppd,pw1,pw2,pe1,pe2,   &
                                ps1,ps2,pn1,pn2,reqs_p)
-          !!$acc update device(ppd)
         endif
 #endif
 
@@ -834,10 +832,8 @@
 #ifdef MPI
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
-          !$acc update host(ppd)
-          call comm_1s_start_GPU(ppd,pw1,pw2,pe1,pe2,   &
+          call comm_1s_start(ppd,pw1,pw2,pe1,pe2,   &
                                  ps1,ps2,pn1,pn2,reqs_p)
-          !$acc update device(ppd)
 #endif
         ENDIF
 

--- a/src/soundcb.F
+++ b/src/soundcb.F
@@ -31,7 +31,7 @@
       use misclibs , only : convinitu,convinitv,get_wnudge,getdiv
       use bc_module, only : bcs, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
           ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn
-      use comm_module, only : comm_1p_end_GPU,comm_1s_start_GPU,comm_1s_end_GPU,sync
+      use comm_module, only : comm_1p_end,comm_1s_start,comm_1s_end,sync
       use ib_module
       implicit none
 
@@ -278,7 +278,7 @@
 #ifdef MPI
         if( n.ne.1 )then
           if(timestats.ge.1) time_sound=time_sound+mytime()
-          call comm_1p_end_GPU(ppd,pw1,pw2,pe1,pe2,   &
+          call comm_1p_end(ppd,pw1,pw2,pe1,pe2,   &
                                ps1,ps2,pn1,pn2,reqs_p)
         endif
 #endif
@@ -509,7 +509,7 @@
 #ifdef MPI
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
-          call comm_1s_start_GPU(ppd,pw1,pw2,pe1,pe2,   &
+          call comm_1s_start(ppd,pw1,pw2,pe1,pe2,   &
                                  ps1,ps2,pn1,pn2,reqs_p)
 #endif
         ENDIF
@@ -593,8 +593,8 @@
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
-      call comm_1s_start_GPU(phi2,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
-      call comm_1s_end_GPU(  phi2,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
+      call comm_1s_start(phi2,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
+      call comm_1s_end(  phi2,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_p)
 #endif
 
 

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -982,7 +982,6 @@
 
         IF( n.lt.nloop )THEN
           if(timestats.ge.1) time_sound=time_sound+mytime()
-!!!          call bcs_GPU(ppd,device=.false.)
           ! 210613: call bcp, only set 1 row/column
           call bcp(ppd)
 #ifdef MPI

--- a/src/sounde.F
+++ b/src/sounde.F
@@ -31,7 +31,7 @@
       use misclibs , only : convinitu,convinitv,get_wnudge
       use bc_module, only : bcp, bcwsfc, radbcew, radbcns, restrict_openbc_we, restrict_openbc_sn, &
           ssopenbcw, ssopenbce, ssopenbcs, ssopenbcn
-      use comm_module, only : comm_1p_start_GPU,comm_1p_end_GPU,sync
+      use comm_module, only : comm_1p_start,comm_1p_end,sync
       use maxmin_module
       use ib_module
       implicit none
@@ -294,7 +294,7 @@
 #ifdef MPI
         if( n.ne.1 )then
           if(timestats.ge.1) time_sound=time_sound+mytime()
-          call comm_1p_end_GPU(ppd,pw1,pw2,pe1,pe2,   &
+          call comm_1p_end(ppd,pw1,pw2,pe1,pe2,   &
                                ps1,ps2,pn1,pn2,reqs_p)
         endif
 #endif
@@ -987,7 +987,7 @@
 #ifdef MPI
           call sync()
           if(timestats.ge.1) time_lb=time_lb+mytime()
-          call comm_1p_start_GPU(ppd,pw1,pw2,pe1,pe2,   &
+          call comm_1p_start(ppd,pw1,pw2,pe1,pe2,   &
                                  ps1,ps2,pn1,pn2,reqs_p)
 #endif
         ENDIF

--- a/src/turb.F
+++ b/src/turb.F
@@ -1313,9 +1313,6 @@
         IF( sgsmodel.eq.5 )THEN
           ! Nonlinear Backscatter and Anisotropy (NBA) model:
           ! TKE version:
-#ifdef _OPENACC
-          stop 'ERROR: call to turbnba not supported in OPENACC'
-#endif
           call   turbnba(nstep,uh,ruh,uf,ruf,vh,rvh,vf,rvf,mh,rmh,mf,rmf,zf,c1,c2,rho,rf,zntmp,ust,  &
                          dum1,dum2,dum3,dum4,dum5,dum6,            &
                          dum7,dum8,thten,thten1,ppten ,divx,       &
@@ -1327,10 +1324,6 @@
         ENDIF
 
       ELSEIF(sgsmodel.eq.2)THEN
-#ifdef _OPENACC
-        stop 'ERROR: call to turbsmag not supported in OPENACC'
-#endif
-
          ! Smagorinsky:
         call turbsmag(nstep,rtime,dt,dosfcflx,ruh,rvh,rmh,mf,rmf,th0,thflux,qvflux,rth0s,rf, &
                       nm,defv,defh,dum4,dum5,thten1,zf,zntmp,ust,        &
@@ -1343,10 +1336,6 @@
                       ks1(1,1,2),ks2(1,1,2),kn1(1,1,2),kn2(1,1,2))
 
       ELSEIF( sgsmodel.eq.6 )THEN
-
-#ifdef _OPENACC
-        stop 'ERROR: call to turbnba2 not supported in OPENACC'
-#endif
         ! Nonlinear Backscatter and Anisotropy (NBA) model:
         ! Smagorinsky version:
         call     turbnba2(nstep,uh,ruh,uf,ruf,vh,rvh,vf,rvf,mh,rmh,mf,rmf,zf,c1,c2,rho,rf,zntmp,ust,  &
@@ -1402,9 +1391,6 @@
         else
 
           if( sgsmodel.eq.3 )then
-#ifdef _OPENACC
-            stop 'ERROR: call to t2psmm not supported in OpenACC'
-#endif
             call  t2psmm(dt,rtime,xf,rxf,c1,c2,                                                &
                          zh,mh,zf,mf,rf0,rr0,rho0,rrf0,u0,v0,                                  &
                          uavg,vavg,savg,l2p,kmw,gamk,gamwall,s2p,s2b,t2pm1,t2pm2,t2pm3,t2pm4,cavg,  &
@@ -1439,9 +1425,6 @@
 !  Simple Smagorinsky-like turbulence schemes:
 
       IF( cm1setup.eq.2 .and. ipbl.eq.2 )THEN
-#ifdef _OPENACC
-        stop 'ERROR: call to turbparam_vert not supported in OPENACC'
-#endif
         call turbparam_vert(nstep,zf,dt,dosfcflx,ruh,rvh,rmh,mf,rmf,th0,thflux,qvflux,rth0s,rf, &
                       nm,defv,defh,dum4,kmv,khv,dissten,out3d,zs,zntmp,ust,xland, &
                       nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,                 &
@@ -1452,9 +1435,6 @@
       ENDIF
 
       IF( cm1setup.eq.2 .and. horizturb.eq.1 )THEN
-#ifdef _OPENACC
-        stop 'ERROR: call to turbparam_horiz not supported in OPENACC'
-#endif
         call turbparam_horiz(nstep,zf,dt,dosfcflx,ruh,rvh,rmh,mf,rmf,th0,thflux,qvflux,rth0s,rf, &
                       nm,defv,defh,dum4,kmh,khh,dissten,out3d,zs,zntmp,ust,xland,psfc,tlh, &
                       nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,                 &
@@ -2750,6 +2730,10 @@
 
 !-----------------------------------------------------------------------
 
+#ifdef _OPENACC
+      stop 'ERROR: call to turbsmag not supported in OPENACC'
+#endif
+
       temx = 0.125*dx*dx/dt
       temy = 0.125*dy*dy/dt
 
@@ -2837,21 +2821,21 @@
 !--------------------------------------------------------------
 
       if(timestats.ge.1) time_turb=time_turb+mytime()
-      call bcw(kmh,1)
-      call bcw(kmv,1)
+      call bcw(kmh,1,device=.false.)
+      call bcw(kmv,1,device=.false.)
 #ifdef MPI
       call comm_1t_start_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
-                             khcs1,khcs2,khcn1,khcn2,reqs_khc)
+                        khcs1,khcs2,khcn1,khcn2,reqs_khc,device=.false.)
       call comm_1t_start_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
-                             kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
+                        kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc,device=.false.)
       call comm_1t_end_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
-                           khcs1,khcs2,khcn1,khcn2,reqs_khc)
+                        khcs1,khcs2,khcn1,khcn2,reqs_khc,device=.false.)
       call comm_1t_end_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
-                           kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
-      call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      call bct2(kmh)
-      call bct2(kmv)
+                       kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc,device=.false.)
+      call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
+      call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
+      call bct2(kmh,device=.false.)
+      call bct2(kmv,device=.false.)
 #endif
 
 !--------------------------------------------------------------
@@ -2904,14 +2888,14 @@
         enddo
         enddo
 
-        call bc2d(kmv(ibc,jbc,1))
+        call bc2d(kmv(ibc,jbc,1),device=.false.)
 #ifdef MPI
         call comm_1s2d_start_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
-                                            khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
+                            khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc,device=.false.)
         call comm_1s2d_end_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
-                                          khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
-        call comm_2d_corner_GPU(kmv(ibc,jbc,1))
-        call bcs2_2d(kmv(ibc,jbc,1))
+                            khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc,device=.false.)
+        call comm_2d_corner_GPU(kmv(ibc,jbc,1),device=.false.)
+        call bcs2_2d(kmv(ibc,jbc,1),device=.false.)
 #endif
 
       IF( tconfig.eq.1 )THEN
@@ -3000,6 +2984,10 @@
       real, parameter :: prinv   = 1.0/prandtl
       real, parameter :: dmin    = 1.0e-10
 
+#ifdef _OPENACC
+        stop 'ERROR: call to turbparam_horiz not supported in OPENACC'
+#endif
+
 !--------------------------------------------------------------
 !  Smagorinsky-type scheme for parameterized turbulence:
 !--------------------------------------------------------------
@@ -3057,11 +3045,11 @@
       call bcw(kmh,1,device=.false.)
 #ifdef MPI
       call comm_1t_start_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
-                             khcs1,khcs2,khcn1,khcn2,reqs_khc)
+                        khcs1,khcs2,khcn1,khcn2,reqs_khc,device=.false.)
       call comm_1t_end_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
-                           khcs1,khcs2,khcn1,khcn2,reqs_khc)
-      call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      call bct2(kmh)
+                      khcs1,khcs2,khcn1,khcn2,reqs_khc,device=.false.)
+      call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
+      call bct2(kmh,device=.false.)
 #endif
 
         ! Extrapolate:
@@ -3161,6 +3149,10 @@
       real, parameter :: prinv   = 1.0/prandtl
       real, parameter :: dmin    = 1.0e-10
 
+#ifdef _OPENACC
+      stop 'ERROR: call to turbparam_vert not supported in OPENACC'
+#endif
+
 !--------------------------------------------------------------
 !  Smagorinsky-type scheme for parameterized turbulence:
 !--------------------------------------------------------------
@@ -3191,13 +3183,12 @@
       call bcw(kmv,1,device=.false.)
 
 #ifdef MPI
-      !JMD FIXME:  These subroutine operate on GPU resident data
       call comm_1t_start_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
-                             kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
+                        kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc,device=.false.)
       call comm_1t_end_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
-                           kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
-      call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      call bct2(kmv)
+                        kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc,device=.false.)
+      call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
+      call bct2(kmv,device=.false.)
 #endif
 
 !--------------------------------------------------------------
@@ -3239,11 +3230,11 @@
         call bc2d(kmv(ibc,jbc,1),device=.false.)
 #ifdef MPI
         call comm_1s2d_start_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
-                                            khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
+                                khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc,device=.false.)
         call comm_1s2d_end_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
-                                          khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
-        call comm_2d_corner_GPU(kmv(ibc,jbc,1))
-        call bcs2_2d(kmv(ibc,jbc,1))
+                                khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc,device=.false.)
+        call comm_2d_corner_GPU(kmv(ibc,jbc,1),device=.false.)
+        call bcs2_2d(kmv(ibc,jbc,1),device=.false.)
 #endif
 
         do j=0,nj+1

--- a/src/turb.F
+++ b/src/turb.F
@@ -1050,21 +1050,21 @@
 #ifdef MPI
     call sync()
     if(timestats.ge.1) time_lb=time_lb+mytime()
-    call comm_1s2d_start_GPU(ust,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
+    call comm_1s2d_start(ust,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
                              us31(1,1,1),us32(1,1,1),un31(1,1,1),un32(1,1,1),reqs_s)
-    call comm_1s2d_start_GPU(u1 ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
+    call comm_1s2d_start(u1 ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
                              us31(1,1,2),us32(1,1,2),un31(1,1,2),un32(1,1,2),reqs_u)
-    call comm_1s2d_start_GPU(v1 ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
+    call comm_1s2d_start(v1 ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
                              us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
-    call comm_1s2d_start_GPU(s1 ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
+    call comm_1s2d_start(s1 ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
                              us31(1,1,4),us32(1,1,4),un31(1,1,4),un32(1,1,4),reqs_w)
-    call comm_1s2d_start_GPU(znt,uw31(1,1,5),uw32(1,1,5),ue31(1,1,5),ue32(1,1,5),  &
+    call comm_1s2d_start(znt,uw31(1,1,5),uw32(1,1,5),ue31(1,1,5),ue32(1,1,5),  &
                              us31(1,1,5),us32(1,1,5),un31(1,1,5),un32(1,1,5),reqs_p)
 #endif
   if( sfcmodel.eq.4 )then
     call bc2d(mznt)
 #ifdef MPI
-    call comm_1s2d_start_GPU(mznt,uw31(1,1,6),uw32(1,1,6),ue31(1,1,6),ue32(1,1,6),  &
+    call comm_1s2d_start(mznt,uw31(1,1,6),uw32(1,1,6),ue31(1,1,6),ue32(1,1,6),  &
                               us31(1,1,6),us32(1,1,6),un31(1,1,6),un32(1,1,6),reqs_x)
 #endif
   endif
@@ -1072,41 +1072,41 @@
 
 #ifdef MPI
     !-------------!
-    call comm_1s2d_end_GPU(ust,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
+    call comm_1s2d_end(ust,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
                            us31(1,1,1),us32(1,1,1),un31(1,1,1),un32(1,1,1),reqs_s)
     call bcs2_2d(ust)
 
-    call comm_1s2d_end_GPU(u1 ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
+    call comm_1s2d_end(u1 ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
                            us31(1,1,2),us32(1,1,2),un31(1,1,2),un32(1,1,2),reqs_u)
     call bcs2_2d(u1 )
 
-    call comm_1s2d_end_GPU(v1 ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
+    call comm_1s2d_end(v1 ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
                            us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
     call bcs2_2d(v1 )
 
-    call comm_1s2d_end_GPU(s1 ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
+    call comm_1s2d_end(s1 ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
                            us31(1,1,4),us32(1,1,4),un31(1,1,4),un32(1,1,4),reqs_w)
     call bcs2_2d(s1 )
 
-    call comm_1s2d_end_GPU(znt,uw31(1,1,5),uw32(1,1,5),ue31(1,1,5),ue32(1,1,5),  &
+    call comm_1s2d_end(znt,uw31(1,1,5),uw32(1,1,5),ue31(1,1,5),ue32(1,1,5),  &
                            us31(1,1,5),us32(1,1,5),un31(1,1,5),un32(1,1,5),reqs_p)
     call bcs2_2d(znt)
 
   if( sfcmodel.eq.4 )then
-    call comm_1s2d_end_GPU(mznt,uw31(1,1,6),uw32(1,1,6),ue31(1,1,6),ue32(1,1,6),  &
+    call comm_1s2d_end(mznt,uw31(1,1,6),uw32(1,1,6),ue31(1,1,6),ue32(1,1,6),  &
                             us31(1,1,6),us32(1,1,6),un31(1,1,6),un32(1,1,6),reqs_x)
     call bcs2_2d(mznt)
   endif
     !-------------!
 
     !-------------!
-    call comm_2d_corner_GPU(ust)
-    call comm_2d_corner_GPU(u1)
-    call comm_2d_corner_GPU(v1)
-    call comm_2d_corner_GPU(s1)
-    call comm_2d_corner_GPU(znt)
+    call comm_2d_corner(ust)
+    call comm_2d_corner(u1)
+    call comm_2d_corner(v1)
+    call comm_2d_corner(s1)
+    call comm_2d_corner(znt)
   if( sfcmodel.eq.4 )then
-    call comm_2d_corner_GPU(mznt)
+    call comm_2d_corner(mznt)
   endif
     !-------------!
 #endif
@@ -1142,26 +1142,26 @@
 #ifdef MPI
     call sync()
     if(timestats.ge.1) time_lb=time_lb+mytime()
-    call comm_1s2d_start_GPU(ustt,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
+    call comm_1s2d_start(ustt,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
                               us31(1,1,1),us32(1,1,1),un31(1,1,1),un32(1,1,1),reqs_s)
-    call comm_1s2d_start_GPU(ut ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
+    call comm_1s2d_start(ut ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
                              us31(1,1,2),us32(1,1,2),un31(1,1,2),un32(1,1,2),reqs_u)
-    call comm_1s2d_start_GPU(vt ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
+    call comm_1s2d_start(vt ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
                              us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
-    call comm_1s2d_start_GPU(st ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
+    call comm_1s2d_start(st ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
                              us31(1,1,4),us32(1,1,4),un31(1,1,4),un32(1,1,4),reqs_w)
 #endif
     !-------------!
 
 #ifdef MPI
     !-------------!
-    call comm_1s2d_end_GPU(ustt,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
+    call comm_1s2d_end(ustt,uw31(1,1,1),uw32(1,1,1),ue31(1,1,1),ue32(1,1,1),  &
                             us31(1,1,1),us32(1,1,1),un31(1,1,1),un32(1,1,1),reqs_s)
-    call comm_1s2d_end_GPU(ut ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
+    call comm_1s2d_end(ut ,uw31(1,1,2),uw32(1,1,2),ue31(1,1,2),ue32(1,1,2),  &
                            us31(1,1,2),us32(1,1,2),un31(1,1,2),un32(1,1,2),reqs_u)
-    call comm_1s2d_end_GPU(vt ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
+    call comm_1s2d_end(vt ,uw31(1,1,3),uw32(1,1,3),ue31(1,1,3),ue32(1,1,3),  &
                            us31(1,1,3),us32(1,1,3),un31(1,1,3),un32(1,1,3),reqs_v)
-    call comm_1s2d_end_GPU(st ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
+    call comm_1s2d_end(st ,uw31(1,1,4),uw32(1,1,4),ue31(1,1,4),ue32(1,1,4),  &
                            us31(1,1,4),us32(1,1,4),un31(1,1,4),un32(1,1,4),reqs_w)
     call bcs2_2d(ustt)
     call bcs2_2d(ut )
@@ -1171,10 +1171,10 @@
     !-------------!
 
     !-------------!
-    call comm_2d_corner_GPU(ustt)
-    call comm_2d_corner_GPU(ut)
-    call comm_2d_corner_GPU(vt)
-    call comm_2d_corner_GPU(st)
+    call comm_2d_corner(ustt)
+    call comm_2d_corner(ut)
+    call comm_2d_corner(vt)
+    call comm_2d_corner(st)
     !-------------!
 #endif
 
@@ -1486,9 +1486,9 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call getcorneru_GPU(ua,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call getcornerv_GPU(va,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
-        call getcornerw_GPU(wa,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call getcorneru(ua,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call getcornerv(va,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+        call getcornerw(wa,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
         call bcu2(ua)
         call bcv2(va)
         call bcw2(wa)
@@ -2247,8 +2247,8 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_1s_start_GPU(upten,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
-        call comm_1s_start_GPU(vpten,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_p)
+        call comm_1s_start(upten,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
+        call comm_1s_start(vpten,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_p)
 #endif
         IF( axisymm.eq.1 )THEN
           ! cm1r19 bug fix:
@@ -2264,8 +2264,8 @@
           enddo
         ENDIF
 #ifdef MPI
-        call comm_1s_end_GPU(upten,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
-        call comm_1s_end_GPU(vpten,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_p)
+        call comm_1s_end(upten,pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,reqs_s)
+        call comm_1s_end(vpten,vw1,vw2,ve1,ve2,vs1,vs2,vn1,vn2,reqs_p)
 #endif
       endif
 
@@ -2479,31 +2479,31 @@
 #ifdef MPI
       call sync()
       if(timestats.ge.1) time_lb=time_lb+mytime()
-      call comm_1t_start_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
+      call comm_1t_start(kmh,khcw1,khcw2,khce1,khce2,   &
                              khcs1,khcs2,khcn1,khcn2,reqs_khc)
-      call comm_1t_start_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
+      call comm_1t_start(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
                              kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
-      call comm_1t_start_GPU(khh,khdw1,khdw2,khde1,khde2,   &
+      call comm_1t_start(khh,khdw1,khdw2,khde1,khde2,   &
                              khds1,khds2,khdn1,khdn2,reqs_khd)
-      call comm_1t_start_GPU(khv,kvdw1,kvdw2,kvde1,kvde2,   &
+      call comm_1t_start(khv,kvdw1,kvdw2,kvde1,kvde2,   &
                              kvds1,kvds2,kvdn1,kvdn2,reqs_kvd)
 #endif
 
 !--------------------------------------------------------------
 !  Finish comms:
 #ifdef MPI
-      call comm_1t_end_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
+      call comm_1t_end(kmh,khcw1,khcw2,khce1,khce2,   &
                            khcs1,khcs2,khcn1,khcn2,reqs_khc)
-      call comm_1t_end_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
+      call comm_1t_end(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
                            kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc)
-      call comm_1t_end_GPU(khh,khdw1,khdw2,khde1,khde2,   &
+      call comm_1t_end(khh,khdw1,khdw2,khde1,khde2,   &
                            khds1,khds2,khdn1,khdn2,reqs_khd)
-      call comm_1t_end_GPU(khv,kvdw1,kvdw2,kvde1,kvde2,   &
+      call comm_1t_end(khv,kvdw1,kvdw2,kvde1,kvde2,   &
                            kvds1,kvds2,kvdn1,kvdn2,reqs_kvd)
       call bct2(kmh)
       call bct2(kmv)
-      call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      call getcornert(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
+      call getcornert(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
 #endif
 !--------------------------------------------------------------
 !   finished
@@ -2581,21 +2581,21 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_1s2d_start_GPU(tkea(ibt,jbt,1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
+        call comm_1s2d_start(tkea(ibt,jbt,1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
                                              kvcs1(1,1),kvcs2(1,1),kvcn1(1,1),kvcn2(1,1),reqs_kvc)
-        call comm_1s2d_start_GPU(kmh(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
+        call comm_1s2d_start(kmh(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                             khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
         !-----
-        call comm_1s2d_end_GPU(tkea(ibt,jbt,1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
+        call comm_1s2d_end(tkea(ibt,jbt,1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
                                            kvcs1(1,1),kvcs2(1,1),kvcn1(1,1),kvcn2(1,1),reqs_kvc)
         call bcs2_2d(tkea(ibt,jbt,1))
-!!!! Problem with comm_1s2d_end_GPU
-        call comm_1s2d_end_GPU(kmh(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
+!!!! Problem with comm_1s2d_end
+        call comm_1s2d_end(kmh(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                           khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
         call bcs2_2d(kmh(ibc,jbc,1))
         !-----
-        call comm_2d_corner_GPU(tkea(ibt,jbt,1))
-        call comm_2d_corner_GPU(kmh(ibc,jbc,1))
+        call comm_2d_corner(tkea(ibt,jbt,1))
+        call comm_2d_corner(kmh(ibc,jbc,1))
         !-----
 #endif
 
@@ -2635,20 +2635,20 @@
 #ifdef MPI
         call sync()
         if(timestats.ge.1) time_lb=time_lb+mytime()
-        call comm_1s2d_start_GPU(tkea(ibt,jbt,nk+1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
+        call comm_1s2d_start(tkea(ibt,jbt,nk+1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
                                                 kvcs1(1,1),kvcs2(1,1),kvcn1(1,1),kvcn2(1,1),reqs_kvc)
-        call comm_1s2d_start_GPU(kmh(ibc,jbc,nk+1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
+        call comm_1s2d_start(kmh(ibc,jbc,nk+1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                                khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
         !-----
-        call comm_1s2d_end_GPU(tkea(ibt,jbt,nk+1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
+        call comm_1s2d_end(tkea(ibt,jbt,nk+1),kvcw1(1,1),kvcw2(1,1),kvce1(1,1),kvce2(1,1),   &
                                               kvcs1(1,1),kvcs2(1,1),kvcn1(1,1),kvcn2(1,1),reqs_kvc)
         call bcs2_2d(tkea(ibt,jbt,nk+1))
-        call comm_1s2d_end_GPU(kmh(ibc,jbc,nk+1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
+        call comm_1s2d_end(kmh(ibc,jbc,nk+1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                              khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc)
         call bcs2_2d(kmh(ibc,jbc,nk+1))
         !-----
-        call comm_2d_corner_GPU(tkea(ibt,jbt,nk+1))
-        call comm_2d_corner_GPU(kmh(ibc,jbc,nk+1))
+        call comm_2d_corner(tkea(ibt,jbt,nk+1))
+        call comm_2d_corner(kmh(ibc,jbc,nk+1))
         !-----
 #endif
 
@@ -2824,16 +2824,16 @@
       call bcw(kmh,1,device=.false.)
       call bcw(kmv,1,device=.false.)
 #ifdef MPI
-      call comm_1t_start_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
+      call comm_1t_start(kmh,khcw1,khcw2,khce1,khce2,   &
                         khcs1,khcs2,khcn1,khcn2,reqs_khc,device=.false.)
-      call comm_1t_start_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
+      call comm_1t_start(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
                         kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc,device=.false.)
-      call comm_1t_end_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
+      call comm_1t_end(kmh,khcw1,khcw2,khce1,khce2,   &
                         khcs1,khcs2,khcn1,khcn2,reqs_khc,device=.false.)
-      call comm_1t_end_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
+      call comm_1t_end(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
                        kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc,device=.false.)
-      call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
-      call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
+      call getcornert(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
+      call getcornert(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
       call bct2(kmh,device=.false.)
       call bct2(kmv,device=.false.)
 #endif
@@ -2890,11 +2890,11 @@
 
         call bc2d(kmv(ibc,jbc,1),device=.false.)
 #ifdef MPI
-        call comm_1s2d_start_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
+        call comm_1s2d_start(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                             khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc,device=.false.)
-        call comm_1s2d_end_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
+        call comm_1s2d_end(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                             khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc,device=.false.)
-        call comm_2d_corner_GPU(kmv(ibc,jbc,1),device=.false.)
+        call comm_2d_corner(kmv(ibc,jbc,1),device=.false.)
         call bcs2_2d(kmv(ibc,jbc,1),device=.false.)
 #endif
 
@@ -3044,11 +3044,11 @@
 
       call bcw(kmh,1,device=.false.)
 #ifdef MPI
-      call comm_1t_start_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
+      call comm_1t_start(kmh,khcw1,khcw2,khce1,khce2,   &
                         khcs1,khcs2,khcn1,khcn2,reqs_khc,device=.false.)
-      call comm_1t_end_GPU(kmh,khcw1,khcw2,khce1,khce2,   &
+      call comm_1t_end(kmh,khcw1,khcw2,khce1,khce2,   &
                       khcs1,khcs2,khcn1,khcn2,reqs_khc,device=.false.)
-      call getcornert_GPU(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
+      call getcornert(kmh,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
       call bct2(kmh,device=.false.)
 #endif
 
@@ -3183,11 +3183,11 @@
       call bcw(kmv,1,device=.false.)
 
 #ifdef MPI
-      call comm_1t_start_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
+      call comm_1t_start(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
                         kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc,device=.false.)
-      call comm_1t_end_GPU(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
+      call comm_1t_end(kmv,kvcw1,kvcw2,kvce1,kvce2,   &
                         kvcs1,kvcs2,kvcn1,kvcn2,reqs_kvc,device=.false.)
-      call getcornert_GPU(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
+      call getcornert(kmv,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
       call bct2(kmv,device=.false.)
 #endif
 
@@ -3229,11 +3229,11 @@
 
         call bc2d(kmv(ibc,jbc,1),device=.false.)
 #ifdef MPI
-        call comm_1s2d_start_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
+        call comm_1s2d_start(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                 khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc,device=.false.)
-        call comm_1s2d_end_GPU(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
+        call comm_1s2d_end(kmv(ibc,jbc,1),khcw1(1,1),khcw2(1,1),khce1(1,1),khce2(1,1),   &
                                 khcs1(1,1),khcs2(1,1),khcn1(1,1),khcn2(1,1),reqs_khc,device=.false.)
-        call comm_2d_corner_GPU(kmv(ibc,jbc,1),device=.false.)
+        call comm_2d_corner(kmv(ibc,jbc,1),device=.false.)
         call bcs2_2d(kmv(ibc,jbc,1),device=.false.)
 #endif
 

--- a/src/turbnba.F
+++ b/src/turbnba.F
@@ -150,7 +150,7 @@
       call comm_1s_end_GPU(lenscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
                               ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s)
       call bcs2(lenscl,device=.false.)
-      call getcorner_GPU(lenscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+      call getcorner_GPU(lenscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
 
       do j=0,nj+1

--- a/src/turbnba.F
+++ b/src/turbnba.F
@@ -77,6 +77,10 @@
 
 !-----------------------------------------------------------------------
 
+#ifdef _OPENACC
+       stop 'ERROR: call to turbnba not supported in OPENACC'
+#endif
+
         nba_ck = (2.0/3.0)*( (pi*c_m)**(-2.0/3.0) )
 
         nba_cs = sqrt( ( 8.0*( 1.0+nba_cb ) )/( 27.0*pi*pi ) )  &
@@ -146,9 +150,9 @@
 
 #ifdef MPI
       call comm_1s_start_GPU(lenscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
-                                ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s)
+                       ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s,device=.false.)
       call comm_1s_end_GPU(lenscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
-                              ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s)
+                       ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s,device=.false.)
       call bcs2(lenscl,device=.false.)
       call getcorner_GPU(lenscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
@@ -198,11 +202,11 @@
         call bc2d(grdscl(ib,jb,k),device=.false.)
 #ifdef MPI
         call comm_2d_start_GPU(grdscl(ib,jb,k),west,newwest,east,neweast,   &
-                                           south,newsouth,north,newnorth,reqs_s)
-        call comm_2dew_end_GPU(grdscl(ib,jb,k),west,newwest,east,neweast,reqs_s)
-        call comm_2dns_end_GPU(grdscl(ib,jb,k),south,newsouth,north,newnorth,reqs_s)
-        call bcs2_2d(grdscl(ib,jb,k))
-        call comm_2d_corner_GPU(grdscl(ib,jb,k))
+                               south,newsouth,north,newnorth,reqs_s,device=.false.)
+        call comm_2dew_end_GPU(grdscl(ib,jb,k),west,newwest,east,neweast,reqs_s,device=.false.)
+        call comm_2dns_end_GPU(grdscl(ib,jb,k),south,newsouth,north,newnorth,reqs_s,device=.false.)
+        call bcs2_2d(grdscl(ib,jb,k),device=.false.)
+        call comm_2d_corner_GPU(grdscl(ib,jb,k),device=.false.)
 #endif
       enddo
 
@@ -227,9 +231,7 @@
 
 #ifdef MPI
       call bct2(tkea,device=.false.)
-      !$acc data copy(tkea)
-      call getcornert_GPU(tkea,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2)
-      !$acc end data
+      call getcornert_GPU(tkea,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
 #endif
 
   kloop:  DO k=1,nk
@@ -512,6 +514,10 @@
 
 !-----------------------------------------------------------------------
 
+#ifdef _OPENACC
+        stop 'ERROR: call to turbnba2 not supported in OPENACC'
+#endif
+
         nba_ck = (2.0/3.0)*( (pi*c_m)**(-2.0/3.0) )
 
         nba_cs = sqrt( ( 8.0*( 1.0+nba_cb ) )/( 27.0*pi*pi ) )  &
@@ -562,11 +568,11 @@
 
 #ifdef MPI
       call comm_1s_start_GPU(grdscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
-                                ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s)
+                   ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s,device=.false.)
       call comm_1s_end_GPU(grdscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
-                              ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s)
+                   ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s,device=.false.)
       call bcs2(grdscl,device=.false.)
-      call getcorner_GPU(grdscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1))
+      call getcorner_GPU(grdscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
 
       do j=0,nj+1

--- a/src/turbnba.F
+++ b/src/turbnba.F
@@ -35,8 +35,8 @@
           tconfig,rdx,rdy,rdz,bbc,axisymm
       use constants
       use bc_module, only: bc2d, bcs2, bct2, bcs2_2d
-      use comm_module, only : comm_1s_start_GPU,comm_1s_end_GPU,comm_2d_start_GPU, &
-          comm_2dew_end_GPU,comm_2dns_end_GPU,comm_2d_corner_GPU,getcorner_GPU,getcornert_GPU
+      use comm_module, only : comm_1s_start,comm_1s_end,comm_2d_start, &
+          comm_2dew_end,comm_2dns_end,comm_2d_corner,getcorner,getcornert
       implicit none
 
 !-----------------------------------------------------------------------
@@ -149,12 +149,12 @@
     endif
 
 #ifdef MPI
-      call comm_1s_start_GPU(lenscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
+      call comm_1s_start(lenscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
                        ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s,device=.false.)
-      call comm_1s_end_GPU(lenscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
+      call comm_1s_end(lenscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
                        ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s,device=.false.)
       call bcs2(lenscl,device=.false.)
-      call getcorner_GPU(lenscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
+      call getcorner(lenscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
 
       do j=0,nj+1
@@ -201,12 +201,12 @@
       do k=1,2
         call bc2d(grdscl(ib,jb,k),device=.false.)
 #ifdef MPI
-        call comm_2d_start_GPU(grdscl(ib,jb,k),west,newwest,east,neweast,   &
+        call comm_2d_start(grdscl(ib,jb,k),west,newwest,east,neweast,   &
                                south,newsouth,north,newnorth,reqs_s,device=.false.)
-        call comm_2dew_end_GPU(grdscl(ib,jb,k),west,newwest,east,neweast,reqs_s,device=.false.)
-        call comm_2dns_end_GPU(grdscl(ib,jb,k),south,newsouth,north,newnorth,reqs_s,device=.false.)
+        call comm_2dew_end(grdscl(ib,jb,k),west,newwest,east,neweast,reqs_s,device=.false.)
+        call comm_2dns_end(grdscl(ib,jb,k),south,newsouth,north,newnorth,reqs_s,device=.false.)
         call bcs2_2d(grdscl(ib,jb,k),device=.false.)
-        call comm_2d_corner_GPU(grdscl(ib,jb,k),device=.false.)
+        call comm_2d_corner(grdscl(ib,jb,k),device=.false.)
 #endif
       enddo
 
@@ -231,7 +231,7 @@
 
 #ifdef MPI
       call bct2(tkea,device=.false.)
-      call getcornert_GPU(tkea,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
+      call getcornert(tkea,nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,device=.false.)
 #endif
 
   kloop:  DO k=1,nk
@@ -473,7 +473,7 @@
           tconfig,rdx,rdy,rdz,bbc,axisymm
       use constants
       use bc_module, only: bcs2
-      use comm_module, only : comm_1s_start_GPU,comm_1s_end_GPU,getcorner_GPU,getcornert_GPU
+      use comm_module, only : comm_1s_start,comm_1s_end,getcorner,getcornert
       implicit none
 
 !-----------------------------------------------------------------------
@@ -567,12 +567,12 @@
     endif
 
 #ifdef MPI
-      call comm_1s_start_GPU(grdscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
+      call comm_1s_start(grdscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
                    ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s,device=.false.)
-      call comm_1s_end_GPU(grdscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
+      call comm_1s_end(grdscl,kw1(1,1,1),kw2(1,1,1),ke1(1,1,1),ke2(1,1,1),  &
                    ks1(1,1,1),ks2(1,1,1),kn1(1,1,1),kn2(1,1,1),reqs_s,device=.false.)
       call bcs2(grdscl,device=.false.)
-      call getcorner_GPU(grdscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
+      call getcorner(grdscl,nw1(1),nw2(1),ne1(1),ne2(1),sw1(1),sw2(1),se1(1),se2(1),device=.false.)
 #endif
 
       do j=0,nj+1


### PR DESCRIPTION
This is the second large PR that involves the deletion of duplication communication subroutines.  Additionally, the _GPU tag has also been deleted.  Several issues with dead code were resolved in the turb.F file.  The correctness statistics are slightly better than  PR #121 but slightly worse than PR #123

ifort CPU versus nvhpc GPU
=====================

Metrics
--------
39 stat variables are identical.
42 stat variables show a mean relative difference > 1e-06
5 stat variables show a mean relative difference <= 1e-06

0th-order
----------
3 stat variables are identical.
7 stat variables show a mean relative difference > 1e-06
2 stat variables show a mean relative difference <= 1e-06

1st-order
----------
254 stat variables are identical.
2 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06 