### PR TITLE
Fix the broken restart functionality

### DIFF
--- a/run/gust.4gpu.sh
+++ b/run/gust.4gpu.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#PBS -N cm1
+#PBS -l select=1:ncpus=4:mpiprocs=4:ngpus=4:mem=100gb
+#PBS -l walltime=01:59:00
+#PBS -j oe
+#PBS -q main
+#PBS -A UNDM0006
+
+module purge
+module load ncarenv nvhpc cuda cray-mpich ncarcompilers
+
+export MPICH_GPU_SUPPORT_ENABLED=1
+
+mpiexec -n 4 -ppn 4 get_local_rank ./cm1.exe --namelist namelist_ASD.restA >& gust.mpi.openacc.namelist.ASD.restA.log
+mpiexec -n 4 -ppn 4 get_local_rank ./cm1.exe --namelist namelist_ASD.restB >& gust.mpi.openacc.namelist.ASD.restB.log
+mpiexec -n 4 -ppn 4 get_local_rank ./cm1.exe --namelist namelist_ASD.restC >& gust.mpi.openacc.namelist.ASD.restC.log

--- a/run/namelist_ASD.restA
+++ b/run/namelist_ASD.restA
@@ -1,0 +1,369 @@
+
+ &param0
+ nx           =     128,
+ ny           =     128,
+ nz           =     128,
+ ppnode       =       4,
+ timeformat   =       1,
+ timestats    =       1,
+ terrain_flag = .false.,
+ procfiles    = .false.,
+ /
+
+ &param1
+ dx     =      40.0,
+ dy     =      40.0,
+ dz     =      20.0,
+ dtl    =       0.5,
+ timax  =     100.0,
+ run_time =  -999.9,
+ tapfrq =    1000.0,
+ rstfrq =     100.0,
+ statfrq =     50.0,
+ prclfrq =     50.0,
+ /
+
+ &param2
+ cm1setup  =  1,
+ testcase  =  10,
+ adapt_dt  =  0,
+ irst      =  0,
+ rstnum    =  1,
+ iconly    =  0,
+ hadvordrs =  5,
+ vadvordrs =  5,
+ hadvordrv =  5,
+ vadvordrv =  5,
+ advwenos  =  2,
+ advwenov  =  0,
+ weno_order = 5,
+ apmasscon =  0,
+ idiff     =  0,
+ mdiff     =  0,
+ difforder =  6,
+ imoist    =  1,
+ ipbl      =  0,
+ sgsmodel  =  1,
+ tconfig   =  1,
+ bcturbs   =  1,
+ horizturb =  0,
+ doimpl    =  0,
+ irdamp    =  1,
+ hrdamp    =  0,
+ psolver   =  2,
+ ptype     =  0,
+ ihail     =  0,
+ iautoc    =  0,
+ icor      =  1,
+ lspgrad   =  3,
+ eqtset    =  1,
+ idiss     =  0,
+ efall     =  0,
+ rterm     =  0,
+ wbc       =  1,
+ ebc       =  1,
+ sbc       =  1,
+ nbc       =  1,
+ bbc       =  3,
+ tbc       =  1,
+ irbc      =  4,
+ roflux    =  0,
+ nudgeobc  =  0,
+ isnd      =  17,
+ iwnd      =  8,
+ itern     =  0,
+ iinit     =  0,
+ irandp    =  1,
+ ibalance  =  0,
+ iorigin   =  1,
+ axisymm   =  0,
+ imove     =  0,
+ iptra     =  0,
+ npt       =  1,
+ pdtra     =  1,
+ iprcl     =  1,       !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
+ nparcelsInit = 1e8,     ! initial number of particles over the whole domain
+ nparcelsMax  = 5e8,   ! the total allowable number of particles over the whole domain
+ injectHMax = 20.0,
+ drop_mult = 1.e10,   !Droplet multiplicity: total number of droplets = nparcels*drop_mult
+ drop_inject_elapse = 4.0,  !Time between spray injection
+ drop_inject_time =  10.0,  !Time after which spray injection begins
+ drop_w_init = 3.0    ! Initial vertical velocity of the newly initialized spray droplet
+ /
+
+ &param3
+ kdiff2  =   75.0,
+ kdiff6  =   0.040,
+ fcor    = 0.00005,
+ kdiv    = 0.10,
+ alph    = 0.60,
+ rdalpha = 3.3333333333e-3,
+ zd      =  2000.0,
+ xhd     = 100000.0,
+ alphobc = 60.0,
+ umove   =  0.0,
+ vmove   =  0.0,
+ v_t     =      0.0,
+ l_h     =      0.0,
+ lhref1  =      0.0,
+ lhref2  =      0.0,
+ l_inf   =     75.0,
+ ndcnst  =    100.0,
+ /
+
+ &param11
+ radopt  =        0,
+ dtrad   =    300.0,
+ ctrlat  =    36.68,
+ ctrlon  =   -98.35,
+ year    =     2009,
+ month   =        5,
+ day     =       15,
+ hour    =       21,
+ minute  =       38,
+ second  =       00,
+ /
+
+ &param12
+ isfcflx    =      1,
+ sfcmodel   =      1,
+ oceanmodel =      1,
+ initsfc    =      1,
+ tsk0       = 302.27,
+ tmn0       = 299.15,
+ xland0     =    2.0,
+ lu0        =     16,
+ season     =      1,
+ cecd       =      1,
+ pertflx    =      0,
+ cnstce     =  0.0012,
+ cnstcd     =  0.0025,
+ isftcflx   =      0,
+ iz0tlnd    =      0,
+ oml_hml0   =   50.0,
+ oml_gamma  =   0.14,
+ set_flx    =      0,
+ cnst_shflx =   0.10,
+ cnst_lhflx =   0.00,
+ set_znt    =      0,
+ cnst_znt   =   0.00,
+ set_ust    =      0,
+ cnst_ust   =   0.00,
+ /
+
+ &param4
+ stretch_x =      0,
+ dx_inner  =    1000.0,
+ dx_outer  =    7000.0,
+ nos_x_len =   40000.0,
+ tot_x_len =  120000.0,
+ /
+
+ &param5
+ stretch_y =      0,
+ dy_inner  =    1000.0,
+ dy_outer  =    7000.0,
+ nos_y_len =   40000.0,
+ tot_y_len =  120000.0,
+ /
+
+ &param6
+ stretch_z =  0,
+ ztop      =  2980.0,
+ str_bot   =  2000.0,
+ str_top   =  2980.0,
+ dz_bot    =   20.0,
+ dz_top    =   50.0,
+ /
+
+ &param7
+ bc_temp   = 1,
+ ptc_top   = 250.0,
+ ptc_bot   = 300.0,
+ viscosity = 1.57e-5,  !Needs to be set to the viscosity of air, even though not doing DNS
+ pr_num    = 0.72,
+ sc_num    = 0.61,     !Need to define a Schmidt number for the droplets
+ /
+
+ &param8
+ var1      =  60.0,     ! Vmax (m/s)
+ var2      =  40000.0,  ! R (m)
+ var3      =  0.80,     ! n
+ var4      =   2.0,
+ var5      =   0.0,
+ var6      =   0.0,
+ var7      =   0.0,
+ var8      =   0.0,
+ var9      =   0.0,
+ var10     =   0.0,
+ var11     =   0.0,
+ var12     =   0.0,
+ var13     =   0.0,
+ var14     =   0.0,
+ var15     =   0.0,
+ var16     =   0.0,
+ var17     =   0.0,
+ var18     =   0.0,
+ var19     =   0.0,
+ var20     =   0.0,
+ /
+
+ &param9
+ output_format    = 1,
+ output_filetype  = 2,
+ output_interp    = 0,
+ output_rain      = 1,
+ output_sws       = 1,
+ output_svs       = 1,
+ output_sps       = 1,
+ output_srs       = 1,
+ output_sgs       = 1,
+ output_sus       = 1,
+ output_shs       = 1,
+ output_coldpool  = 0,
+ output_sfcflx    = 1,
+ output_sfcparams = 1,
+ output_sfcdiags  = 1,
+ output_psfc      = 1,
+ output_zs        = 0,
+ output_zh        = 0,
+ output_basestate = 0,
+ output_th        = 1,
+ output_thpert    = 0,
+ output_prs       = 0,
+ output_prspert   = 0,
+ output_pi        = 0,
+ output_pipert    = 1,
+ output_rho       = 0,
+ output_rhopert   = 0,
+ output_tke       = 1,
+ output_km        = 1,
+ output_kh        = 1,
+ output_qv        = 1,
+ output_qvpert    = 0,
+ output_q         = 1,
+ output_dbz       = 0,
+ output_buoyancy  = 0,
+ output_u         = 1,
+ output_upert     = 0,
+ output_uinterp   = 1,
+ output_v         = 1,
+ output_vpert     = 0,
+ output_vinterp   = 1,
+ output_w         = 1,
+ output_winterp   = 1,
+ output_vort      = 0,
+ output_pv        = 0,
+ output_uh        = 0,
+ output_pblten    = 0,
+ output_dissten   = 0,
+ output_fallvel   = 0,
+ output_nm        = 0,
+ output_def       = 0,
+ output_radten    = 0,
+ output_cape      = 0,
+ output_cin       = 0,
+ output_lcl       = 0,
+ output_lfc       = 0,
+ output_pwat      = 0,
+ output_lwp       = 0,
+ output_thbudget  = 0,
+ output_qvbudget  = 0,
+ output_ubudget   = 0,
+ output_vbudget   = 0,
+ output_wbudget   = 0,
+ /
+
+ &param16
+ restart_format   = 1,
+ restart_filetype = 2,
+ restart_reset_frqtim  =  .true.,
+ restart_file_theta    =  .false.,
+ restart_file_dbz      =  .false.,
+ restart_file_th0      =  .false.,
+ restart_file_prs0     =  .false.,
+ restart_file_pi0      =  .false.,
+ restart_file_rho0     =  .false.,
+ restart_file_qv0      =  .false.,
+ restart_file_u0       =  .false.,
+ restart_file_v0       =  .false.,
+ restart_file_zs       =  .false.,
+ restart_file_zh       =  .false.,
+ restart_file_zf       =  .false.,
+ restart_file_diags    =  .false.,
+ restart_use_theta     =  .false.,
+ /
+
+ &param10
+ stat_w        = 1,
+ stat_wlevs    = 0,
+ stat_u        = 1,
+ stat_v        = 1,
+ stat_rmw      = 1,
+ stat_pipert   = 1,
+ stat_prspert  = 1,
+ stat_thpert   = 1,
+ stat_q        = 1,
+ stat_tke      = 1,
+ stat_km       = 1,
+ stat_kh       = 1,
+ stat_div      = 1,
+ stat_rh       = 1,
+ stat_rhi      = 1,
+ stat_the      = 1,
+ stat_cloud    = 1,
+ stat_sfcprs   = 1,
+ stat_wsp      = 1,
+ stat_cfl      = 1,
+ stat_vort     = 1,
+ stat_tmass    = 1,
+ stat_tmois    = 1,
+ stat_qmass    = 1,
+ stat_tenerg   = 1,
+ stat_mo       = 1,
+ stat_tmf      = 1,
+ stat_pcn      = 1,
+ stat_qsrc     = 1,
+ /
+
+ &param13
+ prcl_th       = 1,
+ prcl_t        = 1,
+ prcl_prs      = 1,
+ prcl_ptra     = 0,
+ prcl_q        = 1,
+ prcl_nc       = 0,
+ prcl_km       = 0,
+ prcl_kh       = 0,
+ prcl_tke      = 0,
+ prcl_dbz      = 0,
+ prcl_b        = 0,
+ prcl_vpg      = 0,
+ prcl_vort     = 0,
+ prcl_rho      = 0,
+ prcl_qsat     = 0,
+ prcl_sfc      = 0,
+ prcl_droplet  = 1, !Makes them "droplets" instead of "parcels"
+ /
+
+ &param14
+ dodomaindiag   =    .true.,
+ diagfrq        =     10.0,
+ /
+
+ &param15
+ doazimavg        =    .false.,
+ azimavgfrq       =     3600.0,
+ rlen             =   300000.0,
+ do_adapt_move    =    .false.,
+ adapt_move_frq   =     3600.0,
+ /
+
+ &nssl2mom_params
+   alphah  = 0,     ! shape parameter of graupel
+   alphahl = 0.5,   ! shape parameter of hail
+   ccn     = 0.6e9  ! base ccn concentration; see README.namelist
+   cnor    = 8.e6,  ! for single moment only
+   cnoh    = 4.e4,  ! for single moment only
+ /
+

--- a/run/namelist_ASD.restB
+++ b/run/namelist_ASD.restB
@@ -1,0 +1,369 @@
+
+ &param0
+ nx           =     128,
+ ny           =     128,
+ nz           =     128,
+ ppnode       =       4,
+ timeformat   =       1,
+ timestats    =       1,
+ terrain_flag = .false.,
+ procfiles    = .false.,
+ /
+
+ &param1
+ dx     =      40.0,
+ dy     =      40.0,
+ dz     =      20.0,
+ dtl    =       0.5,
+ timax  =     200.0,
+ run_time =  -999.9,
+ tapfrq =    1000.0,
+ rstfrq =   10800.0,
+ statfrq =     50.0,
+ prclfrq =     50.0,
+ /
+
+ &param2
+ cm1setup  =  1,
+ testcase  =  10,
+ adapt_dt  =  0,
+ irst      =  1,
+ rstnum    =  1,
+ iconly    =  0,
+ hadvordrs =  5,
+ vadvordrs =  5,
+ hadvordrv =  5,
+ vadvordrv =  5,
+ advwenos  =  2,
+ advwenov  =  0,
+ weno_order = 5,
+ apmasscon =  0,
+ idiff     =  0,
+ mdiff     =  0,
+ difforder =  6,
+ imoist    =  1,
+ ipbl      =  0,
+ sgsmodel  =  1,
+ tconfig   =  1,
+ bcturbs   =  1,
+ horizturb =  0,
+ doimpl    =  0,
+ irdamp    =  1,
+ hrdamp    =  0,
+ psolver   =  2,
+ ptype     =  0,
+ ihail     =  0,
+ iautoc    =  0,
+ icor      =  1,
+ lspgrad   =  3,
+ eqtset    =  1,
+ idiss     =  0,
+ efall     =  0,
+ rterm     =  0,
+ wbc       =  1,
+ ebc       =  1,
+ sbc       =  1,
+ nbc       =  1,
+ bbc       =  3,
+ tbc       =  1,
+ irbc      =  4,
+ roflux    =  0,
+ nudgeobc  =  0,
+ isnd      =  17,
+ iwnd      =  8,
+ itern     =  0,
+ iinit     =  0,
+ irandp    =  1,
+ ibalance  =  0,
+ iorigin   =  1,
+ axisymm   =  0,
+ imove     =  0,
+ iptra     =  0,
+ npt       =  1,
+ pdtra     =  1,
+ iprcl     =  1,       !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
+ nparcelsInit = 1e8,   ! initial number of particles over the whole domain
+ nparcelsMax  = 5e8,   ! the total allowable number of particles over the whole domain
+ injectHMax = 20.0,
+ drop_mult = 1.e10,   !Droplet multiplicity: total number of droplets = nparcels*drop_mult
+ drop_inject_elapse = 4.0,  !Time between spray injection
+ drop_inject_time =  10.0,  !Time after which spray injection begins
+ drop_w_init = 3.0    ! Initial vertical velocity of the newly initialized spray droplet
+ /
+
+ &param3
+ kdiff2  =   75.0,
+ kdiff6  =   0.040,
+ fcor    = 0.00005,
+ kdiv    = 0.10,
+ alph    = 0.60,
+ rdalpha = 3.3333333333e-3,
+ zd      =  2000.0,
+ xhd     = 100000.0,
+ alphobc = 60.0,
+ umove   =  0.0,
+ vmove   =  0.0,
+ v_t     =      0.0,
+ l_h     =      0.0,
+ lhref1  =      0.0,
+ lhref2  =      0.0,
+ l_inf   =     75.0,
+ ndcnst  =    100.0,
+ /
+
+ &param11
+ radopt  =        0,
+ dtrad   =    300.0,
+ ctrlat  =    36.68,
+ ctrlon  =   -98.35,
+ year    =     2009,
+ month   =        5,
+ day     =       15,
+ hour    =       21,
+ minute  =       38,
+ second  =       00,
+ /
+
+ &param12
+ isfcflx    =      1,
+ sfcmodel   =      1,
+ oceanmodel =      1,
+ initsfc    =      1,
+ tsk0       = 302.27,
+ tmn0       = 299.15,
+ xland0     =    2.0,
+ lu0        =     16,
+ season     =      1,
+ cecd       =      1,
+ pertflx    =      0,
+ cnstce     =  0.0012,
+ cnstcd     =  0.0025,
+ isftcflx   =      0,
+ iz0tlnd    =      0,
+ oml_hml0   =   50.0,
+ oml_gamma  =   0.14,
+ set_flx    =      0,
+ cnst_shflx =   0.10,
+ cnst_lhflx =   0.00,
+ set_znt    =      0,
+ cnst_znt   =   0.00,
+ set_ust    =      0,
+ cnst_ust   =   0.00,
+ /
+
+ &param4
+ stretch_x =      0,
+ dx_inner  =    1000.0,
+ dx_outer  =    7000.0,
+ nos_x_len =   40000.0,
+ tot_x_len =  120000.0,
+ /
+
+ &param5
+ stretch_y =      0,
+ dy_inner  =    1000.0,
+ dy_outer  =    7000.0,
+ nos_y_len =   40000.0,
+ tot_y_len =  120000.0,
+ /
+
+ &param6
+ stretch_z =  0,
+ ztop      =  2980.0,
+ str_bot   =  2000.0,
+ str_top   =  2980.0,
+ dz_bot    =   20.0,
+ dz_top    =   50.0,
+ /
+
+ &param7
+ bc_temp   = 1,
+ ptc_top   = 250.0,
+ ptc_bot   = 300.0,
+ viscosity = 1.57e-5,  !Needs to be set to the viscosity of air, even though not doing DNS
+ pr_num    = 0.72,
+ sc_num    = 0.61,     !Need to define a Schmidt number for the droplets
+ /
+
+ &param8
+ var1      =  60.0,     ! Vmax (m/s)
+ var2      =  40000.0,  ! R (m)
+ var3      =  0.80,     ! n
+ var4      =   2.0,
+ var5      =   0.0,
+ var6      =   0.0,
+ var7      =   0.0,
+ var8      =   0.0,
+ var9      =   0.0,
+ var10     =   0.0,
+ var11     =   0.0,
+ var12     =   0.0,
+ var13     =   0.0,
+ var14     =   0.0,
+ var15     =   0.0,
+ var16     =   0.0,
+ var17     =   0.0,
+ var18     =   0.0,
+ var19     =   0.0,
+ var20     =   0.0,
+ /
+
+ &param9
+ output_format    = 1,
+ output_filetype  = 2,
+ output_interp    = 0,
+ output_rain      = 1,
+ output_sws       = 1,
+ output_svs       = 1,
+ output_sps       = 1,
+ output_srs       = 1,
+ output_sgs       = 1,
+ output_sus       = 1,
+ output_shs       = 1,
+ output_coldpool  = 0,
+ output_sfcflx    = 1,
+ output_sfcparams = 1,
+ output_sfcdiags  = 1,
+ output_psfc      = 1,
+ output_zs        = 0,
+ output_zh        = 0,
+ output_basestate = 0,
+ output_th        = 1,
+ output_thpert    = 0,
+ output_prs       = 0,
+ output_prspert   = 0,
+ output_pi        = 0,
+ output_pipert    = 1,
+ output_rho       = 0,
+ output_rhopert   = 0,
+ output_tke       = 1,
+ output_km        = 1,
+ output_kh        = 1,
+ output_qv        = 1,
+ output_qvpert    = 0,
+ output_q         = 1,
+ output_dbz       = 0,
+ output_buoyancy  = 0,
+ output_u         = 1,
+ output_upert     = 0,
+ output_uinterp   = 1,
+ output_v         = 1,
+ output_vpert     = 0,
+ output_vinterp   = 1,
+ output_w         = 1,
+ output_winterp   = 1,
+ output_vort      = 0,
+ output_pv        = 0,
+ output_uh        = 0,
+ output_pblten    = 0,
+ output_dissten   = 0,
+ output_fallvel   = 0,
+ output_nm        = 0,
+ output_def       = 0,
+ output_radten    = 0,
+ output_cape      = 0,
+ output_cin       = 0,
+ output_lcl       = 0,
+ output_lfc       = 0,
+ output_pwat      = 0,
+ output_lwp       = 0,
+ output_thbudget  = 0,
+ output_qvbudget  = 0,
+ output_ubudget   = 0,
+ output_vbudget   = 0,
+ output_wbudget   = 0,
+ /
+
+ &param16
+ restart_format   = 1,
+ restart_filetype = 2,
+ restart_reset_frqtim  =  .true.,
+ restart_file_theta    =  .false.,
+ restart_file_dbz      =  .false.,
+ restart_file_th0      =  .false.,
+ restart_file_prs0     =  .false.,
+ restart_file_pi0      =  .false.,
+ restart_file_rho0     =  .false.,
+ restart_file_qv0      =  .false.,
+ restart_file_u0       =  .false.,
+ restart_file_v0       =  .false.,
+ restart_file_zs       =  .false.,
+ restart_file_zh       =  .false.,
+ restart_file_zf       =  .false.,
+ restart_file_diags    =  .false.,
+ restart_use_theta     =  .false.,
+ /
+
+ &param10
+ stat_w        = 1,
+ stat_wlevs    = 0,
+ stat_u        = 1,
+ stat_v        = 1,
+ stat_rmw      = 1,
+ stat_pipert   = 1,
+ stat_prspert  = 1,
+ stat_thpert   = 1,
+ stat_q        = 1,
+ stat_tke      = 1,
+ stat_km       = 1,
+ stat_kh       = 1,
+ stat_div      = 1,
+ stat_rh       = 1,
+ stat_rhi      = 1,
+ stat_the      = 1,
+ stat_cloud    = 1,
+ stat_sfcprs   = 1,
+ stat_wsp      = 1,
+ stat_cfl      = 1,
+ stat_vort     = 1,
+ stat_tmass    = 1,
+ stat_tmois    = 1,
+ stat_qmass    = 1,
+ stat_tenerg   = 1,
+ stat_mo       = 1,
+ stat_tmf      = 1,
+ stat_pcn      = 1,
+ stat_qsrc     = 1,
+ /
+
+ &param13
+ prcl_th       = 1,
+ prcl_t        = 1,
+ prcl_prs      = 1,
+ prcl_ptra     = 0,
+ prcl_q        = 1,
+ prcl_nc       = 0,
+ prcl_km       = 0,
+ prcl_kh       = 0,
+ prcl_tke      = 0,
+ prcl_dbz      = 0,
+ prcl_b        = 0,
+ prcl_vpg      = 0,
+ prcl_vort     = 0,
+ prcl_rho      = 0,
+ prcl_qsat     = 0,
+ prcl_sfc      = 0,
+ prcl_droplet  = 1, !Makes them "droplets" instead of "parcels"
+ /
+
+ &param14
+ dodomaindiag   =    .true.,
+ diagfrq        =     10.0,
+ /
+
+ &param15
+ doazimavg        =    .false.,
+ azimavgfrq       =     3600.0,
+ rlen             =   300000.0,
+ do_adapt_move    =    .false.,
+ adapt_move_frq   =     3600.0,
+ /
+
+ &nssl2mom_params
+   alphah  = 0,     ! shape parameter of graupel
+   alphahl = 0.5,   ! shape parameter of hail
+   ccn     = 0.6e9  ! base ccn concentration; see README.namelist
+   cnor    = 8.e6,  ! for single moment only
+   cnoh    = 4.e4,  ! for single moment only
+ /
+

--- a/run/namelist_ASD.restC
+++ b/run/namelist_ASD.restC
@@ -1,0 +1,369 @@
+
+ &param0
+ nx           =     128,
+ ny           =     128,
+ nz           =     128,
+ ppnode       =       4,
+ timeformat   =       1,
+ timestats    =       1,
+ terrain_flag = .false.,
+ procfiles    = .false.,
+ /
+
+ &param1
+ dx     =      40.0,
+ dy     =      40.0,
+ dz     =      20.0,
+ dtl    =       0.5,
+ timax  =     200.0,
+ run_time =  -999.9,
+ tapfrq =    1000.0,
+ rstfrq =   10800.0,
+ statfrq =     50.0,
+ prclfrq =     50.0,
+ /
+
+ &param2
+ cm1setup  =  1,
+ testcase  =  10,
+ adapt_dt  =  0,
+ irst      =  0,
+ rstnum    =  1,
+ iconly    =  0,
+ hadvordrs =  5,
+ vadvordrs =  5,
+ hadvordrv =  5,
+ vadvordrv =  5,
+ advwenos  =  2,
+ advwenov  =  0,
+ weno_order = 5,
+ apmasscon =  0,
+ idiff     =  0,
+ mdiff     =  0,
+ difforder =  6,
+ imoist    =  1,
+ ipbl      =  0,
+ sgsmodel  =  1,
+ tconfig   =  1,
+ bcturbs   =  1,
+ horizturb =  0,
+ doimpl    =  0,
+ irdamp    =  1,
+ hrdamp    =  0,
+ psolver   =  2,
+ ptype     =  0,
+ ihail     =  0,
+ iautoc    =  0,
+ icor      =  1,
+ lspgrad   =  3,
+ eqtset    =  1,
+ idiss     =  0,
+ efall     =  0,
+ rterm     =  0,
+ wbc       =  1,
+ ebc       =  1,
+ sbc       =  1,
+ nbc       =  1,
+ bbc       =  3,
+ tbc       =  1,
+ irbc      =  4,
+ roflux    =  0,
+ nudgeobc  =  0,
+ isnd      =  17,
+ iwnd      =  8,
+ itern     =  0,
+ iinit     =  0,
+ irandp    =  1,
+ ibalance  =  0,
+ iorigin   =  1,
+ axisymm   =  0,
+ imove     =  0,
+ iptra     =  0,
+ npt       =  1,
+ pdtra     =  1,
+ iprcl     =  1,       !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
+ nparcelsInit = 1e8,   ! initial number of particles over the whole domain
+ nparcelsMax  = 5e8,   ! the total allowable number of particles over the whole domain
+ injectHMax = 20.0,
+ drop_mult = 1.e10,   !Droplet multiplicity: total number of droplets = nparcels*drop_mult
+ drop_inject_elapse = 4.0,  !Time between spray injection
+ drop_inject_time =  10.0,  !Time after which spray injection begins
+ drop_w_init = 3.0    ! Initial vertical velocity of the newly initialized spray droplet
+ /
+
+ &param3
+ kdiff2  =   75.0,
+ kdiff6  =   0.040,
+ fcor    = 0.00005,
+ kdiv    = 0.10,
+ alph    = 0.60,
+ rdalpha = 3.3333333333e-3,
+ zd      =  2000.0,
+ xhd     = 100000.0,
+ alphobc = 60.0,
+ umove   =  0.0,
+ vmove   =  0.0,
+ v_t     =      0.0,
+ l_h     =      0.0,
+ lhref1  =      0.0,
+ lhref2  =      0.0,
+ l_inf   =     75.0,
+ ndcnst  =    100.0,
+ /
+
+ &param11
+ radopt  =        0,
+ dtrad   =    300.0,
+ ctrlat  =    36.68,
+ ctrlon  =   -98.35,
+ year    =     2009,
+ month   =        5,
+ day     =       15,
+ hour    =       21,
+ minute  =       38,
+ second  =       00,
+ /
+
+ &param12
+ isfcflx    =      1,
+ sfcmodel   =      1,
+ oceanmodel =      1,
+ initsfc    =      1,
+ tsk0       = 302.27,
+ tmn0       = 299.15,
+ xland0     =    2.0,
+ lu0        =     16,
+ season     =      1,
+ cecd       =      1,
+ pertflx    =      0,
+ cnstce     =  0.0012,
+ cnstcd     =  0.0025,
+ isftcflx   =      0,
+ iz0tlnd    =      0,
+ oml_hml0   =   50.0,
+ oml_gamma  =   0.14,
+ set_flx    =      0,
+ cnst_shflx =   0.10,
+ cnst_lhflx =   0.00,
+ set_znt    =      0,
+ cnst_znt   =   0.00,
+ set_ust    =      0,
+ cnst_ust   =   0.00,
+ /
+
+ &param4
+ stretch_x =      0,
+ dx_inner  =    1000.0,
+ dx_outer  =    7000.0,
+ nos_x_len =   40000.0,
+ tot_x_len =  120000.0,
+ /
+
+ &param5
+ stretch_y =      0,
+ dy_inner  =    1000.0,
+ dy_outer  =    7000.0,
+ nos_y_len =   40000.0,
+ tot_y_len =  120000.0,
+ /
+
+ &param6
+ stretch_z =  0,
+ ztop      =  2980.0,
+ str_bot   =  2000.0,
+ str_top   =  2980.0,
+ dz_bot    =   20.0,
+ dz_top    =   50.0,
+ /
+
+ &param7
+ bc_temp   = 1,
+ ptc_top   = 250.0,
+ ptc_bot   = 300.0,
+ viscosity = 1.57e-5,  !Needs to be set to the viscosity of air, even though not doing DNS
+ pr_num    = 0.72,
+ sc_num    = 0.61,     !Need to define a Schmidt number for the droplets
+ /
+
+ &param8
+ var1      =  60.0,     ! Vmax (m/s)
+ var2      =  40000.0,  ! R (m)
+ var3      =  0.80,     ! n
+ var4      =   2.0,
+ var5      =   0.0,
+ var6      =   0.0,
+ var7      =   0.0,
+ var8      =   0.0,
+ var9      =   0.0,
+ var10     =   0.0,
+ var11     =   0.0,
+ var12     =   0.0,
+ var13     =   0.0,
+ var14     =   0.0,
+ var15     =   0.0,
+ var16     =   0.0,
+ var17     =   0.0,
+ var18     =   0.0,
+ var19     =   0.0,
+ var20     =   0.0,
+ /
+
+ &param9
+ output_format    = 1,
+ output_filetype  = 2,
+ output_interp    = 0,
+ output_rain      = 1,
+ output_sws       = 1,
+ output_svs       = 1,
+ output_sps       = 1,
+ output_srs       = 1,
+ output_sgs       = 1,
+ output_sus       = 1,
+ output_shs       = 1,
+ output_coldpool  = 0,
+ output_sfcflx    = 1,
+ output_sfcparams = 1,
+ output_sfcdiags  = 1,
+ output_psfc      = 1,
+ output_zs        = 0,
+ output_zh        = 0,
+ output_basestate = 0,
+ output_th        = 1,
+ output_thpert    = 0,
+ output_prs       = 0,
+ output_prspert   = 0,
+ output_pi        = 0,
+ output_pipert    = 1,
+ output_rho       = 0,
+ output_rhopert   = 0,
+ output_tke       = 1,
+ output_km        = 1,
+ output_kh        = 1,
+ output_qv        = 1,
+ output_qvpert    = 0,
+ output_q         = 1,
+ output_dbz       = 0,
+ output_buoyancy  = 0,
+ output_u         = 1,
+ output_upert     = 0,
+ output_uinterp   = 1,
+ output_v         = 1,
+ output_vpert     = 0,
+ output_vinterp   = 1,
+ output_w         = 1,
+ output_winterp   = 1,
+ output_vort      = 0,
+ output_pv        = 0,
+ output_uh        = 0,
+ output_pblten    = 0,
+ output_dissten   = 0,
+ output_fallvel   = 0,
+ output_nm        = 0,
+ output_def       = 0,
+ output_radten    = 0,
+ output_cape      = 0,
+ output_cin       = 0,
+ output_lcl       = 0,
+ output_lfc       = 0,
+ output_pwat      = 0,
+ output_lwp       = 0,
+ output_thbudget  = 0,
+ output_qvbudget  = 0,
+ output_ubudget   = 0,
+ output_vbudget   = 0,
+ output_wbudget   = 0,
+ /
+
+ &param16
+ restart_format   = 1,
+ restart_filetype = 2,
+ restart_reset_frqtim  =  .true.,
+ restart_file_theta    =  .false.,
+ restart_file_dbz      =  .false.,
+ restart_file_th0      =  .false.,
+ restart_file_prs0     =  .false.,
+ restart_file_pi0      =  .false.,
+ restart_file_rho0     =  .false.,
+ restart_file_qv0      =  .false.,
+ restart_file_u0       =  .false.,
+ restart_file_v0       =  .false.,
+ restart_file_zs       =  .false.,
+ restart_file_zh       =  .false.,
+ restart_file_zf       =  .false.,
+ restart_file_diags    =  .false.,
+ restart_use_theta     =  .false.,
+ /
+
+ &param10
+ stat_w        = 1,
+ stat_wlevs    = 0,
+ stat_u        = 1,
+ stat_v        = 1,
+ stat_rmw      = 1,
+ stat_pipert   = 1,
+ stat_prspert  = 1,
+ stat_thpert   = 1,
+ stat_q        = 1,
+ stat_tke      = 1,
+ stat_km       = 1,
+ stat_kh       = 1,
+ stat_div      = 1,
+ stat_rh       = 1,
+ stat_rhi      = 1,
+ stat_the      = 1,
+ stat_cloud    = 1,
+ stat_sfcprs   = 1,
+ stat_wsp      = 1,
+ stat_cfl      = 1,
+ stat_vort     = 1,
+ stat_tmass    = 1,
+ stat_tmois    = 1,
+ stat_qmass    = 1,
+ stat_tenerg   = 1,
+ stat_mo       = 1,
+ stat_tmf      = 1,
+ stat_pcn      = 1,
+ stat_qsrc     = 1,
+ /
+
+ &param13
+ prcl_th       = 1,
+ prcl_t        = 1,
+ prcl_prs      = 1,
+ prcl_ptra     = 0,
+ prcl_q        = 1,
+ prcl_nc       = 0,
+ prcl_km       = 0,
+ prcl_kh       = 0,
+ prcl_tke      = 0,
+ prcl_dbz      = 0,
+ prcl_b        = 0,
+ prcl_vpg      = 0,
+ prcl_vort     = 0,
+ prcl_rho      = 0,
+ prcl_qsat     = 0,
+ prcl_sfc      = 0,
+ prcl_droplet  = 1, !Makes them "droplets" instead of "parcels"
+ /
+
+ &param14
+ dodomaindiag   =    .true.,
+ diagfrq        =     10.0,
+ /
+
+ &param15
+ doazimavg        =    .false.,
+ azimavgfrq       =     3600.0,
+ rlen             =   300000.0,
+ do_adapt_move    =    .false.,
+ adapt_move_frq   =     3600.0,
+ /
+
+ &nssl2mom_params
+   alphah  = 0,     ! shape parameter of graupel
+   alphahl = 0.5,   ! shape parameter of hail
+   ccn     = 0.6e9  ! base ccn concentration; see README.namelist
+   cnor    = 8.e6,  ! for single moment only
+   cnoh    = 4.e4,  ! for single moment only
+ /
+

--- a/src/restart.F
+++ b/src/restart.F
@@ -3728,11 +3728,6 @@
             if ( iprcl.eq.1 ) then
 #ifdef MPI
                call mpi_bcast(nparcels_per_mpi,numprocs,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-               if ( myid .ne. 0 ) then
-                  if ( .not. allocated(tmp_buf) ) then
-                     allocate( tmp_buf(nparcels_per_mpi(myid+1),npvars) )
-                  end if
-               end if
                if ( myid .eq. 0 ) then
                   do i = 1, numprocs - 1
                      allocate( tmp_buf(nparcels_per_mpi(i+1),npvars) )
@@ -3746,6 +3741,7 @@
                   end do
                else
                   tag = 98765 + myid
+                  allocate( tmp_buf(nparcels_per_mpi(myid+1),npvars) )
                   call mpi_recv(tmp_buf,nparcels_per_mpi(myid+1)*npvars, &
                                 MPI_REAL,0,tag,MPI_COMM_WORLD, &
                                 MPI_STATUS_IGNORE,ierr)

--- a/src/restart.F
+++ b/src/restart.F
@@ -1726,6 +1726,10 @@
         if(myid.eq.0)then
           if( restart_format.eq.1 )then
             write(50) nparcelsRest
+            ! write out the number of active droplets per MPI rank
+            do i = 0, numprocs-1
+               write(50) counts(i)
+            end do
 #ifdef NETCDF
           elseif( restart_format.eq.2 )then
             call disp_err( nf90_inq_varid(ncid,"numactiveparcels",varid) , .true. )
@@ -2272,6 +2276,9 @@
       real, dimension(:,:), allocatable :: rbuf
 #ifdef MPI
       integer :: proc,index,count,req1,req2,req3,reqp
+      integer :: beg_loc, end_loc
+      integer :: nparcels_per_mpi(numprocs)   ! number of active droplets per MPI rank
+                                              ! that is read in from the restart file
 #endif
 #ifdef NETCDF
       integer :: varid,ncstatus
@@ -3685,6 +3692,10 @@
       if( myid.eq.0 )then
         if( restart_format.eq.1 )then
           read(50) nvar
+          ! Read in the number of active droplets for each MPI rank
+          do i = 1, numprocs
+             read(50) nparcels_per_mpi(i)
+          end do
 #ifdef NETCDF
         elseif( restart_format.eq.2 )then
           call disp_err( nf90_inq_varid(ncid,"numparcels",varid) , .true. )
@@ -3697,59 +3708,73 @@
 
       call bcast_int(nvar)
 
-      if( iprcl.eq.1 .or. nvar.gt.0 )then
-        if( nvar.gt.0 )then
-          ! only read position info:
-          if( myid.eq.0 )then
-            ! reset "pdata" that is initialized by the init3d subroutine
-            pdata(:,:) = neg_huge
-            IF( nvar .eq. nparcelsRest )THEN
-              ! easy:  restart file matches current config
-              if( restart_format.eq.1 )then
-                allocate( rbuf(nparcelsRest,npvars) )
-                read(50) rbuf 
+      if ( iprcl.eq.1 .or. nvar.gt.0 ) then
+         if ( nvar.gt.0 ) then
+            ! only read position info:
+            if ( myid.eq.0 ) then
+               ! reset "pdata" that is initialized by the init3d subroutine
+               pdata(:,:) = neg_huge
+               if ( restart_format.eq.1 ) then
+                  allocate( rbuf(nvar,npvars) )
+                  read(50) rbuf 
 #ifdef NETCDF
-              elseif( restart_format.eq.2 )then
-                call disp_err( nf90_inq_varid(ncid,"ploc",varid) , .true. )
-                n = 3
-                call disp_err( nf90_get_var(ncid,varid,ploc,(/1,1,time_index/),(/nparcelsLocal,n,1/)) , .true. )
+               else if ( restart_format.eq.2 ) then
+                  call disp_err( nf90_inq_varid(ncid,"ploc",varid) , .true. )
+                  n = 3
+                  call disp_err( nf90_get_var(ncid,varid,ploc,(/1,1,time_index/),(/nparcelsLocal,n,1/)) , .true. )
 #endif
-              endif
-            ELSE
-              ! annoying:  restart file has different nparcels than current config
-              print *, "unmatched nvar and nparcelsRest..."
-              print *, "nvar_parcels = ",nvar,", nparcelsRest = ",nparcelsRest
-              stop
-            ENDIF
-          endif
-          IF( iprcl.eq.1 )THEN
-#ifdef MPI
-            call MPI_BCAST(nparcelsRest,1,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
-            if ( .not. allocated(rbuf) ) allocate( rbuf(nparcelsRest,npvars) )
-            call MPI_BCAST(rbuf,npvars*nparcelsRest,MPI_REAL,0,MPI_COMM_WORLD,ierr)
-#endif
-            j = 1
-            DO np=1,nparcelsRest
-               ! check if this droplet belongs to this MPI rank
-               if ( rbuf(np,prx) .ge. xf(1) .and. rbuf(np,prx) .le. xf(ni+1) .and. &
-                    rbuf(np,pry) .ge. yf(1) .and. rbuf(np,pry) .le. yf(nj+1) ) then
-                  do i = 1, npvars
-                     pdata(j,i) = rbuf(np,i)
-                  end do
-                  j = j + 1
                end if
-            ENDDO
-            nparcelsLocalActive = j - 1
-            restart_prcl = .true.
-            deallocate( rbuf )
-          ENDIF
-        else
-          if( myid.eq.0 ) print *
-          if( myid.eq.0 ) print *,'  Note:  no parcel data in the restart file '
-          if( myid.eq.0 ) print *
-          restart_prcl = .false.
-        endif
-      endif
+            end if
+            if ( iprcl.eq.1 ) then
+#ifdef MPI
+               call mpi_bcast(nparcels_per_mpi,numprocs,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
+               if ( myid .ne. 0 ) then
+                  if ( .not. allocated(tmp_buf) ) then
+                     allocate( tmp_buf(nparcels_per_mpi(myid+1),npvars) )
+                  end if
+               end if
+               if ( myid .eq. 0 ) then
+                  do i = 1, numprocs - 1
+                     allocate( tmp_buf(nparcels_per_mpi(i+1),npvars) )
+                     beg_loc = sum(nparcels_per_mpi(1:i))+1
+                     end_loc = beg_loc+nparcels_per_mpi(i+1)-1
+                     tmp_buf(:,:) = rbuf(beg_loc:end_loc,:))
+                     tag = 98765 + i
+                     call mpi_send(tmp_buf,nparcels_per_mpi(i+1)*npvars, &
+                                   MPI_REAL,i,tag,MPI_COMM_WORLD,ierr)
+                     deallocate(tmp_buf)
+                  end do
+               else
+                  tag = 98765 + myid
+                  call mpi_recv(tmp_buf,nparcels_per_mpi(myid+1)*npvars, &
+                                MPI_REAL,0,tag,MPI_COMM_WORLD,ierr)
+               end if
+#endif
+               if ( myid .eq. 0 ) then
+                  do np = 1, nparcels_per_mpi(myid+1)
+                     do i = 1, npvars
+                        pdata(np,i) = rbuf(np,i)
+                     end do
+                  end do
+                  deallocate( rbuf )
+               else
+                  do np = 1, nparcels_per_mpi(myid+1)
+                     do i = 1, npvars
+                        pdata(np,i) = tmp_buf(np,i)
+                     end do
+                  end do
+                  deallocate( tmp_buf )
+               end if
+               nparcelsLocalActive = nparcels_per_mpi(myid+1) 
+               restart_prcl = .true.
+            end if   ! if iprcl.eq.1
+         else
+            if ( myid.eq.0 ) print *
+            if ( myid.eq.0 ) print *,'  Note:  no parcel data in the restart file '
+            if ( myid.eq.0 ) print *
+            restart_prcl = .false.
+         end if  ! if nvar.gt.0
+      end if     ! if iprcl.eq.1 .or. nvar.gt.0
 
 !---------------------------------------------------------------
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/restart.F
+++ b/src/restart.F
@@ -3747,7 +3747,8 @@
                else
                   tag = 98765 + myid
                   call mpi_recv(tmp_buf,nparcels_per_mpi(myid+1)*npvars, &
-                                MPI_REAL,0,tag,MPI_COMM_WORLD,ierr)
+                                MPI_REAL,0,tag,MPI_COMM_WORLD, &
+                                MPI_STATUS_IGNORE,ierr)
                end if
 #endif
                if ( myid .eq. 0 ) then

--- a/src/restart.F
+++ b/src/restart.F
@@ -2273,9 +2273,9 @@
       double precision, dimension(numq,0:numprocs-1) :: csq,dsq
       real, dimension(:,:), allocatable :: pfoo
       real, dimension(:), allocatable :: dumx,dumy
-      real, dimension(:,:), allocatable :: rbuf
+      real, dimension(:,:), allocatable :: rbuf, tmp_buf
 #ifdef MPI
-      integer :: proc,index,count,req1,req2,req3,reqp
+      integer :: proc,index,count,req1,req2,req3,reqp,tag
       integer :: beg_loc, end_loc
       integer :: nparcels_per_mpi(numprocs)   ! number of active droplets per MPI rank
                                               ! that is read in from the restart file
@@ -3738,7 +3738,7 @@
                      allocate( tmp_buf(nparcels_per_mpi(i+1),npvars) )
                      beg_loc = sum(nparcels_per_mpi(1:i))+1
                      end_loc = beg_loc+nparcels_per_mpi(i+1)-1
-                     tmp_buf(:,:) = rbuf(beg_loc:end_loc,:))
+                     tmp_buf(:,:) = rbuf(beg_loc:end_loc,:)
                      tag = 98765 + i
                      call mpi_send(tmp_buf,nparcels_per_mpi(i+1)*npvars, &
                                    MPI_REAL,i,tag,MPI_COMM_WORLD,ierr)


### PR DESCRIPTION
This PR fixes the broken restart functionality reported by @drichte2 , where he tried to restart a run with > 100 M droplets.

The underlying reason is that the original implementation uses the **MPI_BCAST** interface and it could only send/receive `int` number of data, which will be exceeded if there are > 100 M droplets.

The new implementation uses **MPI_SEND** and **MPI_RECV** interfaces instead. We assume that the same PE layout is used for the initial and restart runs. We write the number of active droplets from each MPI rank to the restart file and the root MPI rank knows how many active droplets will be sent to each MPI rank during the restart run later.

I verified that the initial run (use `namelist_ASD.restC`) and restart run (use `namelist_ASD.restA` and `namelist_ASD.restB`) match for the total droplet number (> 100 M) when I used 4 MPI ranks + 4 GPUs on Gust.

Fix https://github.com/george-bryan/CM1/issues/120.