### PR TITLE
Count prefix

### DIFF
--- a/run/derecho.verify.cpu.sh
+++ b/run/derecho.verify.cpu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 #PBS -N cm1
-#PBS -l select=1:ncpus=2:mpiprocs=2:ompthreads=1
+#PBS -l select=1:ncpus=4:mpiprocs=4:ompthreads=1
 #PBS -l walltime=00:40:00
 #PBS -j oe
 #PBS -q main
@@ -9,4 +9,4 @@
 module --force purge
 module load ncarenv intel cray-mpich ncarcompilers
 
-mpiexec -n 2 -ppn 2 ./cpu.exe --namelist namelist_ASD.verify >& gust.mpi.ifort.namelist.ASD.log
+mpiexec -n 4 -ppn 4 ./cpu.exe --namelist namelist_ASD.verify >& derecho.mpi.ifort.namelist.ASD.log

--- a/run/derecho.verify.cpu.sh
+++ b/run/derecho.verify.cpu.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -l
+#PBS -N cm1
+#PBS -l select=1:ncpus=2:mpiprocs=2:ompthreads=1
+#PBS -l walltime=00:40:00
+#PBS -j oe
+#PBS -q main
+#PBS -A UNDM0006
+
+module --force purge
+module load ncarenv intel cray-mpich ncarcompilers
+
+mpiexec -n 2 -ppn 2 ./cpu.exe --namelist namelist_ASD.verify >& gust.mpi.ifort.namelist.ASD.log

--- a/run/derecho.verify.gpu.sh
+++ b/run/derecho.verify.gpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #PBS -N cm1
 #PBS -l select=1:ncpus=4:mpiprocs=4:ngpus=4:mem=200gb
-#PBS -l walltime=02:00:00
+#PBS -l walltime=00:20:00
 #PBS -j oe
 #PBS -q main
 #PBS -A UNDM0006

--- a/run/derecho.verify.gpu.sh
+++ b/run/derecho.verify.gpu.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+#PBS -N cm1
+#PBS -l select=1:ncpus=4:mpiprocs=4:ngpus=4:mem=200gb
+#PBS -l walltime=02:00:00
+#PBS -j oe
+#PBS -q main
+#PBS -A UNDM0006
+
+module purge
+module load ncarenv nvhpc cuda cray-mpich ncarcompilers cutensor
+
+
+export MPICH_GPU_SUPPORT_ENABLED=1
+mpiexec -n 4 -ppn 4 get_local_rank ./gpu.exe --namelist namelist_ASD.verify >& derecho.mpi.openacc.namelist.ASD.log
+# mpiexec -n 4 -ppn 4 get_local_rank ./gpu.exe --namelist namelist_ASD.verify.v2 >& derecho.mpi.openacc.namelist.ASDv2.log
+# mpiexec -n 4 -ppn 4 get_local_rank ./gpu.exe --namelist namelist_ASD.verify.v2.buggy >& derecho.mpi.openacc.namelist.ASDv2bug.log

--- a/run/gust.verify.cpu.sh
+++ b/run/gust.verify.cpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -l
 #PBS -N cm1
 #PBS -l select=1:ncpus=2:mpiprocs=2:ompthreads=1
-#PBS -l walltime=00:40:00
+#PBS -l walltime=02:00:00
 #PBS -j oe
 #PBS -q main
 #PBS -A UNDM0006
@@ -9,5 +9,9 @@
 
 module --force purge
 module load ncarenv intel cray-mpich ncarcompilers
+mpiexec -n 2 -ppn 2 ./cpu.ifort.exe --namelist namelist_ASD.verify >& gust.mpi.ifort.namelist.ASD.log
 
-mpiexec -n 2 -ppn 2 ./cpu.exe --namelist namelist_ASD.input >& gust.mpi.ifort.namelist.ASD.log
+module --force purge
+module load ncarenv nvhpc cray-mpich ncarcompilers
+mpiexec -n 2 -ppn 2 ./cpu.nvhpc.exe --namelist namelist_ASD.verify >& gust.mpi.nvhpc.namelist.ASD.log
+

--- a/run/gust.verify.gpu.sh
+++ b/run/gust.verify.gpu.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #PBS -N cm1
 #PBS -l select=1:ncpus=2:mpiprocs=2:ngpus=2:mem=100gb
-#PBS -l walltime=00:40:00
+#PBS -l walltime=02:00:00
 #PBS -j oe
 #PBS -q main
 #PBS -A UNDM0006
@@ -9,5 +9,8 @@
 module purge
 module load ncarenv nvhpc cuda cray-mpich ncarcompilers
 
+
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/glade/u/apps/common/22.12/spack/opt/spack/nvhpc/23.3/Linux_x86_64/23.3/math_libs/12.0/targets/x86_64-linux/lib
 export MPICH_GPU_SUPPORT_ENABLED=1
-mpiexec -n 2 -ppn 2 get_local_rank ./gpu.exe --namelist namelist_ASD.input >& gust.mpi.openacc.namelist.ASD.log
+mpiexec -n 2 -ppn 2 get_local_rank ./gpu.exe --namelist namelist_ASD.verify >& gust.mpi.openacc.namelist.ASD.log
+#mpiexec -n 2 -ppn 2 get_local_rank ./gpu.exe --namelist namelist_ASD.100M >& gust.mpi.openacc.namelist.ASD.log

--- a/src/Makefile
+++ b/src/Makefile
@@ -104,7 +104,7 @@ ifeq (${FC},nvfortran)
             #     -Minfo=accel    Provides verbose output for accelerator compilation phase
             #     -Mpcast         Enables the use of PCAST functionality
             ifeq (${GPU_TYPE_L},a100)
-                OPTS += -acc -gpu=cc80,lineinfo,nofma,math_uniform -Minfo=accel
+                OPTS += -acc -gpu=cc80,lineinfo,nofma,math_uniform -Minfo=accel -cudalib=cutensor 
             else
                 OPTS += -acc -gpu=cc70,lineinfo,nofma,math_uniform -Mpcast -Minfo=accel
             endif

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -3512,7 +3512,6 @@ end module cuda_rt
           enddo
           enddo
         ENDIF
-#if 0
         call     statpack(mtime,nrec,ndt,dt,dtlast,rtime,adt,acfl,cloudvar,   &
                           qname,budname,qbudget,asq,bsq,                      &
                           name_stat,desc_stat,unit_stat,                      &
@@ -3539,7 +3538,6 @@ end module cuda_rt
         if ( iprcl.eq.1 .and. prcl_droplet.eq.1 ) then
            call droplet_diag(rtime,nrec,zh,zf,pdata,pdata_locind,dpten)
         end if
-#endif
 
         nrec = nrec + 1
         nstatout = nstatout + 1
@@ -3585,7 +3583,6 @@ end module cuda_rt
 
 
       if( dowriteout )then
-!#if 0
 #ifdef _NVTX
         call nvtxStartRange("writeout",id=6)
 #endif
@@ -3726,7 +3723,6 @@ end module cuda_rt
 #ifdef _NVTX
       call nvtxEndRange()
 #endif
-!#endif
         if(timestats.ge.1) time_write=time_write+mytime()
       endif
 

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -284,7 +284,6 @@ end module cuda_rt
       real :: mp_total,minval,temx,temy,temni,temnj
       double precision :: tstart,tend
       integer, dimension(:), allocatable :: isum,jsum
-      integer :: padding
 #endif
 #ifdef _OPENACC
       integer :: ndev,idev
@@ -3513,6 +3512,7 @@ end module cuda_rt
           enddo
           enddo
         ENDIF
+#if 0
         call     statpack(mtime,nrec,ndt,dt,dtlast,rtime,adt,acfl,cloudvar,   &
                           qname,budname,qbudget,asq,bsq,                      &
                           name_stat,desc_stat,unit_stat,                      &
@@ -3539,6 +3539,7 @@ end module cuda_rt
         if ( iprcl.eq.1 .and. prcl_droplet.eq.1 ) then
            call droplet_diag(rtime,nrec,zh,zf,pdata,pdata_locind,dpten)
         end if
+#endif
 
         nrec = nrec + 1
         nstatout = nstatout + 1

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -680,12 +680,14 @@ contains
       integer :: n_idx,s_idx,e_idx,w_idx,nw_idx,ne_idx,sw_idx,se_idx
       integer np
       logical, dimension(nparcelsLocalActive) :: mskN,mskS,mskW,mskE,mskNW,mskNE,mskSW,mskSE
-      integer, dimension(nparcelsLocalActive) :: CidxN,CidxS,CidxW,CidxE,CidxNW,CidxNE,CidxSW,CidxSE
-      integer, allocatable :: Depart_ind2(:)
+      integer :: Cidx(nparcelsLocalActive)
       integer :: numDepart,numerrors
+      logical, parameter :: verbose = .false.
+      !!$acc declare present(ptrDepart,Depart,Depart_ind,pdata_neighbor)
+      !$acc declare present(Depart_ind,pdata_neighbor)
 
       numDepart=SUM(Depart)
-      if(numDepart.gt.0) allocate(Depart_ind2(numDepart))
+!      if(numDepart.gt.0) allocate(Depart_ind2(numDepart))
 
       n_idx  = ptrDepart(inorth)
       s_idx  = ptrDepart(isouth)
@@ -695,15 +697,14 @@ contains
       ne_idx = ptrDepart(ine)
       sw_idx = ptrDepart(isw)
       se_idx = ptrDepart(ise)
-      if(numDepart.gt.0) then
+      if(verbose .and. (numDepart.gt.0)) then
          write(*,110) myid,'Depart:',Depart
          write(*,110) myid,'ptrDepart:',ptrDepart
       endif
 
-!$acc data copyin(ptrDepart,Depart,Depart_ind2,pdata_neighbor) &
-!$acc create(mskN,mskS,mskW,mskE,mskNW,mskNE,mskSE,mskSW, &
-!$acc        CidxN,CidxS,CidxW,CidxE,CidxNW,CidxNE,CidxSW,CidxSE)
+#ifdef _COUNTPREFIX
 
+!$acc data create(mskN,mskS,mskW,mskE,mskNW,mskNE,mskSE,mskSW,Cidx)
 
       !$acc parallel loop gang vector default(present)
       do np=1,nparcelsLocalActive
@@ -734,144 +735,143 @@ contains
          endif
       enddo
 
-      if(Depart(inorth).gt.0) CidxN  = count_prefix(mask=mskN,exclusive=.true.)
-      if(Depart(isouth).gt.0) CidxS  = count_prefix(mask=mskS,exclusive=.true.)
-      if(Depart(iwest).gt.0)  CidxW  = count_prefix(mask=mskW,exclusive=.true.)
-      if(Depart(ieast).gt.0)  CidxE  = count_prefix(mask=mskE,exclusive=.true.)
-      if(Depart(inw).gt.0)    CidxNW = count_prefix(mask=mskNW,exclusive=.true.)
-      if(Depart(ine).gt.0)    CidxNE = count_prefix(mask=mskNE,exclusive=.true.)
-      if(Depart(isw).gt.0)    CidxSW = count_prefix(mask=mskSW,exclusive=.true.)
-      if(Depart(ise).gt.0)    CidxSE = count_prefix(mask=mskSE,exclusive=.true.)
-
       if(Depart(inorth).gt.0) then
-      !$acc parallel loop gang vector default(present)
-      do np=1,nparcelsLocalActive-1
-         if(CidxN(np) .ne. CidxN(np+1)) then
-           Depart_ind2(n_idx+CidxN(np))=np
+
+         ! JMD don't know why this function gets a misaligned dealloc ! call
+         ! call GatherIndices(numDepart,nparcelsLocalActive,n_idx,mskN,CidxN,Depart_ind2)
+         Cidx  = count_prefix(mask=mskN,exclusive=.true.)
+         !$acc parallel loop gang vector default(present)
+         do np=1,nparcelsLocalActive-1
+            if(Cidx(np) .ne. Cidx(np+1)) then
+               Depart_ind(n_idx+Cidx(np))=np
+            endif
+         enddo
+         ! special treament for the last value in the array
+         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         if(mskN(nparcelsLocalActive)) then
+            Depart_ind(n_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-      enddo
+         !$acc end parallel
       endif
 
-
       if(Depart(isouth).gt.0) then
-      !$acc parallel loop gang vector default(present)
-      do np=1,nparcelsLocalActive-1
-         if(CidxS(np) .ne. CidxS(np+1)) then
-            Depart_ind2(s_idx+CidxS(np))=np
+         Cidx  = count_prefix(mask=mskS,exclusive=.true.)
+         !$acc parallel loop gang vector default(present)
+         do np=1,nparcelsLocalActive-1
+            if(Cidx(np) .ne. Cidx(np+1)) then
+               Depart_ind(s_idx+Cidx(np))=np
+            endif
+         enddo
+         ! special treament for the last value in the array
+         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         if(mskS(nparcelsLocalActive)) then
+            Depart_ind(s_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-       enddo
+         !$acc end parallel
        endif
 
 
       if(Depart(iwest).gt.0) then
-      !$acc parallel loop gang vector default(present)
-      do np=1,nparcelsLocalActive-1
-         if(CidxW(np) .ne. CidxW(np+1)) then
-            Depart_ind2(w_idx+CidxW(np))=np
+         Cidx  = count_prefix(mask=mskW,exclusive=.true.)
+         !$acc parallel loop gang vector default(present)
+         do np=1,nparcelsLocalActive-1
+            if(Cidx(np) .ne. Cidx(np+1)) then
+               Depart_ind(w_idx+Cidx(np))=np
+            endif
+         enddo
+         ! special treament for the last value in the array
+         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         if(mskW(nparcelsLocalActive)) then
+            Depart_ind(w_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-      enddo
+         !$acc end parallel
       endif
 
       if(Depart(ieast).gt.0) then
-      !$acc parallel loop gang vector default(present)
-      do np=1,nparcelsLocalActive-1
-         if(CidxE(np) .ne. CidxE(np+1)) then
-            Depart_ind2(e_idx+CidxE(np))=np
+         Cidx  = count_prefix(mask=mskE,exclusive=.true.)
+         !$acc parallel loop gang vector default(present)
+         do np=1,nparcelsLocalActive-1
+            if(Cidx(np) .ne. Cidx(np+1)) then
+               Depart_ind(e_idx+Cidx(np))=np
+            endif
+         enddo
+         ! special treament for the last value in the array
+         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         if(mskE(nparcelsLocalActive)) then
+            Depart_ind(e_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-      enddo
+         !$acc end parallel
       endif
 
       if(Depart(inw).gt.0) then
-      !$acc parallel loop gang vector default(present)
-      do np=1,nparcelsLocalActive-1
-         if(CidxNW(np) .ne. CidxNW(np+1)) then
-            Depart_ind2(nw_idx+CidxNW(np))=np
+         Cidx = count_prefix(mask=mskNW,exclusive=.true.)
+         !$acc parallel loop gang vector default(present)
+         do np=1,nparcelsLocalActive-1
+            if(Cidx(np) .ne. Cidx(np+1)) then
+               Depart_ind(nw_idx+Cidx(np))=np
+            endif
+         enddo
+         ! special treament for the last value in the array
+         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         if(mskNW(nparcelsLocalActive)) then
+            Depart_ind(nw_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-      enddo
+         !$acc end parallel
       endif
 
 
       if(Depart(ine).gt.0) then
-      !$acc parallel loop gang vector default(present)
-      do np=1,nparcelsLocalActive-1
-         if(CidxNE(np) .ne. CidxNE(np+1)) then
-            Depart_ind2(ne_idx+CidxNE(np))=np
+         Cidx = count_prefix(mask=mskNE,exclusive=.true.)
+         !$acc parallel loop gang vector default(present)
+         do np=1,nparcelsLocalActive-1
+            if(Cidx(np) .ne. Cidx(np+1)) then
+               Depart_ind(ne_idx+Cidx(np))=np
+            endif
+         enddo
+         ! special treament for the last value in the array
+         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         if(mskNE(nparcelsLocalActive)) then
+            Depart_ind(ne_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-      enddo
+         !$acc end parallel
       endif
 
-      !!$acc update host(Depart_ind2)
 
       if(Depart(isw).gt.0) then
-      !$acc parallel loop gang vector default(present)
-      do np=1,nparcelsLocalActive-1
-         if(CidxSW(np) .ne. CidxSW(np+1)) then
-            Depart_ind2(sw_idx+CidxSW(np))=np
+         Cidx = count_prefix(mask=mskSW,exclusive=.true.)
+         !$acc parallel loop gang vector default(present)
+         do np=1,nparcelsLocalActive-1
+            if(Cidx(np) .ne. Cidx(np+1)) then
+               Depart_ind(sw_idx+Cidx(np))=np
+            endif
+         enddo
+         ! special treament for the last value in the array
+         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         if(mskSW(nparcelsLocalActive)) then
+            Depart_ind(sw_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-      enddo
+         !$acc end parallel
       endif
 
-      !!$acc update device(Depart_ind2)
 
       if(Depart(ise).gt.0) then
-      !$acc parallel loop gang vector default(present)
-      do np=1,nparcelsLocalActive-1
-         if(CidxSE(np) .ne. CidxSE(np+1)) then
-            Depart_ind2(se_idx+CidxSE(np))=np
+         Cidx = count_prefix(mask=mskSE,exclusive=.true.)
+         !$acc parallel loop gang vector default(present)
+         do np=1,nparcelsLocalActive-1
+            if(Cidx(np) .ne. Cidx(np+1)) then
+               Depart_ind(se_idx+Cidx(np))=np
+            endif
+         enddo
+         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         if(mskSE(nparcelsLocalActive)) then
+            Depart_ind(se_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-      enddo
+         !$acc end parallel
       endif
 
 
-      ! special treament for the last value in the array
-      !$acc parallel default(present) num_gangs(1) num_workers(1)
-      if((Depart(inorth) .gt. 0) .and. mskN(nparcelsLocalActive)) then
-         Depart_ind2(n_idx+CidxN(nparcelsLocalActive)) = nparcelsLocalActive
-      endif
-      !$acc end parallel
-
-      !$acc parallel default(present) num_gangs(1) num_workers(1)
-      if((Depart(isouth).gt.0) .and. mskS(nparcelsLocalActive)) then
-         Depart_ind2(s_idx+CidxS(nparcelsLocalActive)) = nparcelsLocalActive
-      endif
-      !$acc end parallel
-
-      !$acc parallel default(present) num_gangs(1) num_workers(1)
-      if((Depart(iwest).gt.0) .and. mskW(nparcelsLocalActive)) then
-         Depart_ind2(w_idx+CidxW(nparcelsLocalActive)) = nparcelsLocalActive
-      endif
-      !$acc end parallel
-
-
-      !$acc parallel default(present) num_gangs(1) num_workers(1)
-      if((Depart(ieast).gt.0) .and. mskE(nparcelsLocalActive)) then
-         Depart_ind2(e_idx+CidxE(nparcelsLocalActive)) = nparcelsLocalActive
-      endif
-      !$acc end parallel
-
-      !$acc parallel default(present) num_gangs(1) num_workers(1)
-      if((Depart(inw).gt.0) .and. mskNW(nparcelsLocalActive)) then
-         Depart_ind2(nw_idx+CidxNW(nparcelsLocalActive)) = nparcelsLocalActive
-      endif
-      !$acc end parallel
-
-      !$acc parallel default(present) num_gangs(1) num_workers(1)
-      if((Depart(ine).gt.0) .and. mskNE(nparcelsLocalActive)) then
-         Depart_ind2(ne_idx+CidxNE(nparcelsLocalActive)) = nparcelsLocalActive
-      endif
-      if((Depart(isw).gt.0) .and. mskSW(nparcelsLocalActive)) then
-         Depart_ind2(sw_idx+CidxSW(nparcelsLocalActive)) = nparcelsLocalActive
-      endif
-      if((Depart(ise).gt.0) .and. mskSE(nparcelsLocalActive)) then
-         Depart_ind2(se_idx+CidxSE(nparcelsLocalActive)) = nparcelsLocalActive
-      endif
-      !$acc end parallel
-
-      !$acc update host(Depart_ind2)
-!$acc end data
-
-!#else
-
+#else
+      !$acc update host(pdata_neighbor)
       n_idx  = ptrDepart(inorth)
       s_idx  = ptrDepart(isouth)
       e_idx  = ptrDepart(ieast)
@@ -907,20 +907,67 @@ contains
           se_idx=se_idx+1
         endif
       enddo
-!#endif
-      if(numDepart.gt.0) then
-         numerrors=0
-         do np=1,numDepart
-            if(Depart_ind(np).ne.Depart_ind2(np).and. numerrors.le.10) then
-               write(*,106) myid,np,Depart_ind(np),Depart_ind2(np)
-               numerrors=numerrors+1
-            endif
-         enddo
-      endif
- 106     format('ERROR in setupDepartDroplet  myid: ',i4,' np: ',i10,' Depart_ind',i10,' != ','Depart_ind2 'i10)
+      !$acc update device(Depart_ind)
+#endif
+!$acc end data
+
+!JMD keep this debugging in here for now
+!      if(numDepart.gt.0) then
+!         numerrors=0
+!         do np=1,numDepart
+!            if(Depart_ind(np).ne.Depart_ind2(np).and. numerrors.le.10) then
+!               write(*,106) myid,np,Depart_ind(np),Depart_ind2(np)
+!               numerrors=numerrors+1
+!            endif
+!         enddo
+!      endif
+! 106     format('ERROR in setupDepartDroplet  myid: ',i4,' np: ',i10,' Depart_ind',i10,' != ','Depart_ind2 'i10)
  110     format('myid: ',i4,' ',a10,' ',8(i8,1x))
 
      end subroutine setupDepartDroplet
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+     subroutine GatherIndices(numDepart,nparcelslocalActive,dir_idx,msk,Cidx,Depart_ind)
+
+#ifdef _OPENACC
+        use cutensorex
+#endif
+
+        integer, intent(in) :: numDepart,nparcelsLocalActive
+        integer, intent(in) :: dir_idx
+        logical, dimension(nparcelsLocalActive) :: msk
+        integer, dimension(numDepart) :: Depart_ind
+        integer :: Cidx(nparcelsLocalActive)
+
+
+        ! local variables
+        integer :: np
+        !$acc declare present(msk,Cidx,Depart_ind)
+
+!!$acc data create(Cidx)
+        print *,'GatherIndicies: point #1'
+        Cidx = count_prefix(mask=msk,exclusive=.true.)
+        print *,'GatherIndicies: point #2'
+        !$acc parallel loop gang vector default(present)
+        do np=1,nparcelsLocalActive-1
+           if(Cidx(np) .ne. Cidx(np+1)) then
+             Depart_ind(dir_idx+Cidx(np))=np
+           endif
+        enddo
+        print *,'GatherIndicies: point #3'
+        ! special treament for the last value in the array
+        !$acc parallel default(present) num_gangs(1) num_workers(1)
+        if(msk(nparcelsLocalActive)) then
+           Depart_ind(dir_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
+        endif
+        !$acc end parallel
+        print *,'GatherIndicies: point #4'
+!!$acc end data
+
+      end subroutine GatherIndices
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -707,8 +707,9 @@ contains
 
       if(Depart(inorth).gt.0) then
 
-         ! JMD don't know why this function gets a misaligned dealloc ! call
-         !call GatherIndices(numDepart,n_idx,mskN,Depart_ind)
+         !JMD don't know why I get the following error when calling this
+         !function: DEALLOCATE: an illegal memory access was encountered
+         !call GatherIndices(inorth,ptrDepart,Cidx,pdata_neighbor,Depart_ind)
          Cidx  = count_prefix(mask=(pdata_neighbor .eq. inorth),exclusive=.true.)
          !$acc parallel loop gang vector default(present)
          do np=1,nparcelsLocalActive-1
@@ -896,44 +897,47 @@ contains
 
      end subroutine setupDepartDroplet
 
-#if (defined(_PREFIXCOUNT) && defined(_OPENACC))
+#if (defined(_COUNTPREFIX) && defined(_OPENACC))
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-     subroutine GatherIndices(numDepart,dir_idx,msk,Depart_ind)
+     subroutine GatherIndices(dir,ptrDepart,Cidx,pdata_neighbor,Depart_ind)
 
+        use constants, only : num_nn
         use input, only : nparcelsLocal, nparcelsLocalActive
 #ifdef _OPENACC
         use cutensorex
 #endif
 
-        integer, intent(in) :: numDepart
-        integer, intent(in) :: dir_idx
-        logical, dimension(nparcelsLocal) :: msk
-        integer, dimension(numDepart) :: Depart_ind
-        integer :: Cidx(nparcelsLocal)
+        integer, intent(in)                             :: dir
+        integer, intent(in), dimension(num_nn)          :: ptrDepart
+        integer, intent(inout),dimension(nparcelsLocal) :: Cidx
+        integer, intent(in), dimension(nparcelsLocal)   :: pdata_neighbor
+        integer, intent(inout), dimension(:)            :: Depart_ind
 
 
         ! local variables
         integer :: np
-        !$acc declare present(msk,Depart_ind)
+        integer :: ptrdir
+        !$acc declare present(Cidx,pdata_neighbor,Depart_ind)
 
-!$acc data create(Cidx)
-        Cidx = count_prefix(mask=msk,exclusive=.true.)
+        ptrdir = ptrDepart(dir)
+!!$acc data create(Cidx)
+        Cidx = count_prefix(mask=(pdata_neighbor.eq.dir),exclusive=.true.)
         !$acc parallel loop gang vector default(present)
         do np=1,nparcelsLocalActive-1
            if(Cidx(np) .ne. Cidx(np+1)) then
-             Depart_ind(dir_idx+Cidx(np))=np
+             Depart_ind(ptrdir+Cidx(np))=np
            endif
         enddo
         ! special treament for the last value in the array
         !$acc parallel default(present) num_gangs(1) num_workers(1)
-        if(msk(nparcelsLocalActive)) then
-           Depart_ind(dir_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
+        if(pdata_neighbor(nparcelsLocalActive).eq.dir) then
+           Depart_ind(ptrdir+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
         endif
         !$acc end parallel
-!$acc end data
+!!$acc end data
 
       end subroutine GatherIndices
 #endif

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -681,10 +681,8 @@ contains
       integer :: n_idx,s_idx,e_idx,w_idx,nw_idx,ne_idx,sw_idx,se_idx
       integer np
 #ifdef _MEMLEAK
-      logical, dimension(nparcelsLocalActive) :: mskN,mskS,mskW,mskE,mskNW,mskNE,mskSW,mskSE
       integer :: Cidx(nparcelsLocalActive)
 #else
-      logical, dimension(nparcelsLocal) :: mskN,mskS,mskW,mskE,mskNW,mskNE,mskSW,mskSE
       integer :: Cidx(nparcelsLocal)
 #endif
 
@@ -693,7 +691,6 @@ contains
       !!$acc declare present(ptrDepart,Depart,Depart_ind,pdata_neighbor)
       !$acc declare present(Depart_ind,pdata_neighbor)
 
-      !!$acc declare create(Cidx,mskN,mskS,mskW,mskE,mskNW,mskNE,mskSW,mskSE)
 
       numDepart=SUM(Depart)
 !      if(numDepart.gt.0) allocate(Depart_ind2(numDepart))
@@ -713,42 +710,13 @@ contains
 
 #if (defined(_OPENACC) && defined(_COUNTPREFIX))
 
-!$acc data create(mskN,mskS,mskW,mskE,mskNW,mskNE,mskSE,mskSW,Cidx)
-
-      !$acc parallel loop gang vector default(present)
-      do np=1,nparcelsLocalActive
-         mskN(np)  = .false.
-         mskS(np)  = .false.
-         mskW(np)  = .false.
-         mskE(np)  = .false.
-         mskNW(np) = .false.
-         mskNE(np) = .false.
-         mskSW(np) = .false.
-         mskSE(np) = .false.
-         if(pdata_neighbor(np) .eq. mynorth) then
-           mskN(np) = .true.
-         else if(pdata_neighbor(np) .eq. mysouth) then
-           mskS(np) = .true.
-         else if(pdata_neighbor(np) .eq. mywest) then
-           mskW(np) = .true.
-         else if(pdata_neighbor(np) .eq. myeast) then
-           mskE(np) = .true.
-         else if(pdata_neighbor(np) .eq. mynw) then
-           mskNW(np) = .true.
-         else if(pdata_neighbor(np) .eq. myne) then
-           mskNE(np) = .true.
-         else if(pdata_neighbor(np) .eq. mysw) then
-           mskSW(np) = .true.
-         else if(pdata_neighbor(np) .eq. myse) then
-           mskSE(np) = .true.
-         endif
-      enddo
+!$acc data create(Cidx)
 
       if(Depart(inorth).gt.0) then
 
          ! JMD don't know why this function gets a misaligned dealloc ! call
          !call GatherIndices(numDepart,n_idx,mskN,Depart_ind)
-         Cidx  = count_prefix(mask=mskN,exclusive=.true.)
+         Cidx  = count_prefix(mask=(pdata_neighbor .eq. inorth),exclusive=.true.)
          !$acc parallel loop gang vector default(present)
          do np=1,nparcelsLocalActive-1
             if(Cidx(np) .ne. Cidx(np+1)) then
@@ -757,14 +725,14 @@ contains
          enddo
          ! special treament for the last value in the array
          !$acc parallel default(present) num_gangs(1) num_workers(1)
-         if(mskN(nparcelsLocalActive)) then
+         if(pdata_neighbor(nparcelsLocalActive).eq.inorth) then
             Depart_ind(n_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
          !$acc end parallel
       endif
 
       if(Depart(isouth).gt.0) then
-         Cidx  = count_prefix(mask=mskS,exclusive=.true.)
+         Cidx  = count_prefix(mask=(pdata_neighbor .eq. isouth),exclusive=.true.)
          !$acc parallel loop gang vector default(present)
          do np=1,nparcelsLocalActive-1
             if(Cidx(np) .ne. Cidx(np+1)) then
@@ -773,7 +741,7 @@ contains
          enddo
          ! special treament for the last value in the array
          !$acc parallel default(present) num_gangs(1) num_workers(1)
-         if(mskS(nparcelsLocalActive)) then
+         if(pdata_neighbor(nparcelsLocalActive).eq.isouth) then
             Depart_ind(s_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
          !$acc end parallel
@@ -781,7 +749,7 @@ contains
 
 
       if(Depart(iwest).gt.0) then
-         Cidx  = count_prefix(mask=mskW,exclusive=.true.)
+         Cidx  = count_prefix(mask=(pdata_neighbor .eq. iwest),exclusive=.true.)
          !$acc parallel loop gang vector default(present)
          do np=1,nparcelsLocalActive-1
             if(Cidx(np) .ne. Cidx(np+1)) then
@@ -790,14 +758,14 @@ contains
          enddo
          ! special treament for the last value in the array
          !$acc parallel default(present) num_gangs(1) num_workers(1)
-         if(mskW(nparcelsLocalActive)) then
+         if(pdata_neighbor(nparcelsLocalActive).eq.iwest) then
             Depart_ind(w_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
          !$acc end parallel
       endif
 
       if(Depart(ieast).gt.0) then
-         Cidx  = count_prefix(mask=mskE,exclusive=.true.)
+         Cidx  = count_prefix(mask=(pdata_neighbor .eq. ieast),exclusive=.true.)
          !$acc parallel loop gang vector default(present)
          do np=1,nparcelsLocalActive-1
             if(Cidx(np) .ne. Cidx(np+1)) then
@@ -806,14 +774,14 @@ contains
          enddo
          ! special treament for the last value in the array
          !$acc parallel default(present) num_gangs(1) num_workers(1)
-         if(mskE(nparcelsLocalActive)) then
+         if(pdata_neighbor(nparcelsLocalActive).eq.ieast) then
             Depart_ind(e_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
          !$acc end parallel
       endif
 
       if(Depart(inw).gt.0) then
-         Cidx = count_prefix(mask=mskNW,exclusive=.true.)
+         Cidx  = count_prefix(mask=(pdata_neighbor .eq. inw),exclusive=.true.)
          !$acc parallel loop gang vector default(present)
          do np=1,nparcelsLocalActive-1
             if(Cidx(np) .ne. Cidx(np+1)) then
@@ -822,7 +790,7 @@ contains
          enddo
          ! special treament for the last value in the array
          !$acc parallel default(present) num_gangs(1) num_workers(1)
-         if(mskNW(nparcelsLocalActive)) then
+         if(pdata_neighbor(nparcelsLocalActive).eq.inw) then
             Depart_ind(nw_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
          !$acc end parallel
@@ -830,7 +798,7 @@ contains
 
 
       if(Depart(ine).gt.0) then
-         Cidx = count_prefix(mask=mskNE,exclusive=.true.)
+         Cidx = count_prefix(mask=(pdata_neighbor .eq. ine),exclusive=.true.)
          !$acc parallel loop gang vector default(present)
          do np=1,nparcelsLocalActive-1
             if(Cidx(np) .ne. Cidx(np+1)) then
@@ -839,7 +807,7 @@ contains
          enddo
          ! special treament for the last value in the array
          !$acc parallel default(present) num_gangs(1) num_workers(1)
-         if(mskNE(nparcelsLocalActive)) then
+         if(pdata_neighbor(nparcelsLocalActive).eq.ine) then
             Depart_ind(ne_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
          !$acc end parallel
@@ -847,7 +815,7 @@ contains
 
 
       if(Depart(isw).gt.0) then
-         Cidx = count_prefix(mask=mskSW,exclusive=.true.)
+         Cidx = count_prefix(mask=(pdata_neighbor .eq. isw),exclusive=.true.)
          !$acc parallel loop gang vector default(present)
          do np=1,nparcelsLocalActive-1
             if(Cidx(np) .ne. Cidx(np+1)) then
@@ -856,7 +824,7 @@ contains
          enddo
          ! special treament for the last value in the array
          !$acc parallel default(present) num_gangs(1) num_workers(1)
-         if(mskSW(nparcelsLocalActive)) then
+         if(pdata_neighbor(nparcelsLocalActive).eq.isw) then
             Depart_ind(sw_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
          !$acc end parallel
@@ -864,7 +832,7 @@ contains
 
 
       if(Depart(ise).gt.0) then
-         Cidx = count_prefix(mask=mskSE,exclusive=.true.)
+         Cidx = count_prefix(mask=(pdata_neighbor .eq. ise),exclusive=.true.)
          !$acc parallel loop gang vector default(present)
          do np=1,nparcelsLocalActive-1
             if(Cidx(np) .ne. Cidx(np+1)) then
@@ -872,7 +840,7 @@ contains
             endif
          enddo
          !$acc parallel default(present) num_gangs(1) num_workers(1)
-         if(mskSE(nparcelsLocalActive)) then
+         if(pdata_neighbor(nparcelsLocalActive).eq.ise) then
             Depart_ind(se_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
          !$acc end parallel
@@ -891,28 +859,28 @@ contains
       sw_idx = ptrDepart(isw)
       se_idx = ptrDepart(ise)
       do np=1, nparcelsLocalActive
-        if(pdata_neighbor(np) .eq. mynorth) then
+        if(pdata_neighbor(np) .eq. inorth) then
           Depart_ind(n_idx) = np
           n_idx=n_idx+1
-        else if(pdata_neighbor(np) .eq. mysouth) then
+        else if(pdata_neighbor(np) .eq. isouth) then
           Depart_ind(s_idx) = np
           s_idx=s_idx+1
-        else if(pdata_neighbor(np) .eq. mywest) then
+        else if(pdata_neighbor(np) .eq. iwest) then
           Depart_ind(w_idx) = np
           w_idx=w_idx+1
-        else if(pdata_neighbor(np) .eq. myeast) then
+        else if(pdata_neighbor(np) .eq. ieast) then
           Depart_ind(e_idx) = np
           e_idx=e_idx+1
-        else if(pdata_neighbor(np) .eq. mynw) then
+        else if(pdata_neighbor(np) .eq. inw) then
           Depart_ind(nw_idx) = np
           nw_idx=nw_idx+1
-        else if(pdata_neighbor(np) .eq. myne) then
+        else if(pdata_neighbor(np) .eq. ine) then
           Depart_ind(ne_idx) = np
           ne_idx=ne_idx+1
-        else if(pdata_neighbor(np) .eq. mysw) then
+        else if(pdata_neighbor(np) .eq. isw) then
           Depart_ind(sw_idx) = np
           sw_idx=sw_idx+1
-        else if(pdata_neighbor(np) .eq. myse) then
+        else if(pdata_neighbor(np) .eq. ise) then
           Depart_ind(se_idx) = np
           se_idx=se_idx+1
         endif

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -882,17 +882,6 @@ contains
       !$acc update device(Depart_ind)
 #endif
 
-!JMD keep this debugging in here for now
-!      if(numDepart.gt.0) then
-!         numerrors=0
-!         do np=1,numDepart
-!            if(Depart_ind(np).ne.Depart_ind2(np).and. numerrors.le.10) then
-!               write(*,106) myid,np,Depart_ind(np),Depart_ind2(np)
-!               numerrors=numerrors+1
-!            endif
-!         enddo
-!      endif
-! 106     format('ERROR in setupDepartDroplet  myid: ',i4,' np: ',i10,' Depart_ind',i10,' != ','Depart_ind2 'i10)
  110     format('myid: ',i4,' ',a10,' ',8(i8,1x))
 
      end subroutine setupDepartDroplet

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -186,7 +186,7 @@ contains
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
   subroutine comm_droplet_value(holes_ind,Depart_ind,Depart,Arrive, &
-                ptrDepart, ptrArrive, pdata, pdata_locind)
+                ptrDepart, ptrArrive, pdata)
 
     use input, only : myid,nparcelsLocal,npvals,mynw,mysw,myne, &
                       myse,myeast,mywest,mynorth,mysouth,ierr, &
@@ -214,7 +214,6 @@ contains
     integer, intent(in) :: ptrArrive(num_nn)                             ! location index into holes_ind 
     integer, intent(in) :: ptrDepart(num_nn)                             ! location index into Depart_ind 
     real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata        ! droplet information
-    integer, intent(inout), dimension(nparcelsLocal,3) :: pdata_locind   ! x/y/z location index of each droplet
     ! integer, intent(in), dimension(nparcelsLocal) :: pdata_neighbor      ! array to store the new MPI region 
     !                                                                      ! info for all the droplets
 

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -4,6 +4,7 @@
 !    to separate the MPI communication of droplets from other    !
 !    MPI calls in the existing comm.F code                       !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+#define _COUNTPREFIX 1
 
 module comm_droplet_module
 
@@ -571,8 +572,8 @@ contains
         do n=1,num_holes
            indx = holes_ind(numArrive+n)            ! index of hole to be filled
            k    = backfill_ind(n)                   ! index of droplet to move into hole
-           if(indx .lt. k) then 
-             if (Debug) then 
+           if(indx .lt. k) then
+             if (Debug) then
                write(*,*) ' backfilled droplet # ',indx,' with droplet # ',k
                call flush(6)
              endif
@@ -648,9 +649,9 @@ contains
 
       ptrCnt(inorth) = 1
       ptrCnt(isouth) = ptrCnt(inorth) + Cnt(inorth)
-      ptrCnt(ieast)  = ptrCnt(isouth) + Cnt(isouth)
-      ptrCnt(iwest)  = ptrCnt(ieast)  + Cnt(ieast)
-      ptrCnt(inw)    = ptrCnt(iwest)  + Cnt(iwest)
+      ptrCnt(iwest)  = ptrCnt(isouth) + Cnt(isouth)
+      ptrCnt(ieast)  = ptrCnt(iwest)  + Cnt(iwest)
+      ptrCnt(inw)    = ptrCnt(ieast)  + Cnt(ieast)
       ptrCnt(ine)    = ptrCnt(inw)    + Cnt(inw)
       ptrCnt(isw)    = ptrCnt(ine)    + Cnt(ine)
       ptrCnt(ise)    = ptrCnt(isw)    + Cnt(isw)
@@ -659,14 +660,18 @@ contains
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
-    subroutine setupDepartDroplet(Depart_ind,ptrDepart,pdata_neighbor)
+    subroutine setupDepartDroplet(Depart_ind,ptrDepart,Depart,pdata_neighbor)
 
       use input, only : mynw,mysw,myne,myse,myeast,mywest,mynorth,mysouth, &
-        nparcelsLocalActive
+        nparcelsLocal,nparcelsLocalActive,myid
       use constants, only: num_nn,inorth,isouth, &
                          iwest,ieast,inw,ine,isw,ise,undefined_index
+#ifdef _OPENACC
+      use cutensorex
+#endif
 
       integer, intent(inout) :: ptrDepart(num_nn)
+      integer, intent(in) :: Depart(num_nn)
 
       integer, intent(inout) :: Depart_ind(:)
       integer, intent(in) :: pdata_neighbor(:)
@@ -674,7 +679,198 @@ contains
       ! local variables
       integer :: n_idx,s_idx,e_idx,w_idx,nw_idx,ne_idx,sw_idx,se_idx
       integer np
+      logical, dimension(nparcelsLocalActive) :: mskN,mskS,mskW,mskE,mskNW,mskNE,mskSW,mskSE
+      integer, dimension(nparcelsLocalActive) :: CidxN,CidxS,CidxW,CidxE,CidxNW,CidxNE,CidxSW,CidxSE
+      integer, allocatable :: Depart_ind2(:)
+      integer :: numDepart,numerrors
 
+      numDepart=SUM(Depart)
+      if(numDepart.gt.0) allocate(Depart_ind2(numDepart))
+
+      n_idx  = ptrDepart(inorth)
+      s_idx  = ptrDepart(isouth)
+      w_idx  = ptrDepart(iwest)
+      e_idx  = ptrDepart(ieast)
+      nw_idx = ptrDepart(inw)
+      ne_idx = ptrDepart(ine)
+      sw_idx = ptrDepart(isw)
+      se_idx = ptrDepart(ise)
+      if(numDepart.gt.0) then
+         write(*,110) myid,'Depart:',Depart
+         write(*,110) myid,'ptrDepart:',ptrDepart
+      endif
+
+!$acc data copyin(ptrDepart,Depart,Depart_ind2,pdata_neighbor) &
+!$acc create(mskN,mskS,mskW,mskE,mskNW,mskNE,mskSE,mskSW, &
+!$acc        CidxN,CidxS,CidxW,CidxE,CidxNW,CidxNE,CidxSW,CidxSE)
+
+
+      !$acc parallel loop gang vector default(present)
+      do np=1,nparcelsLocalActive
+         mskN(np)  = .false.
+         mskS(np)  = .false.
+         mskW(np)  = .false.
+         mskE(np)  = .false.
+         mskNW(np) = .false.
+         mskNE(np) = .false.
+         mskSW(np) = .false.
+         mskSE(np) = .false.
+         if(pdata_neighbor(np) .eq. mynorth) then
+           mskN(np) = .true.
+         else if(pdata_neighbor(np) .eq. mysouth) then
+           mskS(np) = .true.
+         else if(pdata_neighbor(np) .eq. mywest) then
+           mskW(np) = .true.
+         else if(pdata_neighbor(np) .eq. myeast) then
+           mskE(np) = .true.
+         else if(pdata_neighbor(np) .eq. mynw) then
+           mskNW(np) = .true.
+         else if(pdata_neighbor(np) .eq. myne) then
+           mskNE(np) = .true.
+         else if(pdata_neighbor(np) .eq. mysw) then
+           mskSW(np) = .true.
+         else if(pdata_neighbor(np) .eq. myse) then
+           mskSE(np) = .true.
+         endif
+      enddo
+
+      if(Depart(inorth).gt.0) CidxN  = count_prefix(mask=mskN,exclusive=.true.)
+      if(Depart(isouth).gt.0) CidxS  = count_prefix(mask=mskS,exclusive=.true.)
+      if(Depart(iwest).gt.0)  CidxW  = count_prefix(mask=mskW,exclusive=.true.)
+      if(Depart(ieast).gt.0)  CidxE  = count_prefix(mask=mskE,exclusive=.true.)
+      if(Depart(inw).gt.0)    CidxNW = count_prefix(mask=mskNW,exclusive=.true.)
+      if(Depart(ine).gt.0)    CidxNE = count_prefix(mask=mskNE,exclusive=.true.)
+      if(Depart(isw).gt.0)    CidxSW = count_prefix(mask=mskSW,exclusive=.true.)
+      if(Depart(ise).gt.0)    CidxSE = count_prefix(mask=mskSE,exclusive=.true.)
+
+      if(Depart(inorth).gt.0) then
+      !$acc parallel loop gang vector default(present)
+      do np=1,nparcelsLocalActive-1
+         if(CidxN(np) .ne. CidxN(np+1)) then
+           Depart_ind2(n_idx+CidxN(np))=np
+         endif
+      enddo
+      endif
+
+
+      if(Depart(isouth).gt.0) then
+      !$acc parallel loop gang vector default(present)
+      do np=1,nparcelsLocalActive-1
+         if(CidxS(np) .ne. CidxS(np+1)) then
+            Depart_ind2(s_idx+CidxS(np))=np
+         endif
+       enddo
+       endif
+
+
+      if(Depart(iwest).gt.0) then
+      !$acc parallel loop gang vector default(present)
+      do np=1,nparcelsLocalActive-1
+         if(CidxW(np) .ne. CidxW(np+1)) then
+            Depart_ind2(w_idx+CidxW(np))=np
+         endif
+      enddo
+      endif
+
+      if(Depart(ieast).gt.0) then
+      !$acc parallel loop gang vector default(present)
+      do np=1,nparcelsLocalActive-1
+         if(CidxE(np) .ne. CidxE(np+1)) then
+            Depart_ind2(e_idx+CidxE(np))=np
+         endif
+      enddo
+      endif
+
+      if(Depart(inw).gt.0) then
+      !$acc parallel loop gang vector default(present)
+      do np=1,nparcelsLocalActive-1
+         if(CidxNW(np) .ne. CidxNW(np+1)) then
+            Depart_ind2(nw_idx+CidxNW(np))=np
+         endif
+      enddo
+      endif
+
+
+      if(Depart(ine).gt.0) then
+      !$acc parallel loop gang vector default(present)
+      do np=1,nparcelsLocalActive-1
+         if(CidxNE(np) .ne. CidxNE(np+1)) then
+            Depart_ind2(ne_idx+CidxNE(np))=np
+         endif
+      enddo
+      endif
+
+      !!$acc update host(Depart_ind2)
+
+      if(Depart(isw).gt.0) then
+      !$acc parallel loop gang vector default(present)
+      do np=1,nparcelsLocalActive-1
+         if(CidxSW(np) .ne. CidxSW(np+1)) then
+            Depart_ind2(sw_idx+CidxSW(np))=np
+         endif
+      enddo
+      endif
+
+      !!$acc update device(Depart_ind2)
+
+      if(Depart(ise).gt.0) then
+      !$acc parallel loop gang vector default(present)
+      do np=1,nparcelsLocalActive-1
+         if(CidxSE(np) .ne. CidxSE(np+1)) then
+            Depart_ind2(se_idx+CidxSE(np))=np
+         endif
+      enddo
+      endif
+
+
+      ! special treament for the last value in the array
+      !$acc parallel default(present) num_gangs(1) num_workers(1)
+      if((Depart(inorth) .gt. 0) .and. mskN(nparcelsLocalActive)) then
+         Depart_ind2(n_idx+CidxN(nparcelsLocalActive)) = nparcelsLocalActive
+      endif
+      !$acc end parallel
+
+      !$acc parallel default(present) num_gangs(1) num_workers(1)
+      if((Depart(isouth).gt.0) .and. mskS(nparcelsLocalActive)) then
+         Depart_ind2(s_idx+CidxS(nparcelsLocalActive)) = nparcelsLocalActive
+      endif
+      !$acc end parallel
+
+      !$acc parallel default(present) num_gangs(1) num_workers(1)
+      if((Depart(iwest).gt.0) .and. mskW(nparcelsLocalActive)) then
+         Depart_ind2(w_idx+CidxW(nparcelsLocalActive)) = nparcelsLocalActive
+      endif
+      !$acc end parallel
+
+
+      !$acc parallel default(present) num_gangs(1) num_workers(1)
+      if((Depart(ieast).gt.0) .and. mskE(nparcelsLocalActive)) then
+         Depart_ind2(e_idx+CidxE(nparcelsLocalActive)) = nparcelsLocalActive
+      endif
+      !$acc end parallel
+
+      !$acc parallel default(present) num_gangs(1) num_workers(1)
+      if((Depart(inw).gt.0) .and. mskNW(nparcelsLocalActive)) then
+         Depart_ind2(nw_idx+CidxNW(nparcelsLocalActive)) = nparcelsLocalActive
+      endif
+      !$acc end parallel
+
+      !$acc parallel default(present) num_gangs(1) num_workers(1)
+      if((Depart(ine).gt.0) .and. mskNE(nparcelsLocalActive)) then
+         Depart_ind2(ne_idx+CidxNE(nparcelsLocalActive)) = nparcelsLocalActive
+      endif
+      if((Depart(isw).gt.0) .and. mskSW(nparcelsLocalActive)) then
+         Depart_ind2(sw_idx+CidxSW(nparcelsLocalActive)) = nparcelsLocalActive
+      endif
+      if((Depart(ise).gt.0) .and. mskSE(nparcelsLocalActive)) then
+         Depart_ind2(se_idx+CidxSE(nparcelsLocalActive)) = nparcelsLocalActive
+      endif
+      !$acc end parallel
+
+      !$acc update host(Depart_ind2)
+!$acc end data
+
+!#else
 
       n_idx  = ptrDepart(inorth)
       s_idx  = ptrDepart(isouth)
@@ -711,6 +907,18 @@ contains
           se_idx=se_idx+1
         endif
       enddo
+!#endif
+      if(numDepart.gt.0) then
+         numerrors=0
+         do np=1,numDepart
+            if(Depart_ind(np).ne.Depart_ind2(np).and. numerrors.le.10) then
+               write(*,106) myid,np,Depart_ind(np),Depart_ind2(np)
+               numerrors=numerrors+1
+            endif
+         enddo
+      endif
+ 106     format('ERROR in setupDepartDroplet  myid: ',i4,' np: ',i10,' Depart_ind',i10,' != ','Depart_ind2 'i10)
+ 110     format('myid: ',i4,' ',a10,' ',8(i8,1x))
 
      end subroutine setupDepartDroplet
 

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -718,11 +718,11 @@ contains
             endif
          enddo
          ! special treament for the last value in the array
-         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         !$acc serial default(present)
          if(pdata_neighbor(nparcelsLocalActive).eq.inorth) then
             Depart_ind(n_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-         !$acc end parallel
+         !$acc end serial
       endif
 
       if(Depart(isouth).gt.0) then
@@ -734,11 +734,11 @@ contains
             endif
          enddo
          ! special treament for the last value in the array
-         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         !$acc serial default(present)
          if(pdata_neighbor(nparcelsLocalActive).eq.isouth) then
             Depart_ind(s_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-         !$acc end parallel
+         !$acc end serial
        endif
 
 
@@ -751,11 +751,11 @@ contains
             endif
          enddo
          ! special treament for the last value in the array
-         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         !$acc serial default(present)
          if(pdata_neighbor(nparcelsLocalActive).eq.iwest) then
             Depart_ind(w_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-         !$acc end parallel
+         !$acc end serial
       endif
 
       if(Depart(ieast).gt.0) then
@@ -767,11 +767,11 @@ contains
             endif
          enddo
          ! special treament for the last value in the array
-         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         !$acc serial default(present)
          if(pdata_neighbor(nparcelsLocalActive).eq.ieast) then
             Depart_ind(e_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-         !$acc end parallel
+         !$acc end serial
       endif
 
       if(Depart(inw).gt.0) then
@@ -783,11 +783,11 @@ contains
             endif
          enddo
          ! special treament for the last value in the array
-         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         !$acc serial default(present)
          if(pdata_neighbor(nparcelsLocalActive).eq.inw) then
             Depart_ind(nw_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-         !$acc end parallel
+         !$acc end serial
       endif
 
 
@@ -800,11 +800,11 @@ contains
             endif
          enddo
          ! special treament for the last value in the array
-         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         !$acc serial default(present)
          if(pdata_neighbor(nparcelsLocalActive).eq.ine) then
             Depart_ind(ne_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-         !$acc end parallel
+         !$acc end serial
       endif
 
 
@@ -817,11 +817,11 @@ contains
             endif
          enddo
          ! special treament for the last value in the array
-         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         !$acc serial default(present)
          if(pdata_neighbor(nparcelsLocalActive).eq.isw) then
             Depart_ind(sw_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-         !$acc end parallel
+         !$acc end serial
       endif
 
 
@@ -833,11 +833,11 @@ contains
                Depart_ind(se_idx+Cidx(np))=np
             endif
          enddo
-         !$acc parallel default(present) num_gangs(1) num_workers(1)
+         !$acc serial default(present)
          if(pdata_neighbor(nparcelsLocalActive).eq.ise) then
             Depart_ind(se_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
          endif
-         !$acc end parallel
+         !$acc end serial
       endif
 
 !$acc end data

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -678,13 +678,10 @@ contains
 
       ! local variables
       integer :: n_idx,s_idx,e_idx,w_idx,nw_idx,ne_idx,sw_idx,se_idx
-      integer np
-      integer :: Cidx(nparcelsLocal)
+      integer :: np
 
       integer :: numDepart,numerrors
       logical, parameter :: verbose = .false.
-      !$acc declare present(Depart_ind,pdata_neighbor)
-
 
       numDepart=SUM(Depart)
 
@@ -703,146 +700,40 @@ contains
 
 #if (defined(_OPENACC) && defined(_COUNTPREFIX))
 
-!$acc data create(Cidx)
-
       if(Depart(inorth).gt.0) then
-
-         !JMD don't know why I get the following error when calling this
-         !function: DEALLOCATE: an illegal memory access was encountered
-         !call GatherIndices(inorth,ptrDepart,Cidx,pdata_neighbor,Depart_ind)
-         Cidx  = count_prefix(mask=(pdata_neighbor .eq. inorth),exclusive=.true.)
-         !$acc parallel loop gang vector default(present)
-         do np=1,nparcelsLocalActive-1
-            if(Cidx(np) .ne. Cidx(np+1)) then
-               Depart_ind(n_idx+Cidx(np))=np
-            endif
-         enddo
-         ! special treament for the last value in the array
-         !$acc serial default(present)
-         if(pdata_neighbor(nparcelsLocalActive).eq.inorth) then
-            Depart_ind(n_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
-         endif
-         !$acc end serial
+         call GatherIndices(inorth,ptrDepart,pdata_neighbor,Depart_ind)
       endif
 
       if(Depart(isouth).gt.0) then
-         Cidx  = count_prefix(mask=(pdata_neighbor .eq. isouth),exclusive=.true.)
-         !$acc parallel loop gang vector default(present)
-         do np=1,nparcelsLocalActive-1
-            if(Cidx(np) .ne. Cidx(np+1)) then
-               Depart_ind(s_idx+Cidx(np))=np
-            endif
-         enddo
-         ! special treament for the last value in the array
-         !$acc serial default(present)
-         if(pdata_neighbor(nparcelsLocalActive).eq.isouth) then
-            Depart_ind(s_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
-         endif
-         !$acc end serial
-       endif
-
+         call GatherIndices(isouth,ptrDepart,pdata_neighbor,Depart_ind)
+      endif
 
       if(Depart(iwest).gt.0) then
-         Cidx  = count_prefix(mask=(pdata_neighbor .eq. iwest),exclusive=.true.)
-         !$acc parallel loop gang vector default(present)
-         do np=1,nparcelsLocalActive-1
-            if(Cidx(np) .ne. Cidx(np+1)) then
-               Depart_ind(w_idx+Cidx(np))=np
-            endif
-         enddo
-         ! special treament for the last value in the array
-         !$acc serial default(present)
-         if(pdata_neighbor(nparcelsLocalActive).eq.iwest) then
-            Depart_ind(w_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
-         endif
-         !$acc end serial
+         call GatherIndices(iwest,ptrDepart,pdata_neighbor,Depart_ind)
       endif
 
       if(Depart(ieast).gt.0) then
-         Cidx  = count_prefix(mask=(pdata_neighbor .eq. ieast),exclusive=.true.)
-         !$acc parallel loop gang vector default(present)
-         do np=1,nparcelsLocalActive-1
-            if(Cidx(np) .ne. Cidx(np+1)) then
-               Depart_ind(e_idx+Cidx(np))=np
-            endif
-         enddo
-         ! special treament for the last value in the array
-         !$acc serial default(present)
-         if(pdata_neighbor(nparcelsLocalActive).eq.ieast) then
-            Depart_ind(e_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
-         endif
-         !$acc end serial
+         call GatherIndices(ieast,ptrDepart,pdata_neighbor,Depart_ind)
       endif
 
       if(Depart(inw).gt.0) then
-         Cidx  = count_prefix(mask=(pdata_neighbor .eq. inw),exclusive=.true.)
-         !$acc parallel loop gang vector default(present)
-         do np=1,nparcelsLocalActive-1
-            if(Cidx(np) .ne. Cidx(np+1)) then
-               Depart_ind(nw_idx+Cidx(np))=np
-            endif
-         enddo
-         ! special treament for the last value in the array
-         !$acc serial default(present)
-         if(pdata_neighbor(nparcelsLocalActive).eq.inw) then
-            Depart_ind(nw_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
-         endif
-         !$acc end serial
+         call GatherIndices(inw,ptrDepart,pdata_neighbor,Depart_ind)
       endif
-
 
       if(Depart(ine).gt.0) then
-         Cidx = count_prefix(mask=(pdata_neighbor .eq. ine),exclusive=.true.)
-         !$acc parallel loop gang vector default(present)
-         do np=1,nparcelsLocalActive-1
-            if(Cidx(np) .ne. Cidx(np+1)) then
-               Depart_ind(ne_idx+Cidx(np))=np
-            endif
-         enddo
-         ! special treament for the last value in the array
-         !$acc serial default(present)
-         if(pdata_neighbor(nparcelsLocalActive).eq.ine) then
-            Depart_ind(ne_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
-         endif
-         !$acc end serial
+         call GatherIndices(ine,ptrDepart,pdata_neighbor,Depart_ind)
       endif
-
 
       if(Depart(isw).gt.0) then
-         Cidx = count_prefix(mask=(pdata_neighbor .eq. isw),exclusive=.true.)
-         !$acc parallel loop gang vector default(present)
-         do np=1,nparcelsLocalActive-1
-            if(Cidx(np) .ne. Cidx(np+1)) then
-               Depart_ind(sw_idx+Cidx(np))=np
-            endif
-         enddo
-         ! special treament for the last value in the array
-         !$acc serial default(present)
-         if(pdata_neighbor(nparcelsLocalActive).eq.isw) then
-            Depart_ind(sw_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
-         endif
-         !$acc end serial
+         call GatherIndices(isw,ptrDepart,pdata_neighbor,Depart_ind)
       endif
-
 
       if(Depart(ise).gt.0) then
-         Cidx = count_prefix(mask=(pdata_neighbor .eq. ise),exclusive=.true.)
-         !$acc parallel loop gang vector default(present)
-         do np=1,nparcelsLocalActive-1
-            if(Cidx(np) .ne. Cidx(np+1)) then
-               Depart_ind(se_idx+Cidx(np))=np
-            endif
-         enddo
-         !$acc serial default(present)
-         if(pdata_neighbor(nparcelsLocalActive).eq.ise) then
-            Depart_ind(se_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
-         endif
-         !$acc end serial
+         call GatherIndices(ise,ptrDepart,pdata_neighbor,Depart_ind)
       endif
 
-!$acc end data
-
 #else
+
       !$acc update host(pdata_neighbor)
       n_idx  = ptrDepart(inorth)
       s_idx  = ptrDepart(isouth)
@@ -891,7 +782,7 @@ contains
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-     subroutine GatherIndices(dir,ptrDepart,Cidx,pdata_neighbor,Depart_ind)
+     subroutine GatherIndices(dir,ptrDepart,pdata_neighbor,Depart_ind)
 
         use constants, only : num_nn
         use input, only : nparcelsLocal, nparcelsLocalActive
@@ -901,32 +792,35 @@ contains
 
         integer, intent(in)                             :: dir
         integer, intent(in), dimension(num_nn)          :: ptrDepart
-        integer, intent(inout),dimension(nparcelsLocal) :: Cidx
         integer, intent(in), dimension(nparcelsLocal)   :: pdata_neighbor
         integer, intent(inout), dimension(:)            :: Depart_ind
-
 
         ! local variables
         integer :: np
         integer :: ptrdir
-        !$acc declare present(Cidx,pdata_neighbor,Depart_ind)
+        integer, dimension(nparcelsLocal) :: Cidx
+
+        !$acc data create(Cidx) present(pdata_neighbor)
 
         ptrdir = ptrDepart(dir)
-!!$acc data create(Cidx)
         Cidx = count_prefix(mask=(pdata_neighbor.eq.dir),exclusive=.true.)
+
         !$acc parallel loop gang vector default(present)
         do np=1,nparcelsLocalActive-1
            if(Cidx(np) .ne. Cidx(np+1)) then
              Depart_ind(ptrdir+Cidx(np))=np
            endif
         enddo
+        !$acc end parallel
+
         ! special treament for the last value in the array
-        !$acc parallel default(present) num_gangs(1) num_workers(1)
+        !$acc serial default(present)
         if(pdata_neighbor(nparcelsLocalActive).eq.dir) then
            Depart_ind(ptrdir+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
         endif
-        !$acc end parallel
-!!$acc end data
+        !$acc end serial 
+
+        !$acc end data
 
       end subroutine GatherIndices
 #endif

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -5,6 +5,7 @@
 !    MPI calls in the existing comm.F code                       !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #define _COUNTPREFIX 1
+#undef _MEMLEAK 
 
 module comm_droplet_module
 
@@ -679,12 +680,20 @@ contains
       ! local variables
       integer :: n_idx,s_idx,e_idx,w_idx,nw_idx,ne_idx,sw_idx,se_idx
       integer np
+#ifdef _MEMLEAK
       logical, dimension(nparcelsLocalActive) :: mskN,mskS,mskW,mskE,mskNW,mskNE,mskSW,mskSE
       integer :: Cidx(nparcelsLocalActive)
+#else
+      logical, dimension(nparcelsLocal) :: mskN,mskS,mskW,mskE,mskNW,mskNE,mskSW,mskSE
+      integer :: Cidx(nparcelsLocal)
+#endif
+
       integer :: numDepart,numerrors
       logical, parameter :: verbose = .false.
       !!$acc declare present(ptrDepart,Depart,Depart_ind,pdata_neighbor)
       !$acc declare present(Depart_ind,pdata_neighbor)
+
+      !!$acc declare create(Cidx,mskN,mskS,mskW,mskE,mskNW,mskNE,mskSW,mskSE)
 
       numDepart=SUM(Depart)
 !      if(numDepart.gt.0) allocate(Depart_ind2(numDepart))
@@ -702,7 +711,7 @@ contains
          write(*,110) myid,'ptrDepart:',ptrDepart
       endif
 
-#ifdef _COUNTPREFIX
+#if (defined(_OPENACC) && defined(_COUNTPREFIX))
 
 !$acc data create(mskN,mskS,mskW,mskE,mskNW,mskNE,mskSE,mskSW,Cidx)
 
@@ -738,7 +747,7 @@ contains
       if(Depart(inorth).gt.0) then
 
          ! JMD don't know why this function gets a misaligned dealloc ! call
-         ! call GatherIndices(numDepart,nparcelsLocalActive,n_idx,mskN,CidxN,Depart_ind2)
+         !call GatherIndices(numDepart,n_idx,mskN,Depart_ind)
          Cidx  = count_prefix(mask=mskN,exclusive=.true.)
          !$acc parallel loop gang vector default(present)
          do np=1,nparcelsLocalActive-1
@@ -869,6 +878,7 @@ contains
          !$acc end parallel
       endif
 
+!$acc end data
 
 #else
       !$acc update host(pdata_neighbor)
@@ -909,7 +919,6 @@ contains
       enddo
       !$acc update device(Depart_ind)
 #endif
-!$acc end data
 
 !JMD keep this debugging in here for now
 !      if(numDepart.gt.0) then
@@ -926,48 +935,47 @@ contains
 
      end subroutine setupDepartDroplet
 
+#if (defined(_PREFIXCOUNT) && defined(_OPENACC))
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-     subroutine GatherIndices(numDepart,nparcelslocalActive,dir_idx,msk,Cidx,Depart_ind)
+     subroutine GatherIndices(numDepart,dir_idx,msk,Depart_ind)
 
+        use input, only : nparcelsLocal, nparcelsLocalActive
 #ifdef _OPENACC
         use cutensorex
 #endif
 
-        integer, intent(in) :: numDepart,nparcelsLocalActive
+        integer, intent(in) :: numDepart
         integer, intent(in) :: dir_idx
-        logical, dimension(nparcelsLocalActive) :: msk
+        logical, dimension(nparcelsLocal) :: msk
         integer, dimension(numDepart) :: Depart_ind
-        integer :: Cidx(nparcelsLocalActive)
+        integer :: Cidx(nparcelsLocal)
 
 
         ! local variables
         integer :: np
-        !$acc declare present(msk,Cidx,Depart_ind)
+        !$acc declare present(msk,Depart_ind)
 
-!!$acc data create(Cidx)
-        print *,'GatherIndicies: point #1'
+!$acc data create(Cidx)
         Cidx = count_prefix(mask=msk,exclusive=.true.)
-        print *,'GatherIndicies: point #2'
         !$acc parallel loop gang vector default(present)
         do np=1,nparcelsLocalActive-1
            if(Cidx(np) .ne. Cidx(np+1)) then
              Depart_ind(dir_idx+Cidx(np))=np
            endif
         enddo
-        print *,'GatherIndicies: point #3'
         ! special treament for the last value in the array
         !$acc parallel default(present) num_gangs(1) num_workers(1)
         if(msk(nparcelsLocalActive)) then
            Depart_ind(dir_idx+Cidx(nparcelsLocalActive)) = nparcelsLocalActive
         endif
         !$acc end parallel
-        print *,'GatherIndicies: point #4'
-!!$acc end data
+!$acc end data
 
       end subroutine GatherIndices
+#endif
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -5,7 +5,6 @@
 !    MPI calls in the existing comm.F code                       !
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 #define _COUNTPREFIX 1
-#undef _MEMLEAK 
 
 module comm_droplet_module
 
@@ -680,20 +679,14 @@ contains
       ! local variables
       integer :: n_idx,s_idx,e_idx,w_idx,nw_idx,ne_idx,sw_idx,se_idx
       integer np
-#ifdef _MEMLEAK
-      integer :: Cidx(nparcelsLocalActive)
-#else
       integer :: Cidx(nparcelsLocal)
-#endif
 
       integer :: numDepart,numerrors
       logical, parameter :: verbose = .false.
-      !!$acc declare present(ptrDepart,Depart,Depart_ind,pdata_neighbor)
       !$acc declare present(Depart_ind,pdata_neighbor)
 
 
       numDepart=SUM(Depart)
-!      if(numDepart.gt.0) allocate(Depart_ind2(numDepart))
 
       n_idx  = ptrDepart(inorth)
       s_idx  = ptrDepart(isouth)

--- a/src/constants.F
+++ b/src/constants.F
@@ -64,11 +64,13 @@
 
       integer, parameter :: undefined_index = -100
 
-      real, parameter :: pdata_buffer = 0.20      ! additional storage space for pdata from
+      real, parameter :: pdata_buffer = 0.10      ! additional storage space for pdata from
                                                   ! each MPI rank to account for the droplet
                                                   ! communication between MPI ranks;
                                                   ! this is a percent of
                                                   ! "nparcelsMax" value
+      integer :: padding                          ! The actual number of words used for 
+                                                  ! padding the "pdata" array
 
       real, parameter :: neg_huge = -1.0e30       ! define a large negative number
 

--- a/src/constants.F
+++ b/src/constants.F
@@ -64,7 +64,7 @@
 
       integer, parameter :: undefined_index = -100
 
-      real, parameter :: pdata_buffer = 0.10      ! additional storage space for pdata from
+      real, parameter :: pdata_buffer = 0.20      ! additional storage space for pdata from
                                                   ! each MPI rank to account for the droplet
                                                   ! communication between MPI ranks;
                                                   ! this is a percent of

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -210,7 +210,7 @@
 !     (for the parcel subroutines only!)
 
 #ifdef MPI
-      !$acc data create(pdata_neighbor)
+      !$acc data create(pdata_neighbor,msk)
 
       !$acc parallel loop gang vector default(present)
       do np = 1, nparcelsLocalActive
@@ -553,7 +553,6 @@
      allocate(holes_ind(numHoles))
 !$acc enter data create(holes_ind)
 
-!$acc data create(msk)
 
      !$acc parallel loop gang vector default(present) 
      do np=1,nparcelsLocal
@@ -747,8 +746,7 @@
     if(timestats.ge.1) time_droplet=time_droplet+mytime()
 
 #endif
-!$acc end data ! (msk)
-!$acc end data ! (pdata_neighbr)
+!$acc end data ! (pdata_neighbr,msk)
 
     ! free up the memory for temporary variables
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -753,11 +753,15 @@
      !$acc exit data delete(holes_ind)
      deallocate(holes_ind)
 
-     !$acc exit data delete(Depart_ind)
-     if(allocated(Depart_ind)) deallocate(Depart_ind)
+     if(allocated(Depart_ind)) then 
+        !$acc exit data delete(Depart_ind)
+        deallocate(Depart_ind)
+     endif
 
-     !$acc exit data delete(backfill_ind)
-     if(allocated(backfill_ind)) deallocate(backfill_ind)
+     if(allocated(backfill_ind)) then 
+        !$acc exit data delete(backfill_ind)
+        deallocate(backfill_ind)
+     endif
 
 !----------------------------------------------------------------------
 !  get height ASL:

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -174,8 +174,8 @@
 #ifdef _OPENACC
       ! arrays used by count_prefix operator
       integer :: Cindx(nparcelsLocal)
-      logical :: msk(nparcelsLocal)
 #endif
+      logical :: msk(nparcelsLocal)
 
       logical, parameter :: verbose=.false.
       integer :: errcode
@@ -220,7 +220,6 @@
 #else
       !$acc data copyin (randomNumbers,randomNumbers%state)
 #endif
-!!!      !$acc enter data create (ta)    ! GHB: now passed from solve3
 
     IF(bbc.eq.1)THEN
       ! free slip ... extrapolate:
@@ -527,8 +526,9 @@
     Depart(isw)    = numDepartSW
     Depart(ise)    = numDepartSE
 
-    numDepart=SUM(Depart)
-    if(numDepart .gt. 0) allocate(Depart_ind(numDepart))
+     numDepart=SUM(Depart)
+     if(numDepart .gt. 0) allocate(Depart_ind(max(numDepart,padding)))
+     !$acc enter data create(Depart_ind)
 
     numHoles = numDepart + num_fallout + (nparcelsLocal-nparcelsLocalActive)
 
@@ -544,8 +544,9 @@
      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
      allocate(holes_ind(numHoles))
+!$acc enter data create(holes_ind)
 
-!$acc data create(holes_ind,msk)
+!$acc data create(msk)
 
      !$acc parallel loop gang vector default(present) 
      do np=1,nparcelsLocal
@@ -553,7 +554,7 @@
                  (pdata_locind(np,2) .eq. undefined_index)
      enddo
 
-#ifdef _COUNTPREFIX
+#if (defined(_COUNTPREFIX) && defined(_OPENACC))
 
      !$acc data create(Cindx)
      !$acc parallel loop gang vector default(present)
@@ -613,7 +614,6 @@
 
      ! On the CPU, assign the indirect address array (Depart_ind)
      ! for departing droplets
-!$acc data  create(Depart_ind)
      call setupDepartDroplet(Depart_ind,ptrDepart,Depart,pdata_neighbor)
 
      if(timestats.ge.1) time_dropC2=time_dropC2+mytime()
@@ -639,9 +639,7 @@
      ! the "pdata" array to the remaining holes
      if (numBackfill .gt. 0) then 
        allocate(backfill_ind(numBackfill))
-     endif
-!$acc data create(backfill_ind)
-     if (numBackfill .gt. 0) then 
+       !$acc enter data create(backfill_ind)
        if ((nparcelsLocalActive - numBackfill) .eq. 0) then
           ! Set backfill_ind to 1 to handle an exception case, 
           ! where all the active droplets fall out or leave
@@ -699,7 +697,6 @@
     !     droplets are contiguous (no "holes" between "pdata" slots)
     call makeContiguous(Depart,Arrive,num_fallout,holes_ind,backfill_ind,pdata,pdata_locind)
 
-!$acc end data ! (backfill_ind)
 
     if(timestats.ge.1) time_dropC4=time_dropC4+mytime()
 
@@ -743,14 +740,19 @@
     if(timestats.ge.1) time_droplet=time_droplet+mytime()
 
 #endif
-!$acc end data ! (Depart,ptrDepart)
-!$acc end data ! (holes_ind,msk)
-!$acc end data ! (pdata_neighbr,randomNumbers,randomNumbers%state)
+!$acc end data ! (msk)
+!$acc end data ! (pdata_neighbr)
 
     ! free up the memory for temporary variables
-    deallocate(holes_ind)
-    if(allocated(Depart_ind)) deallocate(Depart_ind)
-    if(allocated(backfill_ind)) deallocate(backfill_ind)
+
+     !$acc exit data delete(holes_ind)
+     deallocate(holes_ind)
+
+     !$acc exit data delete(Depart_ind)
+     if(allocated(Depart_ind)) deallocate(Depart_ind)
+
+     !$acc exit data delete(backfill_ind)
+     if(allocated(backfill_ind)) deallocate(backfill_ind)
 
 !----------------------------------------------------------------------
 !  get height ASL:

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -534,7 +534,7 @@
     Depart(ise)    = numDepartSE
 
     numDepart=SUM(Depart)
-    if(numDepart .gt. 0) allocate(Depart_ind(max(numDepart,padding)))
+    if(numDepart .gt. 0) allocate(Depart_ind(numDepart))
     !$acc enter data create(Depart_ind)
 
     numHoles = numDepart + num_fallout + (nparcelsLocal-nparcelsLocalActive)

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -457,22 +457,29 @@
                           neighbor,num_fallout,errcode)
 
 #ifdef MPI
-      pdata_neighbor(np) = neighbor 
       if(neighbor .eq. mynorth) then 
+         pdata_neighbor(np) = inorth
          numDepartN=numDepartN+1
       else if(neighbor .eq. mysouth) then 
+         pdata_neighbor(np) = isouth
          numDepartS=numDepartS+1
       else if(neighbor .eq. mywest) then 
+         pdata_neighbor(np) = iwest
          numDepartW=numDepartW+1
       else if(neighbor .eq. myeast) then 
+         pdata_neighbor(np) = ieast
          numDepartE=numDepartE+1
       else if(neighbor .eq. mynw) then 
+         pdata_neighbor(np) = inw
          numDepartNW=numDepartNW+1
       else if(neighbor .eq. myne) then 
+         pdata_neighbor(np) = ine
          numDepartNE=numDepartNE+1
       else if(neighbor .eq. mysw) then 
+         pdata_neighbor(np) = isw
          numDepartSW=numDepartSW+1
       else if(neighbor .eq. myse) then 
+         pdata_neighbor(np) = ise
          numDepartSE=numDepartSE+1
       endif
 #endif

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1,4 +1,5 @@
 #define _VERIFY 1
+#define _COUNTPREFIX 1
 #define TROUBLE 0
 #define PITER 1048576
 #ifdef _B4B
@@ -71,6 +72,9 @@
       use mpi
 #endif
       use MersenneTwister_mod
+#ifdef _OPENACC
+      use cutensorex
+#endif
 
       implicit none
 
@@ -167,12 +171,18 @@
       integer, dimension(:), allocatable :: backfill_ind   ! indicies of valid droplets to backfill into 
                                                            ! holes  in "pdata" array created by droplet 
                                                            ! fall-out or departure
+#ifdef _OPENACC
+      ! arrays used by count_prefix operator
+      integer :: Cindx(nparcelsLocal)
+      logical :: msk(nparcelsLocal)
+#endif
 
       logical, parameter :: verbose=.false.
       integer :: errcode
 #ifdef _VERIFY_FIND_LOC
       integer :: tmp_flag
 #endif
+
 
       call date_and_time(values=values)
       ! 1) To match the initial and restart runs for total droplet number,
@@ -516,9 +526,6 @@
 
     if(timestats.ge.1) time_phys_D2H=time_phys_D2H+mytime()
 
-
-
-
     Depart(inorth) = numDepartN
     Depart(isouth) = numDepartS
     Depart(ieast)  = numDepartE
@@ -546,19 +553,63 @@
 
      allocate(holes_ind(numHoles))
 
-     i=0
+!$acc data create(holes_ind,msk)
 
+     !$acc parallel loop gang vector default(present) 
+     do np=1,nparcelsLocal
+       msk(np) = (pdata_locind(np,1) .eq. undefined_index) .and. &
+                 (pdata_locind(np,2) .eq. undefined_index)
+     enddo
+     !$acc update host(msk)
+
+#ifdef _COUNTPREFIX
+!$acc data create(Cindx)
+
+     !$acc parallel loop gang vector default(present)
      do np = 1, numHoles
        holes_ind(np) = undefined_index
      end do
 
+     ! Use a CUDA-based function count_prefix determins which array
+     ! elements satisfy a particular condition.  For example consider
+     ! locind = [1 2 3 4 undefined 5 6 7 undefined 8]
+     ! C = COUNT_PREFIX(mask = (locind .eq. undefined), EXCLUSIVE=.true.)
+     ! would generate the array 
+     ! C = [0 0 0 0 0 1 1 1 1 2]
+     Cindx = count_prefix(mask=msk,exclusive=.true.)
+
+     ! collect the location of the special values into a smaller array
+     !$acc parallel loop gang vector default(present)
+     do np=1,nparcelsLocal-1
+        if(Cindx(np).ne.Cindx(np+1)) then 
+           holes_ind(Cindx(np)+1)=np
+        endif
+     enddo
+
+     ! Special treatment for the last value in the array
+     !$acc parallel default(present) num_gangs(1) num_workers(1)
+     if(msk(nparcelsLocal)) then
+       holes_ind(Cindx(nparcelsLocal)+1) = nparcelsLocal
+     endif
+     !$acc end parallel 
+
+!$acc end data 
+
+#else
+     !CPU based calculations 
+     do np = 1, numHoles
+       holes_ind(np) = undefined_index
+     end do
+
+     i=0
      do np = 1, nparcelsLocal
-       if ( (pdata_locind(np,1) .eq. undefined_index) .and. &
-            (pdata_locind(np,2) .eq. undefined_index) ) then
+       if (msk(np)) then 
           i = i + 1
           holes_ind(i) = np
        end if
      end do
+     !$acc update device(holes_ind)
+#endif
 
      if(timestats.ge.1) time_dropC1=time_dropC1+mytime()
 
@@ -593,19 +644,25 @@
     ! number of holes in "pdata" to fill after the arrival droplets have
     ! been assigned a location
     numBackfill = sum(Depart) + num_fallout - sum(Arrive) 
+    print *,'numBackfill: ',numBackfill
 
-    ! Determine which droplets to relocated from the end of 
-    ! the "pdata" array to the remaining holes
-    if (numBackfill .gt. 0) then 
+     ! Determine which droplets to relocated from the end of 
+     ! the "pdata" array to the remaining holes
+     if (numBackfill .gt. 0) then 
        allocate(backfill_ind(numBackfill))
+     endif
+!$acc data create(backfill_ind)
+     if (numBackfill .gt. 0) then 
        if ((nparcelsLocalActive - numBackfill) .eq. 0) then
           ! Set backfill_ind to 1 to handle an exception case, 
           ! where all the active droplets fall out or leave
           ! the current MPI domain
+          !$acc parallel loop gang vector default(present)
           do i = 1, numBackfill
              backfill_ind(i) = 1
           end do
        else
+          !$acc parallel num_gangs(1) num_workers(1) default(present)
           np = nparcelsLocalActive
           i=0
           do while (i.lt. numBackfill) 
@@ -615,15 +672,19 @@
               i=i+1
               backfill_ind(i) = nparcelsLocalActive+1
             else
-            if ( .not. ((pdata_locind(np,1) .eq. undefined_index) .and. &
-              (pdata_locind(np,2) .eq. undefined_index)) ) then
+            if (.not.msk(np)) then 
               i=i+1
               backfill_ind(i) = np
             end if
             np=np-1
             endif
           enddo
+          !$acc end parallel
+          !$acc update host(backfill_ind)
+          print *,'backfill_ind: ',backfill_ind(1:numBackfill)
+          stop 'after first iteration of backfill code'
        end if
+       !$acc update device(backfill_ind)
     end if
 
     if(verbose) then 
@@ -640,11 +701,11 @@
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Most of the indirect address arrays are calculated on the CPU.
     ! So copy them to the GPU
-    !$acc data copyin(holes_ind,backfill_ind,Depart_ind,Depart,Arrive,ptrDepart,ptrArrive)
+    !$acc data copyin(Depart_ind,Depart,Arrive,ptrDepart,ptrArrive)
 
     ! On the GPU, move droplets between different MPI ranks.
     call comm_droplet_value(holes_ind,Depart_ind, Depart,Arrive, &
-                            ptrDepart,ptrArrive, pdata, pdata_locind)
+                            ptrDepart,ptrArrive, pdata)
 
     ! On the GPU, compress the new "pdata" to make sure that all the active
     !     droplets are contiguous (no "holes" between "pdata" slots)
@@ -697,6 +758,8 @@
 
 
     ! free up the memory for temporary variables
+!$acc end data
+!$acc end data
 
     deallocate(holes_ind)
     if(allocated(Depart_ind)) deallocate(Depart_ind)
@@ -810,8 +873,6 @@
    end if  ! end of "if use_wall_bc" statement
 
    if(timestats.ge.1) time_droplet_inject=time_droplet_inject+mytime()
-  
-!!!   !$acc exit data delete (ta)    ! GHB: now passed from solve3
 
    if(timestats.ge.1) time_phys_H2D=time_phys_H2D+mytime()
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -209,9 +209,9 @@
 !  [Note:  for u,v the array index (i,j,0) means the surface, ie z=0]
 !     (for the parcel subroutines only!)
 
+!      !$acc data create(pdata_neighbor)
 #ifdef MPI
-      !$acc data copyout (pdata_neighbor) &
-      !$acc      copyin  (randomNumbers,randomNumbers%state)
+      !$acc data copyout(pdata_neighbor) copyin  (randomNumbers,randomNumbers%state)
 
       !$acc parallel loop gang vector default(present)
       do np = 1, nparcelsLocalActive
@@ -517,14 +517,13 @@
        end do
     end do
     !$acc end parallel   
-
-    !$acc end data
-
     if(timestats.ge.1) time_droplet=time_droplet+mytime()
 
-    !$acc update host(pdata_locind)
-
+    !$acc end data
     if(timestats.ge.1) time_phys_D2H=time_phys_D2H+mytime()
+
+
+
 
     Depart(inorth) = numDepartN
     Depart(isouth) = numDepartS
@@ -560,7 +559,6 @@
        msk(np) = (pdata_locind(np,1) .eq. undefined_index) .and. &
                  (pdata_locind(np,2) .eq. undefined_index)
      enddo
-     !$acc update host(msk)
 
 #ifdef _COUNTPREFIX
 !$acc data create(Cindx)
@@ -623,7 +621,7 @@
 
      ! On the CPU, assign the indirect address array (Depart_ind)
      ! for departing droplets
-     call setupDepartDroplet(Depart_ind,ptrDepart,pdata_neighbor)
+     call setupDepartDroplet(Depart_ind,ptrDepart,Depart,pdata_neighbor)
 
      if(timestats.ge.1) time_dropC2=time_dropC2+mytime()
 
@@ -644,8 +642,6 @@
     ! number of holes in "pdata" to fill after the arrival droplets have
     ! been assigned a location
     numBackfill = sum(Depart) + num_fallout - sum(Arrive) 
-    print *,'numBackfill: ',numBackfill
-
      ! Determine which droplets to relocated from the end of 
      ! the "pdata" array to the remaining holes
      if (numBackfill .gt. 0) then 
@@ -680,12 +676,12 @@
             endif
           enddo
           !$acc end parallel
-          !$acc update host(backfill_ind)
-          print *,'backfill_ind: ',backfill_ind(1:numBackfill)
-          stop 'after first iteration of backfill code'
+          if(verbose) then
+             !$acc update host(backfill_ind)
+             print *,'backfill_ind: ',backfill_ind(1:numBackfill)
+          endif
        end if
-       !$acc update device(backfill_ind)
-    end if
+     end if
 
     if(verbose) then 
       write(*,'(f10.3,a6,i4,a8,8i6)') mtime, ' myid: ', myid, ' Depart: ', Depart

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -533,9 +533,9 @@
     Depart(isw)    = numDepartSW
     Depart(ise)    = numDepartSE
 
-     numDepart=SUM(Depart)
-     if(numDepart .gt. 0) allocate(Depart_ind(max(numDepart,padding)))
-     !$acc enter data create(Depart_ind)
+    numDepart=SUM(Depart)
+    if(numDepart .gt. 0) allocate(Depart_ind(max(numDepart,padding)))
+    !$acc enter data create(Depart_ind)
 
     numHoles = numDepart + num_fallout + (nparcelsLocal-nparcelsLocalActive)
 
@@ -551,8 +551,7 @@
      !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
      allocate(holes_ind(numHoles))
-!$acc enter data create(holes_ind)
-
+     !$acc enter data create(holes_ind)
 
      !$acc parallel loop gang vector default(present) 
      do np=1,nparcelsLocal
@@ -563,10 +562,12 @@
 #if (defined(_COUNTPREFIX) && defined(_OPENACC))
 
      !$acc data create(Cindx)
+
      !$acc parallel loop gang vector default(present)
      do np = 1, numHoles
        holes_ind(np) = undefined_index
      end do
+     !$acc end parallel
 
      ! Use a CUDA-based function count_prefix determins which array
      ! elements satisfy a particular condition.  For example consider
@@ -578,19 +579,21 @@
 
      ! collect the location of the special values into a smaller array
      !$acc parallel loop gang vector default(present)
-     do np=1,nparcelsLocal-1
-        if(Cindx(np).ne.Cindx(np+1)) then 
-           holes_ind(Cindx(np)+1)=np
-        endif
-     enddo
+     do np = 1, nparcelsLocal-1
+        if ( Cindx(np) .ne. Cindx(np+1) ) then 
+           holes_ind(Cindx(np)+1) = np
+        end if
+     end do
+     !$acc end parallel
 
      ! Special treatment for the last value in the array
-     !$acc parallel default(present) num_gangs(1) num_workers(1)
+     !$acc serial default(present)
      if(msk(nparcelsLocal)) then
        holes_ind(Cindx(nparcelsLocal)+1) = nparcelsLocal
      endif
-     !$acc end parallel 
-     !$acc end data  ! (Cindx)
+     !$acc end serial
+
+     !$acc end data
 
 #else
      !CPU based calculations 
@@ -710,13 +713,7 @@
     ! Step 5: Update the count of new active droplets with contiguous memory !
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-!    write(*,105) mtime,myid,nparcelsLocalActive, &
-!        (nparcelsLocalActive + sum(Arrive) - sum(Depart) - num_fallout), &
-!        sum(Arrive),sum(Depart),num_fallout
-!    call flush(6) 
     nparcelsLocalActive = nparcelsLocalActive + sum(Arrive) - sum(Depart) - num_fallout
-! 105     format(f8.3,' myid: ',i4,' nlocalAct: ',i10,2x,i10,' num{Arrive,Depart,Fall}: ',i10,2x,i10,2x,i10)
-
 
 #else
 
@@ -808,7 +805,9 @@
       if (floor(mtime/drop_inject_elapse) .ne. floor((mtime+dt)/drop_inject_elapse)) then
          !Only start droplet injection after a specified time
          if (mtime .gt. drop_inject_time) then  !Only inject if past a certain time (specified in the namelist file)
+
             call droplet_injection(pdata,xf,yf,dt,drop_inject_elapse,mtime,my_reintro)
+
             !This loop isn't strictly necessary, but populate the interpolated values to the newly injected particles
             !Doesn't affect solution at all! Since interpolation happens at start of droplet_driver 
             !But makes sure that the interpolated mean quantities in droplet_diag are meaningful

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -209,9 +209,8 @@
 !  [Note:  for u,v the array index (i,j,0) means the surface, ie z=0]
 !     (for the parcel subroutines only!)
 
-!      !$acc data create(pdata_neighbor)
 #ifdef MPI
-      !$acc data copyout(pdata_neighbor) copyin  (randomNumbers,randomNumbers%state)
+      !$acc data create(pdata_neighbor)
 
       !$acc parallel loop gang vector default(present)
       do np = 1, nparcelsLocalActive
@@ -519,12 +518,6 @@
     !$acc end parallel   
     if(timestats.ge.1) time_droplet=time_droplet+mytime()
 
-    !$acc end data
-    if(timestats.ge.1) time_phys_D2H=time_phys_D2H+mytime()
-
-
-
-
     Depart(inorth) = numDepartN
     Depart(isouth) = numDepartS
     Depart(ieast)  = numDepartE
@@ -561,8 +554,8 @@
      enddo
 
 #ifdef _COUNTPREFIX
-!$acc data create(Cindx)
 
+     !$acc data create(Cindx)
      !$acc parallel loop gang vector default(present)
      do np = 1, numHoles
        holes_ind(np) = undefined_index
@@ -590,8 +583,7 @@
        holes_ind(Cindx(nparcelsLocal)+1) = nparcelsLocal
      endif
      !$acc end parallel 
-
-!$acc end data 
+     !$acc end data  ! (Cindx)
 
 #else
      !CPU based calculations 
@@ -621,6 +613,7 @@
 
      ! On the CPU, assign the indirect address array (Depart_ind)
      ! for departing droplets
+!$acc data  create(Depart_ind)
      call setupDepartDroplet(Depart_ind,ptrDepart,Depart,pdata_neighbor)
 
      if(timestats.ge.1) time_dropC2=time_dropC2+mytime()
@@ -697,7 +690,6 @@
     !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     ! Most of the indirect address arrays are calculated on the CPU.
     ! So copy them to the GPU
-    !$acc data copyin(Depart_ind,Depart,Arrive,ptrDepart,ptrArrive)
 
     ! On the GPU, move droplets between different MPI ranks.
     call comm_droplet_value(holes_ind,Depart_ind, Depart,Arrive, &
@@ -707,7 +699,7 @@
     !     droplets are contiguous (no "holes" between "pdata" slots)
     call makeContiguous(Depart,Arrive,num_fallout,holes_ind,backfill_ind,pdata,pdata_locind)
 
-    !$acc end data
+!$acc end data ! (backfill_ind)
 
     if(timestats.ge.1) time_dropC4=time_dropC4+mytime()
 
@@ -751,12 +743,11 @@
     if(timestats.ge.1) time_droplet=time_droplet+mytime()
 
 #endif
-
+!$acc end data ! (Depart,ptrDepart)
+!$acc end data ! (holes_ind,msk)
+!$acc end data ! (pdata_neighbr,randomNumbers,randomNumbers%state)
 
     ! free up the memory for temporary variables
-!$acc end data
-!$acc end data
-
     deallocate(holes_ind)
     if(allocated(Depart_ind)) deallocate(Depart_ind)
     if(allocated(backfill_ind)) deallocate(backfill_ind)
@@ -869,8 +860,6 @@
    end if  ! end of "if use_wall_bc" statement
 
    if(timestats.ge.1) time_droplet_inject=time_droplet_inject+mytime()
-
-   if(timestats.ge.1) time_phys_H2D=time_phys_H2D+mytime()
 
    end subroutine droplet_driver
 


### PR DESCRIPTION
This PR eliminates the last remaining significant data movement associated with the droplet code.  This is achieved using the count_prefix() operator which counts the number of occurrences of a particular value in a GPU-resident array using a parallel prefix algorithm.  Note that a CUDA function in the CUDA tensorex module provides this capability.  An example use of this operator is as follows

     use tensorex
     locind = [1 2 3 4 undefined 5 6 7 undefined 8]
     C = COUNT_PREFIX(mask = (locind .eq. undefined), EXCLUSIVE=.true.)
     ! would generate the array 
     ! C = [0 0 0 0 0 1 1 1 1 2]

The build of CM1 needs to be slightly modified.  On Derecho, this is achieved by loading of the module 'cutensor'.  On Gust the build is not quite as clean and requires the setting of two environment variables.

export LIBRARY_PATH=$LIBRARY_PATH:/glade/u/apps/common/22.12/spack/opt/spack/nvhpc/23.3/Linux_x86_64/23.3/math_libs/12.0/targets/x86_64-linux/lib
export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/glade/u/apps/common/22.12/spack/opt/spack/nvhpc/23.3/Linux_x86_64/23.3/math_libs/12.0/targets/x86_64-linux/lib

The verification results are similar to the previous PR, and are as follows:

Metrics:
======
38 stat variables are identical.
41 stat variables show a mean relative difference > 1e-06
7 stat variables show a mean relative difference <= 1e-06


Oth-order diagnostics:
=================
4 stat variables are identical.
8 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06

1st-order diagnostics 
================
254 stat variables are identical.
2 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06




