### PR TITLE
Enable long integer type for large droplet count

### DIFF
--- a/run/derecho.verify.cpu.sh
+++ b/run/derecho.verify.cpu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 #PBS -N cm1
-#PBS -l select=1:ncpus=4:mpiprocs=4:ompthreads=1
+#PBS -l select=1:ncpus=2:mpiprocs=2:ompthreads=1:mem=235GB
 #PBS -l walltime=00:40:00
 #PBS -j oe
 #PBS -q main
@@ -9,4 +9,4 @@
 module --force purge
 module load ncarenv intel cray-mpich ncarcompilers
 
-mpiexec -n 4 -ppn 4 ./cpu.exe --namelist namelist_ASD.verify >& derecho.mpi.ifort.namelist.ASD.log
+mpiexec -n 2 -ppn 2 ./cpu.exe --namelist namelist_ASD.verify >& derecho.mpi.ifort.namelist.ASD.log

--- a/run/derecho.verify.gpu.sh
+++ b/run/derecho.verify.gpu.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #PBS -N cm1
-#PBS -l select=1:ncpus=4:mpiprocs=4:ngpus=4:mem=200gb
+#PBS -l select=1:ncpus=2:mpiprocs=2:ngpus=2:mem=235gb
 #PBS -l walltime=00:20:00
 #PBS -j oe
 #PBS -q main
@@ -9,8 +9,8 @@
 module purge
 module load ncarenv nvhpc cuda cray-mpich ncarcompilers cutensor
 
-
 export MPICH_GPU_SUPPORT_ENABLED=1
-mpiexec -n 4 -ppn 4 get_local_rank ./gpu.exe --namelist namelist_ASD.verify >& derecho.mpi.openacc.namelist.ASD.log
-# mpiexec -n 4 -ppn 4 get_local_rank ./gpu.exe --namelist namelist_ASD.verify.v2 >& derecho.mpi.openacc.namelist.ASDv2.log
-# mpiexec -n 4 -ppn 4 get_local_rank ./gpu.exe --namelist namelist_ASD.verify.v2.buggy >& derecho.mpi.openacc.namelist.ASDv2bug.log
+mpiexec -n 2 -ppn 2 get_local_rank ./gpu.exe --namelist namelist_ASD.verify >& derecho.mpi.openacc.namelist.ASD.log
+#mpiexec -n 16 -ppn 4 get_local_rank ./gpu.exe --namelist namelist_ASD.restA >& derecho.mpi.openacc.namelist.ASD.restA.log
+#mpiexec -n 16 -ppn 4 get_local_rank ./gpu.exe --namelist namelist_ASD.restB >& derecho.mpi.openacc.namelist.ASD.restB.log
+#mpiexec -n 16 -ppn 4 get_local_rank ./gpu.exe --namelist namelist_ASD.restC >& derecho.mpi.openacc.namelist.ASD.restC.log

--- a/run/namelist_ASD.restA
+++ b/run/namelist_ASD.restA
@@ -82,8 +82,8 @@
  npt       =  1,
  pdtra     =  1,
  iprcl     =  1,       !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
- nparcelsInit = 1e8,     ! initial number of particles over the whole domain
- nparcelsMax  = 5e8,   ! the total allowable number of particles over the whole domain
+ nparcelsInit = 100000000,     ! initial number of particles over the whole domain
+ nparcelsMax  = 500000000,   ! the total allowable number of particles over the whole domain
  injectHMax = 20.0,
  drop_mult = 1.e10,   !Droplet multiplicity: total number of droplets = nparcels*drop_mult
  drop_inject_elapse = 4.0,  !Time between spray injection
@@ -348,7 +348,7 @@
 
  &param14
  dodomaindiag   =    .true.,
- diagfrq        =     10.0,
+ diagfrq        =     50.0,
  /
 
  &param15

--- a/run/namelist_ASD.restB
+++ b/run/namelist_ASD.restB
@@ -82,8 +82,8 @@
  npt       =  1,
  pdtra     =  1,
  iprcl     =  1,       !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
- nparcelsInit = 1e8,   ! initial number of particles over the whole domain
- nparcelsMax  = 5e8,   ! the total allowable number of particles over the whole domain
+ nparcelsInit = 100000000,   ! initial number of particles over the whole domain
+ nparcelsMax  = 500000000,   ! the total allowable number of particles over the whole domain
  injectHMax = 20.0,
  drop_mult = 1.e10,   !Droplet multiplicity: total number of droplets = nparcels*drop_mult
  drop_inject_elapse = 4.0,  !Time between spray injection
@@ -348,7 +348,7 @@
 
  &param14
  dodomaindiag   =    .true.,
- diagfrq        =     10.0,
+ diagfrq        =     50.0,
  /
 
  &param15

--- a/run/namelist_ASD.restC
+++ b/run/namelist_ASD.restC
@@ -82,8 +82,8 @@
  npt       =  1,
  pdtra     =  1,
  iprcl     =  1,       !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
- nparcelsInit = 1e8,   ! initial number of particles over the whole domain
- nparcelsMax  = 5e8,   ! the total allowable number of particles over the whole domain
+ nparcelsInit = 100000000,   ! initial number of particles over the whole domain
+ nparcelsMax  = 500000000,   ! the total allowable number of particles over the whole domain
  injectHMax = 20.0,
  drop_mult = 1.e10,   !Droplet multiplicity: total number of droplets = nparcels*drop_mult
  drop_inject_elapse = 4.0,  !Time between spray injection
@@ -348,7 +348,7 @@
 
  &param14
  dodomaindiag   =    .true.,
- diagfrq        =     10.0,
+ diagfrq        =     50.0,
  /
 
  &param15

--- a/run/namelist_ASD.verify
+++ b/run/namelist_ASD.verify
@@ -3,7 +3,7 @@
  nx           =    128,
  ny           =    128,
  nz           =    128,
- ppnode       =      4,
+ ppnode       =      2,
  timeformat   =       1,
  timestats    =       1,
  terrain_flag = .false.,
@@ -83,7 +83,7 @@
  pdtra     =  1,
  iprcl     =  1,  !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
  nparcelsInit = 1,   ! initial number of particles over the whole domain
- nparcelsMax  = 5e6,   ! the total allowable number of particles over the whole domain
+ nparcelsMax  = 5000000,   ! the total allowable number of particles over the whole domain
  injectHMax = 20.0,
  drop_mult = 1.0e11,   !Droplet multiplicity: total number of droplets = nparcels*drop_mult
  drop_inject_elapse = 4.0,  !Time between spray injection

--- a/src/Makefile
+++ b/src/Makefile
@@ -410,3 +410,5 @@ turbtend.o: constants.o input.o cm1libs.o
 turbnba.o: constants.o input.o bc.o comm.o
 writeout.o: constants.o input.o bc.o comm.o writeout_nc.o misclibs.o getcape.o ib_module.o cm1libs.o
 writeout_nc.o: constants.o input.o
+mersennetwister_mod.o: constants.o
+input.o: constants.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -348,7 +348,7 @@ anelp.o: constants.o input.o misclibs.o bc.o poiss.o
 azimavg.o: input.o constants.o cm1libs.o writeout_nc.o comm.o bc.o
 base.o: constants.o input.o bc.o comm.o goddard.o cm1libs.o getcape.o turb.o
 bc.o: constants.o input.o
-bcast.o:
+bcast.o: constants.o
 cm1.o: constants.o input.o param.o base.o init3d.o misclibs.o solve1.o solve2.o solve3.o diff2.o turb.o statpack.o writeout.o restart.o radiation_driver.o radtrns3d.o domaindiag.o azimavg.o hifrq.o parcel.o init_physics.o init_surface.o mp_driver.o ib_module.o eddy_recycle.o lsnudge.o nvtx_mod.o droplet.o
 cm1libs.o: input.o constants.o
 comm.o: input.o bc.o

--- a/src/bcast.F
+++ b/src/bcast.F
@@ -9,6 +9,7 @@ end interface bcast_log
 
 interface bcast_int 
    module procedure bcast_int_scalar 
+   module procedure bcast_int8_scalar 
    module procedure bcast_int_vector
 end interface bcast_int
 
@@ -53,6 +54,22 @@ end interface bcast_double
       !$acc update device(val) if_present
 
       end subroutine bcast_int_scalar
+
+!cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+      subroutine bcast_int8_scalar(val)
+
+      use constants, only : i8
+#ifdef MPI
+      use mpi
+#endif
+      integer :: ierr
+      integer(i8),intent(inout) :: val
+#ifdef MPI
+      call MPI_BCAST(val,1,MPI_INTEGER8,0,MPI_COMM_WORLD,ierr)
+#endif
+      !$acc update device(val) if_present
+
+      end subroutine bcast_int8_scalar
 
 !cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
       subroutine bcast_int_vector(val,str_ind,end_ind)

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2276,7 +2276,7 @@ end module cuda_rt
 #endif
             ! number of droplets read from / write to a restart file
             ! initialize its value as "nparcelsInit"
-            nparcelsRest = int(nparcelsInit, i8)
+            nparcelsRest = nparcelsInit
             if(dowr) write(outfile,*) 'PDATA: padding,nparcelsLocal,nparcelsMax',padding,nparcelsLocal,nparcelsMax
          end if
       else   ! if no parcels

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -2276,7 +2276,7 @@ end module cuda_rt
 #endif
             ! number of droplets read from / write to a restart file
             ! initialize its value as "nparcelsInit"
-            nparcelsRest = nparcelsInit
+            nparcelsRest = int(nparcelsInit, i8)
             if(dowr) write(outfile,*) 'PDATA: padding,nparcelsLocal,nparcelsMax',padding,nparcelsLocal,nparcelsMax
          end if
       else   ! if no parcels

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -905,7 +905,7 @@ contains
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-     subroutine CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
+     subroutine CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelsout )
 
      ! This subroutine will collect the "pdata" information from each
      ! MPI rank and assemble them into a single big array "rbuf" for 
@@ -913,7 +913,6 @@ contains
      ! It works for > 2 billions droplets that can not be represented 
      ! by a normal integer type of length
 
-     use constants, only : i8
      use input, only : myid,numprocs,ierr,nparcelsLocalActive, &
                        nparcelsLocal,npvals
      use mpi
@@ -922,14 +921,14 @@ contains
 
      real, intent(in), dimension(nparcelsLocal,npvals) :: pdata
      integer, intent(in) :: nparcels_per_mpi(numprocs)   ! number of active droplets per MPI rank     
-     integer(i8), intent(in) :: nparcelstot              ! total number of active droplets
-                                                         ! over the whole domain
+     integer(), intent(in) :: nparcelsout                ! total number of active droplets
+                                                         ! to be written out to a binary file
      real, intent(out) :: rbuf(:,:)                      ! buffer to store all the active droplet 
                                                          ! information over the domain
 
      ! Local variable
-     integer :: i,np,iv,tag
-     integer(i8) :: beg_loc,end_loc,np_i8
+     integer :: i,n,np,iv,tag
+     integer :: beg_loc,end_loc
      real, dimension(:,:), allocatable :: tmp_buf
 
      ! Collect the information of active droplets from each MPI rank
@@ -945,14 +944,18 @@ contains
            call mpi_recv(tmp_buf,nparcels_per_mpi(i)*npvals, &
                          MPI_REAL,i-1,tag,MPI_COMM_WORLD, &
                          MPI_STATUS_IGNORE,ierr)
-           beg_loc = int(sum(real(nparcels_per_mpi(1:i-1)))+1, i8)
-           end_loc = int(real(beg_loc)+real(nparcels_per_mpi(i))-1, i8)
-           do iv = 1, npvals
-              do np_i8 = beg_loc, end_loc 
-                 np = int(real(np_i8) - real(beg_loc) + 1)
-                 rbuf(np_i8,iv) = tmp_buf(np,iv)
+           beg_loc = sum(nparcels_per_mpi(1:i-1))+1
+           end_loc = beg_loc+nparcels_per_mpi(i)-1
+           ! JS: we only save first "nparcelsout" droplets for I/O
+           if ( beg_loc <= nparcelsout ) then
+              do iv = 1, npvals
+                 do np = beg_loc, end_loc 
+                    if ( np <= nparcelsout ) then 
+                       n = np - beg_loc + 1
+                       rbuf(np,iv) = tmp_buf(n,iv)
+                    end if
+                 end do
               end do
-           end do
            deallocate(tmp_buf)
         end do
      else

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -921,7 +921,7 @@ contains
 
      real, intent(in), dimension(nparcelsLocal,npvals) :: pdata
      integer, intent(in) :: nparcels_per_mpi(numprocs)   ! number of active droplets per MPI rank     
-     integer(), intent(in) :: nparcelsout                ! total number of active droplets
+     integer, intent(in) :: nparcelsout                  ! total number of active droplets
                                                          ! to be written out to a binary file
      real, intent(out) :: rbuf(:,:)                      ! buffer to store all the active droplet 
                                                          ! information over the domain
@@ -930,6 +930,7 @@ contains
      integer :: i,n,np,iv,tag
      integer :: beg_loc,end_loc
      real, dimension(:,:), allocatable :: tmp_buf
+     real :: tmp
 
      ! Collect the information of active droplets from each MPI rank
      if ( myid .eq. 0 ) then
@@ -944,10 +945,11 @@ contains
            call mpi_recv(tmp_buf,nparcels_per_mpi(i)*npvals, &
                          MPI_REAL,i-1,tag,MPI_COMM_WORLD, &
                          MPI_STATUS_IGNORE,ierr)
-           beg_loc = sum(nparcels_per_mpi(1:i-1))+1
-           end_loc = beg_loc+nparcels_per_mpi(i)-1
-           ! JS: we only save first "nparcelsout" droplets for I/O
-           if ( beg_loc <= nparcelsout ) then
+           tmp = sum(real(nparcels_per_mpi(1:i-1)))+1
+           ! We only save first "nparcelsout" droplets for I/O
+           if ( tmp <= nparcelsout ) then
+              beg_loc = sum(nparcels_per_mpi(1:i-1))+1
+              end_loc = beg_loc+nparcels_per_mpi(i)-1
               do iv = 1, npvals
                  do np = beg_loc, end_loc 
                     if ( np <= nparcelsout ) then 
@@ -956,6 +958,7 @@ contains
                     end if
                  end do
               end do
+           end if
            deallocate(tmp_buf)
         end do
      else

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -910,8 +910,8 @@ contains
      ! This subroutine will collect the "pdata" information from each
      ! MPI rank and assemble them into a single big array "rbuf" for 
      ! writing out later.
-     ! It works for > 2 billions droplets that can not be represented 
-     ! by a normal integer type of length
+     ! It does not work for > 2 billions droplets since we can not write
+     ! out restart / pdata files with the current I/O interface
 
      use input, only : myid,numprocs,ierr,nparcelsLocalActive, &
                        nparcelsLocal,npvals
@@ -945,10 +945,10 @@ contains
            call mpi_recv(tmp_buf,nparcels_per_mpi(i)*npvals, &
                          MPI_REAL,i-1,tag,MPI_COMM_WORLD, &
                          MPI_STATUS_IGNORE,ierr)
-           tmp = sum(real(nparcels_per_mpi(1:i-1)))+1
+           tmp = sum(real(nparcels_per_mpi(1:i-1)))+1.0
            ! We only save first "nparcelsout" droplets for I/O
-           if ( tmp <= nparcelsout ) then
-              beg_loc = sum(nparcels_per_mpi(1:i-1))+1
+           if ( int(tmp) <= nparcelsout ) then
+              beg_loc = int(tmp)
               end_loc = beg_loc+nparcels_per_mpi(i)-1
               do iv = 1, npvals
                  do np = beg_loc, end_loc 

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -872,6 +872,7 @@ contains
 
      use constants, only : i8
      use input, only : myid,numprocs,ierr,nparcelsLocalActive
+     use mpi
 
      implicit none
 
@@ -913,7 +914,9 @@ contains
      ! by a normal integer type of length
 
      use constants, only : i8
-     use input, only : myid,numprocs,ierr,nparcelsLocalActive
+     use input, only : myid,numprocs,ierr,nparcelsLocalActive, &
+                       nparcelsLocal,npvals
+     use mpi
 
      implicit none
 
@@ -921,7 +924,7 @@ contains
      integer, intent(in) :: nparcels_per_mpi(numprocs)   ! number of active droplets per MPI rank     
      integer(i8), intent(in) :: nparcelstot              ! total number of active droplets
                                                          ! over the whole domain
-     real, intent(out), :: rbuf(:,:)                     ! buffer to store all the active droplet 
+     real, intent(out) :: rbuf(:,:)                      ! buffer to store all the active droplet 
                                                          ! information over the domain
 
      ! Local variable
@@ -931,20 +934,20 @@ contains
 
      ! Collect the information of active droplets from each MPI rank
      if ( myid .eq. 0 ) then
-        do iv = 1, npvars
+        do iv = 1, npvals
            do np = 1, nparcelsLocalActive
               rbuf(np,iv) = pdata(np,iv)
            end do
         end do
         do i = 2, numprocs
-           allocate( tmp_buf(nparcels_per_mpi(i),npvars) )
+           allocate( tmp_buf(nparcels_per_mpi(i),npvals) )
            tag = 98765 + i - 1
-           call mpi_recv(tmp_buf,nparcels_per_mpi(i)*npvars, &
+           call mpi_recv(tmp_buf,nparcels_per_mpi(i)*npvals, &
                          MPI_REAL,i-1,tag,MPI_COMM_WORLD, &
                          MPI_STATUS_IGNORE,ierr)
            beg_loc = int(sum(real(nparcels_per_mpi(1:i-1)))+1, i8)
            end_loc = int(real(beg_loc)+real(nparcels_per_mpi(i))-1, i8)
-           do iv = 1, npvars
+           do iv = 1, npvals
               do np_i8 = beg_loc, end_loc 
                  np = int(real(np_i8) - real(beg_loc) + 1)
                  rbuf(np_i8,iv) = tmp_buf(np,iv)
@@ -954,13 +957,13 @@ contains
         end do
      else
         tag = 98765 + myid
-        allocate( tmp_buf(nparcelsLocalActive,npvars) )
-        do iv = 1, npvars
+        allocate( tmp_buf(nparcelsLocalActive,npvals) )
+        do iv = 1, npvals
            do np = 1, nparcelsLocalActive
               tmp_buf(np,iv) = pdata(np,iv)
            end do
         end do
-        call mpi_send(tmp_buf,nparcelsLocalActive*npvars, &
+        call mpi_send(tmp_buf,nparcelsLocalActive*npvals, &
                       MPI_REAL,0,tag,MPI_COMM_WORLD,ierr)
         deallocate(tmp_buf)
      end if

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -877,7 +877,7 @@ contains
      implicit none
 
      integer, intent(out) :: nparcels_per_mpi(numprocs)   ! number of active droplets per MPI rank     
-     integer(i8), intent(out) :: nparcelstot              ! total number of active droplets
+     real, intent(out)    :: nparcelstot                  ! total number of active droplets
                                                           ! over the whole domain
 
      ! Local variable
@@ -897,7 +897,7 @@ contains
                       0,tag,MPI_COMM_WORLD,ierr)
 
      end if
-     nparcelstot = int(sum(real(nparcels_per_mpi)), i8)
+     nparcelstot = sum(real(nparcels_per_mpi))
 
      end subroutine CollectDropCount
 
@@ -935,7 +935,7 @@ contains
      ! Collect the information of active droplets from each MPI rank
      if ( myid .eq. 0 ) then
         do iv = 1, npvals
-           do np = 1, nparcelsLocalActive
+           do np = 1, min(nparcelsout,nparcelsLocalActive) 
               rbuf(np,iv) = pdata(np,iv)
            end do
         end do
@@ -949,13 +949,12 @@ contains
            ! We only save first "nparcelsout" droplets for I/O
            if ( int(tmp) <= nparcelsout ) then
               beg_loc = int(tmp)
-              end_loc = beg_loc+nparcels_per_mpi(i)-1
+              end_loc = int( min( real(beg_loc)+real(nparcels_per_mpi(i))-1.0, &
+                                  real(nparcelsout) ) )
               do iv = 1, npvals
                  do np = beg_loc, end_loc 
-                    if ( np <= nparcelsout ) then 
-                       n = np - beg_loc + 1
-                       rbuf(np,iv) = tmp_buf(n,iv)
-                    end if
+                    n = np - beg_loc + 1
+                    rbuf(np,iv) = tmp_buf(n,iv)
                  end do
               end do
            end if

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -914,7 +914,7 @@ contains
      ! out restart / pdata files with the current I/O interface
 
      use input, only : myid,numprocs,ierr,nparcelsLocalActive, &
-                       nparcelsLocal,npvals
+                       nparcelsLocal,npvals,i8
      use mpi
 
      implicit none
@@ -929,8 +929,8 @@ contains
      ! Local variable
      integer :: i,n,np,iv,tag
      integer :: beg_loc,end_loc
+     integer(i8) :: tmp
      real, dimension(:,:), allocatable :: tmp_buf
-     real :: tmp
 
      ! Collect the information of active droplets from each MPI rank
      if ( myid .eq. 0 ) then
@@ -940,20 +940,18 @@ contains
               rbuf(np,iv) = pdata(np,iv)
            end do
         end do
-        tmp = 0.0
+        tmp = 1 
         do i = 2, numprocs
            allocate( tmp_buf(nparcels_per_mpi(i),npvals) )
            tag = 98765 + i - 1
            call mpi_recv(tmp_buf,nparcels_per_mpi(i)*npvals, &
                          MPI_REAL,i-1,tag,MPI_COMM_WORLD, &
                          MPI_STATUS_IGNORE,ierr)
-           tmp = tmp + real(nparcels_per_mpi(i-1))
-           print *, "JS: tmp = ", tmp, ", nparcelsout = ", nparcelsout
+           tmp = tmp + nparcels_per_mpi(i-1)
            ! We only save first "nparcelsout" droplets for I/O
-           if ( tmp+1 <= nparcelsout ) then
-              beg_loc = int(tmp)+1
+           if ( tmp <= nparcelsout ) then
+              beg_loc = tmp
               end_loc = min( beg_loc+nparcels_per_mpi(i)-1, nparcelsout )
-              print *, "JS: beg_loc = ", beg_loc, ", end_loc = ", end_loc
               do iv = 1, npvals
                  do np = beg_loc, end_loc 
                     n = np - beg_loc + 1

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -877,7 +877,7 @@ contains
      implicit none
 
      integer, intent(out) :: nparcels_per_mpi(numprocs)   ! number of active droplets per MPI rank     
-     real, intent(out)    :: nparcelstot                  ! total number of active droplets
+     integer(i8), intent(out) :: nparcelstot              ! total number of active droplets
                                                           ! over the whole domain
 
      ! Local variable
@@ -886,18 +886,18 @@ contains
      ! Collect the number of active droplets from each MPI rank
      if ( myid .eq. 0 ) then
         nparcels_per_mpi(1) = nparcelsLocalActive
+        nparcelstot = nparcels_per_mpi(1)
         do i = 2, numprocs
            tag = 98765 + i - 1
            call mpi_recv(nparcels_per_mpi(i),1,MPI_INTEGER,i-1, &
                          tag,MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+           nparcelstot = nparcelstot + nparcels_per_mpi(i)
         end do
      else
         tag = 98765 + myid
         call mpi_send(nparcelsLocalActive,1,MPI_INTEGER, &
                       0,tag,MPI_COMM_WORLD,ierr)
-
      end if
-     nparcelstot = sum(real(nparcels_per_mpi))
 
      end subroutine CollectDropCount
 
@@ -934,23 +934,26 @@ contains
 
      ! Collect the information of active droplets from each MPI rank
      if ( myid .eq. 0 ) then
+        end_loc = min(nparcelsout,nparcelsLocalActive)
         do iv = 1, npvals
-           do np = 1, min(nparcelsout,nparcelsLocalActive) 
+           do np = 1, end_loc 
               rbuf(np,iv) = pdata(np,iv)
            end do
         end do
+        tmp = 0.0
         do i = 2, numprocs
            allocate( tmp_buf(nparcels_per_mpi(i),npvals) )
            tag = 98765 + i - 1
            call mpi_recv(tmp_buf,nparcels_per_mpi(i)*npvals, &
                          MPI_REAL,i-1,tag,MPI_COMM_WORLD, &
                          MPI_STATUS_IGNORE,ierr)
-           tmp = sum(real(nparcels_per_mpi(1:i-1)))+1.0
+           tmp = tmp + real(nparcels_per_mpi(i-1))
+           print *, "JS: tmp = ", tmp, ", nparcelsout = ", nparcelsout
            ! We only save first "nparcelsout" droplets for I/O
-           if ( int(tmp) <= nparcelsout ) then
-              beg_loc = int(tmp)
-              end_loc = int( min( real(beg_loc)+real(nparcels_per_mpi(i))-1.0, &
-                                  real(nparcelsout) ) )
+           if ( tmp+1 <= nparcelsout ) then
+              beg_loc = int(tmp)+1
+              end_loc = min( beg_loc+nparcels_per_mpi(i)-1, nparcelsout )
+              print *, "JS: beg_loc = ", beg_loc, ", end_loc = ", end_loc
               do iv = 1, npvals
                  do np = beg_loc, end_loc 
                     n = np - beg_loc + 1

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -15,6 +15,7 @@ private
 public :: comm_droplet_number,comm_droplet_value
 public :: setupIndexPointers, setupDepartDroplet
 public :: makeContiguous
+public :: CollectDropCount, CollectDropInfo
 
 contains
 
@@ -215,8 +216,6 @@ contains
     integer, intent(in) :: ptrArrive(num_nn)                             ! location index into holes_ind 
     integer, intent(in) :: ptrDepart(num_nn)                             ! location index into Depart_ind 
     real, intent(inout), dimension(nparcelsLocal,npvals) :: pdata        ! droplet information
-    ! integer, intent(in), dimension(nparcelsLocal) :: pdata_neighbor      ! array to store the new MPI region 
-    !                                                                      ! info for all the droplets
 
     ! Local variables
 
@@ -858,7 +857,115 @@ contains
        end do
      end do
 
-  end subroutine update_new_droplet
+     end subroutine update_new_droplet
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+     subroutine CollectDropCount ( nparcels_per_mpi, nparcelstot )
+
+     ! This subroutine will collect the active droplet count from each
+     ! MPI rank and assemble them into a single array for later usage.
+     ! It works for > 2 billions droplets that can not be represented 
+     ! by a normal integer type of length
+
+     use constants, only : i8
+     use input, only : myid,numprocs,ierr,nparcelsLocalActive
+
+     implicit none
+
+     integer, intent(out) :: nparcels_per_mpi(numprocs)   ! number of active droplets per MPI rank     
+     integer(i8), intent(out) :: nparcelstot              ! total number of active droplets
+                                                          ! over the whole domain
+
+     ! Local variable
+     integer :: i,tag
+
+     ! Collect the number of active droplets from each MPI rank
+     if ( myid .eq. 0 ) then
+        nparcels_per_mpi(1) = nparcelsLocalActive
+        do i = 2, numprocs
+           tag = 98765 + i - 1
+           call mpi_recv(nparcels_per_mpi(i),1,MPI_INTEGER,i-1, &
+                         tag,MPI_COMM_WORLD,MPI_STATUS_IGNORE,ierr)
+        end do
+     else
+        tag = 98765 + myid
+        call mpi_send(nparcelsLocalActive,1,MPI_INTEGER, &
+                      0,tag,MPI_COMM_WORLD,ierr)
+
+     end if
+     nparcelstot = int(sum(real(nparcels_per_mpi)), i8)
+
+     end subroutine CollectDropCount
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+     subroutine CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
+
+     ! This subroutine will collect the "pdata" information from each
+     ! MPI rank and assemble them into a single big array "rbuf" for 
+     ! writing out later.
+     ! It works for > 2 billions droplets that can not be represented 
+     ! by a normal integer type of length
+
+     use constants, only : i8
+     use input, only : myid,numprocs,ierr,nparcelsLocalActive
+
+     implicit none
+
+     real, intent(in), dimension(nparcelsLocal,npvals) :: pdata
+     integer, intent(in) :: nparcels_per_mpi(numprocs)   ! number of active droplets per MPI rank     
+     integer(i8), intent(in) :: nparcelstot              ! total number of active droplets
+                                                         ! over the whole domain
+     real, intent(out), :: rbuf(:,:)                     ! buffer to store all the active droplet 
+                                                         ! information over the domain
+
+     ! Local variable
+     integer :: i,np,iv,tag
+     integer(i8) :: beg_loc,end_loc,np_i8
+     real, dimension(:,:), allocatable :: tmp_buf
+
+     ! Collect the information of active droplets from each MPI rank
+     if ( myid .eq. 0 ) then
+        do iv = 1, npvars
+           do np = 1, nparcelsLocalActive
+              rbuf(np,iv) = pdata(np,iv)
+           end do
+        end do
+        do i = 2, numprocs
+           allocate( tmp_buf(nparcels_per_mpi(i),npvars) )
+           tag = 98765 + i - 1
+           call mpi_recv(tmp_buf,nparcels_per_mpi(i)*npvars, &
+                         MPI_REAL,i-1,tag,MPI_COMM_WORLD, &
+                         MPI_STATUS_IGNORE,ierr)
+           beg_loc = int(sum(real(nparcels_per_mpi(1:i-1)))+1, i8)
+           end_loc = int(real(beg_loc)+real(nparcels_per_mpi(i))-1, i8)
+           do iv = 1, npvars
+              do np_i8 = beg_loc, end_loc 
+                 np = int(real(np_i8) - real(beg_loc) + 1)
+                 rbuf(np_i8,iv) = tmp_buf(np,iv)
+              end do
+           end do
+           deallocate(tmp_buf)
+        end do
+     else
+        tag = 98765 + myid
+        allocate( tmp_buf(nparcelsLocalActive,npvars) )
+        do iv = 1, npvars
+           do np = 1, nparcelsLocalActive
+              tmp_buf(np,iv) = pdata(np,iv)
+           end do
+        end do
+        call mpi_send(tmp_buf,nparcelsLocalActive*npvars, &
+                      MPI_REAL,0,tag,MPI_COMM_WORLD,ierr)
+        deallocate(tmp_buf)
+     end if
+
+     end subroutine CollectDropInfo
 
 #endif
 

--- a/src/constants.F
+++ b/src/constants.F
@@ -14,7 +14,7 @@
 
       !----------------
 
-      integer,parameter :: i8 = selected_int_kind(15)
+      integer,parameter :: i8 = selected_int_kind(12)
 
       real, parameter ::  pi     = 3.1415926535897932384626433
       real, parameter ::  th0r   = 300.0

--- a/src/constants.F
+++ b/src/constants.F
@@ -14,6 +14,8 @@
 
       !----------------
 
+      integer,parameter :: i8 = selected_int_kind(15)
+
       real, parameter ::  pi     = 3.1415926535897932384626433
       real, parameter ::  th0r   = 300.0
       real, parameter ::  to     = 273.15

--- a/src/constants.F
+++ b/src/constants.F
@@ -73,6 +73,8 @@
                                                   ! "nparcelsMax" value
       integer :: padding                          ! The actual number of words used for 
                                                   ! padding the "pdata" array
+      real, parameter :: write_frac_droplet = 0.1 ! fraction of total active droplets
+                                                  ! to be written out to a binary file
 
       real, parameter :: neg_huge = -1.0e30       ! define a large negative number
 

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -152,7 +152,6 @@
       integer, dimension(:), allocatable :: holes_fallout_ind  !their location index in pdata prior to removal
 
 #ifdef MPI 
-      integer :: num_holes                                 ! how many new droplets could be added to "pdata"
       integer, dimension(:), allocatable :: holes_ind      ! location index in "pdata" that can add a new droplet
       integer, dimension(:), allocatable :: Depart_ind     ! Index location in "pdata" of a point that is departing
       integer :: Depart(num_nn)                            ! Number of droplets that will enter each nearest 
@@ -191,7 +190,7 @@
       ! 2) Otherwise, use David's original form with date and time to achieve
       !    more randomness but unmatched results between initial and restart runs
       local_seed = int(mtime) * 1000 + myid          ! -(myid+values(8)+values(7)+values(6))
-      call new_RandomNumberSequence(randomNumbers, local_seed)
+      call new_RandomNumberSequence(randomNumbers, int(local_seed,i8))
 
       num_fallout = 0  !Reset the number of droplets that have fallen out of physical domain
       errcode     = 0  ! Number of errors that occurred in the index search 
@@ -1951,7 +1950,7 @@
       real :: dumzh(1:nk),dumzf(kb:ke+1),dzf,xl,yl
       real :: Tpsrc_tmp,qvsrc_tmp,m1src_tmp,m2src_tmp,m3src_tmp
 
-      integer :: tnumpart
+      integer(i8) :: tnumpart
       real :: radavg,radsqr,radmin,radmax,Tpavg,Tpmin,Tpmax,Tpsqr,Tfavg,qfavg,prsavg,rhoavg,tnummult,tnumdrop,tnumaerosol
 
       real :: partnum(nk),multnum(nk),partmass(nk),numconc(nk),massconc(nk),vp1mean(nk),vp2mean(nk),vp3mean(nk),vp1msqr(nk),vp2msqr(nk),vp3msqr(nk),uf1mean(nk),uf2mean(nk),uf3mean(nk),Tpsrc(nk),qvsrc(nk),qf(nk),Tf(nk),radmean(nk),radmsqr(nk),Tpmean(nk),Tpmsqr(nk),qfsat(nk),m1src(nk),m2src(nk),m3src(nk),qstarmean(nk)
@@ -3176,7 +3175,8 @@
       double precision, intent(in) :: mtime
       integer, intent(out) :: my_reintro
     
-      integer :: i,np,tot_after_reintro
+      integer :: i,np
+      integer(i8) :: tot_after_reintro
       integer :: sum_buf(2)
       real :: dFssum(101)  !Discretized cumulative spray generation function (to be calculated)
       real :: binsdata(100)  !Discretized bins for cumulative SSGF
@@ -3281,7 +3281,7 @@
                ! initialize a new random number generator for each
                ! injected droplet
                local_seed = floor(29.*mtime) + (97*myid) + (7*j)
-               call new_RandomNumberSequence(randomNumbers, local_seed)
+               call new_RandomNumberSequence(randomNumbers,int(local_seed, i8))
                rand = getRandomReal(randomNumbers)
                a = totdrops*rand
                !Set the droplet radius based on the sea spray generation function (SSGF)
@@ -3432,7 +3432,8 @@
       integer, intent(inout) :: nrec
       real,    intent(in)    :: rtime,radavg,radsqr,radmin,radmax,Tpavg,Tpsqr,Tpmin,Tpmax,Tfavg,qfavg,prsavg,rhoavg,tnummult,tnumaerosol,tnumdrop
       real,    intent(in)    :: zhvec(nk),numconc(nk),massconc(nk),vp1mean(nk),vp2mean(nk),vp3mean(nk),vp1msqr(nk),vp2msqr(nk),vp3msqr(nk),m1src(nk),m2src(nk),m3src(nk),Tpsrc(nk),qvsrc(nk),Tf(nk),qf(nk),Tpmean(nk),Tpmsqr(nk),radmean(nk),radmsqr(nk),qfsat(nk),qstarmean(nk),uf1mean(nk),uf2mean(nk),uf3mean(nk)
-      integer, intent(in)    :: tnumpart,nbins
+      integer, intent(in)    :: nbins
+      integer(i8), intent(in) :: tnumpart
 
       integer :: i,ncid,status,dimid,varid,time_index,timeid,tfile,zhid,binsid
       logical :: allinfo

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1952,10 +1952,9 @@
       real :: dumzh(1:nk),dumzf(kb:ke+1),dzf,xl,yl
       real :: Tpsrc_tmp,qvsrc_tmp,m1src_tmp,m2src_tmp,m3src_tmp
 
-      integer(i8) :: tnumpart
       real :: radavg,radsqr,radmin,radmax,Tpavg,Tpmin,Tpmax,Tpsqr, &
               Tfavg,qfavg,prsavg,rhoavg,tnummult,tnumdrop, &
-              tnumaerosol
+              tnumaerosol,tnumpart
 
       real :: partnum(nk),multnum(nk),partmass(nk),numconc(nk),massconc(nk),vp1mean(nk),vp2mean(nk),vp3mean(nk),vp1msqr(nk),vp2msqr(nk),vp3msqr(nk),uf1mean(nk),uf2mean(nk),uf3mean(nk),Tpsrc(nk),qvsrc(nk),qf(nk),Tf(nk),radmean(nk),radmsqr(nk),Tpmean(nk),Tpmsqr(nk),qfsat(nk),m1src(nk),m2src(nk),m3src(nk),qstarmean(nk)
       double precision, dimension(nk) :: qstardp,radmsqrdp
@@ -1984,7 +1983,7 @@
 
       !!!!!!! 0th order  !!!!!!!!
 
-      tnumpart = 0
+      tnumpart = 0.0
       tnumaerosol = 0.0
       tnumdrop = 0.0
       tnummult = 0.0
@@ -2006,7 +2005,7 @@
       !$acc          reduction(max:radmax,Tpmax) &
       !$acc          reduction(min:radmin,Tpmin)
       do np=1,nparcelsLocalActive
-         tnumpart = tnumpart + 1
+         tnumpart = tnumpart + 1.0
          tnummult = tnummult + pdata(np,prmult)
          if (pdata(np,prrp) .lt. crit_radius(pdata(np,prms),pdata(np,prt))) then
              tnumaerosol = tnumaerosol + pdata(np,prmult)
@@ -2095,7 +2094,7 @@
          radmax = droplet_diag0(19)
          Tpmax = droplet_diag0(20)
 #endif
-         if (tnumpart .gt. 0) then
+         if (tnumpart .gt. 0.0) then
             radavg = radavg/dble(tnumpart)
             radsqr = radsqr/dble(tnumpart)
             Tpavg = Tpavg/dble(tnumpart)
@@ -3439,7 +3438,7 @@
       real,    intent(in)    :: rtime,radavg,radsqr,radmin,radmax,Tpavg,Tpsqr,Tpmin,Tpmax,Tfavg,qfavg,prsavg,rhoavg,tnummult,tnumaerosol,tnumdrop
       real,    intent(in)    :: zhvec(nk),numconc(nk),massconc(nk),vp1mean(nk),vp2mean(nk),vp3mean(nk),vp1msqr(nk),vp2msqr(nk),vp3msqr(nk),m1src(nk),m2src(nk),m3src(nk),Tpsrc(nk),qvsrc(nk),Tf(nk),qf(nk),Tpmean(nk),Tpmsqr(nk),radmean(nk),radmsqr(nk),qfsat(nk),qstarmean(nk),uf1mean(nk),uf2mean(nk),uf3mean(nk)
       integer, intent(in)    :: nbins
-      integer(i8), intent(in) :: tnumpart
+      real, intent(in) :: tnumpart
 
       integer :: i,ncid,status,dimid,varid,time_index,timeid,tfile,zhid,binsid
       logical :: allinfo

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -1950,8 +1950,9 @@
       real :: dumzh(1:nk),dumzf(kb:ke+1),dzf,xl,yl
       real :: Tpsrc_tmp,qvsrc_tmp,m1src_tmp,m2src_tmp,m3src_tmp
 
-      integer(i8) :: tnumpart
-      real :: radavg,radsqr,radmin,radmax,Tpavg,Tpmin,Tpmax,Tpsqr,Tfavg,qfavg,prsavg,rhoavg,tnummult,tnumdrop,tnumaerosol
+      real :: radavg,radsqr,radmin,radmax,Tpavg,Tpmin,Tpmax,Tpsqr, &
+              Tfavg,qfavg,prsavg,rhoavg,tnummult,tnumdrop, &
+              tnumaerosol,tnumpart
 
       real :: partnum(nk),multnum(nk),partmass(nk),numconc(nk),massconc(nk),vp1mean(nk),vp2mean(nk),vp3mean(nk),vp1msqr(nk),vp2msqr(nk),vp3msqr(nk),uf1mean(nk),uf2mean(nk),uf3mean(nk),Tpsrc(nk),qvsrc(nk),qf(nk),Tf(nk),radmean(nk),radmsqr(nk),Tpmean(nk),Tpmsqr(nk),qfsat(nk),m1src(nk),m2src(nk),m3src(nk),qstarmean(nk)
       double precision, dimension(nk) :: qstardp,radmsqrdp
@@ -2002,7 +2003,7 @@
       !$acc          reduction(max:radmax,Tpmax) &
       !$acc          reduction(min:radmin,Tpmin)
       do np=1,nparcelsLocalActive
-         tnumpart = tnumpart + 1
+         tnumpart = tnumpart + 1.0
          tnummult = tnummult + pdata(np,prmult)
          if (pdata(np,prrp) .lt. crit_radius(pdata(np,prms),pdata(np,prt))) then
              tnumaerosol = tnumaerosol + pdata(np,prmult)
@@ -3176,7 +3177,7 @@
       integer, intent(out) :: my_reintro
     
       integer :: i,np
-      integer(i8) :: tot_after_reintro
+      real :: tot_after_reintro
       integer :: sum_buf(2)
       real :: dFssum(101)  !Discretized cumulative spray generation function (to be calculated)
       real :: binsdata(100)  !Discretized bins for cumulative SSGF
@@ -3265,10 +3266,12 @@
 
 #ifdef MPI
       !For deciding whether to inject more:
-      call mpi_allreduce(my_reintro+nparcelsLocalActive,tot_after_reintro,1,mpi_int,mpi_sum,mpi_comm_world,ierr)
+      call mpi_allreduce(real(my_reintro+nparcelsLocalActive), &
+                         tot_after_reintro,1,mpi_real,mpi_sum, &
+                         mpi_comm_world,ierr)
 #else
       !Calculate the total number which will occur after injection
-      tot_after_reintro = my_reintro+nparcelsLocalActive
+      tot_after_reintro = real(my_reintro+nparcelsLocalActive)
 #endif
 
       if (tot_after_reintro .lt. nparcelsMax) then   !Only add particles if the total number injected
@@ -3433,7 +3436,7 @@
       real,    intent(in)    :: rtime,radavg,radsqr,radmin,radmax,Tpavg,Tpsqr,Tpmin,Tpmax,Tfavg,qfavg,prsavg,rhoavg,tnummult,tnumaerosol,tnumdrop
       real,    intent(in)    :: zhvec(nk),numconc(nk),massconc(nk),vp1mean(nk),vp2mean(nk),vp3mean(nk),vp1msqr(nk),vp2msqr(nk),vp3msqr(nk),m1src(nk),m2src(nk),m3src(nk),Tpsrc(nk),qvsrc(nk),Tf(nk),qf(nk),Tpmean(nk),Tpmsqr(nk),radmean(nk),radmsqr(nk),qfsat(nk),qstarmean(nk),uf1mean(nk),uf2mean(nk),uf3mean(nk)
       integer, intent(in)    :: nbins
-      integer(i8), intent(in) :: tnumpart
+      real, intent(in) :: tnumpart
 
       integer :: i,ncid,status,dimid,varid,time_index,timeid,tfile,zhid,binsid
       logical :: allinfo
@@ -3741,7 +3744,7 @@
 
     !!0th order
     call disp_err( nf90_inq_varid(ncid,"tnumpart",varid) , .true. )
-    call disp_err( nf90_put_var(ncid,varid,real(tnumpart),(/time_index/)) , .true. )
+    call disp_err( nf90_put_var(ncid,varid,tnumpart,(/time_index/)) , .true. )
 
     call disp_err( nf90_inq_varid(ncid,"tnummult",varid) , .true. )
     call disp_err( nf90_put_var(ncid,varid,tnummult,(/time_index/)) , .true. )

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -161,7 +161,7 @@
       integer :: ptrDepart(num_nn)                         ! Points to the begining of Depart_ind for various departure buffers
       integer :: ptrArrive(num_nn)                         ! Points to the begining of holes_ind for various arrival buffers
       integer, dimension(nparcelsLocal) :: pdata_neighbor  ! array to store the new MPI region info for all the droplets
-      real    :: np_tmp
+      integer(i8) :: np_tmp
 #endif
       integer :: neighbor                                  ! indicate which MPI region a droplet stays after this time step 
 
@@ -862,7 +862,7 @@
       end if    ! if floor(mtime/drop_inject_elapse) .ne. floor((mtime+dt)/drop_inject_elapse) 
       !This is helpful to see in the output, but not absolutely necessary:
 #ifdef MPI
-      call mpi_allreduce(real(nparcelsLocalActive),np_tmp,1,mpi_real, &
+      call mpi_allreduce(nparcelsLocalActive,np_tmp,1,mpi_integer8, &
                          mpi_sum,mpi_comm_world,ierr)
 #endif
       if (myid==0) then 
@@ -1952,9 +1952,10 @@
       real :: dumzh(1:nk),dumzf(kb:ke+1),dzf,xl,yl
       real :: Tpsrc_tmp,qvsrc_tmp,m1src_tmp,m2src_tmp,m3src_tmp
 
+      integer(i8) :: tnumpart
       real :: radavg,radsqr,radmin,radmax,Tpavg,Tpmin,Tpmax,Tpsqr, &
               Tfavg,qfavg,prsavg,rhoavg,tnummult,tnumdrop, &
-              tnumaerosol,tnumpart
+              tnumaerosol
 
       real :: partnum(nk),multnum(nk),partmass(nk),numconc(nk),massconc(nk),vp1mean(nk),vp2mean(nk),vp3mean(nk),vp1msqr(nk),vp2msqr(nk),vp3msqr(nk),uf1mean(nk),uf2mean(nk),uf3mean(nk),Tpsrc(nk),qvsrc(nk),qf(nk),Tf(nk),radmean(nk),radmsqr(nk),Tpmean(nk),Tpmsqr(nk),qfsat(nk),m1src(nk),m2src(nk),m3src(nk),qstarmean(nk)
       double precision, dimension(nk) :: qstardp,radmsqrdp
@@ -2005,7 +2006,7 @@
       !$acc          reduction(max:radmax,Tpmax) &
       !$acc          reduction(min:radmin,Tpmin)
       do np=1,nparcelsLocalActive
-         tnumpart = tnumpart + 1.0
+         tnumpart = tnumpart + 1
          tnummult = tnummult + pdata(np,prmult)
          if (pdata(np,prrp) .lt. crit_radius(pdata(np,prms),pdata(np,prt))) then
              tnumaerosol = tnumaerosol + pdata(np,prmult)
@@ -3179,7 +3180,7 @@
       integer, intent(out) :: my_reintro
     
       integer :: i,np
-      real :: tot_after_reintro
+      integer(i8) :: tot_after_reintro
       integer :: sum_buf(2)
       real :: dFssum(101)  !Discretized cumulative spray generation function (to be calculated)
       real :: binsdata(100)  !Discretized bins for cumulative SSGF
@@ -3268,12 +3269,12 @@
 
 #ifdef MPI
       !For deciding whether to inject more:
-      call mpi_allreduce(real(my_reintro+nparcelsLocalActive), &
-                         tot_after_reintro,1,mpi_real,mpi_sum, &
+      call mpi_allreduce(my_reintro+nparcelsLocalActive, &
+                         tot_after_reintro,1,mpi_integer8,mpi_sum, &
                          mpi_comm_world,ierr)
 #else
       !Calculate the total number which will occur after injection
-      tot_after_reintro = real(my_reintro+nparcelsLocalActive)
+      tot_after_reintro = my_reintro+nparcelsLocalActive
 #endif
 
       if (tot_after_reintro .lt. nparcelsMax) then   !Only add particles if the total number injected
@@ -3438,7 +3439,7 @@
       real,    intent(in)    :: rtime,radavg,radsqr,radmin,radmax,Tpavg,Tpsqr,Tpmin,Tpmax,Tfavg,qfavg,prsavg,rhoavg,tnummult,tnumaerosol,tnumdrop
       real,    intent(in)    :: zhvec(nk),numconc(nk),massconc(nk),vp1mean(nk),vp2mean(nk),vp3mean(nk),vp1msqr(nk),vp2msqr(nk),vp3msqr(nk),m1src(nk),m2src(nk),m3src(nk),Tpsrc(nk),qvsrc(nk),Tf(nk),qf(nk),Tpmean(nk),Tpmsqr(nk),radmean(nk),radmsqr(nk),qfsat(nk),qstarmean(nk),uf1mean(nk),uf2mean(nk),uf3mean(nk)
       integer, intent(in)    :: nbins
-      real, intent(in) :: tnumpart
+      integer(i8), intent(in) :: tnumpart
 
       integer :: i,ncid,status,dimid,varid,time_index,timeid,tfile,zhid,binsid
       logical :: allinfo

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -190,7 +190,7 @@
       ! 2) Otherwise, use David's original form with date and time to achieve
       !    more randomness but unmatched results between initial and restart runs
       local_seed = int(mtime) * 1000 + myid          ! -(myid+values(8)+values(7)+values(6))
-      call new_RandomNumberSequence(randomNumbers, int(local_seed,i8))
+      call new_RandomNumberSequence(randomNumbers, local_seed)
 
       num_fallout = 0  !Reset the number of droplets that have fallen out of physical domain
       errcode     = 0  ! Number of errors that occurred in the index search 
@@ -3284,7 +3284,7 @@
                ! initialize a new random number generator for each
                ! injected droplet
                local_seed = floor(29.*mtime) + (97*myid) + (7*j)
-               call new_RandomNumberSequence(randomNumbers,int(local_seed, i8))
+               call new_RandomNumberSequence(randomNumbers, local_seed)
                rand = getRandomReal(randomNumbers)
                a = totdrops*rand
                !Set the droplet radius based on the sea spray generation function (SSGF)

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -145,7 +145,7 @@
 
       type(randomNumberSequence) :: randomNumbers
 
-      integer :: num_fallout,idx,np_tmp                        !droplets which fell out of domain
+      integer :: num_fallout,idx                        !droplets which fell out of domain
       integer :: numDepart
       integer :: numDepartN, numDepartS, numDepartE, numDepartW, &
                  numDepartSW,numDepartSE,numDepartNE,numDepartNW
@@ -161,6 +161,7 @@
       integer :: ptrDepart(num_nn)                         ! Points to the begining of Depart_ind for various departure buffers
       integer :: ptrArrive(num_nn)                         ! Points to the begining of holes_ind for various arrival buffers
       integer, dimension(nparcelsLocal) :: pdata_neighbor  ! array to store the new MPI region info for all the droplets
+      real    :: np_tmp
 #endif
       integer :: neighbor                                  ! indicate which MPI region a droplet stays after this time step 
 
@@ -861,7 +862,8 @@
       end if    ! if floor(mtime/drop_inject_elapse) .ne. floor((mtime+dt)/drop_inject_elapse) 
       !This is helpful to see in the output, but not absolutely necessary:
 #ifdef MPI
-      call mpi_allreduce(nparcelsLocalActive,np_tmp,1,mpi_int,mpi_sum,mpi_comm_world,ierr)
+      call mpi_allreduce(real(nparcelsLocalActive),np_tmp,1,mpi_real, &
+                         mpi_sum,mpi_comm_world,ierr)
 #endif
       if (myid==0) then 
          write(*,'(a8,3i)')  'DHR1:',myid,np_tmp,nparcelsLocalActive

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -179,7 +179,7 @@
       logical, parameter :: use_truly_random_pert  =  .false.
 
       real :: tmpx, tmpy, tmpz
-      integer :: np_tmp
+      real :: np_tmp
 
 !--------------------------
 
@@ -503,7 +503,7 @@
 
 #ifdef MPI
         ! Sanity check
-        call mpi_allreduce(nparcelsLocalActive,np_tmp,1,mpi_int,mpi_sum,mpi_comm_world,ierr)
+        call mpi_allreduce(real(nparcelsLocalActive),np_tmp,1,mpi_real,mpi_sum,mpi_comm_world,ierr)
         if ( np_tmp .ne. nparcelsInit ) then
            print *
            print *,'  Error: nparcelsInit does not equal np_tmp '

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -131,7 +131,7 @@
  
 !-----------------------------------------------------------------------
 
-      integer(i8) :: n
+      integer(i8) :: n,iter
       integer i,j,k,kk,l,nn,nbub,nloop
       integer ic,jc,ifoo,jfoo
       real ric,rjc
@@ -417,8 +417,9 @@
 
         i = 1
         nparcelsLocalActive = 0
+        iter = int(nparcelsInit, i8)
 
-        do n=1,int(nparcelsInit, i8)
+        do n = 1, iter
 
           rand = getRandomReal(randomNumbers)
           tmpx = rand*maxx

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -1,5 +1,7 @@
   MODULE init3d_module
 
+  use constants, only : i8
+
   implicit none
 
   private
@@ -129,7 +131,8 @@
  
 !-----------------------------------------------------------------------
 
-      integer i,j,k,kk,l,n,nn,nbub,nloop
+      integer(i8) :: n
+      integer i,j,k,kk,l,nn,nbub,nloop
       integer ic,jc,ifoo,jfoo
       real ric,rjc
       real xc,yc,zc,bhrad,bvrad,bptpert,beta,tmp,zdep
@@ -410,12 +413,12 @@
         !     https://github.com/ESCOMP/CESM_share/blob/main/RandNum/src/mt19937/mersennetwister_mod.F90
         !
         ! The generated random number is independent of compilers and MPI ranks
-        call new_RandomNumberSequence(randomNumbers, nparcelsMax)
+        call new_RandomNumberSequence(randomNumbers, int(nparcelsMax, i8))
 
         i = 1
         nparcelsLocalActive = 0
 
-        do n=1,nparcelsInit
+        do n=1,int(nparcelsInit, i8)
 
           rand = getRandomReal(randomNumbers)
           tmpx = rand*maxx
@@ -1577,7 +1580,7 @@
           !     https://github.com/ESCOMP/CESM_share/blob/main/RandNum/src/mt19937/mersennetwister_mod.F90
           !
           ! The generated random number is independent of compilers and MPI ranks
-          call new_RandomNumberSequence(randomNumbers, (nx+1)*(ny+1))
+          call new_RandomNumberSequence(randomNumbers, int((nx+1)*(ny+1), i8))
           do jj = 0,ny+1
           do ii = 0,nx+1
             rand = getRandomReal(randomNumbers)

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -1,6 +1,6 @@
   MODULE init3d_module
 
-  use constants, only : i8
+  use constants, only : i8, write_frac_droplet
 
   implicit none
 
@@ -413,7 +413,7 @@
         !     https://github.com/ESCOMP/CESM_share/blob/main/RandNum/src/mt19937/mersennetwister_mod.F90
         !
         ! The generated random number is independent of compilers and MPI ranks
-        call new_RandomNumberSequence(randomNumbers, int(nparcelsMax, i8))
+        call new_RandomNumberSequence(randomNumbers, max(1, int(nparcelsInit * write_frac_droplet)))
 
         i = 1
         nparcelsLocalActive = 0
@@ -1581,7 +1581,7 @@
           !     https://github.com/ESCOMP/CESM_share/blob/main/RandNum/src/mt19937/mersennetwister_mod.F90
           !
           ! The generated random number is independent of compilers and MPI ranks
-          call new_RandomNumberSequence(randomNumbers, int((nx+1)*(ny+1), i8))
+          call new_RandomNumberSequence(randomNumbers, (nx+1)*(ny+1))
           do jj = 0,ny+1
           do ii = 0,nx+1
             rand = getRandomReal(randomNumbers)

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -131,7 +131,7 @@
  
 !-----------------------------------------------------------------------
 
-      integer(i8) :: n,iter
+      integer(i8) :: n
       integer i,j,k,kk,l,nn,nbub,nloop
       integer ic,jc,ifoo,jfoo
       real ric,rjc
@@ -179,7 +179,7 @@
       logical, parameter :: use_truly_random_pert  =  .false.
 
       real :: tmpx, tmpy, tmpz
-      real :: np_tmp
+      integer(i8) :: np_tmp
 
 !--------------------------
 
@@ -417,9 +417,8 @@
 
         i = 1
         nparcelsLocalActive = 0
-        iter = int(nparcelsInit, i8)
 
-        do n = 1, iter
+        do n = 1, nparcelsInit 
 
           rand = getRandomReal(randomNumbers)
           tmpx = rand*maxx
@@ -504,7 +503,8 @@
 
 #ifdef MPI
         ! Sanity check
-        call mpi_allreduce(real(nparcelsLocalActive),np_tmp,1,mpi_real,mpi_sum,mpi_comm_world,ierr)
+        call mpi_allreduce(nparcelsLocalActive,np_tmp,1, &
+                           mpi_integer8,mpi_sum,mpi_comm_world,ierr)
         if ( np_tmp .ne. nparcelsInit ) then
            print *
            print *,'  Error: nparcelsInit does not equal np_tmp '

--- a/src/input.F
+++ b/src/input.F
@@ -1,5 +1,6 @@
   MODULE input
 
+  use constants, only: i8
   implicit none
 
   public
@@ -160,7 +161,8 @@
               bl_mynn_cloudmix,bl_mynn_mixqt,initflag,spp_pbl,bl_mynn_output, &
               nutk,nvtk,nwtk,nparcelsLocal,nparcelsLocalActive
 
-      real :: nparcelsInit,nparcelsMax,nparcelsRest
+      real :: nparcelsInit,nparcelsMax
+      integer(i8) :: nparcelsRest
 
       !$acc declare create (ib,ie,jb,je,kb,ke,numq,nparcelsInit,npvals,nx,ny, &
       !$acc       axisymm,terrain_flag,ni,nj,nip1,njp1,nk,nkp1,nkm1,imoist,   &

--- a/src/input.F
+++ b/src/input.F
@@ -1,7 +1,5 @@
   MODULE input
 
-  use constants, only : i8
-
   implicit none
 
   public
@@ -162,8 +160,7 @@
               bl_mynn_cloudmix,bl_mynn_mixqt,initflag,spp_pbl,bl_mynn_output, &
               nutk,nvtk,nwtk,nparcelsLocal,nparcelsLocalActive
 
-      integer(i8) :: nparcelsRest
-      real :: nparcelsInit,nparcelsMax
+      real :: nparcelsInit,nparcelsMax,nparcelsRest
 
       !$acc declare create (ib,ie,jb,je,kb,ke,numq,nparcelsInit,npvals,nx,ny, &
       !$acc       axisymm,terrain_flag,ni,nj,nip1,njp1,nk,nkp1,nkm1,imoist,   &

--- a/src/input.F
+++ b/src/input.F
@@ -159,10 +159,10 @@
               bl_mynn_mixlength,bl_mynn_edmf,                                 &
               bl_mynn_edmf_mom,bl_mynn_edmf_tke,bl_mynn_mixscalars,           &
               bl_mynn_cloudmix,bl_mynn_mixqt,initflag,spp_pbl,bl_mynn_output, &
-              nutk,nvtk,nwtk,nparcelsLocal,nparcelsLocalActive
+              nutk,nvtk,nwtk
 
-      real :: nparcelsInit,nparcelsMax
-      integer(i8) :: nparcelsRest
+      integer(i8) :: nparcelsInit,nparcelsMax,nparcelsRest,nparcelsLocal, &
+                     nparcelsLocalActive
 
       !$acc declare create (ib,ie,jb,je,kb,ke,numq,nparcelsInit,npvals,nx,ny, &
       !$acc       axisymm,terrain_flag,ni,nj,nip1,njp1,nk,nkp1,nkm1,imoist,   &

--- a/src/input.F
+++ b/src/input.F
@@ -1,5 +1,7 @@
   MODULE input
 
+  use constants, only : i8
+
   implicit none
 
   public
@@ -92,7 +94,7 @@
               wbc,ebc,sbc,nbc,bbc,tbc,irbc,roflux,nudgeobc,                   &
               isnd,iwnd,itern,iinit,                                          &
               irandp,ibalance,iorigin,axisymm,imove,iptra,npt,pdtra,          &
-              iprcl,nparcelsInit,                                             &
+              iprcl,                                                          &
               stretch_x,stretch_y,stretch_z,                                  &
               bc_temp,ibw,ibe,ibs,ibn,npvals,npvars,                          &
               outfile,myid,numprocs,myi,myj,nf,nu,nv,nw,                      &
@@ -158,8 +160,10 @@
               bl_mynn_mixlength,bl_mynn_edmf,                                 &
               bl_mynn_edmf_mom,bl_mynn_edmf_tke,bl_mynn_mixscalars,           &
               bl_mynn_cloudmix,bl_mynn_mixqt,initflag,spp_pbl,bl_mynn_output, &
-              nutk,nvtk,nwtk,nparcelsLocal,nparcelsLocalActive,nparcelsMax,   &
-              nparcelsRest
+              nutk,nvtk,nwtk,nparcelsLocal,nparcelsLocalActive
+
+      integer(i8) :: nparcelsRest
+      real :: nparcelsInit,nparcelsMax
 
       !$acc declare create (ib,ie,jb,je,kb,ke,numq,nparcelsInit,npvals,nx,ny, &
       !$acc       axisymm,terrain_flag,ni,nj,nip1,njp1,nk,nkp1,nkm1,imoist,   &

--- a/src/mersennetwister_mod.F
+++ b/src/mersennetwister_mod.F
@@ -71,14 +71,13 @@
 module MersenneTwister_mod
   ! -------------------------------------------------------------
 
-  use constants, only : i8
-
   implicit none
   private
 
   ! Algorithm parameters
   ! -------
   ! Period parameters
+  integer, parameter :: i8 = selected_int_kind(13)
   integer, parameter :: blockSize = 624,         &
        M         = 397,         &
        MATRIX_A  = -1727483681, & ! constant vector a         (0x9908b0dfUL)
@@ -166,7 +165,7 @@ contains
   ! --------------------
   subroutine initialize_scalar(twister, seed)
     !$acc routine seq
-    integer(i8),       intent(in   ) :: seed
+    integer,       intent(in   ) :: seed
     type(randomNumberSequence)                :: twister
     
 
@@ -188,10 +187,10 @@ contains
     integer, dimension(0:), intent(in) :: seed
     type(randomNumberSequence)                      :: twister
 
-    integer(i8) :: i, j, k, nFirstLoop, nWraps
+    integer :: i, j, k, nFirstLoop, nWraps
 
     nWraps  = 0
-    call initialize_scalar(twister, 19650218_i8)
+    call initialize_scalar(twister, 19650218)
 
     nFirstLoop = max(blockSize, size(seed))
     do k = 1, nFirstLoop

--- a/src/mersennetwister_mod.F
+++ b/src/mersennetwister_mod.F
@@ -70,13 +70,15 @@
 
 module MersenneTwister_mod
   ! -------------------------------------------------------------
+
+  use constants, only : i8
+
   implicit none
   private
 
   ! Algorithm parameters
   ! -------
   ! Period parameters
-  integer, parameter :: i8 = selected_int_kind(13)
   integer, parameter :: blockSize = 624,         &
        M         = 397,         &
        MATRIX_A  = -1727483681, & ! constant vector a         (0x9908b0dfUL)
@@ -164,7 +166,7 @@ contains
   ! --------------------
   subroutine initialize_scalar(twister, seed)
     !$acc routine seq
-    integer,       intent(in   ) :: seed
+    integer(i8),       intent(in   ) :: seed
     type(randomNumberSequence)                :: twister
     
 
@@ -186,10 +188,10 @@ contains
     integer, dimension(0:), intent(in) :: seed
     type(randomNumberSequence)                      :: twister
 
-    integer :: i, j, k, nFirstLoop, nWraps
+    integer(i8) :: i, j, k, nFirstLoop, nWraps
 
     nWraps  = 0
-    call initialize_scalar(twister, 19650218)
+    call initialize_scalar(twister, 19650218_i8)
 
     nFirstLoop = max(blockSize, size(seed))
     do k = 1, nFirstLoop

--- a/src/param.F
+++ b/src/param.F
@@ -2423,7 +2423,7 @@
       endif
 
       ! for parcels:
-      nparcelsInit = max(1,nparcelsInit)
+      nparcelsInit = max(1.0,nparcelsInit)
 
 !-----
 

--- a/src/param.F
+++ b/src/param.F
@@ -297,8 +297,8 @@
       call bcast_int(npt)
       call bcast_int(pdtra)
       call bcast_int(iprcl)
-      call bcast_real(nparcelsInit) ! DEVICE
-      call bcast_real(nparcelsMax)
+      call bcast_int(nparcelsInit) ! DEVICE
+      call bcast_int(nparcelsMax)
       call bcast_real(injectHMax)
       call bcast_real(drop_inject_elapse)
       call bcast_real(drop_inject_time)
@@ -2423,7 +2423,7 @@
       endif
 
       ! for parcels:
-      nparcelsInit = max(1.0,nparcelsInit)
+      nparcelsInit = max(1_i8,nparcelsInit)
 
 !-----
 

--- a/src/param.F
+++ b/src/param.F
@@ -297,8 +297,8 @@
       call bcast_int(npt)
       call bcast_int(pdtra)
       call bcast_int(iprcl)
-      call bcast_int(nparcelsInit) ! DEVICE
-      call bcast_int(nparcelsMax)
+      call bcast_real(nparcelsInit) ! DEVICE
+      call bcast_real(nparcelsMax)
       call bcast_real(injectHMax)
       call bcast_real(drop_inject_elapse)
       call bcast_real(drop_inject_time)

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1783,12 +1783,10 @@
 #ifdef MPI
     ! Collect number of active droplets from each MPI rank
     call CollectDropCount ( nparcels_per_mpi, nparcelstot )
-    if (myid == 0) print *, "JS: nparcels_per_mpi = ", nparcels_per_mpi, ", nparcelstot = ",nparcelstot
 
     ! Collect information of active droplets from each MPI rank
     if ( myid .eq. 0 ) then
        nparcelsout = int( max( 1.0, write_frac_droplet*nparcelstot ) )
-       if (myid == 0) print *, "JS: nparcelsout = ", nparcelsout 
        allocate(rbuf(nparcelsout,npvals))
     end if
     call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelsout )
@@ -2383,7 +2381,7 @@
       write(50,401) string
       write(50,402) trim(cm1version)
       write(50,403) grads_undef
-      write(50,404) int(nparcelsInit, i8)
+      write(50,404) nparcelsInit
       write(50,405)
       write(50,406)
       write(50,407) prec

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1744,7 +1744,7 @@
       subroutine parcel_write(prec,rtime,qname,name_prcl,desc_prcl,unit_prcl,pdata,ploc)
       use input, only : maxq,maxvars,nparcelsLocal,npvals,output_format, &
                         myid,dowr,maxstring,string,outfile,numprocs,ierr, &
-                        nparcelsLocalActive
+                        nparcelsLocalActive,nparcelsInit
 #ifdef MPI
       use mpi
       use comm_droplet_module, only : CollectDropCount, CollectDropInfo
@@ -1752,7 +1752,8 @@
 #ifdef NETCDF
       use writeout_nc_module, only : writepdata_nc
 #endif
-      use constants, only : i8
+      use constants, only : i8, write_frac_droplet
+
       implicit none
 
       integer, intent(inout) :: prec
@@ -1768,7 +1769,10 @@
 #ifdef MPI
       integer :: nparcels_per_mpi(numprocs)
       integer(i8) :: nparcelstot
-      real, dimension(:,:),allocatable :: rbuf
+      integer :: nparcelsout     ! this number must be able to be represented
+                                 ! by an integer type to reduce memory
+                                 ! pressure on I/O
+      real, dimension(:,:), allocatable :: rbuf
 #endif
 
 !----------------------------------------------------------------------
@@ -1781,8 +1785,11 @@
     call CollectDropCount ( nparcels_per_mpi, nparcelstot )
 
     ! Collect information of active droplets from each MPI rank
-    if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvals))
-    call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
+    if ( myid .eq. 0 ) then
+       nparcelsout = int(min(real(nparcelstot), write_frac_droplet*nparcelsInit))
+       allocate(rbuf(nparcelsout,npvals))
+    end if
+    call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelsout )
 #endif
 
     IF(myid.eq.0)THEN
@@ -1809,9 +1816,9 @@
         if(dowr) write(outfile,*) '  pdata prec = ',prec
         if(dowr) write(outfile,*) '  writing for total number of parcels:',nparcelstot
 
-        write(61) nparcelstot
+        write(61) nparcelsout 
 #ifdef MPI
-        write(61) rbuf(1:nparcelstot,1:npvals)
+        write(61) rbuf(1:nparcelsout,1:npvals)
 #else
         write(61) pdata(1:nparcelsLocalActive,1:npvals)
 #endif

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1752,7 +1752,7 @@
 #ifdef NETCDF
       use writeout_nc_module, only : writepdata_nc
 #endif
-      use constants, only : i8, write_frac_droplet
+      use constants, only : write_frac_droplet
 
       implicit none
 
@@ -1768,7 +1768,7 @@
 
 #ifdef MPI
       integer :: nparcels_per_mpi(numprocs)
-      integer(i8) :: nparcelstot
+      real    :: nparcelstot
       integer :: nparcelsout     ! this number must be able to be represented
                                  ! by an integer type to reduce memory
                                  ! pressure on I/O
@@ -1786,8 +1786,7 @@
 
     ! Collect information of active droplets from each MPI rank
     if ( myid .eq. 0 ) then
-       nparcelsout = int( max( 1.0, min( real(nparcelstot), &
-                                    write_frac_droplet*nparcelsInit ) ) )
+       nparcelsout = int( max( 1.0, write_frac_droplet*nparcelstot ) )
        allocate(rbuf(nparcelsout,npvals))
     end if
     call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelsout )
@@ -1827,7 +1826,7 @@
         close(unit=61)
 
 #ifdef MPI     
-        if (myid .eq. 0) deallocate(rbuf)
+        deallocate(rbuf)
 #endif
 
 #ifdef NETCDF

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1747,7 +1747,7 @@
                         nparcelsLocalActive
 #ifdef MPI
       use mpi
-      use comm_droplet :: CollectDropCount, CollectDropInfo
+      use comm_droplet, only : CollectDropCount, CollectDropInfo
 #endif
 #ifdef NETCDF
       use writeout_nc_module, only : writepdata_nc

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -2346,7 +2346,7 @@
       subroutine write_prclctl(name_prcl,desc_prcl,unit_prcl,prec)
       use input, only : maxvars,myid,string,maxstring,dowr,cm1version, &
           nparcelsInit,prcl_out,outfile
-      use constants , only : grads_undef
+      use constants , only : grads_undef, i8
       implicit none
 
       character(len=40), intent(in), dimension(maxvars) :: name_prcl,desc_prcl,unit_prcl
@@ -2375,7 +2375,7 @@
       write(50,401) string
       write(50,402) trim(cm1version)
       write(50,403) grads_undef
-      write(50,404) nparcelsInit
+      write(50,404) int(nparcelsInit, i8)
       write(50,405)
       write(50,406)
       write(50,407) prec
@@ -2403,7 +2403,7 @@
 401   format('dset ^',a)
 402   format('title CM1 parcel data output, using version ',a,'; time is generic, see variable mtime for actual times')
 403   format('undef ',f10.1)
-404   format('xdef ',i10,' linear 1 1')
+404   format('xdef ',i15,' linear 1 1')
 405   format('ydef          1 linear 0 1')
 406   format('zdef          1 linear 0 1')
 407   format('tdef ',i10,' linear 00:00Z01JAN0001 1YR')

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1752,7 +1752,7 @@
 #ifdef NETCDF
       use writeout_nc_module, only : writepdata_nc
 #endif
-      use constants, only : write_frac_droplet
+      use constants, only : write_frac_droplet, i8
 
       implicit none
 
@@ -1768,7 +1768,7 @@
 
 #ifdef MPI
       integer :: nparcels_per_mpi(numprocs)
-      real    :: nparcelstot
+      integer(i8) :: nparcelstot
       integer :: nparcelsout     ! this number must be able to be represented
                                  ! by an integer type to reduce memory
                                  ! pressure on I/O
@@ -1783,10 +1783,12 @@
 #ifdef MPI
     ! Collect number of active droplets from each MPI rank
     call CollectDropCount ( nparcels_per_mpi, nparcelstot )
+    if (myid == 0) print *, "JS: nparcels_per_mpi = ", nparcels_per_mpi, ", nparcelstot = ",nparcelstot
 
     ! Collect information of active droplets from each MPI rank
     if ( myid .eq. 0 ) then
        nparcelsout = int( max( 1.0, write_frac_droplet*nparcelstot ) )
+       if (myid == 0) print *, "JS: nparcelsout = ", nparcelsout 
        allocate(rbuf(nparcelsout,npvals))
     end if
     call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelsout )

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1747,7 +1747,7 @@
                         nparcelsLocalActive
 #ifdef MPI
       use mpi
-      use comm_droplet, only : CollectDropCount, CollectDropInfo
+      use comm_droplet_module, only : CollectDropCount, CollectDropInfo
 #endif
 #ifdef NETCDF
       use writeout_nc_module, only : writepdata_nc

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1763,8 +1763,7 @@
       real, intent(in), dimension(nparcelsLocal,npvals) :: pdata
       real, intent(inout), dimension(:,:) :: ploc
 
-      integer :: i,n,np
-      integer(i8) :: nparcelstot
+      integer :: i
 
 #ifdef MPI
       integer :: nparcels_per_mpi(numprocs)

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1786,7 +1786,8 @@
 
     ! Collect information of active droplets from each MPI rank
     if ( myid .eq. 0 ) then
-       nparcelsout = int(min(real(nparcelstot), write_frac_droplet*nparcelsInit))
+       nparcelsout = int( max( 1.0, min( real(nparcelstot), &
+                                    write_frac_droplet*nparcelsInit ) ) )
        allocate(rbuf(nparcelsout,npvals))
     end if
     call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelsout )

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1747,6 +1747,7 @@
                         nparcelsLocalActive
 #ifdef MPI
       use mpi
+      use comm_droplet :: CollectDropCount, CollectDropInfo
 #endif
 #ifdef NETCDF
       use writeout_nc_module, only : writepdata_nc
@@ -1781,7 +1782,7 @@
     call CollectDropCount ( nparcels_per_mpi, nparcelstot )
 
     ! Collect information of active droplets from each MPI rank
-    if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvars))
+    if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvals))
     call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
 #endif
 

--- a/src/parcel.F
+++ b/src/parcel.F
@@ -1751,6 +1751,7 @@
 #ifdef NETCDF
       use writeout_nc_module, only : writepdata_nc
 #endif
+      use constants, only : i8
       implicit none
 
       integer, intent(inout) :: prec
@@ -1761,13 +1762,13 @@
       real, intent(in), dimension(nparcelsLocal,npvals) :: pdata
       real, intent(inout), dimension(:,:) :: ploc
 
-      integer :: i,n,np,nparcelstot
+      integer :: i,n,np
+      integer(i8) :: nparcelstot
 
 #ifdef MPI
-      real, dimension(:),allocatable :: sbuf
+      integer :: nparcels_per_mpi(numprocs)
+      integer(i8) :: nparcelstot
       real, dimension(:,:),allocatable :: rbuf
-      integer, dimension(0:numprocs-1) :: displacements, counts, cnts
-      integer :: ierror
 #endif
 
 !----------------------------------------------------------------------
@@ -1775,45 +1776,13 @@
 
     !$acc update host(pdata)
 
-    ! JS: use MPI_GATHERV to collect all the droplet information
-    !     from different MPI ranks;
-    !     also collect the number of active droplets from each MPI rank
-
 #ifdef MPI
-    ! local buffer for sending array on each MPI rank
-    allocate(sbuf(0:nparcelsLocalActive-1))
-    if ( myid .eq. 0 ) then
-       ! initialize the displacement and count for the mpi_gatherv call
-       do i = 0, numprocs-1
-          displacements(i) = i
-          counts(i) = 1 
-       end do
-    end if
-    ! collect number of active droplets from each MPI rank
-    call mpi_gatherv(nparcelsLocalActive,1,MPI_INTEGER,cnts,counts, &
-                     displacements,MPI_INTEGER,0,mpi_comm_world,ierror)
-    if ( myid .eq. 0 ) then
-       ! update the displacement and count for the second mpi_gatherv call
-       do i = 0, numprocs-1
-          if ( i == 0 ) then
-             displacements(i) = 0
-          else
-             displacements(i) = sum(cnts(0:i-1))
-          end if
-          counts(i) = cnts(i)
-       end do
-       ! local buffer for receiving array on root rank
-       nparcelstot = sum(counts)
-       allocate(rbuf(0:nparcelstot-1,0:npvals-1))
-    end if
-    ! collect the information of active droplets from each MPI rank
-    do i = 0, npvals-1
-       do np = 0, nparcelsLocalActive-1
-          sbuf(np) = pdata(np+1,i+1)
-       end do
-       call mpi_gatherv(sbuf,nparcelsLocalActive,MPI_REAL,rbuf(:,i),counts, &
-                        displacements,MPI_REAL,0,mpi_comm_world,ierror)
-    end do
+    ! Collect number of active droplets from each MPI rank
+    call CollectDropCount ( nparcels_per_mpi, nparcelstot )
+
+    ! Collect information of active droplets from each MPI rank
+    if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvars))
+    call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
 #endif
 
     IF(myid.eq.0)THEN
@@ -1833,10 +1802,7 @@
         string = 'cm1out_pdata_'//prec_string//'.dat'
         if (dowr) write(*,*) 'DHR3:',string
 
-!!!        write(string(15:20),101) prec
-!!!101     format(i6.6)
-
-        if(dowr) write(outfile,*) string
+        if (dowr) write(outfile,*) string
         open(unit=61,file=string,form='unformatted',status='unknown')
 
         if(dowr) write(outfile,*)
@@ -1845,7 +1811,7 @@
 
         write(61) nparcelstot
 #ifdef MPI
-        write(61) rbuf(0:nparcelstot-1,0:npvals-1)
+        write(61) rbuf(1:nparcelstot,1:npvals)
 #else
         write(61) pdata(1:nparcelsLocalActive,1:npvals)
 #endif
@@ -1853,7 +1819,7 @@
         close(unit=61)
 
 #ifdef MPI     
-        deallocate(rbuf)
+        if (myid .eq. 0) deallocate(rbuf)
 #endif
 
 #ifdef NETCDF

--- a/src/restart.F
+++ b/src/restart.F
@@ -1683,6 +1683,9 @@
         !$acc update host(pdata) if_present
 
 #ifdef MPI
+        ! JS: this interface is broken if "nparcelstot" is too large
+        !     (e.g., 2 billions), due to the memory limitation
+
         ! Collect number of active droplets from each MPI rank
         call CollectDropCount ( nparcels_per_mpi, nparcelstot )
 

--- a/src/restart.F
+++ b/src/restart.F
@@ -49,7 +49,7 @@
       use lsnudge_module
 #ifdef MPI
       use mpi
-      use comm_droplet :: CollectDropCount, CollectDropInfo
+      use comm_droplet, only : CollectDropCount, CollectDropInfo
 #endif
 #ifdef NETCDF
       use netcdf

--- a/src/restart.F
+++ b/src/restart.F
@@ -49,6 +49,7 @@
       use lsnudge_module
 #ifdef MPI
       use mpi
+      use comm_droplet :: CollectDropCount, CollectDropInfo
 #endif
 #ifdef NETCDF
       use netcdf
@@ -1686,7 +1687,7 @@
         call CollectDropCount ( nparcels_per_mpi, nparcelstot )
 
         ! Collect information of active droplets from each MPI rank
-        if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvars))
+        if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvals))
         call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
 #else
         nparcelsRest = int(nparcelsLocalActive, i8)
@@ -1709,7 +1710,7 @@
         if(myid.eq.0)then
           if( restart_format.eq.1 )then
 #ifdef MPI
-            write(50) rbuf
+            write(50) rbuf(1:nparcelstot,1:npvars)
             deallocate(rbuf)            
 #else
             write(50) pdata(1:nparcelsLocalActive,1:npvars)

--- a/src/restart.F
+++ b/src/restart.F
@@ -2249,7 +2249,7 @@
       real, dimension(:,:), allocatable :: rbuf, tmp_buf
 #ifdef MPI
       integer :: proc,index,count,req1,req2,req3,reqp,tag
-      integer(i8) :: beg_loc,end_loc,np_i8
+      integer :: beg_loc,end_loc
       integer :: nparcels_per_mpi(numprocs)       ! number of active droplets per MPI rank
                                                   ! that is read in from the restart file
       real :: nparcelsRest_tmp                    ! "real" type of nparcelsRest to
@@ -3685,16 +3685,16 @@
       endif
 
       call bcast_real(nparcelsRest_tmp)
-      nparcelsRest = int(nparcelsRest_tmp, i8)
+      nvar = int(nparcelsRest_tmp)
 
-      if ( iprcl.eq.1 .or. nparcelsRest.gt.0 ) then
-         if ( nparcelsRest.gt.0 ) then
+      if ( iprcl.eq.1 .or. nvar.gt.0 ) then
+         if ( nvar.gt.0 ) then
             ! only read position info:
             if ( myid.eq.0 ) then
                ! reset "pdata" that is initialized by the init3d subroutine
                pdata(:,:) = neg_huge
                if ( restart_format.eq.1 ) then
-                  allocate( rbuf(nparcelsRest,npvars) )
+                  allocate( rbuf(nvar,npvars) )
                   read(50) rbuf 
 #ifdef NETCDF
                else if ( restart_format.eq.2 ) then
@@ -3710,12 +3710,12 @@
                if ( myid .eq. 0 ) then
                   do i = 1, numprocs - 1
                      allocate( tmp_buf(nparcels_per_mpi(i+1),npvars) )
-                     beg_loc = int(sum(real(nparcels_per_mpi(1:i))) + 1, i8)
-                     end_loc = int(real(beg_loc) + real(nparcels_per_mpi(i+1)) - 1, i8)
+                     beg_loc = sum(nparcels_per_mpi(1:i)) + 1
+                     end_loc = beg_loc + nparcels_per_mpi(i+1) - 1
                      do j = 1, npvars
-                        do np_i8 = beg_loc, end_loc
-                           np = int(real(np_i8) - real(beg_loc) + 1)
-                           tmp_buf(np,j) = rbuf(np_i8,j)
+                        do n = beg_loc, end_loc
+                           np = n - beg_loc + 1
+                           tmp_buf(np,j) = rbuf(n,j)
                         end do
                      end do
                      tag = 98765 + i

--- a/src/restart.F
+++ b/src/restart.F
@@ -148,8 +148,7 @@
       double precision, dimension(nbudget) :: cfoo
       double precision, dimension(numq) :: afoo,bfoo
       integer :: nparcels_per_mpi(numprocs)
-      integer(i8) :: nparcelstot
-      integer :: nparcelstot_tmp
+      integer :: nparcelstot
       real, dimension(:,:), allocatable :: rbuf
 #endif
 #ifdef NETCDF
@@ -1688,12 +1687,12 @@
         !     (e.g., 2 billions), due to the memory limitation
 
         ! Collect number of active droplets from each MPI rank
-        call CollectDropCount ( nparcels_per_mpi, nparcelstot )
+        call CollectDropCount ( nparcels_per_mpi, nparcelsRest )
 
         ! Collect information of active droplets from each MPI rank
-        nparcelstot_tmp = int(nparcelstot)
-        if ( myid .eq. 0 ) allocate(rbuf(nparcelstot_tmp,npvals))
-        call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot_tmp )
+        nparcelstot = int(nparcelsRest)
+        if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvals))
+        call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
 #else
         nparcelsRest = int(nparcelsLocalActive, i8)
 #endif

--- a/src/restart.F
+++ b/src/restart.F
@@ -1694,11 +1694,11 @@
         if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvals))
         call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
 #else
-        nparcelsRest = int(nparcelsLocalActive, i8)
+        nparcelsRest = real(nparcelsLocalActive)
 #endif
         if(myid.eq.0)then
           if( restart_format.eq.1 )then
-            write(50) real(nparcelsRest)
+            write(50) nparcelsRest
             ! write out the number of active droplets per MPI rank
             do i = 1, numprocs
                write(50) nparcels_per_mpi(i)
@@ -2252,10 +2252,6 @@
       integer :: beg_loc,end_loc
       integer :: nparcels_per_mpi(numprocs)       ! number of active droplets per MPI rank
                                                   ! that is read in from the restart file
-      real :: nparcelsRest_tmp                    ! "real" type of nparcelsRest to
-                                                  ! account for > 2 billions droplets
-                                                  ! that can not be sent through MPI using
-                                                  ! integer type
 #endif
 #ifdef NETCDF
       integer :: varid,ncstatus
@@ -3668,8 +3664,8 @@
 
       if( myid.eq.0 )then
         if( restart_format.eq.1 )then
-          read(50) nparcelsRest_tmp
-          nparcelsRest = int(nparcelsRest_tmp, i8)
+          read(50) nparcelsRest
+          nvar = int(nparcelsRest)
           ! Read in the number of active droplets for each MPI rank
           do i = 1, numprocs
              read(50) nparcels_per_mpi(i)
@@ -3678,15 +3674,16 @@
         elseif( restart_format.eq.2 )then
           call disp_err( nf90_inq_varid(ncid,"numparcels",varid) , .true. )
           call disp_err( nf90_get_var(ncid,varid,nparcelsRest,(/time_index/)) , .true. )
-          if( iprcl.eq.0 ) nparcelsRest = 0
+          if( iprcl.eq.0 ) nparcelsRest = 0.0
 #endif
         endif
         print *,'  nparcelsRest = ',nparcelsRest
       endif
 
-      call bcast_real(nparcelsRest_tmp)
-      nvar = int(nparcelsRest_tmp)
+      call bcast_real(nparcelsRest)
+      nvar = int(nparcelsRest)
 
+      ! JS: the code section below does not work for > 2 billions droplets
       if ( iprcl.eq.1 .or. nvar.gt.0 ) then
          if ( nvar.gt.0 ) then
             ! only read position info:

--- a/src/restart.F
+++ b/src/restart.F
@@ -49,7 +49,7 @@
       use lsnudge_module
 #ifdef MPI
       use mpi
-      use comm_droplet, only : CollectDropCount, CollectDropInfo
+      use comm_droplet_module, only : CollectDropCount, CollectDropInfo
 #endif
 #ifdef NETCDF
       use netcdf

--- a/src/restart.F
+++ b/src/restart.F
@@ -149,6 +149,7 @@
       double precision, dimension(numq) :: afoo,bfoo
       integer :: nparcels_per_mpi(numprocs)
       integer(i8) :: nparcelstot
+      integer :: nparcelstot_tmp
       real, dimension(:,:), allocatable :: rbuf
 #endif
 #ifdef NETCDF
@@ -1690,8 +1691,9 @@
         call CollectDropCount ( nparcels_per_mpi, nparcelstot )
 
         ! Collect information of active droplets from each MPI rank
-        if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvals))
-        call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
+        nparcelstot_tmp = int(nparcelstot)
+        if ( myid .eq. 0 ) allocate(rbuf(nparcelstot_tmp,npvals))
+        call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot_tmp )
 #else
         nparcelsRest = int(nparcelsLocalActive, i8)
 #endif

--- a/src/restart.F
+++ b/src/restart.F
@@ -1694,7 +1694,7 @@
         if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvals))
         call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
 #else
-        nparcelsRest = real(nparcelsLocalActive)
+        nparcelsRest = int(nparcelsLocalActive, i8)
 #endif
         if(myid.eq.0)then
           if( restart_format.eq.1 )then
@@ -2252,6 +2252,7 @@
       integer :: beg_loc,end_loc
       integer :: nparcels_per_mpi(numprocs)       ! number of active droplets per MPI rank
                                                   ! that is read in from the restart file
+      real :: tmp
 #endif
 #ifdef NETCDF
       integer :: varid,ncstatus
@@ -3665,7 +3666,7 @@
       if( myid.eq.0 )then
         if( restart_format.eq.1 )then
           read(50) nparcelsRest
-          nvar = int(nparcelsRest)
+          tmp = real(nparcelsRest)
           ! Read in the number of active droplets for each MPI rank
           do i = 1, numprocs
              read(50) nparcels_per_mpi(i)
@@ -3680,8 +3681,8 @@
         print *,'  nparcelsRest = ',nparcelsRest
       endif
 
-      call bcast_real(nparcelsRest)
-      nvar = int(nparcelsRest)
+      call bcast_real(tmp)
+      nvar = int(tmp)
 
       ! JS: the code section below does not work for > 2 billions droplets
       if ( iprcl.eq.1 .or. nvar.gt.0 ) then

--- a/src/restart.F
+++ b/src/restart.F
@@ -1723,7 +1723,9 @@
           elseif( restart_format.eq.2 )then
             call disp_err( nf90_inq_varid(ncid,"ploc",varid) , .true. )
             n = 3
-            call disp_err( nf90_put_var(ncid,varid,ploc,(/1,1,time_index/),(/nparcelsLocal,n,1/)) , .true. )
+            call disp_err( nf90_put_var(ncid,varid,ploc, &
+                           (/1,1,time_index/), &
+                           (/int(nparcelsLocal),n,1/)) , .true. )
 #endif
           endif
         endif
@@ -3696,7 +3698,9 @@
                else if ( restart_format.eq.2 ) then
                   call disp_err( nf90_inq_varid(ncid,"ploc",varid) , .true. )
                   n = 3
-                  call disp_err( nf90_get_var(ncid,varid,ploc,(/1,1,time_index/),(/nparcelsLocal,n,1/)) , .true. )
+                  call disp_err( nf90_get_var(ncid,varid,ploc, &
+                                 (/1,1,time_index/), &
+                                 (/int(nparcelsLocal),n,1/)) , .true. )
 #endif
                end if
             end if

--- a/src/restart.F
+++ b/src/restart.F
@@ -146,10 +146,9 @@
       integer :: proc,index,count,req1,req2,req3,reqp
       double precision, dimension(nbudget) :: cfoo
       double precision, dimension(numq) :: afoo,bfoo
-      real, dimension(:), allocatable :: sbuf
+      integer :: nparcels_per_mpi(numprocs)
+      integer(i8) :: nparcelstot
       real, dimension(:,:), allocatable :: rbuf
-      integer, dimension(0:numprocs-1) :: displacements, counts, cnts
-      integer :: ierror
 #endif
 #ifdef NETCDF
       integer :: varid,ncstatus
@@ -1683,52 +1682,21 @@
         !$acc update host(pdata) if_present
 
 #ifdef MPI
-        ! Collect the droplet information before writing out to a file
+        ! Collect number of active droplets from each MPI rank
+        call CollectDropCount ( nparcels_per_mpi, nparcelstot )
 
-        ! local buffer for sending array on each MPI rank
-        allocate( sbuf(0:nparcelsLocalActive-1) )
-        if ( myid .eq. 0 ) then
-           ! initialize the displacement and count for the mpi_gatherv call
-           do i = 0, numprocs-1
-              displacements(i) = i
-              counts(i) = 1
-           end do
-        end if
-        ! collect number of active droplets from each MPI rank
-        call mpi_gatherv(nparcelsLocalActive,1,MPI_INTEGER,cnts,counts, &
-                         displacements,MPI_INTEGER,0,mpi_comm_world,ierror)
-        if ( myid .eq. 0 ) then
-           ! update the displacement and count for the second mpi_gatherv call
-           do i = 0, numprocs-1
-              if ( i == 0 ) then
-                 displacements(i) = 0
-              else
-                 displacements(i) = sum(cnts(0:i-1))
-              end if
-              counts(i) = cnts(i)
-           end do
-           ! update "nparcelsRest" as the current total number of active droplets
-           nparcelsRest = sum(counts)
-           allocate(rbuf(0:nparcelsRest-1,0:npvars-1))
-        end if
-        ! collect the information of active droplets from each MPI rank
-        do i = 1, npvars
-           do np = 0, nparcelsLocalActive-1
-              sbuf(np) = pdata(np+1,i)
-           end do
-           call mpi_gatherv(sbuf,nparcelsLocalActive,MPI_REAL,rbuf(0,i-1),counts, &
-                            displacements,MPI_REAL,0,mpi_comm_world,ierror)
-        end do
-        deallocate(sbuf)
+        ! Collect information of active droplets from each MPI rank
+        if ( myid .eq. 0 ) allocate(rbuf(nparcelstot,npvars))
+        call CollectDropInfo ( pdata, rbuf, nparcels_per_mpi, nparcelstot )
 #else
-        nparcelsRest = nparcelsLocalActive
+        nparcelsRest = int(nparcelsLocalActive, i8)
 #endif
         if(myid.eq.0)then
           if( restart_format.eq.1 )then
-            write(50) nparcelsRest
+            write(50) real(nparcelsRest)
             ! write out the number of active droplets per MPI rank
-            do i = 0, numprocs-1
-               write(50) counts(i)
+            do i = 1, numprocs
+               write(50) nparcels_per_mpi(i)
             end do
 #ifdef NETCDF
           elseif( restart_format.eq.2 )then
@@ -1744,7 +1712,7 @@
             write(50) rbuf
             deallocate(rbuf)            
 #else
-            write(50) pdata(1:nparcelsRest,1:npvars)
+            write(50) pdata(1:nparcelsLocalActive,1:npvars)
 #endif
 #ifdef NETCDF
           elseif( restart_format.eq.2 )then
@@ -2276,9 +2244,13 @@
       real, dimension(:,:), allocatable :: rbuf, tmp_buf
 #ifdef MPI
       integer :: proc,index,count,req1,req2,req3,reqp,tag
-      integer :: beg_loc, end_loc
-      integer :: nparcels_per_mpi(numprocs)   ! number of active droplets per MPI rank
-                                              ! that is read in from the restart file
+      integer(i8) :: beg_loc,end_loc,np_i8
+      integer :: nparcels_per_mpi(numprocs)       ! number of active droplets per MPI rank
+                                                  ! that is read in from the restart file
+      real :: nparcelsRest_tmp                    ! "real" type of nparcelsRest to
+                                                  ! account for > 2 billions droplets
+                                                  ! that can not be sent through MPI using
+                                                  ! integer type
 #endif
 #ifdef NETCDF
       integer :: varid,ncstatus
@@ -3691,7 +3663,8 @@
 
       if( myid.eq.0 )then
         if( restart_format.eq.1 )then
-          read(50) nvar
+          read(50) nparcelsRest_tmp
+          nparcelsRest = int(nparcelsRest_tmp, i8)
           ! Read in the number of active droplets for each MPI rank
           do i = 1, numprocs
              read(50) nparcels_per_mpi(i)
@@ -3699,23 +3672,24 @@
 #ifdef NETCDF
         elseif( restart_format.eq.2 )then
           call disp_err( nf90_inq_varid(ncid,"numparcels",varid) , .true. )
-          call disp_err( nf90_get_var(ncid,varid,nvar,(/time_index/)) , .true. )
-          if( iprcl.eq.0 ) nvar = 0
+          call disp_err( nf90_get_var(ncid,varid,nparcelsRest,(/time_index/)) , .true. )
+          if( iprcl.eq.0 ) nparcelsRest = 0
 #endif
         endif
-        print *,'  nvar_parcels = ',nvar
+        print *,'  nparcelsRest = ',nparcelsRest
       endif
 
-      call bcast_int(nvar)
+      call bcast_real(nparcelsRest_tmp)
+      nparcelsRest = int(nparcelsRest_tmp, i8)
 
-      if ( iprcl.eq.1 .or. nvar.gt.0 ) then
-         if ( nvar.gt.0 ) then
+      if ( iprcl.eq.1 .or. nparcelsRest.gt.0 ) then
+         if ( nparcelsRest.gt.0 ) then
             ! only read position info:
             if ( myid.eq.0 ) then
                ! reset "pdata" that is initialized by the init3d subroutine
                pdata(:,:) = neg_huge
                if ( restart_format.eq.1 ) then
-                  allocate( rbuf(nvar,npvars) )
+                  allocate( rbuf(nparcelsRest,npvars) )
                   read(50) rbuf 
 #ifdef NETCDF
                else if ( restart_format.eq.2 ) then
@@ -3731,9 +3705,14 @@
                if ( myid .eq. 0 ) then
                   do i = 1, numprocs - 1
                      allocate( tmp_buf(nparcels_per_mpi(i+1),npvars) )
-                     beg_loc = sum(nparcels_per_mpi(1:i))+1
-                     end_loc = beg_loc+nparcels_per_mpi(i+1)-1
-                     tmp_buf(:,:) = rbuf(beg_loc:end_loc,:)
+                     beg_loc = int(sum(real(nparcels_per_mpi(1:i))) + 1, i8)
+                     end_loc = int(real(beg_loc) + real(nparcels_per_mpi(i+1)) - 1, i8)
+                     do j = 1, npvars
+                        do np_i8 = beg_loc, end_loc
+                           np = int(real(np_i8) - real(beg_loc) + 1)
+                           tmp_buf(np,j) = rbuf(np_i8,j)
+                        end do
+                     end do
                      tag = 98765 + i
                      call mpi_send(tmp_buf,nparcels_per_mpi(i+1)*npvars, &
                                    MPI_REAL,i,tag,MPI_COMM_WORLD,ierr)
@@ -3747,22 +3726,22 @@
                                 MPI_STATUS_IGNORE,ierr)
                end if
 #endif
+               nparcelsLocalActive = nparcels_per_mpi(myid+1) 
                if ( myid .eq. 0 ) then
-                  do np = 1, nparcels_per_mpi(myid+1)
+                  do np = 1, nparcelsLocalActive 
                      do i = 1, npvars
                         pdata(np,i) = rbuf(np,i)
                      end do
                   end do
                   deallocate( rbuf )
                else
-                  do np = 1, nparcels_per_mpi(myid+1)
+                  do np = 1, nparcelsLocalActive
                      do i = 1, npvars
                         pdata(np,i) = tmp_buf(np,i)
                      end do
                   end do
                   deallocate( tmp_buf )
                end if
-               nparcelsLocalActive = nparcels_per_mpi(myid+1) 
                restart_prcl = .true.
             end if   ! if iprcl.eq.1
          else

--- a/src/restart.F
+++ b/src/restart.F
@@ -2252,7 +2252,6 @@
       integer :: beg_loc,end_loc
       integer :: nparcels_per_mpi(numprocs)       ! number of active droplets per MPI rank
                                                   ! that is read in from the restart file
-      real :: tmp
 #endif
 #ifdef NETCDF
       integer :: varid,ncstatus
@@ -3666,7 +3665,6 @@
       if( myid.eq.0 )then
         if( restart_format.eq.1 )then
           read(50) nparcelsRest
-          tmp = real(nparcelsRest)
           ! Read in the number of active droplets for each MPI rank
           do i = 1, numprocs
              read(50) nparcels_per_mpi(i)
@@ -3675,14 +3673,14 @@
         elseif( restart_format.eq.2 )then
           call disp_err( nf90_inq_varid(ncid,"numparcels",varid) , .true. )
           call disp_err( nf90_get_var(ncid,varid,nparcelsRest,(/time_index/)) , .true. )
-          if( iprcl.eq.0 ) nparcelsRest = 0.0
+          if( iprcl.eq.0 ) nparcelsRest = 0
 #endif
         endif
         print *,'  nparcelsRest = ',nparcelsRest
       endif
 
-      call bcast_real(tmp)
-      nvar = int(tmp)
+      call bcast_int(nparcelsRest)
+      nvar = int(nparcelsRest)
 
       ! JS: the code section below does not work for > 2 billions droplets
       if ( iprcl.eq.1 .or. nvar.gt.0 ) then
@@ -3706,9 +3704,10 @@
 #ifdef MPI
                call mpi_bcast(nparcels_per_mpi,numprocs,MPI_INTEGER,0,MPI_COMM_WORLD,ierr)
                if ( myid .eq. 0 ) then
+                  beg_loc = 1
                   do i = 1, numprocs - 1
                      allocate( tmp_buf(nparcels_per_mpi(i+1),npvars) )
-                     beg_loc = sum(nparcels_per_mpi(1:i)) + 1
+                     beg_loc = beg_loc + nparcels_per_mpi(i)
                      end_loc = beg_loc + nparcels_per_mpi(i+1) - 1
                      do j = 1, npvars
                         do n = beg_loc, end_loc

--- a/src/writeout_nc.F
+++ b/src/writeout_nc.F
@@ -1732,7 +1732,7 @@
       call disp_err( nf90_create(path=string,cmode=0,ncid=ncid) , .true. )
 #endif
 
-    call disp_err( nf90_def_dim(ncid,"xh",nparcelsLocal,npid) , .true. )
+    call disp_err( nf90_def_dim(ncid,"xh",int(nparcelsLocal),npid) , .true. )
     call disp_err( nf90_def_dim(ncid,"yh",1,yhid) , .true. )
     call disp_err( nf90_def_dim(ncid,"zh",1,zhid) , .true. )
     call disp_err( nf90_def_dim(ncid,"time",nf90_unlimited,timeid) , .true. )
@@ -1804,7 +1804,8 @@
         do np=1,nparcelsLocal
           pdata2(np) = pdata(np,n)
         enddo
-        call disp_err( nf90_put_var(ncid,varid,pdata2,(/1,time_index/),(/nparcelsLocal,1/)) , .true. )
+        call disp_err( nf90_put_var(ncid,varid,pdata2,(/1,time_index/), &
+                                     (/int(nparcelsLocal),1/)) , .true. )
       ENDDO
 
       ! close file


### PR DESCRIPTION
This PR allows CM1 to simulate number of droplets that can not be represented by the default integer type. The code now worked for 3 billions droplets.

I declared many droplet count variables as `integer(i8)` type when it was necessary. As a result, the `nparcelsInit` and `nparcelsMax` namelist variables need to be expanded explicitly.

The current I/O implementation did not work for 3 billions droplets as it would exceed the memory limitation on Derecho. As a temporary solution, we only wrote out a fraction of total droplets to the binary file.

The verification results are similar to the previous PR (Derecho; CPU: ifort, 2 MPI ranks; GPU: nvhpc, 2 MPI ranks + 2 A100 GPUs):

# Metrics
41 stat variables are identical.
42 stat variables show a mean relative difference > 1e-06
3 stat variables show a mean relative difference <= 1e-06

# 0th-order diagnostics
4 stat variables are identical.
7 stat variables show a mean relative difference > 1e-06
1 stat variables show a mean relative difference <= 1e-06

# 1st-order diagnostics
254 stat variables are identical.
2 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06

---

Fix #126 