### PR TITLE
Improve the droplet ownership check

### DIFF
--- a/src/droplet.F
+++ b/src/droplet.F
@@ -3888,8 +3888,7 @@
       !$acc routine seq
 
       use input, only : ni,nj,ib,ie,jb,je,ngxy,nx,ny,dx,dy,mywest, &
-                        mysw,mynw,myeast,myse,myne,mysouth,mynorth, &
-                        maxx,maxy
+                        mysw,mynw,myeast,myse,myne,mysouth,mynorth
       use constants, only : undefined_index
 
       implicit none
@@ -3910,25 +3909,6 @@
            y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
          is_local = .true.
       end if
-!      ! special case: a droplet falls on the eastmost
-!      !               boundary of the whole domain
-!      if ( x3d .eq. maxx .and. xf(ni+1) .eq. maxx .and. &
-!           y3d .ge. yf(1) .and. y3d .lt. yf(nj+1) ) then
-!         is_local = .true.
-!      end if
-!      ! special case: a droplet falls on the northmost
-!      !               boundary of the whole domain
-!      if ( y3d .eq. maxy .and. yf(nj+1) .eq. maxy .and. &
-!           x3d .ge. xf(1) .and. x3d .lt. xf(ni+1) ) then
-!         is_local = .true.
-!      end if
-!      ! special case: a droplet falls on the upperright
-!      !               corner of the whole domain
-!      if ( x3d .eq. maxx .and. y3d .eq. maxy .and. &
-!           xf(ni+1) .eq. maxx .and. &
-!           yf(nj+1) .eq. maxy ) then
-!         is_local = .true.
-!      end if
 
       ! check optional input
       if ( present(neighbor) ) then

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -10,9 +10,8 @@
   implicit none
 
   private
-  public :: droplet_driver,droplet_diag,initialize_droplet_histograms
-
-
+  public :: droplet_driver,droplet_diag,initialize_droplet_histograms, &
+            check_droplet_ownership
 
   !These are quantities which are needed in the droplet_diag output, so must be public
   real :: num100,num1000
@@ -3918,6 +3917,157 @@
 
 
 #endif
+
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+!ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+
+      subroutine check_droplet_ownership(x3d,y3d,xf,xfref,yf,yfref, &
+                                         is_local,neighbor,errcode)
+
+      ! This subroutine will check if a droplet falls into this MPI region or not
+      !     Exception case:
+      !       - if droplet is on a tile boundary, let the eastmost/northmost tile own it
+      !       - if droplet is on the northmost or eastmost boundary of the whole domain,
+      !         let the MPI rank which inclues that boundary owns it
+      !
+      ! Optionally, this subroutine will also calculate which neighbor
+      ! a droplet will move to.
+
+      !$acc routine seq
+
+      use input, only : ni,nj,ib,ie,jb,je,ngxy,nx,ny,dx,dy,mywest, &
+                        mysw,mynw,myeast,myse,myne,mysouth,mynorth
+      use constants, only : undefined_index
+
+      implicit none
+
+      real, intent(in) :: x3d, y3d
+      real, dimension(ib:ie+1), intent(in) :: xf
+      real, dimension(jb:je+1), intent(in) :: yf
+      real, dimension(1-ngxy:nx+ngxy+1), intent(in) :: xfref
+      real, dimension(1-ngxy:ny+ngxy+1), intent(in) :: yfref
+      logical, intent(out) :: is_local
+      integer, intent(out), optional :: neighbor, errcode
+
+      ! Local variable
+
+      is_local = .false.
+
+      ! normal case: a droplet falls within the domain or
+      !              on the westmost/southmost boundary
+      if ( x3d .ge. xf(1) .and. x3d .lt. xf(ni+1) .and. &
+           y3d .ge. yf(1) .and. y3d .lt. yf(nj+1) ) then
+         is_local = .true.
+      end if
+      ! special case: a droplet falls on the eastmost
+      !               boundary of the whole domain
+      if ( x3d .eq. xfref(nx+1) .and. xf(ni+1) .eq. xfref(nx+1) .and. &
+           y3d .ge. yf(1) .and. y3d .lt. yf(nj+1) ) then
+         is_local = .true.
+      end if
+      ! special case: a droplet falls on the northmost
+      !               boundary of the whole domain
+      if ( y3d .eq. yfref(ny+1) .and. yf(nj+1) .eq. yfref(ny+1) .and. &
+           x3d .ge. xf(1) .and. x3d .lt. xf(ni+1) ) then
+         is_local = .true.
+      end if
+      ! special case: a droplet falls on the upperright
+      !               corner of the whole domain
+      if ( x3d .eq. xfref(nx+1) .and. y3d .eq. yfref(ny+1) .and. &
+           xf(ni+1) .eq. xfref(nx+1) .and. &
+           yf(nj+1) .eq. yfref(ny+1) ) then
+         is_local = .true.
+      end if
+
+      ! check optional input
+      if ( present(neighbor) ) then
+         if ( .not. present(errcode) ) then
+            stop "neighbor is provided but errcode is not provided ..."
+         end if
+      end if
+      if ( present(errcode) ) then
+         if ( .not. present(neighbor) ) then
+            stop "errcode is provided but neighbor is not provided ..."
+         end if
+      end if
+
+      if ( present(neighbor) ) then
+         if ( is_local ) then 
+            neighbor = undefined_index
+            return
+         end if
+         if ( x3d .lt. xf(1) .and. y3d .ge. yf(1) .and. &
+              y3d .lt. yf(nj+1) ) then
+            if ( x3d .lt. xf(1)-dx*ni ) then
+               print *,'BE_integration: Droplet jumped over &
+                        the west nearest neighbor'
+               errcode = 50
+            end if
+            neighbor = mywest
+         else if ( x3d .lt. xf(1) .and. y3d .lt. yf(1) ) then
+            if ( x3d .lt. xf(1)-dx*ni .or. y3d .lt. yf(1)-dy*nj ) then
+               print *,'BE_integration: Droplet jumped over &
+                        the southwest nearest neighbor'
+               errcode = 50
+            end if
+            neighbor = mysw
+         else if ( x3d .lt. xf(1) .and. y3d .ge. yf(nj+1) ) then
+            if ( x3d .lt. xf(1)-dx*ni .or. y3d .ge. yf(nj+1)+dy*nj ) then
+               print *,'BE_integration: Droplet jumped over &
+                        the northwest nearest neighbor'
+               errcode = 50
+            end if
+            neighbor = mynw
+         else if ( x3d .ge. xf(ni+1) .and. y3d .ge. yf(1) .and. &
+                   y3d .lt. yf(nj+1) ) then
+            if ( x3d .ge. xf(ni+1)+dx*ni ) then
+               print *,'BE_integration: Droplet jumped over &
+                        the east nearest neighbor'
+               errcode = 50
+            end if
+            neighbor = myeast
+         else if ( x3d .ge. xf(ni+1) .and. y3d .lt. yf(1) ) then
+            if ( x3d .ge. xf(ni+1)+dx*ni .or. y3d .lt. yf(1)-dy*nj ) then
+               print *,'BE_integration: Droplet jumped over &
+                        the southeast nearest neighbor'
+               errcode = 50
+            end if
+            neighbor = myse
+         else if ( x3d .ge. xf(ni+1) .and. y3d .ge. yf(nj+1) ) then
+            if ( x3d .ge. xf(ni+1)+dx*ni .or. y3d .ge. yf(nj+1)+dy*nj ) then
+               print *,'BE_integration: Droplet jumped over &
+                        the northeast nearest neighbor'
+               errcode = 50
+            end if
+            neighbor = myne
+         else if ( x3d .ge. xf(1) .and. x3d .lt. xf(ni+1) .and. &
+                   y3d .lt. yf(1) ) then
+            if ( y3d .lt. yf(1)-dy*nj ) then
+               print *,'BE_integration: Droplet jumped over &
+                        the south nearest neighbor'
+               errcode = 50
+            end if
+            neighbor = mysouth
+         else if ( x3d .ge. xf(1) .and. x3d .lt. xf(ni+1) .and. &
+                   y3d .ge. yf(nj+1) ) then
+            if ( y3d .ge. yf(nj+1)+dy*nj ) then
+               print *,'BE_integration: Droplet jumped over &
+                        the north nearest neighbor'
+               errcode = 50
+            end if
+            neighbor = mynorth
+         else
+            ! This condition should never be entered
+            errcode = 12345
+            if ( x3d .ne. x3d .or. y3d .ne. y3d ) then
+               print *,'BE_integration: x or y position of droplet &
+                        is invalid: x3d = ', x3d, ', y3d = ', y3d
+            end if
+         end if     ! if statement for neighbor check
+      end if        ! if "neighbor" is present
+
+      end subroutine check_droplet_ownership
 
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/src/droplet.F
+++ b/src/droplet.F
@@ -48,21 +48,28 @@
 
   CONTAINS
 
-      subroutine droplet_driver(dt,dbldt,mtime,xh,uh,ruh,xf,yh,vh,rvh,yf,zh,mh,rmh,zf,mf,zs, &
-                               sigma,sigmaf,znt,rho,ua,va,wa,s10,pdata,                   &
-                               th_in,qa,th0,pi0,ppa,prs,ta,                               &
-                               pw1,pw2,pe1,pe2,ps1,ps2,pn1,pn2,                           &
-                               nw1,nw2,ne1,ne2,sw1,sw2,se1,se2,reqs_p,                    &
-                               sw31,sw32,se31,se32,ss31,ss32,sn31,sn32,                   &
-                               n3w1,n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2,reqs_s,            &
-                               dpten,pdata_locind)
-      use input, only : ib,ie,jb,je,kb,ke,ibl,iel,jbl,jel,numq,ni,nj,nk,imp,jmp,kmp,rmp,cmp, &
-          kmt,npvals,npvars,cgs1,cgs2,cgs3,cgt1,cgt2,cgt3,bbc,tbc,imove,zt,rzt, &
-          umove,vmove,nqv,terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
-          prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult,prms,przs,pru,prv,prw,prt,prqv,prprs,prrho,prtime, &
-          timestats,time_droplet,time_droplet_inject,mytime,ierr,maxx,maxy,maxz, &
-          ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast,mywest,myid,nparcelsLocal,nparcelsLocalActive, &
-          time_phys_H2D,time_phys_D2H,drop_inject_elapse,drop_inject_time,time_dropC1,time_dropC2,time_dropC3,time_dropC4
+      subroutine droplet_driver (dt,dbldt,mtime,xh,uh,ruh,xf,yh,vh, &
+                                 rvh,yf,zh,mh,rmh,zf,mf,zs,sigma, &
+                                 sigmaf,znt,rho,ua,va,wa,s10,pdata, &
+                                 th_in,qa,th0,pi0,ppa,prs,ta,pw1,pw2, &
+                                 pe1,pe2,ps1,ps2,pn1,pn2,nw1,nw2,ne1, &
+                                 ne2,sw1,sw2,se1,se2,reqs_p,sw31,sw32, &
+                                 se31,se32,ss31,ss32,sn31,sn32,n3w1, &
+                                 n3w2,n3e1,n3e2,s3w1,s3w2,s3e1,s3e2, &
+                                 reqs_s,dpten,pdata_locind)
+
+      use input, only : ib,ie,jb,je,kb,ke,ibl,iel,jbl,jel,numq,ni,nj, &
+          nk,imp,jmp,kmp,rmp,cmp,kmt,npvals,npvars,cgs1,cgs2,cgs3, &
+          cgt1,cgt2,cgt3,bbc,tbc,imove,zt,rzt,umove,vmove,nqv, &
+          terrain_flag,nx,ny,axisymm,nodex,nodey,myi,myj,viscosity, &
+          prx,pry,prz,prsig,pract,prvpx,prvpy,prvpz,prtp,prrp,prmult, &
+          prms,przs,pru,prv,prw,prt,prqv,prprs,prrho,prtime, &
+          timestats,time_droplet,time_droplet_inject,mytime,ierr,maxx, &
+          maxy,maxz,ierr,mynw,mysw,myne,myse,mynorth,mysouth,myeast, &
+          mywest,myid,nparcelsLocal,nparcelsLocalActive, &
+          time_phys_H2D,time_phys_D2H,drop_inject_elapse, &
+          drop_inject_time,time_dropC1,time_dropC2,time_dropC3, &
+          time_dropC4,ngxy
       use constants
       use comm_module
       use comm_droplet_module
@@ -450,10 +457,11 @@
 !      write(*,'(a8,i,8e15.6)') 'DHR3',np,rhval,tval,rhoval,qval,x3d,y3d,z3d,pdata(np,prrp)
 !      end if
 
-      call BE_integration(dt,dbldt,np,pdata,pdata_locind,xf,yf,x3d,y3d,z3d,sig3d, &
-                          uval,vval,wval,qval,rhoval,prsval,tval,Nup,rhop0, &
-                          taup0,rp0,part_grav1,part_grav2,part_grav3,debug, &
-                          neighbor,num_fallout,errcode)
+      call BE_integration (dt,dbldt,np,pdata,pdata_locind,xf,yf, &
+                           x3d,y3d,z3d,sig3d,uval,vval,wval,qval, &
+                           rhoval,prsval,tval,Nup,rhop0,taup0,rp0, &
+                           part_grav1,part_grav2,part_grav3,debug, &
+                           neighbor,num_fallout,errcode)
 
 #ifdef MPI
       if(neighbor .eq. mynorth) then 
@@ -506,9 +514,9 @@
 
     END DO nploop
     !$acc end parallel
-    if(errcode .gt. 0) then 
-      stop 'FATAL error occurred in the index search BE_integration'
-    endif
+    if (errcode .gt. 0) then 
+       stop 'FATAL error occurred in the index search BE_integration'
+    end if
 
 
     !$acc parallel default(present)
@@ -875,16 +883,20 @@
 
 !----------------------------------------------------------------------
 
-   subroutine BE_integration(dt,dbldt,np,pdata,pdata_locind,xf,yf,x3d,y3d, &
-                                z3d,sig3d,uval,vval,wval,qval,rhoval, &
-                                prsval,tval,Nup,rhop0,taup0,rp0, &
-                                part_grav1,part_grav2,part_grav3, &
-                                debug,neighbor,num_fallout,errcode)
+   subroutine BE_integration(dt,dbldt,np,pdata,pdata_locind,xf,yf, &
+                             x3d,y3d,z3d,sig3d,uval,vval,wval,qval, &
+                             rhoval,prsval,tval,Nup,rhop0,taup0,rp0, &
+                             part_grav1,part_grav2,part_grav3,debug, &
+                             neighbor,num_fallout,errcode)
+
       !$acc routine seq
+
       use input, only : ib,ie,jb,je,kb,ke,numq,npvals,nx,ny,viscosity, &
           pr_num,sc_num,axisymm,terrain_flag,maxz,minx,maxx,miny,maxy, &
-          prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pru,prv,prw,prt,prqv,prprs,prrho,pract,prtime,prmult, &
-          ni,nj,mywest,mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcelsLocal,myid,dx,dy,pi_sp,pi_dp
+          prvpx,prvpy,prvpz,prrp,prms,prtp,prx,pry,prsig,prz,pru,prv, &
+          prw,prt,prqv,prprs,prrho,pract,prtime,prmult,ni,nj,mywest, &
+          mysw,mynw,myeast,myse,myne,mysouth,mynorth,nparcelsLocal, &
+          myid,dx,dy,pi_sp,pi_dp,ngxy
       use constants , only : rhow,rhow_dp,undefined_index
       use comm_module
       use parcel_module
@@ -925,10 +937,8 @@
       double precision :: taup_scale,dt_nondim
       double precision :: guess
       double precision :: rt_zeros(2),rt_start(2)
-    
+      logical :: is_local
       integer :: mflag,flag
-
-
 
       !Store interpolated quantities for the sake of statistics
       pdata(np,pru) = uval
@@ -1096,72 +1106,14 @@
       ! determine which new MPI region this droplet 
       ! enters or stays for the next time step
 
-      if ( (x3d .ge. xf(1)) .and. (x3d .le. xf(ni+1)) .and.  &
-           (y3d .ge. yf(1)) .and. (y3d .le. yf(nj+1)) ) then
-           neighbor = undefined_index   ! undefined_index means this droplet
-                                        ! stays within the same MPI region
-      else if ( (x3d .lt. xf(1)) .and. (y3d .ge. yf(1)) .and. (y3d .le. yf(nj+1)) ) then
-           if ( x3d .lt. xf(1)-dx*ni ) then
-              print *,'BE_integration: Droplet jumped over west nearest neighbor'
-              errcode = 50
-           end if
-           neighbor = mywest
-      else if ( (x3d .lt. xf(1)) .and. (y3d .lt. yf(1)) ) then
-           if ( (x3d .lt. xf(1)-dx*ni) .or. (y3d .lt. yf(1)-dy*nj) ) then
-              print *,'BE_integration: Droplet jumped over southwest nearest neighbor'
-              errcode = 50
-           end if
-           neighbor = mysw
-      else if ( (x3d .lt. xf(1)) .and. (y3d .gt. yf(nj+1)) ) then
-           if ( (x3d .lt. xf(1)-dx*ni) .or. (y3d .gt. yf(nj+1)+dy*nj) ) then
-              print *,'BE_integration: Droplet jumped over northwest nearest neighbor'
-              errcode = 50
-           end if
-           neighbor = mynw
-      else if ( (x3d .gt. xf(ni+1)) .and. (y3d .ge. yf(1)) .and. (y3d .le. yf(nj+1)) ) then
-           if ( x3d .gt. xf(ni+1)+dx*ni ) then
-              print *,'BE_integration: Droplet jumped over east nearest neighbor'
-              errcode = 50
-           end if
-           neighbor = myeast
-      else if ( (x3d .gt. xf(ni+1)) .and. (y3d .lt. yf(1)) ) then
-           if ( (x3d .gt. xf(ni+1)+dx*ni) .or. (y3d .lt. yf(1)-dy*nj) ) then
-              print *,'BE_integration: Droplet jumped over southeast nearest neighbor'
-              errcode = 50
-           end if
-           neighbor = myse
-      else if ( (x3d .gt. xf(ni+1)) .and. (y3d .gt. yf(nj+1)) ) then
-           if ( (x3d .gt. xf(ni+1)+dx*ni) .or. (y3d .gt. yf(nj+1)+dy*nj) ) then
-              print *,'BE_integration: Droplet jumped over northeast nearest neighbor'
-              errcode = 50
-           end if
-           neighbor = myne
-      else if ( (x3d .ge. xf(1)) .and. (x3d .le. xf(ni+1)) .and. (y3d .lt. yf(1)) ) then
-           if ( y3d .lt. yf(1)-dy*nj ) then
-              print *,'BE_integration: Droplet jumped over south nearest neighbor'
-              errcode = 50
-           end if
-           neighbor = mysouth
-      else if ( (x3d .ge. xf(1)) .and. (x3d .le. xf(ni+1)) .and. (y3d .gt. yf(nj+1)) ) then
-           if ( y3d .gt. yf(nj+1)+dy*nj ) then
-              print *,'BE_integration: Droplet jumped over north nearest neighbor'
-              errcode = 50
-           end if
-           neighbor = mynorth
-      else
-           ! This condition should never be entered
-           errcode=200
-           if((x3d.ne.x3d) .or. (y3d.ne.y3d)) then 
-               print *,'BE_integration: x or y position of droplet is invalid: x3d,y3d: ',x3d,y3d
-           endif
-      end if
+      call check_droplet_ownership(x3d,y3d,xf,yf,is_local, &
+                                   neighbor,errcode)
 
       if ( neighbor .ne. undefined_index ) then
          pdata_locind(np,1) = undefined_index
          pdata_locind(np,2) = undefined_index
          pdata_locind(np,3) = undefined_index
       end if
-
 #endif
 
       if ( x3d .lt. minx ) then
@@ -1173,36 +1125,35 @@
          pdata_locind(np,1) = undefined_index
       end if
 
-      if( (y3d.gt.maxy).and.(axisymm.ne.1).and.(ny.ne.1) )then
-        y3d=y3d-(maxy-miny)
-        pdata_locind(np,2) = undefined_index
-      endif
-      if( (y3d.lt.miny).and.(axisymm.ne.1).and.(ny.ne.1) )then
-        y3d=y3d+(maxy-miny)
-        pdata_locind(np,2) = undefined_index
-      endif
+      if ( y3d .gt. maxy .and. axisymm .ne. 1 .and. ny .ne. 1 ) then
+         y3d = y3d - ( maxy - miny )
+         pdata_locind(np,2) = undefined_index
+      end if
+      if ( y3d .lt. miny .and. axisymm .ne. 1 .and. ny .ne. 1 ) then
+         y3d = y3d + ( maxy - miny )
+         pdata_locind(np,2) = undefined_index
+      end if
 
-      pdata(np,prx)=x3d
-      pdata(np,pry)=y3d
-      if( .not. terrain_flag )then
-        pdata(np,prz)=z3d
+      pdata(np,prx) = x3d
+      pdata(np,pry) = y3d
+      if ( .not. terrain_flag )then
+         pdata(np,prz) = z3d
       else
-        pdata(np,prsig)=sig3d
-      endif
+         pdata(np,prsig) = sig3d
+      end if
 
       ! If this droplet falls outside the bottom boundary,
       ! it "dies" and should not enter any other MPI rank
       ! even if its x/y location is valid
-      if (pdata(np,pract) .lt. 0.0) then
+      if ( pdata(np,pract) .lt. 0.0 ) then
          neighbor = undefined_index
          pdata_locind(np,1) = undefined_index
          pdata_locind(np,2) = undefined_index
-         !pdata(np,:) = neg_huge
       end if
 
-      if (pdata_locind(np,1) .eq. undefined_index .or. &
-          pdata_locind(np,2) .eq. undefined_index) then
-          pdata_locind(np,3) = undefined_index
+      if ( pdata_locind(np,1) .eq. undefined_index .or. &
+           pdata_locind(np,2) .eq. undefined_index ) then
+           pdata_locind(np,3) = undefined_index
       end if
 
       end subroutine BE_integration
@@ -3922,8 +3873,8 @@
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 !ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
 
-      subroutine check_droplet_ownership(x3d,y3d,xf,xfref,yf,yfref, &
-                                         is_local,neighbor,errcode)
+      subroutine check_droplet_ownership(x3d,y3d,xf,yf,is_local, &
+                                         neighbor,errcode)
 
       ! This subroutine will check if a droplet falls into this MPI region or not
       !     Exception case:
@@ -3937,7 +3888,8 @@
       !$acc routine seq
 
       use input, only : ni,nj,ib,ie,jb,je,ngxy,nx,ny,dx,dy,mywest, &
-                        mysw,mynw,myeast,myse,myne,mysouth,mynorth
+                        mysw,mynw,myeast,myse,myne,mysouth,mynorth, &
+                        maxx,maxy
       use constants, only : undefined_index
 
       implicit none
@@ -3945,8 +3897,6 @@
       real, intent(in) :: x3d, y3d
       real, dimension(ib:ie+1), intent(in) :: xf
       real, dimension(jb:je+1), intent(in) :: yf
-      real, dimension(1-ngxy:nx+ngxy+1), intent(in) :: xfref
-      real, dimension(1-ngxy:ny+ngxy+1), intent(in) :: yfref
       logical, intent(out) :: is_local
       integer, intent(out), optional :: neighbor, errcode
 
@@ -3956,29 +3906,29 @@
 
       ! normal case: a droplet falls within the domain or
       !              on the westmost/southmost boundary
-      if ( x3d .ge. xf(1) .and. x3d .lt. xf(ni+1) .and. &
-           y3d .ge. yf(1) .and. y3d .lt. yf(nj+1) ) then
+      if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. &
+           y3d .ge. yf(1) .and. y3d .le. yf(nj+1) ) then
          is_local = .true.
       end if
-      ! special case: a droplet falls on the eastmost
-      !               boundary of the whole domain
-      if ( x3d .eq. xfref(nx+1) .and. xf(ni+1) .eq. xfref(nx+1) .and. &
-           y3d .ge. yf(1) .and. y3d .lt. yf(nj+1) ) then
-         is_local = .true.
-      end if
-      ! special case: a droplet falls on the northmost
-      !               boundary of the whole domain
-      if ( y3d .eq. yfref(ny+1) .and. yf(nj+1) .eq. yfref(ny+1) .and. &
-           x3d .ge. xf(1) .and. x3d .lt. xf(ni+1) ) then
-         is_local = .true.
-      end if
-      ! special case: a droplet falls on the upperright
-      !               corner of the whole domain
-      if ( x3d .eq. xfref(nx+1) .and. y3d .eq. yfref(ny+1) .and. &
-           xf(ni+1) .eq. xfref(nx+1) .and. &
-           yf(nj+1) .eq. yfref(ny+1) ) then
-         is_local = .true.
-      end if
+!      ! special case: a droplet falls on the eastmost
+!      !               boundary of the whole domain
+!      if ( x3d .eq. maxx .and. xf(ni+1) .eq. maxx .and. &
+!           y3d .ge. yf(1) .and. y3d .lt. yf(nj+1) ) then
+!         is_local = .true.
+!      end if
+!      ! special case: a droplet falls on the northmost
+!      !               boundary of the whole domain
+!      if ( y3d .eq. maxy .and. yf(nj+1) .eq. maxy .and. &
+!           x3d .ge. xf(1) .and. x3d .lt. xf(ni+1) ) then
+!         is_local = .true.
+!      end if
+!      ! special case: a droplet falls on the upperright
+!      !               corner of the whole domain
+!      if ( x3d .eq. maxx .and. y3d .eq. maxy .and. &
+!           xf(ni+1) .eq. maxx .and. &
+!           yf(nj+1) .eq. maxy ) then
+!         is_local = .true.
+!      end if
 
       ! check optional input
       if ( present(neighbor) ) then
@@ -3998,62 +3948,54 @@
             return
          end if
          if ( x3d .lt. xf(1) .and. y3d .ge. yf(1) .and. &
-              y3d .lt. yf(nj+1) ) then
+              y3d .le. yf(nj+1) ) then
             if ( x3d .lt. xf(1)-dx*ni ) then
-               print *,'BE_integration: Droplet jumped over &
-                        the west nearest neighbor'
+               print *, 'Droplet jumped over west nearest neighbor'
                errcode = 50
             end if
             neighbor = mywest
          else if ( x3d .lt. xf(1) .and. y3d .lt. yf(1) ) then
             if ( x3d .lt. xf(1)-dx*ni .or. y3d .lt. yf(1)-dy*nj ) then
-               print *,'BE_integration: Droplet jumped over &
-                        the southwest nearest neighbor'
+               print *, 'Droplet jumped over southwest nearest neighbor'
                errcode = 50
             end if
             neighbor = mysw
-         else if ( x3d .lt. xf(1) .and. y3d .ge. yf(nj+1) ) then
-            if ( x3d .lt. xf(1)-dx*ni .or. y3d .ge. yf(nj+1)+dy*nj ) then
-               print *,'BE_integration: Droplet jumped over &
-                        the northwest nearest neighbor'
+         else if ( x3d .lt. xf(1) .and. y3d .gt. yf(nj+1) ) then
+            if ( x3d .lt. xf(1)-dx*ni .or. y3d .gt. yf(nj+1)+dy*nj ) then
+               print *, 'Droplet jumped over northwest nearest neighbor'
                errcode = 50
             end if
             neighbor = mynw
-         else if ( x3d .ge. xf(ni+1) .and. y3d .ge. yf(1) .and. &
-                   y3d .lt. yf(nj+1) ) then
-            if ( x3d .ge. xf(ni+1)+dx*ni ) then
-               print *,'BE_integration: Droplet jumped over &
-                        the east nearest neighbor'
+         else if ( x3d .gt. xf(ni+1) .and. y3d .ge. yf(1) .and. &
+                   y3d .le. yf(nj+1) ) then
+            if ( x3d .gt. xf(ni+1)+dx*ni ) then
+               print *, 'Droplet jumped over east nearest neighbor'
                errcode = 50
             end if
             neighbor = myeast
-         else if ( x3d .ge. xf(ni+1) .and. y3d .lt. yf(1) ) then
-            if ( x3d .ge. xf(ni+1)+dx*ni .or. y3d .lt. yf(1)-dy*nj ) then
-               print *,'BE_integration: Droplet jumped over &
-                        the southeast nearest neighbor'
+         else if ( x3d .gt. xf(ni+1) .and. y3d .lt. yf(1) ) then
+            if ( x3d .gt. xf(ni+1)+dx*ni .or. y3d .lt. yf(1)-dy*nj ) then
+               print *, 'Droplet jumped over southeast nearest neighbor'
                errcode = 50
             end if
             neighbor = myse
-         else if ( x3d .ge. xf(ni+1) .and. y3d .ge. yf(nj+1) ) then
-            if ( x3d .ge. xf(ni+1)+dx*ni .or. y3d .ge. yf(nj+1)+dy*nj ) then
-               print *,'BE_integration: Droplet jumped over &
-                        the northeast nearest neighbor'
+         else if ( x3d .gt. xf(ni+1) .and. y3d .gt. yf(nj+1) ) then
+            if ( x3d .gt. xf(ni+1)+dx*ni .or. y3d .gt. yf(nj+1)+dy*nj ) then
+               print *, 'Droplet jumped over northeast nearest neighbor'
                errcode = 50
             end if
             neighbor = myne
-         else if ( x3d .ge. xf(1) .and. x3d .lt. xf(ni+1) .and. &
+         else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. &
                    y3d .lt. yf(1) ) then
             if ( y3d .lt. yf(1)-dy*nj ) then
-               print *,'BE_integration: Droplet jumped over &
-                        the south nearest neighbor'
+               print *, 'Droplet jumped over south nearest neighbor'
                errcode = 50
             end if
             neighbor = mysouth
-         else if ( x3d .ge. xf(1) .and. x3d .lt. xf(ni+1) .and. &
-                   y3d .ge. yf(nj+1) ) then
-            if ( y3d .ge. yf(nj+1)+dy*nj ) then
-               print *,'BE_integration: Droplet jumped over &
-                        the north nearest neighbor'
+         else if ( x3d .ge. xf(1) .and. x3d .le. xf(ni+1) .and. &
+                   y3d .gt. yf(nj+1) ) then
+            if ( y3d .gt. yf(nj+1)+dy*nj ) then
+               print *,'Droplet jumped over north nearest neighbor'
                errcode = 50
             end if
             neighbor = mynorth
@@ -4061,8 +4003,8 @@
             ! This condition should never be entered
             errcode = 12345
             if ( x3d .ne. x3d .or. y3d .ne. y3d ) then
-               print *,'BE_integration: x or y position of droplet &
-                        is invalid: x3d = ', x3d, ', y3d = ', y3d
+               print *, 'x or y position of droplet is invalid: x3d = ', &
+                        x3d, ', y3d = ', y3d
             end if
          end if     ! if statement for neighbor check
       end if        ! if "neighbor" is present

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -132,7 +132,7 @@
  
 !-----------------------------------------------------------------------
 
-      integer(i8) :: n
+      integer :: n, iter
       integer i,j,k,kk,l,nn,nbub,nloop
       integer ic,jc,ifoo,jfoo
       real ric,rjc
@@ -180,6 +180,7 @@
       logical, parameter :: use_truly_random_pert  =  .false.
 
       real :: tmpx, tmpy, tmpz
+      real :: xrange, yrange
       integer(i8) :: np_tmp
 
 !--------------------------
@@ -418,76 +419,81 @@
 
         i = 1
         nparcelsLocalActive = 0
+        xrange = xf(ni+1) - xf(1)
+        yrange = yf(nj+1) - yf(1)
 
-        do n = 1, nparcelsInit 
+        iter = floor(real(nparcelsInit) / real(numprocs))
+        if ( mod(real(nparcelsInit),real(numprocs)) /= 0 ) then
+           ! handle the case where nparcelsInit can not be divided
+           ! evenly between different MPI ranks
+           if ( myid == 0 ) iter = nparcelsInit - iter * (numprocs - 1)
+        end if
+
+        do n = 1, iter
 
           rand = getRandomReal(randomNumbers)
-          tmpx = rand*maxx
+          tmpx = xf(1)+rand*xrange
           rand = getRandomReal(randomNumbers)
-          tmpy = rand*maxy
+          tmpy = yf(1)+rand*yrange
           rand = getRandomReal(randomNumbers)
           tmpz = rand*injectHMax
 
-          ! Check if this parcel falls into this MPI region
-          call check_droplet_ownership(tmpx,tmpy,xf,xfref,yf,yfref, &
-                                       is_local) 
+          pdata(i,prx) = tmpx
+          pdata(i,pry) = tmpy
+          pdata(i,prz) = tmpz
 
-          if ( is_local ) then
+          if (prcl_droplet.eq.1) then
 
-             pdata(i,prx) = tmpx
-             pdata(i,pry) = tmpy
-             pdata(i,prz) = tmpz
-
-             if (prcl_droplet.eq.1) then
-
-                pdata(i,prvpx) = 0.0
-                pdata(i,prvpy) = 0.0
-                pdata(i,prvpz) = 0.0
+             pdata(i,prvpx) = 0.0
+             pdata(i,prvpy) = 0.0
+             pdata(i,prvpz) = 0.0
      
-                !Droplet size (radius)
-                pdata(i,prrp) = 2.0e-6
+             !Droplet size (radius)
+             pdata(i,prrp) = 2.0e-6
      
-                !Droplet solute mass
-                salinity = 0.034
-                pdata(i,prms) = salinity*rhow*4.0/3.0*pi*pdata(i,prrp)**3
+             !Droplet solute mass
+             salinity = 0.034
+             pdata(i,prms) = salinity*rhow*4.0/3.0*pi*pdata(i,prrp)**3
      
-                !Droplet temperature
-                pdata(i,prtp) = 302.0
+             !Droplet temperature
+             pdata(i,prtp) = 302.0
      
-                !Droplet multiplicity
-                pdata(i,prmult) = drop_mult
+             !Droplet multiplicity
+             pdata(i,prmult) = drop_mult
         
-                !Is droplet alive?
-                pdata(i,pract) = 1.0
+             !Is droplet alive?
+             pdata(i,pract) = 1.0
      
-                !Initialize the interpolated quantities to zero
-                pdata(i,pru) = 0.0
-                pdata(i,prv) = 0.0
-                pdata(i,prw) = 0.0
-                !Set to something realistic so it doesn't break the stats at initiation
-                pdata(i,prt) = 302.0
-                pdata(i,prqv) = 0.01
-                pdata(i,prprs) = 101325.0
-                pdata(i,prrho) = 1.0
+             !Initialize the interpolated quantities to zero
+             pdata(i,pru) = 0.0
+             pdata(i,prv) = 0.0
+             pdata(i,prw) = 0.0
+             !Set to something realistic so it doesn't break the stats at initiation
+             pdata(i,prt) = 302.0
+             pdata(i,prqv) = 0.01
+             pdata(i,prprs) = 101325.0
+             pdata(i,prrho) = 1.0
        
-                !Start the stopwatch for each particle at 0
-                pdata(i,prtime) = 0.0
+             !Start the stopwatch for each particle at 0
+             pdata(i,prtime) = 0.0
 
-             end if ! end of if statement for prcl_droplet == 1
+          end if ! end of if statement for prcl_droplet == 1
 
-             i = i + 1
-             nparcelsLocalActive = nparcelsLocalActive + 1
+          i = i + 1
+          nparcelsLocalActive = nparcelsLocalActive + 1
 
-#ifdef MPI   
-             if ( i .gt. nparcelsLocal ) then
-                write(*,*) "Not enough space to initialize the droplets on myid = ", myid 
-                write(*,*) 'Please increase the value of namelist variable "nparcelsMax" or the value of "pdata_buffer" in the constants.F' 
-                stop "Stop the program..."
-             end if
+#ifdef MPI
+          if ( i .gt. nparcelsLocal ) then
+             write(*,*) "Not enough space to initialize the &
+                         droplets on myid = ", myid 
+             write(*,*) 'Please increase the value of namelist &
+                         variable "nparcelsMax" or the value of &
+                         "pdata_buffer" in the constants.F' 
+             stop "Stop the program..."
+          end if
 #endif
-          end if    ! end of if statement for xf/yf check
 
-        end do      ! end of loop for nparcelsInit
+        end do      ! end of loop for iter 
 
 #ifdef MPI
         ! Sanity check

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -84,8 +84,7 @@
       use module_mp_nssl_2mom, only: ccn, lccn
       use poiss_module
       use parcel_module , only : getparcelzs
-      use droplet_module, only: initialize_droplet_histograms, &
-                                check_droplet_ownership
+      use droplet_module, only: initialize_droplet_histograms
 #ifdef MPI
       use mpi
 #endif
@@ -169,7 +168,7 @@
       integer :: tctype
       real :: dr,tem
       double precision :: tem1,tem2,temd
-      logical :: doit,is_local
+      logical :: doit
 
       real :: salinity
 

--- a/src/init3d.F
+++ b/src/init3d.F
@@ -84,7 +84,8 @@
       use module_mp_nssl_2mom, only: ccn, lccn
       use poiss_module
       use parcel_module , only : getparcelzs
-      use droplet_module, only: initialize_droplet_histograms
+      use droplet_module, only: initialize_droplet_histograms, &
+                                check_droplet_ownership
 #ifdef MPI
       use mpi
 #endif
@@ -168,7 +169,7 @@
       integer :: tctype
       real :: dr,tem
       double precision :: tem1,tem2,temd
-      logical :: doit
+      logical :: doit,is_local
 
       real :: salinity
 
@@ -428,26 +429,14 @@
           tmpz = rand*injectHMax
 
           ! Check if this parcel falls into this MPI region
-          ! Exception case:
-          !   - if parcel is on a tile boundary, let the eastmost/northmost tile own it
-          !   - if parcel is on the northmost or eastmost boundary of the whole domain,
-          !     let the MPI rank which inclues that boundary owns it
-          if ( (tmpx .ge. xf(1) .and. tmpx .lt. xf(ni+1) .and. &
-                tmpy .ge. yf(1) .and. tmpy .lt. yf(nj+1)) .or. &
-               (tmpx .eq. xfref(nx+1) .and. xf(ni+1) .eq. xfref(nx+1) .and. & 
-                tmpy .ge. yf(1) .and. tmpy .lt. yf(nj+1)) .or. & 
-               (tmpy .eq. yfref(ny+1) .and. yf(nj+1) .eq. yfref(ny+1) .and. &
-                tmpx .ge. xf(1) .and. tmpx .lt. xf(ni+1)) .or. & 
-               (tmpx .eq. xfref(nx+1) .and. tmpy .eq. yfref(ny+1) .and. &
-                xf(ni+1) .eq. xfref(nx+1) .and. yf(nj+1) .eq. yfref(ny+1)) ) then
+          call check_droplet_ownership(tmpx,tmpy,xf,xfref,yf,yfref, &
+                                       is_local) 
+
+          if ( is_local ) then
 
              pdata(i,prx) = tmpx
              pdata(i,pry) = tmpy
              pdata(i,prz) = tmpz
-
-!             if(MODULO(n,100)==0) then 
-!               if(dowr) write(outfile,*) i,pdata(i,prx),pdata(i,pry),pdata(i,prz)
-!             endif
 
              if (prcl_droplet.eq.1) then
 
@@ -484,7 +473,6 @@
                 !Start the stopwatch for each particle at 0
                 pdata(i,prtime) = 0.0
 
-    
              end if ! end of if statement for prcl_droplet == 1
 
              i = i + 1


### PR DESCRIPTION
This PR:

- improved the droplet initialization in `init3d.F` suggested by @drichte2 . Instead of looping over the `nparcelsInit` droplets for each MPI rank, now each MPI rank only loops over `nparcelsInit/numprocs` droplets and they are all active. Thus there is no need to check the droplet ownership and we just need to change the x/y range to the boundary of each MPI rank before initialization. In this way, no more droplets will fall on the boundary between tiles.

- improved the droplet ownership check in the `droplet.F` code. We first moved a huge code block with several logical checks into a separate subroutine. Then we updated the ownership check logics to treat all the droplets on the boundary of a MPI rank as `local` (i.e., no MPI communication is needed).

The verification results are slightly worse than the previous PR #129 (Derecho; CPU: ifort, 2 MPI ranks; GPU: nvhpc, 2 MPI ranks + 2 A100 GPUs):

# Metrics
39 stat variables are identical.
42 stat variables show a mean relative difference > 1e-06
5 stat variables show a mean relative difference <= 1e-06

# 0th-order diagnostics
3 stat variables are identical.
8 stat variables show a mean relative difference > 1e-06
1 stat variables show a mean relative difference <= 1e-06

# 1st-order diagnostics
254 stat variables are identical.
2 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06