### PR TITLE
Modifications necessary for PASC24 submission.

### DIFF
--- a/run/derecho.ncpu8k.sh
+++ b/run/derecho.ncpu8k.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#PBS -N cm1
+#PBS -l select=64:ncpus=128:mpiprocs=128:ompthreads=1:mem=235GB
+#PBS -l walltime=04:00:00
+#PBS -j oe
+#PBS -q main
+#PBS -A NTDD0004
+
+module --force purge
+module load ncarenv/23.06 intel cray-mpich/8.1.25 ncarcompilers/1.0.0
+# mpiexec -n 8192 -ppn 128 ./cpu.exe --namelist namelist.scale1k.gpu >& derecho.intel.ncpu8k.scale.1024.log
+mpiexec -n 8192 -ppn 128 ./cpu.intel.exe --namelist namelist.scale1kB.cpu >& derecho.intel.ncpu8k.scaleB.1024.log
+
+
+module --force purge
+module load ncarenv/23.06 nvhpc/23.5 cray-mpich/8.1.25 ncarcompilers/1.0.0
+mpiexec -n 8192 -ppn 128 ./cpu.nvhpc.exe --namelist namelist.scale1k.cpu >& derecho.nvhpc.ncpu8k.scale.1024.log
+
+
+
+

--- a/run/derecho.ncpu8k.sh
+++ b/run/derecho.ncpu8k.sh
@@ -9,12 +9,12 @@
 module --force purge
 module load ncarenv/23.06 intel cray-mpich/8.1.25 ncarcompilers/1.0.0
 # mpiexec -n 8192 -ppn 128 ./cpu.exe --namelist namelist.scale1k.gpu >& derecho.intel.ncpu8k.scale.1024.log
-mpiexec -n 8192 -ppn 128 ./cpu.intel.exe --namelist namelist.scale1kB.cpu >& derecho.intel.ncpu8k.scaleB.1024.log
+mpiexec -n 8192 -ppn 128 ./cpu.intel.exe --namelist namelist.scale1k.cpu >& derecho.intel.ncpu8k.scale.1024.log
 
 
-module --force purge
-module load ncarenv/23.06 nvhpc/23.5 cray-mpich/8.1.25 ncarcompilers/1.0.0
-mpiexec -n 8192 -ppn 128 ./cpu.nvhpc.exe --namelist namelist.scale1k.cpu >& derecho.nvhpc.ncpu8k.scale.1024.log
+#module --force purge
+#module load ncarenv/23.06 nvhpc/23.5 cray-mpich/8.1.25 ncarcompilers/1.0.0
+#mpiexec -n 8192 -ppn 128 ./cpu.nvhpc.exe --namelist namelist.scale1k.cpu >& derecho.nvhpc.ncpu8k.scale.1024.log
 
 
 

--- a/run/derecho.ngpu64.sh
+++ b/run/derecho.ngpu64.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#PBS -N cm1
+#PBS -l select=16:ncpus=4:mpiprocs=4:ngpus=4:mem=200gb
+#PBS -l walltime=01:00:00
+#PBS -j oe
+#PBS -q main
+#PBS -A NTDD0004
+
+module purge
+module load ncarenv/23.06 nvhpc/23.5 cuda/11.7.1 ncarcompilers/1.0.0 cray-mpich/8.1.25 cutensor
+
+export MPICH_GPU_SUPPORT_ENABLED=1
+export MPICH_GPU_MANAGED_MEMORY_SUPPORT_ENABLED=1
+# mpiexec -n 8 -ppn 4 get_local_rank ./cm1.exe --namelist namelist.small.gpu >& derecho.ngpu8.small.512x512.log
+# mpiexec -n 8 -ppn 4 get_local_rank ./gpu.exe --namelist namelist.restC >& derecho.ngpu8.restC.log
+# mpiexec -n 8 -ppn 4 get_local_rank ./nsys_wrap ./gpu.exe --namelist namelist.figureE.gpu >& derecho.ngpu8.figureEg.log
+
+# mpiexec -n 64 -ppn 4 get_local_rank ./gpu.exe --namelist namelist.scale1k.gpu >& derecho.ngpu64.scale.1024.log
+mpiexec -n 64 -ppn 4 get_local_rank ./gpu.exe --namelist namelist.scale1k.gpu >& derecho.ngpu64.scale.1024.log
+
+#mpiexec -n 8 -ppn 4 get_local_rank ./gpu.exe --namelist namelist.figureE.gpu >& derecho.ngpu8.figureEc.log
+#mpiexec -n 8 -ppn 4 get_local_rank ./gpu.exe --namelist namelist.figureE.gpu >& derecho.ngpu8.figureEd.log
+#mpiexec -n 8 -ppn 4 get_local_rank ./gpu.exe --namelist namelist.figureE.gpu >& derecho.ngpu8.figureEe.log
+#mpiexec -n 8 -ppn 4 get_local_rank ./gpu.exe --namelist namelist.figureE.gpu >& derecho.ngpu8.figureEf.log

--- a/run/derecho.verify.cpu.sh
+++ b/run/derecho.verify.cpu.sh
@@ -1,12 +1,15 @@
 #!/bin/bash -l
 #PBS -N cm1
 #PBS -l select=1:ncpus=2:mpiprocs=2:ompthreads=1:mem=235GB
-#PBS -l walltime=00:40:00
+#PBS -l walltime=01:30:00
 #PBS -j oe
 #PBS -q main
 #PBS -A UNDM0006
 
 module --force purge
-module load ncarenv intel cray-mpich ncarcompilers
+module load ncarenv/23.06 intel/2023.0.0  ncarcompilers/1.0.0 cray-mpich/8.1.25
+mpiexec -n 2 -ppn 2 ./cpu.intel.exe --namelist namelist_ASD.verify >& derecho.mpi.ifort.namelist.ASD.log
 
-mpiexec -n 2 -ppn 2 ./cpu.exe --namelist namelist_ASD.verify >& derecho.mpi.ifort.namelist.ASD.log
+#module --force purge
+#module load ncarenv/23.06 nvhpc/23.5 cray-mpich/8.1.25 ncarcompilers/1.0.0
+#mpiexec -n 2 -ppn 2 ./cpu.nvhpc.exe --namelist namelist_ASD.verify >& derecho.mpi.nvhpc.namelist.ASD.log

--- a/run/namelist.scale1k.cpu
+++ b/run/namelist.scale1k.cpu
@@ -1,0 +1,369 @@
+
+ &param0
+ nx           =    1024,
+ ny           =    1024,
+ nz           =    1024,
+ ppnode       =     128,
+ timeformat   =       2,
+ timestats    =       1,
+ terrain_flag = .false.,
+ procfiles    = .false.,
+ /
+
+ &param1
+ dx     =    5.0,
+ dy     =    5.0,
+ dz     =     2.5,
+ dtl    =   0.125,
+ timax  = 120.0,
+ run_time =  -999.9,
+ tapfrq =   900.0,
+ rstfrq = 10800.0,
+ statfrq =  60.0,
+ prclfrq =  60.0,
+ /
+
+ &param2
+ cm1setup  =  1,
+ testcase  = 10,
+ adapt_dt  =  1,
+ irst      =  0,
+ rstnum    =  1,
+ iconly    =  0,
+ hadvordrs =  5,
+ vadvordrs =  5,
+ hadvordrv =  5,
+ vadvordrv =  5,
+ advwenos  =  2,
+ advwenov  =  0,
+ weno_order = 5,
+ apmasscon =  0,
+ idiff     =  0,
+ mdiff     =  0,
+ difforder =  6,
+ imoist    =  1,
+ ipbl      =  0,
+ sgsmodel  =  4,
+ tconfig   =  1,
+ bcturbs   =  1,
+ horizturb =  0,
+ doimpl    =  0,
+ irdamp    =  1,
+ hrdamp    =  0,
+ psolver   =  2,
+ ptype     =  0,
+ ihail     =  0,
+ iautoc    =  0,
+ icor      =  1,
+ lspgrad   =  3,
+ eqtset    =  1,
+ idiss     =  0,
+ efall     =  0,
+ rterm     =  0,
+ wbc       =  1,
+ ebc       =  1,
+ sbc       =  1,
+ nbc       =  1,
+ bbc       =  3,
+ tbc       =  1,
+ irbc      =  4,
+ roflux    =  0,
+ nudgeobc  =  0,
+ isnd      =  8,
+ iwnd      =  8,
+ itern     =  0,
+ iinit     =  0,
+ irandp    =  1,
+ ibalance  =  0,
+ iorigin   =  1,
+ axisymm   =  0,
+ imove     =  1,
+ iptra     =  0,
+ npt       =  1,
+ pdtra     =  1,
+ iprcl     =  1,  !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
+ nparcelsInit = 400000000,   ! initial number of particles over the whole domain
+ nparcelsMax  = 600000000,   ! the total allowable number of particles over the whole domain
+ injectHMax = 20.0,
+ drop_mult = 0.1e10,   !Droplet multiplicity: total number of droplets = nparcels*drop_mult
+ drop_inject_elapse = 1.0,  !Time between spray injection
+ drop_inject_time =  30.0,  !Time after which spray injection begins
+ drop_w_init = 3.0    ! Initial vertical velocity of the newly initialized spray droplet
+ /
+
+ &param3
+ kdiff2  =   75.0,
+ kdiff6  =   0.040,
+ fcor    = 0.00005,
+ kdiv    = 0.10,
+ alph    = 0.60,
+ rdalpha = 3.3333333333e-3,
+ zd      =  2000.0,
+ xhd     = 100000.0,
+ alphobc = 60.0,
+ umove   =  0.0,
+ vmove   = 50.0,
+ v_t     =      0.0,
+ l_h     =      0.0,
+ lhref1  =      0.0,
+ lhref2  =      0.0,
+ l_inf   =     75.0,
+ ndcnst  =    100.0,
+ /
+
+ &param11
+ radopt  =        0,
+ dtrad   =    300.0,
+ ctrlat  =    36.68,
+ ctrlon  =   -98.35,
+ year    =     2009,
+ month   =        5,
+ day     =       15,
+ hour    =       21,
+ minute  =       38,
+ second  =       00,
+ /
+
+ &param12
+ isfcflx    =      1,
+ sfcmodel   =      1,
+ oceanmodel =      1,
+ initsfc    =      1,
+ tsk0       = 302.27,
+ tmn0       = 299.15,
+ xland0     =    2.0,
+ lu0        =     16,
+ season     =      1,
+ cecd       =      1,
+ pertflx    =      0,
+ cnstce     =  0.0012,
+ cnstcd     =  0.0025,
+ isftcflx   =      0,
+ iz0tlnd    =      0,
+ oml_hml0   =   50.0,
+ oml_gamma  =   0.14,
+ set_flx    =      0,
+ cnst_shflx =   0.10,
+ cnst_lhflx =   0.00,
+ set_znt    =      0,
+ cnst_znt   =   0.00,
+ set_ust    =      0,
+ cnst_ust   =   0.00,
+ /
+
+ &param4
+ stretch_x =      0,
+ dx_inner  =    1000.0,
+ dx_outer  =    7000.0,
+ nos_x_len =   40000.0,
+ tot_x_len =  120000.0,
+ /
+
+ &param5
+ stretch_y =      0,
+ dy_inner  =    1000.0,
+ dy_outer  =    7000.0,
+ nos_y_len =   40000.0,
+ tot_y_len =  120000.0,
+ /
+
+ &param6
+ stretch_z =  0,
+ ztop      =  2980.0,
+ str_bot   =  2000.0,
+ str_top   =  2980.0,
+ dz_bot    =   20.0,
+ dz_top    =   50.0,
+ /
+
+ &param7
+ bc_temp   = 1,
+ ptc_top   = 250.0,
+ ptc_bot   = 300.0,
+ viscosity = 1.57e-5,  !Needs to be set to the viscosity of air, even though not doing DNS
+ pr_num    = 0.72,
+ sc_num    = 0.61,     !Need to define a Schmidt number for the droplets
+ /
+
+ &param8
+ var1      =  50.0,     ! Vmax (m/s)
+ var2      =  20000.0,  ! R (m)
+ var3      =  0.60,     ! n
+ var4      =   0.0,
+ var5      =   0.0,
+ var6      =   0.0,
+ var7      =   0.0,
+ var8      =   0.0,
+ var9      =   0.0,
+ var10     =   0.0,
+ var11     =   0.0,
+ var12     =   0.0,
+ var13     =   0.0,
+ var14     =   0.0,
+ var15     =   0.0,
+ var16     =   0.0,
+ var17     =   0.0,
+ var18     =   0.0,
+ var19     =   0.0,
+ var20     =   0.0,
+ /
+
+ &param9
+ output_format    = 1,
+ output_filetype  = 3,
+ output_interp    = 0,
+ output_rain      = 1,
+ output_sws       = 1,
+ output_svs       = 1,
+ output_sps       = 1,
+ output_srs       = 1,
+ output_sgs       = 1,
+ output_sus       = 1,
+ output_shs       = 1,
+ output_coldpool  = 0,
+ output_sfcflx    = 1,
+ output_sfcparams = 1,
+ output_sfcdiags  = 1,
+ output_psfc      = 1,
+ output_zs        = 0,
+ output_zh        = 0,
+ output_basestate = 0,
+ output_th        = 1,
+ output_thpert    = 0,
+ output_prs       = 0,
+ output_prspert   = 0,
+ output_pi        = 0,
+ output_pipert    = 1,
+ output_rho       = 0,
+ output_rhopert   = 0,
+ output_tke       = 1,
+ output_km        = 1,
+ output_kh        = 1,
+ output_qv        = 1,
+ output_qvpert    = 0,
+ output_q         = 1,
+ output_dbz       = 0,
+ output_buoyancy  = 0,
+ output_u         = 1,
+ output_upert     = 0,
+ output_uinterp   = 1,
+ output_v         = 1,
+ output_vpert     = 0,
+ output_vinterp   = 1,
+ output_w         = 1,
+ output_winterp   = 1,
+ output_vort      = 0,
+ output_pv        = 0,
+ output_uh        = 0,
+ output_pblten    = 0,
+ output_dissten   = 0,
+ output_fallvel   = 0,
+ output_nm        = 0,
+ output_def       = 0,
+ output_radten    = 0,
+ output_cape      = 0,
+ output_cin       = 0,
+ output_lcl       = 0,
+ output_lfc       = 0,
+ output_pwat      = 0,
+ output_lwp       = 0,
+ output_thbudget  = 0,
+ output_qvbudget  = 0,
+ output_ubudget   = 0,
+ output_vbudget   = 0,
+ output_wbudget   = 0,
+ /
+
+ &param16
+ restart_format   = 1,
+ restart_filetype = 2,
+ restart_reset_frqtim  =  .true.,
+ restart_file_theta    =  .false.,
+ restart_file_dbz      =  .false.,
+ restart_file_th0      =  .false.,
+ restart_file_prs0     =  .false.,
+ restart_file_pi0      =  .false.,
+ restart_file_rho0     =  .false.,
+ restart_file_qv0      =  .false.,
+ restart_file_u0       =  .false.,
+ restart_file_v0       =  .false.,
+ restart_file_zs       =  .false.,
+ restart_file_zh       =  .false.,
+ restart_file_zf       =  .false.,
+ restart_file_diags    =  .false.,
+ restart_use_theta     =  .false.,
+ /
+
+ &param10
+ stat_w        = 1,
+ stat_wlevs    = 0,
+ stat_u        = 1,
+ stat_v        = 1,
+ stat_rmw      = 1,
+ stat_pipert   = 1,
+ stat_prspert  = 1,
+ stat_thpert   = 1,
+ stat_q        = 1,
+ stat_tke      = 1,
+ stat_km       = 1,
+ stat_kh       = 1,
+ stat_div      = 1,
+ stat_rh       = 1,
+ stat_rhi      = 1,
+ stat_the      = 1,
+ stat_cloud    = 1,
+ stat_sfcprs   = 1,
+ stat_wsp      = 1,
+ stat_cfl      = 1,
+ stat_vort     = 1,
+ stat_tmass    = 1,
+ stat_tmois    = 1,
+ stat_qmass    = 1,
+ stat_tenerg   = 1,
+ stat_mo       = 1,
+ stat_tmf      = 1,
+ stat_pcn      = 1,
+ stat_qsrc     = 1,
+ /
+
+ &param13
+ prcl_th       = 1,
+ prcl_t        = 1,
+ prcl_prs      = 1,
+ prcl_ptra     = 1,
+ prcl_q        = 1,
+ prcl_nc       = 1,
+ prcl_km       = 1,
+ prcl_kh       = 1,
+ prcl_tke      = 1,
+ prcl_dbz      = 1,
+ prcl_b        = 1,
+ prcl_vpg      = 1,
+ prcl_vort     = 1,
+ prcl_rho      = 1,
+ prcl_qsat     = 1,
+ prcl_sfc      = 1,
+ prcl_droplet  = 1, !Makes them "droplets" instead of "parcels"
+ /
+
+ &param14
+ dodomaindiag   =    .true.,
+ diagfrq        =    60.0,
+ /
+
+ &param15
+ doazimavg        =    .false.,
+ azimavgfrq       =     3600.0,
+ rlen             =   300000.0,
+ do_adapt_move    =    .false.,
+ adapt_move_frq   =     3600.0,
+ /
+
+ &nssl2mom_params
+   alphah  = 0,     ! shape parameter of graupel
+   alphahl = 0.5,   ! shape parameter of hail
+   ccn     = 0.6e9  ! base ccn concentration; see README.namelist
+   cnor    = 8.e6,  ! for single moment only
+   cnoh    = 4.e4,  ! for single moment only
+ /
+

--- a/run/namelist.scale1k.gpu
+++ b/run/namelist.scale1k.gpu
@@ -1,0 +1,369 @@
+
+ &param0
+ nx           =    1024,
+ ny           =    1024,
+ nz           =    1024,
+ ppnode       =      4,
+ timeformat   =       2,
+ timestats    =       1,
+ terrain_flag = .false.,
+ procfiles    = .false.,
+ /
+
+ &param1
+ dx     =    5.0,
+ dy     =    5.0,
+ dz     =     2.5,
+ dtl    =   0.125,
+ timax  = 120.0,
+ run_time =  -999.9,
+ tapfrq =   900.0,
+ rstfrq = 10800.0,
+ statfrq =  60.0,
+ prclfrq =  60.0,
+ /
+
+ &param2
+ cm1setup  =  1,
+ testcase  = 10,
+ adapt_dt  =  1,
+ irst      =  0,
+ rstnum    =  1,
+ iconly    =  0,
+ hadvordrs =  5,
+ vadvordrs =  5,
+ hadvordrv =  5,
+ vadvordrv =  5,
+ advwenos  =  2,
+ advwenov  =  0,
+ weno_order = 5,
+ apmasscon =  0,
+ idiff     =  0,
+ mdiff     =  0,
+ difforder =  6,
+ imoist    =  1,
+ ipbl      =  0,
+ sgsmodel  =  4,
+ tconfig   =  1,
+ bcturbs   =  1,
+ horizturb =  0,
+ doimpl    =  0,
+ irdamp    =  1,
+ hrdamp    =  0,
+ psolver   =  2,
+ ptype     =  0,
+ ihail     =  0,
+ iautoc    =  0,
+ icor      =  1,
+ lspgrad   =  3,
+ eqtset    =  1,
+ idiss     =  0,
+ efall     =  0,
+ rterm     =  0,
+ wbc       =  1,
+ ebc       =  1,
+ sbc       =  1,
+ nbc       =  1,
+ bbc       =  3,
+ tbc       =  1,
+ irbc      =  4,
+ roflux    =  0,
+ nudgeobc  =  0,
+ isnd      =  8,
+ iwnd      =  8,
+ itern     =  0,
+ iinit     =  0,
+ irandp    =  1,
+ ibalance  =  0,
+ iorigin   =  1,
+ axisymm   =  0,
+ imove     =  1,
+ iptra     =  0,
+ npt       =  1,
+ pdtra     =  1,
+ iprcl     =  1,  !This turns on the parcels, and with prcl_droplet=1 below, makes them droplets
+ nparcelsInit = 400000000,   ! initial number of particles over the whole domain
+ nparcelsMax  = 600000000,   ! the total allowable number of particles over the whole domain
+ injectHMax = 20.0,
+ drop_mult = 0.1e10,   !Droplet multiplicity: total number of droplets = nparcels*drop_mult
+ drop_inject_elapse = 1.0,  !Time between spray injection
+ drop_inject_time =  30.0,  !Time after which spray injection begins
+ drop_w_init = 3.0    ! Initial vertical velocity of the newly initialized spray droplet
+ /
+
+ &param3
+ kdiff2  =   75.0,
+ kdiff6  =   0.040,
+ fcor    = 0.00005,
+ kdiv    = 0.10,
+ alph    = 0.60,
+ rdalpha = 3.3333333333e-3,
+ zd      =  2000.0,
+ xhd     = 100000.0,
+ alphobc = 60.0,
+ umove   =  0.0,
+ vmove   = 50.0,
+ v_t     =      0.0,
+ l_h     =      0.0,
+ lhref1  =      0.0,
+ lhref2  =      0.0,
+ l_inf   =     75.0,
+ ndcnst  =    100.0,
+ /
+
+ &param11
+ radopt  =        0,
+ dtrad   =    300.0,
+ ctrlat  =    36.68,
+ ctrlon  =   -98.35,
+ year    =     2009,
+ month   =        5,
+ day     =       15,
+ hour    =       21,
+ minute  =       38,
+ second  =       00,
+ /
+
+ &param12
+ isfcflx    =      1,
+ sfcmodel   =      1,
+ oceanmodel =      1,
+ initsfc    =      1,
+ tsk0       = 302.27,
+ tmn0       = 299.15,
+ xland0     =    2.0,
+ lu0        =     16,
+ season     =      1,
+ cecd       =      1,
+ pertflx    =      0,
+ cnstce     =  0.0012,
+ cnstcd     =  0.0025,
+ isftcflx   =      0,
+ iz0tlnd    =      0,
+ oml_hml0   =   50.0,
+ oml_gamma  =   0.14,
+ set_flx    =      0,
+ cnst_shflx =   0.10,
+ cnst_lhflx =   0.00,
+ set_znt    =      0,
+ cnst_znt   =   0.00,
+ set_ust    =      0,
+ cnst_ust   =   0.00,
+ /
+
+ &param4
+ stretch_x =      0,
+ dx_inner  =    1000.0,
+ dx_outer  =    7000.0,
+ nos_x_len =   40000.0,
+ tot_x_len =  120000.0,
+ /
+
+ &param5
+ stretch_y =      0,
+ dy_inner  =    1000.0,
+ dy_outer  =    7000.0,
+ nos_y_len =   40000.0,
+ tot_y_len =  120000.0,
+ /
+
+ &param6
+ stretch_z =  0,
+ ztop      =  2980.0,
+ str_bot   =  2000.0,
+ str_top   =  2980.0,
+ dz_bot    =   20.0,
+ dz_top    =   50.0,
+ /
+
+ &param7
+ bc_temp   = 1,
+ ptc_top   = 250.0,
+ ptc_bot   = 300.0,
+ viscosity = 1.57e-5,  !Needs to be set to the viscosity of air, even though not doing DNS
+ pr_num    = 0.72,
+ sc_num    = 0.61,     !Need to define a Schmidt number for the droplets
+ /
+
+ &param8
+ var1      =  50.0,     ! Vmax (m/s)
+ var2      =  20000.0,  ! R (m)
+ var3      =  0.60,     ! n
+ var4      =   0.0,
+ var5      =   0.0,
+ var6      =   0.0,
+ var7      =   0.0,
+ var8      =   0.0,
+ var9      =   0.0,
+ var10     =   0.0,
+ var11     =   0.0,
+ var12     =   0.0,
+ var13     =   0.0,
+ var14     =   0.0,
+ var15     =   0.0,
+ var16     =   0.0,
+ var17     =   0.0,
+ var18     =   0.0,
+ var19     =   0.0,
+ var20     =   0.0,
+ /
+
+ &param9
+ output_format    = 1,
+ output_filetype  = 3,
+ output_interp    = 0,
+ output_rain      = 1,
+ output_sws       = 1,
+ output_svs       = 1,
+ output_sps       = 1,
+ output_srs       = 1,
+ output_sgs       = 1,
+ output_sus       = 1,
+ output_shs       = 1,
+ output_coldpool  = 0,
+ output_sfcflx    = 1,
+ output_sfcparams = 1,
+ output_sfcdiags  = 1,
+ output_psfc      = 1,
+ output_zs        = 0,
+ output_zh        = 0,
+ output_basestate = 0,
+ output_th        = 1,
+ output_thpert    = 0,
+ output_prs       = 0,
+ output_prspert   = 0,
+ output_pi        = 0,
+ output_pipert    = 1,
+ output_rho       = 0,
+ output_rhopert   = 0,
+ output_tke       = 1,
+ output_km        = 1,
+ output_kh        = 1,
+ output_qv        = 1,
+ output_qvpert    = 0,
+ output_q         = 1,
+ output_dbz       = 0,
+ output_buoyancy  = 0,
+ output_u         = 1,
+ output_upert     = 0,
+ output_uinterp   = 1,
+ output_v         = 1,
+ output_vpert     = 0,
+ output_vinterp   = 1,
+ output_w         = 1,
+ output_winterp   = 1,
+ output_vort      = 0,
+ output_pv        = 0,
+ output_uh        = 0,
+ output_pblten    = 0,
+ output_dissten   = 0,
+ output_fallvel   = 0,
+ output_nm        = 0,
+ output_def       = 0,
+ output_radten    = 0,
+ output_cape      = 0,
+ output_cin       = 0,
+ output_lcl       = 0,
+ output_lfc       = 0,
+ output_pwat      = 0,
+ output_lwp       = 0,
+ output_thbudget  = 0,
+ output_qvbudget  = 0,
+ output_ubudget   = 0,
+ output_vbudget   = 0,
+ output_wbudget   = 0,
+ /
+
+ &param16
+ restart_format   = 1,
+ restart_filetype = 2,
+ restart_reset_frqtim  =  .true.,
+ restart_file_theta    =  .false.,
+ restart_file_dbz      =  .false.,
+ restart_file_th0      =  .false.,
+ restart_file_prs0     =  .false.,
+ restart_file_pi0      =  .false.,
+ restart_file_rho0     =  .false.,
+ restart_file_qv0      =  .false.,
+ restart_file_u0       =  .false.,
+ restart_file_v0       =  .false.,
+ restart_file_zs       =  .false.,
+ restart_file_zh       =  .false.,
+ restart_file_zf       =  .false.,
+ restart_file_diags    =  .false.,
+ restart_use_theta     =  .false.,
+ /
+
+ &param10
+ stat_w        = 1,
+ stat_wlevs    = 0,
+ stat_u        = 1,
+ stat_v        = 1,
+ stat_rmw      = 1,
+ stat_pipert   = 1,
+ stat_prspert  = 1,
+ stat_thpert   = 1,
+ stat_q        = 1,
+ stat_tke      = 1,
+ stat_km       = 1,
+ stat_kh       = 1,
+ stat_div      = 1,
+ stat_rh       = 1,
+ stat_rhi      = 1,
+ stat_the      = 1,
+ stat_cloud    = 1,
+ stat_sfcprs   = 1,
+ stat_wsp      = 1,
+ stat_cfl      = 1,
+ stat_vort     = 1,
+ stat_tmass    = 1,
+ stat_tmois    = 1,
+ stat_qmass    = 1,
+ stat_tenerg   = 1,
+ stat_mo       = 1,
+ stat_tmf      = 1,
+ stat_pcn      = 1,
+ stat_qsrc     = 1,
+ /
+
+ &param13
+ prcl_th       = 1,
+ prcl_t        = 1,
+ prcl_prs      = 1,
+ prcl_ptra     = 1,
+ prcl_q        = 1,
+ prcl_nc       = 1,
+ prcl_km       = 1,
+ prcl_kh       = 1,
+ prcl_tke      = 1,
+ prcl_dbz      = 1,
+ prcl_b        = 1,
+ prcl_vpg      = 1,
+ prcl_vort     = 1,
+ prcl_rho      = 1,
+ prcl_qsat     = 1,
+ prcl_sfc      = 1,
+ prcl_droplet  = 1, !Makes them "droplets" instead of "parcels"
+ /
+
+ &param14
+ dodomaindiag   =    .true.,
+ diagfrq        =    60.0,
+ /
+
+ &param15
+ doazimavg        =    .false.,
+ azimavgfrq       =     3600.0,
+ rlen             =   300000.0,
+ do_adapt_move    =    .false.,
+ adapt_move_frq   =     3600.0,
+ /
+
+ &nssl2mom_params
+   alphah  = 0,     ! shape parameter of graupel
+   alphahl = 0.5,   ! shape parameter of hail
+   ccn     = 0.6e9  ! base ccn concentration; see README.namelist
+   cnor    = 8.e6,  ! for single moment only
+   cnoh    = 4.e4,  ! for single moment only
+ /
+

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -3538,6 +3538,7 @@ end module cuda_rt
         !     The second method is expected to avoid the creation of an
         !     array with size "nparcels*npvals" (saving memory space) 
         !     and thus implemented below 
+        if(timestats.ge.1) time_stat=time_stat+mytime()
         if ( iprcl.eq.1 .and. prcl_droplet.eq.1 ) then
            call droplet_diag(rtime,nrec,zh,zf,pdata,pdata_locind,dpten)
         end if
@@ -3554,7 +3555,7 @@ end module cuda_rt
           enddo
         endif
         if(myid.eq.0) print *,'  next stattim = ',stattim
-        if(timestats.ge.1) time_stat=time_stat+mytime()
+        if(timestats.ge.1) time_statD=time_statD+mytime()
       endif
 
 
@@ -4041,7 +4042,7 @@ end module cuda_rt
 
         if(timestats.eq.2)then
           steptime2=time_sound+time_poiss+time_buoyan+time_turb+            &
-                    time_diffu+time_microphy+time_stat+time_cflq+           &
+                    time_diffu+time_microphy+time_stat+time_statD+time_cflq+           &
                     time_bc+time_nvtx+time_integ+time_rdamp+time_divx+    &
                     time_misc+time_misc01+time_misc02+time_misc03+time_misc04+time_misc05+ &
                     time_misc06+time_misc07+time_misc08+time_misc09+time_misc10+ &
@@ -4060,7 +4061,6 @@ end module cuda_rt
                     time_mps2+time_mps4+time_mpq2+time_mptk2+time_mpb+                &
                     time_dpc+time_parceli_reduce+time_lb+         &
                     time_dropC1+time_dropC2+time_dropC3+time_dropC4+ &
-                    time_dropC4a+time_dropC4b+time_dropC4c+time_dropC4d+time_dropC4e+time_dropC4f+ &
 #endif
                     time_advs+time_advu+time_advv+time_advw+                &
                     time_phys_H2D + time_phys_D2H
@@ -4241,9 +4241,15 @@ end module cuda_rt
         sum = 0.0
         call MPI_REDUCE(time_pbl     ,sum,1,MPI_REAL,MPI_SUM,0,MPI_COMM_WORLD,ierr)
         time_pbl = sum/float(numprocs)
+
         sum = 0.0
         call MPI_REDUCE(time_stat    ,sum,1,MPI_REAL,MPI_SUM,0,MPI_COMM_WORLD,ierr)
         time_stat = sum/float(numprocs)
+
+        sum = 0.0
+        call MPI_REDUCE(time_statD   ,sum,1,MPI_REAL,MPI_SUM,0,MPI_COMM_WORLD,ierr)
+        time_statD = sum/float(numprocs)
+
         sum = 0.0
         call MPI_REDUCE(time_cflq    ,sum,1,MPI_REAL,MPI_SUM,0,MPI_COMM_WORLD,ierr)
         time_cflq = sum/float(numprocs)
@@ -4467,7 +4473,7 @@ end module cuda_rt
 #endif
 
       time_solve=time_sound+time_poiss+time_buoyan+time_turb+             &
-                  time_diffu+time_microphy+time_stat+time_cflq+           &
+                  time_diffu+time_microphy+time_stat+time_statD+time_cflq+           &
                   time_bc+time_nvtx+time_integ+time_rdamp+time_divx+ &
                   time_misc+time_misc01+time_misc02+time_misc03+time_misc04+time_misc05+ & 
                   time_misc11+time_misc12+time_misc13+time_misc14+time_misc15+ &
@@ -4486,7 +4492,6 @@ end module cuda_rt
                   time_mps2+time_mps4+time_mpq2+time_mptk2+time_mpb+            &
                   time_dpc+time_lb+                         &
                   time_dropC1+time_dropC2+time_dropC3+time_dropC4+ &
-                  time_dropC4a+time_dropC4b+time_dropC4c+time_dropC4d+time_dropC4e+time_dropC4f+ &
 #endif
                   time_advs+time_advu+time_advv+time_advw+                &
                   time_phys_H2D+time_phys_D2H
@@ -4531,6 +4536,7 @@ end module cuda_rt
       write(outfile,100) 'radiatio',time_rad,time_rad/time_solve
       write(outfile,100) 'pbl     ',time_pbl,time_pbl/time_solve
       write(outfile,100) 'stat    ',time_stat,time_stat/time_solve
+      write(outfile,100) 'statD   ',time_statD,time_statD/time_solve
       write(outfile,100) 'cflq    ',time_cflq,time_cflq/time_solve
       write(outfile,100) 'bc      ',time_bc,time_bc/time_solve
       write(outfile,100) 'bcs     ',time_bcs,time_bcs/time_solve
@@ -4613,12 +4619,12 @@ end module cuda_rt
       write(outfile,100) 'dropC2  ',time_dropC2,time_dropC2/time_solve
       write(outfile,100) 'dropC3  ',time_dropC3,time_dropC3/time_solve
       write(outfile,100) 'dropC4  ',time_dropC4,time_dropC4/time_solve
-      write(outfile,100) 'dropC4a ',time_dropC4a,time_dropC4a/time_solve
-      write(outfile,100) 'dropC4b ',time_dropC4b,time_dropC4b/time_solve
-      write(outfile,100) 'dropC4c ',time_dropC4c,time_dropC4c/time_solve
-      write(outfile,100) 'dropC4d ',time_dropC4d,time_dropC4d/time_solve
-      write(outfile,100) 'dropC4e ',time_dropC4e,time_dropC4e/time_solve
-      write(outfile,100) 'dropC4f ',time_dropC4f,time_dropC4f/time_solve
+      !write(outfile,100) 'dropC4a ',time_dropC4a,time_dropC4a/time_solve
+      !write(outfile,100) 'dropC4b ',time_dropC4b,time_dropC4b/time_solve
+      !write(outfile,100) 'dropC4c ',time_dropC4c,time_dropC4c/time_solve
+      !write(outfile,100) 'dropC4d ',time_dropC4d,time_dropC4d/time_solve
+      !write(outfile,100) 'dropC4e ',time_dropC4e,time_dropC4e/time_solve
+      !write(outfile,100) 'dropC4f ',time_dropC4f,time_dropC4f/time_solve
       write(outfile,100) 'parceliA',time_parceli_reduce,time_parceli_reduce/time_solve
       write(outfile,100) 'dpc     ',time_dpc,time_dpc/time_solve
 #endif

--- a/src/cm1.F
+++ b/src/cm1.F
@@ -4619,12 +4619,6 @@ end module cuda_rt
       write(outfile,100) 'dropC2  ',time_dropC2,time_dropC2/time_solve
       write(outfile,100) 'dropC3  ',time_dropC3,time_dropC3/time_solve
       write(outfile,100) 'dropC4  ',time_dropC4,time_dropC4/time_solve
-      !write(outfile,100) 'dropC4a ',time_dropC4a,time_dropC4a/time_solve
-      !write(outfile,100) 'dropC4b ',time_dropC4b,time_dropC4b/time_solve
-      !write(outfile,100) 'dropC4c ',time_dropC4c,time_dropC4c/time_solve
-      !write(outfile,100) 'dropC4d ',time_dropC4d,time_dropC4d/time_solve
-      !write(outfile,100) 'dropC4e ',time_dropC4e,time_dropC4e/time_solve
-      !write(outfile,100) 'dropC4f ',time_dropC4f,time_dropC4f/time_solve
       write(outfile,100) 'parceliA',time_parceli_reduce,time_parceli_reduce/time_solve
       write(outfile,100) 'dpc     ',time_dpc,time_dpc/time_solve
 #endif

--- a/src/comm_droplet.F
+++ b/src/comm_droplet.F
@@ -193,9 +193,7 @@ contains
     use input, only : myid,nparcelsLocal,npvals,mynw,mysw,myne, &
                       myse,myeast,mywest,mynorth,mysouth,ierr, &
                       pract,nparcelsLocalActive, &
-                      timestats,mytime, &
-      time_dropC4a,time_dropC4b,time_dropC4c, &
-      time_dropC4d,time_dropC4e,time_dropC4f
+                      timestats,mytime
     use constants, only: undefined_index,neg_huge,num_nn,inorth, &
                          isouth,iwest,ieast,inw,ine,isw,ise
     use mpi
@@ -281,7 +279,6 @@ contains
      !$acc             droplet_n2,droplet_s2,droplet_w2,droplet_e2,     &
      !$acc             droplet_nw2,droplet_ne2,droplet_sw2,droplet_se2)
 
-     if(timestats.ge.1) time_dropC4a=time_dropC4a+mytime()
 
      ! extract the information of droplets that will leave the current MPI region 
      ! and reset the corresponding "pdata" record to a large negative value
@@ -310,12 +307,10 @@ contains
      if(Depart(ise) .gt. 0) &
         call packDroplets(ise, Depart, ptrDepart, Depart_ind, pdata, droplet_se1)
 
-     if(timestats.ge.1) time_dropC4b=time_dropC4b+mytime()
 
 
      ! initiate the MPI non-blocking receive interface to 
      ! obtain new droplet information from the nearest neighbors
-     if(timestats.ge.1) time_dropC4c=time_dropC4c+mytime()
 
      n_recv   = 0
      if ( Arrive(inorth) .ne. 0 ) then
@@ -489,7 +484,6 @@ contains
        end if
        n = n + 1
      end do
-     if(timestats.ge.1) time_dropC4d=time_dropC4d+mytime()
 
     ! make sure that all the non-blocking MPI send operations are complete
 
@@ -498,7 +492,6 @@ contains
        call mpi_waitall(n_send,reqs(9:9+n_send-1),status1(1:mpi_status_size,9:9+n_send-1),ierr)
     end if
 
-     if(timestats.ge.1) time_dropC4e=time_dropC4e+mytime()
 
      ! free up the memory for temporary variables
      !$acc end data
@@ -520,7 +513,6 @@ contains
      if (allocated(droplet_sw1)) deallocate(droplet_sw1)
      if (allocated(droplet_sw2)) deallocate(droplet_sw2)
 
-     if(timestats.ge.1) time_dropC4f=time_dropC4f+mytime()
 
   end subroutine comm_droplet_value
 

--- a/src/constants.F
+++ b/src/constants.F
@@ -66,7 +66,7 @@
 
       integer, parameter :: undefined_index = -100
 
-      real, parameter :: pdata_buffer = 0.20      ! additional storage space for pdata from
+      real, parameter :: pdata_buffer = 0.30      ! additional storage space for pdata from
                                                   ! each MPI rank to account for the droplet
                                                   ! communication between MPI ranks;
                                                   ! this is a percent of

--- a/src/input.F
+++ b/src/input.F
@@ -233,7 +233,7 @@
 !  timestats:
 
       real clock_rate,time_sound,time_buoyan,time_turb,              &
-           time_diffu,time_microphy,time_stat,time_cflq,time_bc,     &
+           time_diffu,time_microphy,time_stat,time_statD,time_cflq,time_bc,     &
            time_bcs,time_bcst,time_bcs2, &
            time_integ,time_rdamp,time_divx,time_write,time_nvtx,     &
            time_misc,time_misc01,time_misc02,time_misc03,time_misc04,time_misc05, &
@@ -251,7 +251,6 @@
            time_mps2,time_mps4,time_mpq2,time_mptk2,time_mpb,time_dpc,        &
            time_parcels,time_parceli,time_droplet, &
            time_dropC1,time_dropC2,time_dropC3,time_dropC4, &
-           time_dropC4a,time_dropC4b,time_dropC4c,time_dropC4d,time_dropC4e,time_dropC4f, &
            time_droplet_inject, time_parceli_reduce, &
            time_rad,time_pbl,time_swath,time_pdef,      &
            time_prsrho,time_restart,time_poiss,time_diag,            &

--- a/src/misclibs.F
+++ b/src/misclibs.F
@@ -4468,7 +4468,7 @@
       subroutine set_time_to_zero
       use input, only : time_sound,time_poiss,time_advs,time_phys_H2D,time_phys_D2H, &
           time_H2D,time_D2H,time_advu,time_advv,time_advw,time_buoyan,time_turb, &
-          time_diffu,time_microphy,time_dbz,time_stat,time_cflq,time_bc,time_bcs, &
+          time_diffu,time_microphy,time_dbz,time_stat,time_statD,time_cflq,time_bc,time_bcs, &
           time_bcs2,time_bcst,time_misc,time_misc01,time_misc02,time_misc03,time_misc04, &
           time_misc05,time_misc06,time_misc07,time_misc08,time_misc09,time_misc10, &
           time_misc11,time_misc12,time_misc13,time_misc14,time_misc15,time_misc16, &
@@ -4476,7 +4476,6 @@
           time_misc23,time_integ,time_rdamp,time_divx,time_write,time_nvtx,time_restart, &
           time_ttend,time_cor,time_fall,time_satadj,time_sfcphys,time_parcels,time_parceli, &
           time_droplet,time_dropC1,time_dropC2,time_dropC3,time_dropC4, &
-          time_dropC4a,time_dropC4b,time_dropC4c,time_dropC4d,time_dropC4e,time_dropC4f, &
           time_droplet_inject, time_parceli_reduce,time_rad,time_pbl,time_swath, &
           time_pdef,time_prsrho,time_diag,time_azimavg,time_hifrq,time_ercyl,time_mpu1, &
           time_mpv1,time_mpw1,time_mpp1,time_mpu2,time_mpv2,time_mpw2,time_mpp2,time_mps1, &
@@ -4502,6 +4501,7 @@
       time_microphy=0.0
       time_dbz=0.0
       time_stat=0.0
+      time_statD=0.0
       time_cflq=0.0
       time_bc=0.0
       time_bcs=0.0
@@ -4549,12 +4549,6 @@
       time_dropC2=0.0
       time_dropC3=0.0
       time_dropC4=0.0
-      time_dropC4a=0.0
-      time_dropC4b=0.0
-      time_dropC4c=0.0
-      time_dropC4d=0.0
-      time_dropC4e=0.0
-      time_dropC4f=0.0
       time_droplet_inject=0.0
       time_parceli_reduce=0.0
       time_rad=0.0

--- a/src/statpack.F
+++ b/src/statpack.F
@@ -20,7 +20,7 @@
 
       use input
       use constants
-      use maxmin_module, only : maxmin2d, maxmin => maxmin_orig
+      use maxmin_module, only : maxmin2d, maxmin => maxmin_fold
       use misclibs
       use cm1libs , only : rslf,rsif
 #ifdef NETCDF


### PR DESCRIPTION
This PR makes several different changes that were identified during preparation for a PASC24 submission.  They are 

- The algorithm is used to calculate min and max values by statpack. 
-  It eliminates excessive timers that were used for development purposes in the droplet communication library.
- Defined new namelist for scalability testing
- increase the droplet buffer size

The correctness statistics between Intel and nvhpc compiler on GPU is similar to the previous commit:

============================================
39 stat variables are identical.
40 stat variables show a mean relative difference > 1e-06
7 stat variables show a mean relative difference <= 1e-06

============================================
1 stat variables are identical.
8 stat variables show a mean relative difference > 1e-06
3 stat variables show a mean relative difference <= 1e-06

============================================
254 stat variables are identical.
2 stat variables show a mean relative difference > 1e-06
0 stat variables show a mean relative difference <= 1e-06